### PR TITLE
Add session report browser dialog

### DIFF
--- a/protocol_grid/extra_ui_elements.py
+++ b/protocol_grid/extra_ui_elements.py
@@ -4,8 +4,10 @@ from pyface.qt.QtCore import Qt, Signal
 from pyface.qt.QtWidgets import (QMenu, QDialog, QVBoxLayout, QHBoxLayout,
                                QPushButton, QSizePolicy, QLabel, QLineEdit,
                                QFrame, QToolButton, QWidget, QScrollArea,
-                               QCheckBox, QDialogButtonBox, QApplication, QTextBrowser)
-from pyface.qt.QtGui import QAction, QCursor, QContextMenuEvent
+                               QCheckBox, QDialogButtonBox, QApplication, QTextBrowser,
+                               QHeaderView, QTreeWidget, QTreeWidgetItem)
+from pyface.qt.QtGui import QAction, QCursor, QContextMenuEvent, QDesktopServices
+from pyface.qt.QtCore import QUrl
 
 from pyface.action.api import Action
 
@@ -946,6 +948,131 @@ class DropletDetectionFailureDialogAction(Action):
         if hasattr(self, 'dialog'):
             self.dialog.close()
             self.dialog = None
+
+
+class _ReportSortableTreeWidgetItem(QTreeWidgetItem):
+    """QTreeWidgetItem subclass that sorts the Size column numerically
+    and the Date column chronologically instead of lexicographically."""
+
+    _SIZE_COL = 1
+    _DATE_COL = 2
+
+    def __lt__(self, other):
+        col = self.treeWidget().sortColumn()
+        if col == self._SIZE_COL:
+            return (self.data(col, Qt.UserRole) or 0) < (other.data(col, Qt.UserRole) or 0)
+        if col == self._DATE_COL:
+            return (self.data(col, Qt.UserRole) or 0) < (other.data(col, Qt.UserRole) or 0)
+        return super().__lt__(other)
+
+
+class ReportBrowserDialog(QDialog):
+    """File-manager style dialog to browse and open session reports."""
+
+    _COL_NAME = 0
+    _COL_SIZE = 1
+    _COL_DATE = 2
+
+    def __init__(self, report_paths, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Session Reports")
+        self.setModal(True)
+        self.setMinimumSize(650, 420)
+        self._report_paths = report_paths
+        self._setup_ui()
+
+    def _setup_ui(self):
+        import os
+        from datetime import datetime
+
+        layout = QVBoxLayout(self)
+
+        # --- search bar ---
+        search_layout = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self._search_box = QLineEdit()
+        self._search_box.setPlaceholderText("Filter by file name...")
+        self._search_box.setClearButtonEnabled(True)
+        self._search_box.textChanged.connect(self._apply_filter)
+        search_layout.addWidget(search_label)
+        search_layout.addWidget(self._search_box)
+        layout.addLayout(search_layout)
+
+        # --- file table ---
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(["Name", "Size", "Date Created"])
+        self._tree.setRootIsDecorated(False)
+        self._tree.setAlternatingRowColors(True)
+        self._tree.setSortingEnabled(True)
+        self._tree.setSelectionMode(QTreeWidget.SingleSelection)
+
+        header = self._tree.header()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(self._COL_NAME, QHeaderView.Stretch)
+        header.setSectionResizeMode(self._COL_SIZE, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(self._COL_DATE, QHeaderView.ResizeToContents)
+
+        for path_str in self._report_paths:
+            p = Path(path_str)
+            try:
+                stat = os.stat(p)
+                size_bytes = stat.st_size
+                ctime = stat.st_ctime
+            except OSError:
+                size_bytes = 0
+                ctime = 0.0
+
+            item = _ReportSortableTreeWidgetItem([
+                p.name,
+                self._format_size(size_bytes),
+                datetime.fromtimestamp(ctime).strftime("%Y-%m-%d  %H:%M:%S") if ctime else "",
+            ])
+            item.setToolTip(self._COL_NAME, str(p))
+            item.setData(self._COL_NAME, Qt.UserRole, path_str)
+            item.setData(self._COL_SIZE, Qt.UserRole, size_bytes)
+            item.setData(self._COL_DATE, Qt.UserRole, ctime)
+            self._tree.addTopLevelItem(item)
+
+        self._tree.sortByColumn(self._COL_DATE, Qt.DescendingOrder)
+        layout.addWidget(self._tree)
+
+        # --- buttons ---
+        button_layout = QHBoxLayout()
+        open_btn = QPushButton("Open")
+        open_btn.setDefault(True)
+        open_btn.clicked.connect(self._open_selected)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(open_btn)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+
+        self._tree.itemDoubleClicked.connect(self._open_item)
+
+    def _apply_filter(self, text):
+        text_lower = text.lower()
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            item.setHidden(text_lower not in item.text(self._COL_NAME).lower())
+
+    def _open_selected(self):
+        items = self._tree.selectedItems()
+        if items:
+            self._open_item(items[0])
+
+    def _open_item(self, item):
+        path_str = item.data(self._COL_NAME, Qt.UserRole)
+        QDesktopServices.openUrl(QUrl.fromLocalFile(path_str))
+
+    @staticmethod
+    def _format_size(size_bytes):
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        elif size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        else:
+            return f"{size_bytes / (1024 * 1024):.1f} MB"
 
 
 def make_separator():

--- a/protocol_grid/quick_action_bar.py
+++ b/protocol_grid/quick_action_bar.py
@@ -36,6 +36,7 @@ quick_protocol_actions = [
     ("open_protocol", "file_open", "Open Protocol"),
     ("save_protocol", "save", "Save Protocol"),
     ("new_protocol", "new_window", "New protocol"),
+    ("browse_reports", "summarize", "Browse session reports (R)"),
 ]
 
 
@@ -61,6 +62,7 @@ class QuickProtocolActions:
             ("open_protocol", "file_open", "Open Protocol"),
             ("save_protocol", "save", "Save Protocol"),
             ("new_protocol", "new_window", "New protocol"),
+            ("browse_reports", "summarize", "Browse session reports (R)"),
         ]:
 
             _add_button(id, text, tooltip)
@@ -91,6 +93,9 @@ class QuickProtocolActionsController:
         )
         self.view.actions["new_protocol"].clicked.connect(
             self.protocol_grid.new_protocol
+        )
+        self.view.actions["browse_reports"].clicked.connect(
+            self.protocol_grid.show_report_browser_dialog
         )
 
     def on_selection_changed(self):

