### PR TITLE
style app using one helper method in one place (after creating the qt app in the runner script).

### DIFF
--- a/device_viewer/views/calibration_view/widget.py
+++ b/device_viewer/views/calibration_view/widget.py
@@ -1,11 +1,7 @@
-from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton, QVBoxLayout, QLabel, QSizePolicy
-from pathlib import Path
+from PySide6.QtWidgets import QWidget, QHBoxLayout, QPushButton, QLabel, QSizePolicy
 
 from microdrop_style.button_styles import get_complete_stylesheet
-from microdrop_style.font_paths import load_material_symbols_font
 
-# Load the Material Symbols font using the clean API
-ICON_FONT_FAMILY = load_material_symbols_font() or "Material Symbols Outlined"
 
 
 class CalibrationView(QWidget):

--- a/device_viewer/views/mode_picker/widget.py
+++ b/device_viewer/views/mode_picker/widget.py
@@ -1,16 +1,8 @@
-from PySide6.QtWidgets import (QWidget, QHBoxLayout, QPushButton, QVBoxLayout, 
-                                QLabel, QGridLayout)
-from PySide6.QtCore import Qt
-from pathlib import Path
+from PySide6.QtWidgets import QWidget, QPushButton, QVBoxLayout, QLabel, QGridLayout
 
-from microdrop_style.icons.icons import (ICON_AUTOMATION, ICON_DRAW, ICON_EDIT, 
-                                         ICON_RESET_WRENCH)
+from microdrop_style.icons.icons import ICON_AUTOMATION, ICON_DRAW, ICON_EDIT,ICON_RESET_WRENCH
+
 from microdrop_style.button_styles import get_complete_stylesheet
-from microdrop_style.font_paths import load_material_symbols_font
-
-# Load the Material Symbols font using the clean API
-ICON_FONT_FAMILY = load_material_symbols_font() or "Material Symbols Outlined"
-
 
 def if_editable(func):
     """Decorator to check if the model is editable before executing the function."""

--- a/examples/run_device_viewer_pluggable.py
+++ b/examples/run_device_viewer_pluggable.py
@@ -13,7 +13,8 @@ from functools import partial
 
 from envisage.ui.tasks.tasks_application import TasksApplication
 from PySide6.QtWidgets import QApplication
-from PySide6.QtGui import QFont
+
+from microdrop_style.helpers import style_app
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
@@ -22,10 +23,6 @@ from microdrop_utils.root_dir_utils import get_project_root
 root = get_project_root()
 
 os.environ["PATH"] = str(root) + os.pathsep + os.environ.get("PATH", "") # Add root to PATH for PyInstaller. Should do nothing normal operation
-
-# Font paths
-LABEL_FONT_FAMILY = "Inter"
-ICON_FONT_FAMILY = "Material Symbols Outlined"
 
 logger = get_logger(__name__)
 
@@ -44,7 +41,8 @@ def main(plugins, contexts, application, persist):
     """Run the application."""
 
     app_instance = QApplication.instance() or QApplication(sys.argv)
-    app_instance.setFont(QFont(LABEL_FONT_FAMILY, 11))
+
+    style_app(app_instance)
 
     logger.debug(f"Instantiating application {application} with plugins {plugins}")
 

--- a/microdrop_style/helpers.py
+++ b/microdrop_style/helpers.py
@@ -1,6 +1,11 @@
 import os
 import sys
 
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import QApplication
+
+from microdrop_style.font_paths import load_material_symbols_font, load_inter_font
+
 
 def is_dark_mode():
     if sys.platform == "darwin":
@@ -42,3 +47,11 @@ def is_dark_mode():
             except Exception:
                 pass
         return False
+
+def style_app(app_instance: 'QApplication'):
+    # Load the Material Symbols font
+    load_material_symbols_font()
+    # load inter font and set with some size
+    LABEL_FONT_FAMILY = load_inter_font()
+
+    app_instance.setFont(QFont(LABEL_FONT_FAMILY, 11))


### PR DESCRIPTION
- Previously we were setting the syle by loading the google font family though many of the app widgets. 
- Should be done at top level once so it is clearer and should be done via a style app method. Gives one point to edit the styling.