### PR TITLE
Show failed channel numbers in scan test board results

### DIFF
--- a/dropbot_controller/services/dropbot_self_tests_mixin_service.py
+++ b/dropbot_controller/services/dropbot_self_tests_mixin_service.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 from functools import wraps
+
+import numpy as np
 from tqdm import tqdm
 # ******************************** DO NOT remove unused imports here **************************************
 from dropbot.hardware_test import (ALL_TESTS, system_info, test_system_metrics,
@@ -141,16 +143,21 @@ class DropbotSelfTestsMixinService(HasTraits):
                     plot_data = plot_test_on_board_feedback_calibration_results(result[test_name], 
                                                                                 return_fig=True)
                 elif test_name == "test_channels":
-                    plot_data = plot_test_channels_results(result[test_name], 
+                    plot_data = plot_test_channels_results(result[test_name],
                                                         return_fig=True)
+                    c = np.array(result[test_name]['c'])
+                    test_channels_list = result[test_name]['test_channels']
+                    failed_channels = [test_channels_list[i] for i in range(c.shape[0])
+                                       if np.mean(c[i]) < 5e-12]
 
                 if plot_data is not None:
                     # Pull up the report in a window
                     def show_results_dialog():
                         self.results_dialog = ResultsDialogAction()
                         test_name_display = test_name.replace("_", " ").capitalize() + " Results"
-                        self.results_dialog.perform(title=test_name_display, 
-                                                    plot_data=plot_data)
+                        self.results_dialog.perform(title=test_name_display,
+                                                    plot_data=plot_data,
+                                                    failed_channels=failed_channels if test_name == "test_channels" else None)
                     GUI.invoke_later(show_results_dialog)
                 else:
                     shorts_dict = {'Shorts_detected': result[test_name]['shorts'], 

--- a/dropbot_tools_menu/self_test_dialogs.py
+++ b/dropbot_tools_menu/self_test_dialogs.py
@@ -339,7 +339,7 @@ class WaitForTestDialogAction:
 
 
 class ResultsDialog(QDialog):
-    def __init__(self, parent=None, title="Test Results", plot_data=None):
+    def __init__(self, parent=None, title="Test Results", plot_data=None, failed_channels=None):
         super().__init__(parent)
         self.setWindowTitle(title)
         self.resize(600, 400)
@@ -355,6 +355,20 @@ class ResultsDialog(QDialog):
         self.canvas = FigureCanvas(fig)
         layout.addWidget(self.canvas)
 
+        # Show failed channel numbers if provided
+        if failed_channels is not None:
+            if failed_channels:
+                channel_list = ", ".join(str(ch) for ch in failed_channels)
+                label_text = f"<b>Failed channels ({len(failed_channels)}):</b> {channel_list}"
+                label_color = "color: red;"
+            else:
+                label_text = "<b>All channels passed.</b>"
+                label_color = "color: green;"
+            failed_label = QLabel(label_text)
+            failed_label.setStyleSheet(label_color)
+            failed_label.setWordWrap(True)
+            layout.addWidget(failed_label)
+
         button_box = QDialogButtonBox(QDialogButtonBox.Close)
         button_box.clicked.connect(self.close)
         layout.addWidget(button_box, alignment=Qt.AlignCenter)
@@ -363,9 +377,9 @@ class ResultsDialog(QDialog):
 class ResultsDialogAction(Action):
     name = Str("&Results Dialog")
 
-    def perform(self, parent=None, title="Test Results", plot_data=None):
+    def perform(self, parent=None, title="Test Results", plot_data=None, failed_channels=None):
         # The dialong is a child window of non UI class
-        dialog = ResultsDialog(parent=parent, title=title, plot_data=plot_data)
+        dialog = ResultsDialog(parent=parent, title=title, plot_data=plot_data, failed_channels=failed_channels)
         # use exec_() to block the main thread until the dialog is closed otherwise the window is garbage collected
         dialog.exec_()
 


### PR DESCRIPTION
## Summary
- Added `failed_channels` parameter to `ResultsDialog` and `ResultsDialogAction` to display failed channel numbers below the plot
- Extract failed channels (mean capacitance < 5pF) from test results in `DropbotSelfTestsMixinService` and pass them to the dialog
- Shows failed channel count and numbers in red, or "All channels passed." in green

Resolves #63

## Test plan
- [x] Run "Scan test board" with a test board that has known failing channels and verify numbers are listed
- [x] Run "Scan test board" with all channels passing and verify "All channels passed." message appears
- [x] Verify other test dialogs (voltage, calibration) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)