### PR TITLE
Trim dropbot status measurement display

### DIFF
--- a/dropbot_controller/dropbot_controller_base.py
+++ b/dropbot_controller/dropbot_controller_base.py
@@ -8,11 +8,9 @@ from traits.api import Instance, Dict
 import dramatiq
 
 # unit handling
-from pint import UnitRegistry
 
+from microdrop_utils.ureg_helpers import ureg
 from microdrop_utils.dramatiq_controller_base import generate_class_method_dramatiq_listener_actor, invoke_class_method, TimestampedMessage
-
-ureg = UnitRegistry()
 
 from .consts import (CHIP_INSERTED, CAPACITANCE_UPDATED, HALTED, HALT, START_DEVICE_MONITORING,
                      RETRY_CONNECTION, OUTPUT_ENABLE_PIN, SHORTS_DETECTED, PKG, SELF_TEST_CANCEL)

--- a/dropbot_status/dramatiq_UI.py
+++ b/dropbot_status/dramatiq_UI.py
@@ -5,7 +5,6 @@ import os
 from PySide6.QtCore import QObject, Signal, Slot
 # pyside imports
 from PySide6.QtWidgets import QVBoxLayout, QPushButton, QMessageBox, QDialog, QTextBrowser, QWidget
-from pint import UnitRegistry
 from traits.has_traits import HasTraits
 from traits.trait_types import Instance
 
@@ -25,7 +24,7 @@ from .model import DropBotStatusModel
 
 logger = get_logger(__name__, level="DEBUG")
 
-ureg = UnitRegistry()
+from microdrop_utils.ureg_helpers import ureg
 
 disconnected_color = GREY["lighter"]  #ERROR_COLOR
 connected_no_device_color = WARNING_COLOR

--- a/dropbot_status/model.py
+++ b/dropbot_status/model.py
@@ -10,7 +10,7 @@ class DropBotStatusModel(HasTraits):
     # Sensor readings
     capacitance = Str("-", desc="Raw capacitance in pF")
     voltage = Str("-", desc="Voltage set to device in V")
-    pressure = Str("-", desc="Pressure reading in kPa")
+    pressure = Str("-", desc="Pressure reading in pF/mm^2 ")
     force = Str("-", desc="Calculated force in N")
 
     def reset_readings(self):

--- a/dropbot_status/status_label_widgets.py
+++ b/dropbot_status/status_label_widgets.py
@@ -63,9 +63,6 @@ class DropBotStatusGridWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        # Use a size policy that prevents horizontal stretching
-        self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
-
         layout = QGridLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setHorizontalSpacing(10)
@@ -116,3 +113,12 @@ class DropBotStatusGridWidget(QWidget):
         self.force_reading = QLabel("-")
         layout.addWidget(force_label, 5, 0)
         layout.addWidget(self.force_reading, 5, 1)
+
+
+        # The 'Maximum' policy tells the layout that the widget's size hint
+        # is also its maximum size.
+        self.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Preferred)
+
+        # This calculates the ideal size needed to fit all content and
+        # sets it as the maximum size, preventing the widget from stretching.
+        self.setMaximumSize(self.sizeHint())

--- a/dropbot_status/test.py
+++ b/dropbot_status/test.py
@@ -32,7 +32,7 @@ class Window(QMainWindow):
         )
 
         # The View is the UI component we are testing
-        self.status_view = DropBotStatusView(view_signals=self.view_signals)
+        self.status_view = DropBotStatusView(view_model=self.view_model)
 
         # 2. --- Create controls that will ONLY interact with the model ---
         self.connect_button = QPushButton("Toggle Connection")
@@ -75,11 +75,15 @@ class Window(QMainWindow):
     def _simulate_backend_updates(self):
         """Simulates receiving new sensor data from a backend."""
         if self.model.connected:
-            cap = f"{random.uniform(10, 50):.2f} pF"
-            volt = f"{random.uniform(3.0, 3.3):.2f} V"
+            cap = f"{random.uniform(10, 50):.5f} pF"
+            volt = f"{random.uniform(1, 100):.5f} V"
+            pressure = f"{random.uniform(1, 100):.4f} pF/mm^2"
+            force = self.model.force = f"{random.uniform(1,100):.4f} mN/m"
             self.model.capacitance = cap
             self.model.voltage = volt
-            print(f"HARNESS: Simulating backend update. Capacitance: {cap}")
+            self.model.pressure = pressure
+            self.model.force = force
+            print(f"HARNESS: Simulating backend update. Capacitance: {cap}; Voltage: {volt}; Pressure: {pressure}; Force: {force}")
         else:
             # If not connected, reset to default values
             self.model.capacitance = "-"

--- a/microdrop_utils/ureg_helpers.py
+++ b/microdrop_utils/ureg_helpers.py
@@ -2,21 +2,24 @@ from pint import UnitRegistry
 
 ureg = UnitRegistry()
 
+
 def ureg_quant_percent_change(old, new):
     old = get_ureg_magnitude(old)
     new = get_ureg_magnitude(new)
 
     return 100 * abs(old - new) / old
 
+
 def ureg_diff(old, new):
     old = get_ureg_magnitude(old)
     new = get_ureg_magnitude(new)
 
-
     return old - new
+
 
 def get_ureg_magnitude(text):
     return ureg(text).magnitude
 
+
 def trim_to_n_digits(text, n_digits):
-    return f'{ureg.Quantity(text):.{n_digits}g~}'
+    return f'{ureg.Quantity(text):.{n_digits}g~H}'

--- a/microdrop_utils/ureg_helpers.py
+++ b/microdrop_utils/ureg_helpers.py
@@ -17,3 +17,6 @@ def ureg_diff(old, new):
 
 def get_ureg_magnitude(text):
     return ureg(text).magnitude
+
+def trim_to_n_digits(text, n_digits):
+    return f'{ureg.Quantity(text):.{n_digits}g~}'

--- a/microdrop_utils/ureg_helpers.py
+++ b/microdrop_utils/ureg_helpers.py
@@ -1,7 +1,6 @@
-from pint import UnitRegistry
 
-ureg = UnitRegistry()
-
+# ureg = UnitRegistry()
+from nadamq import ureg
 
 def ureg_quant_percent_change(old, new):
     old = get_ureg_magnitude(old)

--- a/protocol_grid/services/force_calculation_service.py
+++ b/protocol_grid/services/force_calculation_service.py
@@ -1,4 +1,3 @@
-from pint import UnitRegistry
 from typing import Dict, List, Optional, Tuple
 from PySide6.QtCore import Qt
 
@@ -6,7 +5,7 @@ from microdrop_utils._logger import get_logger
 
 logger = get_logger(__name__)
 
-ureg = UnitRegistry()
+from microdrop_utils.ureg_helpers import ureg
 
 class ForceCalculationService:
     """Service for calculating forces based on calibration data and voltages."""


### PR DESCRIPTION
Make the capacitance, voltage and other measurements in the dropbot status show always with a set number of significant digits. 