--- a/protocol_grid/services/protocol_data_logger.py
+++ b/protocol_grid/services/protocol_data_logger.py
@@ -54,6 +54,7 @@ class ProtocolDataLogger:
         self._image_captures = []
         self._other_media_captures = []
         self.last_saved_summary_path = None
+        self.all_report_paths = []
 
         self._is_logging_active = False
         self._latest_capacitance_per_unit_area = None
@@ -711,6 +712,7 @@ class ProtocolDataLogger:
             f.write(report)
             logger.critical(f"Run summary report saved to: {report_path}")
             self.last_saved_summary_path = report_path
+            self.all_report_paths.append(str(report_path))
 
         # cleanup:
         del self._active_analysis_df

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -61,6 +61,7 @@ from protocol_grid.extra_ui_elements import (
     make_separator,
     ExperimentLabel,
     DropbotDisconnectedBeforeRunDialogAction,
+    ReportBrowserDialog,
 )
 
 from protocol_grid.services.protocol_runner_controller import ProtocolRunnerController
@@ -2140,6 +2141,7 @@ class PGCWidget(QWidget):
             (QKeySequence("F"), self.navigate_to_last_step),
             (QKeySequence("E"), self.add_step),
             (QKeySequence("W"), self.add_group),
+            (QKeySequence("R"), self.show_report_browser_dialog),
         ]
 
         for key_seq, slot in shortcuts:
@@ -2168,6 +2170,15 @@ class PGCWidget(QWidget):
 
     def show_column_toggle_dialog(self):
         dialog = ColumnToggleDialog(self)
+        dialog.exec()
+
+    def show_report_browser_dialog(self):
+        report_paths = self.protocol_data_logger.all_report_paths
+        if not report_paths:
+            from microdrop_application.dialogs.pyface_wrapper import information
+            information(None, "No reports have been generated during this session.", title="No Reports")
+            return
+        dialog = ReportBrowserDialog(report_paths, parent=self)
         dialog.exec()
 
     def _delayed_sync(self):


### PR DESCRIPTION
## Summary
- Adds a file-manager style dialog to browse and open any report generated during the current app session
- Accessible via a new quick action bar button (summarize icon) and keyboard shortcut (`R`) in the protocol grid
- Reports displayed in a sortable table with Name, Size, and Date Created columns, with a real-time search filter
- Tracks all report paths across the session in `ProtocolDataLogger.all_report_paths`
- resolves #276 

## Test plan
- [x] Run a protocol to completion and verify the report path is tracked
- [x] Press `R` or click the summarize button in the quick action bar to open the dialog
- [x] Verify reports are listed with correct name, size, and creation date
- [x] Verify sorting works on all three columns (including numeric sort for size)
- [x] Verify search filter narrows the list in real-time
- [x] Double-click or select + Open to open a report in the default browser
- [x] Verify "No Reports" info dialog appears when no reports have been generated yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)