### PR TITLE
Reset proxy on exception during initialization of SerialProxy.

### DIFF
--- a/dropbot_controller/dropbot_controller_base.py
+++ b/dropbot_controller/dropbot_controller_base.py
@@ -170,6 +170,7 @@ class DropbotControllerBase(HasTraits):
             self.proxy.signals.signal('output_disabled').connect(self._output_state_changed_wrapper, weak=False)
             self.proxy.signals.signal('capacitance-updated').connect(self._capacitance_updated_wrapper)
             self.proxy.signals.signal('shorts-detected').connect(self._shorts_detected_wrapper)
+            logger.debug("Connected DropBot signals to handlers")
             
             # Configure feedback capacitor
             if self.proxy.config.C16 < 0.3e-6:

--- a/dropbot_controller/services/dropbot_monitor_mixin_service.py
+++ b/dropbot_controller/services/dropbot_monitor_mixin_service.py
@@ -83,7 +83,7 @@ class DropbotMonitorMixinService(HasTraits):
             logger.info(f"Detected shorts: {shorts_dict}")
             publish_message(topic=SHORTS_DETECTED, message=json.dumps(shorts_dict))
 
-    @debounce(wait_seconds=1.5)
+    @debounce(wait_seconds=1) # take into account rapid chip insertion changes
     def on_chip_check_request(self, message):
         if self.proxy is not None:
             chip_check_result = not bool(self.proxy.digital_read(OUTPUT_ENABLE_PIN))

--- a/dropbot_controller/services/dropbot_monitor_mixin_service.py
+++ b/dropbot_controller/services/dropbot_monitor_mixin_service.py
@@ -92,6 +92,7 @@ class DropbotMonitorMixinService(HasTraits):
     
     def on_retry_connection_request(self, message):
         if self.dropbot_connection_active:
+            logger.info(f"Retry connection request rejected: Dropbot already connected")
             return
         logger.info("Attempting to retry connecting with a dropbot")
         self.monitor_scheduler.resume()
@@ -203,6 +204,8 @@ class DropbotMonitorMixinService(HasTraits):
             finally:
                 if err:
                     logger.error(err)
+                    # reset proxy
+                    self.proxy = None
 
         # if the dropbot is already connected
         else:

--- a/examples/run_device_viewer_pluggable_backend.py
+++ b/examples/run_device_viewer_pluggable_backend.py
@@ -1,7 +1,5 @@
 import sys
 import os
-import signal
-import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -9,7 +7,7 @@ from examples.run_device_viewer_pluggable import main as run_device_viewer_plugg
 from examples.plugin_consts import *
 
 
-def main(args):
+def main():
     """Run only the backend plugins."""
     plugins = REQUIRED_PLUGINS + BACKEND_PLUGINS
     contexts = BACKEND_CONTEXT + REQUIRED_CONTEXT
@@ -18,4 +16,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main()

--- a/microdrop_utils/decorators.py
+++ b/microdrop_utils/decorators.py
@@ -36,7 +36,7 @@ def debounce(wait_seconds: float = 0.5) -> Callable[[F], F]:
                     fn(*args, **kwargs)
                 except Exception as e:
                     # Log the error but don't let it propagate to avoid breaking the timer
-                    print(f"Error in debounced function: {e}")
+                    logger.warning(f"Error in debounced function {fn}: {e}", exc_info=True)
 
             with lock:
                 if timer is not None:

--- a/microdrop_utils/dramatiq_dropbot_serial_proxy.py
+++ b/microdrop_utils/dramatiq_dropbot_serial_proxy.py
@@ -33,7 +33,7 @@ class DramatiqDropbotSerialProxy(SerialProxy):
                 return    # already connected, skip
             _connection_state['connected'] = True
             publish_message(f'dropbot_connected', DROPBOT_CONNECTED)
-            publish_message('', CHIP_CHECK)
+            # publish_message('', CHIP_CHECK) # this should be done at the handler for the dropbot connected.
 
         def disconnected_wrapper(f, *args, **kwargs):
             f(*args, **kwargs)


### PR DESCRIPTION
We want to reset the proxy to none so during a retry after an exception, the signal handlers for the SerialProxy blinker signals are re-established.