### PR TITLE
view_change/status_icon_size_fix

### DIFF
--- a/device_viewer/menus.py
+++ b/device_viewer/menus.py
@@ -9,7 +9,7 @@ def open_file_dialogue_menu_factory(plugin=None):
 
     return DockPaneAction(
         id=PKG + ".open_file_dialogue",
-        dock_pane_id=PKG + ".pane",
+        dock_pane_id=PKG + ".dock_pane",
         name=f"Open SVG File",
         method="open_file_dialog"
     )
@@ -21,7 +21,7 @@ def open_svg_dialogue_menu_factory(plugin=None):
 
     return DockPaneAction(
         id=PKG + ".open_svg_dialogue",
-        dock_pane_id=PKG + ".pane",
+        dock_pane_id=PKG + ".dock_pane",
         name=f"Save to SVG",
         method="open_svg_dialog"
     )

--- a/device_viewer/plugin.py
+++ b/device_viewer/plugin.py
@@ -38,7 +38,7 @@ class DeviceViewerPlugin(Plugin):
     contributed_task_extensions = List(contributes_to=TASK_EXTENSIONS)
 
     def _contributed_task_extensions_default(self):
-        from .views.device_view_pane import DeviceViewerDockPane
+        from .views.device_view_dock_pane import DeviceViewerDockPane
 
         return [ 
             TaskExtension(

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -61,7 +61,7 @@ class DeviceViewerDockPane(TraitsDockPane):
 
     model = Instance(DeviceViewMainModel)
 
-    id = PKG + ".pane"
+    id = PKG + ".dock_pane"
     name = PKG_name + " Dock Pane"
 
     # Views

--- a/dropbot_status/displayed_UI.py
+++ b/dropbot_status/displayed_UI.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from PySide6.QtWidgets import QWidget, QHBoxLayout
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QSpacerItem, QSizePolicy
 from PySide6.QtCore import Signal, QObject
 from traits.api import HasTraits, observe, Instance
 
@@ -150,8 +150,10 @@ class DropBotStatusView(QWidget):
         self.grid_widget = DropBotStatusGridWidget()
 
         # compose main layout (icon on left, grid on right)
-        self.main_layout.addWidget(self.icon_widget, 1)
-        self.main_layout.addWidget(self.grid_widget, 2)
+        self.main_layout.addWidget(self.icon_widget)
+        self.main_layout.addWidget(self.grid_widget)
+        spacer = QSpacerItem(0, 0, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.main_layout.addSpacerItem(spacer)
 
         # --- Data Binding ---
         # Connect ViewModel signals to the appropriate widget slots/methods.

--- a/dropbot_status/dock_pane.py
+++ b/dropbot_status/dock_pane.py
@@ -10,7 +10,7 @@ class DropbotStatusDockPane(DockPane):
     """
     #### 'ITaskPane' interface ################################################
 
-    id = PKG + ".pane"
+    id = PKG + ".dock_pane"
     name = f"{PKG_name} Dock Pane"
 
     def create_contents(self, parent):

--- a/dropbot_status/status_label_widgets.py
+++ b/dropbot_status/status_label_widgets.py
@@ -19,7 +19,9 @@ class DropBotIconWidget(QLabel):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setMinimumSize(60, 60)
+        self.setMinimumWidth(60)
+        self.setMaximumWidth(106)
+        self.setFixedHeight(106)
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 

--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -108,12 +108,12 @@ class MicrodropTask(Task):
 
         right = VSplitter(
             top_right,
-            PaneItem("protocol_grid.dock_pane", height=1000),
+            PaneItem("protocol_grid.dock_pane", height=1000), # we want this to take up as much space as it can
         )
 
         return TaskLayout(
             right=right,
-            left=PaneItem("device_viewer.dock_pane", width=1000),
+            left=PaneItem("device_viewer.dock_pane", width=1000), # we want this to take up as much space as it can
         )
 
     ##########################################################

--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -4,7 +4,7 @@ import dramatiq
 
 # Enthought library imports.
 from pyface.tasks.action.api import SMenu, SMenuBar, TaskToggleGroup, TaskAction
-from pyface.tasks.api import Task, TaskLayout, Tabbed, PaneItem
+from pyface.tasks.api import PaneItem, Task, TaskLayout, HSplitter, VSplitter
 from pyface.api import GUI
 from traits.api import Instance, provides
 
@@ -100,9 +100,20 @@ class MicrodropTask(Task):
     # ------------------ Trait initializers ---------------------------------
 
     def _default_layout_default(self):
+
+        top_right = HSplitter(
+            PaneItem("dropbot_status.dock_pane"),
+            PaneItem("manual_controls.dock_pane"),
+        )
+
+        right = VSplitter(
+            top_right,
+            PaneItem("protocol_grid.dock_pane", height=1000),
+        )
+
         return TaskLayout(
-            left=PaneItem("microdrop.central_canvas"),
-            right=Tabbed()
+            right=right,
+            left=PaneItem("device_viewer.dock_pane", width=1000),
         )
 
     ##########################################################

--- a/protocol_grid/dock_pane.py
+++ b/protocol_grid/dock_pane.py
@@ -18,7 +18,7 @@ class PGCDockPane(DockPane):
     """
     #### 'ITaskPane' interface ################################################
 
-    id = Str(PKG + ".widget")
+    id = Str(PKG + ".dock_pane")
     name = Str(PKG_name)
 
     def create_contents(self, parent):


### PR DESCRIPTION
Create a default layout for the app
Consistent naming for the dock pane to help with the default layout definition. 
Spacer in the status icon to stop stretching. 