### PR TITLE
Add option to apply bulk params to nested groups

### DIFF
--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -1926,11 +1926,28 @@ class PGCWidget(QWidget):
         global_pos = self.tree.mapToGlobal(pos)
         menu.exec(global_pos)
 
+    @staticmethod
+    def _collect_steps_from_group(group_item, recursive=False):
+        """Collect step items from a group, optionally recursing into nested sub-groups."""
+        steps = []
+        for row in range(group_item.rowCount()):
+            child = group_item.child(row, 0)
+            if not child:
+                continue
+            child_type = child.data(ROW_TYPE_ROLE)
+            if child_type == STEP_TYPE:
+                steps.append(child)
+            elif child_type == GROUP_TYPE and recursive:
+                steps.extend(PGCWidget._collect_steps_from_group(child, recursive=True))
+        return steps
+
     def bulk_set_values(self):
         """
         Opens a dialog to set specific values for columns.
         - If a Step is selected, it updates that step.
-        - If a Group is selected, it updates all DIRECT child steps (non-recursive).
+        - If a Group is selected, it updates child steps. If "Apply to all nested
+          groups" is checked, it recurses into sub-groups; otherwise only direct
+          child steps are affected.
         """
         if self._protocol_running:
             return
@@ -1948,6 +1965,8 @@ class PGCWidget(QWidget):
         updates = dialog.get_row_data()
         if not updates:
             return
+
+        apply_nested = dialog.apply_nested
 
         self.state.snapshot_for_undo()
         self._programmatic_change = True
@@ -1977,11 +1996,9 @@ class PGCWidget(QWidget):
 
                     elif item_type == GROUP_TYPE:
                         # Case 2: User selected a Group
-                        # Iterate DIRECT children only (No recursion into subgroups)
-                        for row in range(selected_item.rowCount()):
-                            child = selected_item.child(row, 0)
-                            if child and child.data(ROW_TYPE_ROLE) == STEP_TYPE:
-                                target_step_items.append(child)
+                        target_step_items = self._collect_steps_from_group(
+                            selected_item, recursive=apply_nested
+                        )
 
                     # --- APPLY TO IDENTIFIED STEPS ---
                     for step_item in target_step_items:


### PR DESCRIPTION
## Summary
- Adds an "Apply to all nested groups" checkbox to the Bulk Set Values dialog in the protocol grid
- When checked, bulk parameter changes are applied recursively to all steps within nested sub-groups, not just direct children of the selected group
- When unchecked (default), existing behavior is preserved — only direct child steps are affected
- Extracts step collection into a reusable `_collect_steps_from_group()` helper method

## Test plan
- [x] Launch MicroDrop and create a protocol with nested groups (a group containing another group with steps inside it)
- [x] Select the outer group, open Bulk Set Values (Edit menu or shortcut)
- [x] **Without** checkbox: set a parameter (e.g., Duration) and verify only the direct child steps of the outer group are updated — steps inside nested sub-groups should remain unchanged
- [x] **With** checkbox checked: set a parameter and verify all steps in the outer group AND all nested sub-groups are updated
- [x] Verify the checkbox defaults to unchecked each time the dialog is opened
- [x] Test undo (Ctrl+Z) after a recursive bulk set — all changes should be reverted
- [x] Verify group aggregations (Duration, Voltage, etc.) update correctly after recursive bulk set
- [x] Test with deeply nested groups (3+ levels) to confirm full recursion works
- [x] Test selecting a single step (not a group) — behavior should be unchanged regardless of checkbox state

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)