### PR TITLE
Expose message topics and dramatiq controls through centralized API

### DIFF
--- a/examples/tests/test_messaging_api.py
+++ b/examples/tests/test_messaging_api.py
@@ -1,0 +1,390 @@
+"""
+Tests for microdrop_utils.api -- the centralised messaging API module.
+
+These tests verify that the API module:
+1. Exposes all expected topic constants with correct string values.
+2. Re-exports core messaging primitives.
+3. The get_all_topics() introspection helper works correctly.
+4. Topic classes are consistent with their source-of-truth consts.py modules.
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the API under test
+# ---------------------------------------------------------------------------
+from microdrop_utils.api import (
+    # Core primitives
+    publish_message,
+    ValidatedTopicPublisher,
+    MessageRouterActor,
+    MessageRouterData,
+    MQTTMatcher,
+    DramatiqControllerBase,
+    basic_listener_actor_routine,
+    generate_class_method_dramatiq_listener_actor,
+    # Topic namespaces
+    DropbotTopics,
+    HardwareTopics,
+    UITopics,
+    ApplicationTopics,
+    ZStageTopics,
+    SSHTopics,
+    OpenDropTopics,
+    PGVATopics,
+    MockDropbotTopics,
+    WildcardPatterns,
+    # Helpers
+    get_all_topics,
+)
+
+
+# ===================================================================
+# 1. Core primitives are importable and have the right types
+# ===================================================================
+
+class TestCorePrimitivesExported:
+
+    def test_publish_message_is_callable(self):
+        assert callable(publish_message)
+
+    def test_validated_topic_publisher_is_class(self):
+        assert isinstance(ValidatedTopicPublisher, type)
+
+    def test_message_router_actor_is_class(self):
+        assert isinstance(MessageRouterActor, type)
+
+    def test_message_router_data_is_class(self):
+        assert isinstance(MessageRouterData, type)
+
+    def test_mqtt_matcher_is_class(self):
+        assert isinstance(MQTTMatcher, type)
+
+    def test_dramatiq_controller_base_is_class(self):
+        assert isinstance(DramatiqControllerBase, type)
+
+    def test_basic_listener_actor_routine_is_callable(self):
+        assert callable(basic_listener_actor_routine)
+
+    def test_generate_class_method_dramatiq_listener_actor_is_callable(self):
+        assert callable(generate_class_method_dramatiq_listener_actor)
+
+
+# ===================================================================
+# 2. Topic constants match their source-of-truth consts.py values
+# ===================================================================
+
+class TestDropbotTopicsMatchConsts:
+    """Cross-check API topic values against dropbot_controller.consts."""
+
+    def test_signals(self):
+        from dropbot_controller.consts import (
+            CAPACITANCE_UPDATED, SHORTS_DETECTED, HALTED,
+            CHIP_INSERTED, SELF_TESTS_PROGRESS,
+            DROPLETS_DETECTED,
+        )
+        assert DropbotTopics.Signals.CAPACITANCE_UPDATED == CAPACITANCE_UPDATED
+        assert DropbotTopics.Signals.SHORTS_DETECTED == SHORTS_DETECTED
+        assert DropbotTopics.Signals.HALTED == HALTED
+        assert DropbotTopics.Signals.CHIP_INSERTED == CHIP_INSERTED
+        assert DropbotTopics.Signals.SELF_TESTS_PROGRESS == SELF_TESTS_PROGRESS
+        assert DropbotTopics.Signals.DROPLETS_DETECTED == DROPLETS_DETECTED
+
+    def test_warnings(self):
+        from dropbot_controller.consts import NO_DROPBOT_AVAILABLE, NO_POWER
+        assert DropbotTopics.Warnings.NO_DROPBOT_AVAILABLE == NO_DROPBOT_AVAILABLE
+        assert DropbotTopics.Warnings.NO_POWER == NO_POWER
+
+    def test_requests(self):
+        from dropbot_controller.consts import (
+            START_DEVICE_MONITORING, DETECT_SHORTS, RETRY_CONNECTION,
+            HALT, SET_VOLTAGE, SET_FREQUENCY, RUN_ALL_TESTS,
+            TEST_VOLTAGE, TEST_ON_BOARD_FEEDBACK_CALIBRATION,
+            TEST_SHORTS, TEST_CHANNELS, CHIP_CHECK,
+            SELF_TEST_CANCEL, DETECT_DROPLETS, CHANGE_SETTINGS,
+        )
+        assert DropbotTopics.Requests.START_DEVICE_MONITORING == START_DEVICE_MONITORING
+        assert DropbotTopics.Requests.DETECT_SHORTS == DETECT_SHORTS
+        assert DropbotTopics.Requests.RETRY_CONNECTION == RETRY_CONNECTION
+        assert DropbotTopics.Requests.HALT == HALT
+        assert DropbotTopics.Requests.SET_VOLTAGE == SET_VOLTAGE
+        assert DropbotTopics.Requests.SET_FREQUENCY == SET_FREQUENCY
+        assert DropbotTopics.Requests.RUN_ALL_TESTS == RUN_ALL_TESTS
+        assert DropbotTopics.Requests.TEST_VOLTAGE == TEST_VOLTAGE
+        assert DropbotTopics.Requests.TEST_ON_BOARD_FEEDBACK_CALIBRATION == TEST_ON_BOARD_FEEDBACK_CALIBRATION
+        assert DropbotTopics.Requests.TEST_SHORTS == TEST_SHORTS
+        assert DropbotTopics.Requests.TEST_CHANNELS == TEST_CHANNELS
+        assert DropbotTopics.Requests.CHIP_CHECK == CHIP_CHECK
+        assert DropbotTopics.Requests.SELF_TEST_CANCEL == SELF_TEST_CANCEL
+        assert DropbotTopics.Requests.DETECT_DROPLETS == DETECT_DROPLETS
+        assert DropbotTopics.Requests.CHANGE_SETTINGS == CHANGE_SETTINGS
+
+    def test_errors(self):
+        from dropbot_controller.consts import DROPBOT_ERROR
+        assert DropbotTopics.Errors.DROPBOT_ERROR == DROPBOT_ERROR
+
+
+class TestHardwareTopicsMatchConsts:
+    """Cross-check API topic values against dropbot_controller and electrode_controller consts."""
+
+    def test_signals(self):
+        from dropbot_controller.consts import (
+            DROPBOT_CONNECTED, DROPBOT_DISCONNECTED,
+            REALTIME_MODE_UPDATED, DISABLED_CHANNELS_CHANGED,
+        )
+        assert HardwareTopics.Signals.CONNECTED == DROPBOT_CONNECTED
+        assert HardwareTopics.Signals.DISCONNECTED == DROPBOT_DISCONNECTED
+        assert HardwareTopics.Signals.REALTIME_MODE_UPDATED == REALTIME_MODE_UPDATED
+        assert HardwareTopics.Signals.DISABLED_CHANNELS_CHANGED == DISABLED_CHANNELS_CHANGED
+
+    def test_requests(self):
+        from electrode_controller.consts import ELECTRODES_STATE_CHANGE, ELECTRODES_DISABLE_REQUEST
+        from dropbot_controller.consts import SET_REALTIME_MODE
+        assert HardwareTopics.Requests.ELECTRODES_STATE_CHANGE == ELECTRODES_STATE_CHANGE
+        assert HardwareTopics.Requests.ELECTRODES_DISABLE == ELECTRODES_DISABLE_REQUEST
+        assert HardwareTopics.Requests.SET_REALTIME_MODE == SET_REALTIME_MODE
+
+
+class TestUITopicsMatchConsts:
+    """Cross-check API topic values against protocol_grid.consts."""
+
+    def test_ui_topics(self):
+        from protocol_grid.consts import (
+            DEVICE_VIEWER_STATE_CHANGED, PROTOCOL_GRID_DISPLAY_STATE,
+            CALIBRATION_DATA, DEVICE_VIEWER_SCREEN_CAPTURE,
+            DEVICE_VIEWER_SCREEN_RECORDING, DEVICE_VIEWER_CAMERA_ACTIVE,
+            DEVICE_VIEWER_MEDIA_CAPTURED, DEVICE_VIEWER_RECORDING_STATE,
+            ROUTES_EXECUTING,
+        )
+        assert UITopics.DEVICE_VIEWER_STATE_CHANGED == DEVICE_VIEWER_STATE_CHANGED
+        assert UITopics.PROTOCOL_GRID_DISPLAY_STATE == PROTOCOL_GRID_DISPLAY_STATE
+        assert UITopics.CALIBRATION_DATA == CALIBRATION_DATA
+        assert UITopics.DEVICE_VIEWER_SCREEN_CAPTURE == DEVICE_VIEWER_SCREEN_CAPTURE
+        assert UITopics.DEVICE_VIEWER_SCREEN_RECORDING == DEVICE_VIEWER_SCREEN_RECORDING
+        assert UITopics.DEVICE_VIEWER_CAMERA_ACTIVE == DEVICE_VIEWER_CAMERA_ACTIVE
+        assert UITopics.DEVICE_VIEWER_MEDIA_CAPTURED == DEVICE_VIEWER_MEDIA_CAPTURED
+        assert UITopics.DEVICE_VIEWER_RECORDING_STATE == DEVICE_VIEWER_RECORDING_STATE
+        assert UITopics.ROUTES_EXECUTING == ROUTES_EXECUTING
+
+
+class TestApplicationTopicsMatchConsts:
+
+    def test_application_topics(self):
+        from microdrop_application.consts import ADVANCED_MODE_CHANGE
+        from protocol_grid.consts import PROTOCOL_RUNNING
+        assert ApplicationTopics.ADVANCED_MODE_CHANGE == ADVANCED_MODE_CHANGE
+        assert ApplicationTopics.PROTOCOL_RUNNING == PROTOCOL_RUNNING
+
+
+class TestZStageTopicsMatchConsts:
+
+    def test_signals(self):
+        from peripheral_controller.consts import (
+            CONNECTED, DISCONNECTED, ZSTAGE_POSITION_UPDATED,
+        )
+        assert ZStageTopics.Signals.CONNECTED == CONNECTED
+        assert ZStageTopics.Signals.DISCONNECTED == DISCONNECTED
+        assert ZStageTopics.Signals.POSITION_UPDATED == ZSTAGE_POSITION_UPDATED
+
+    def test_requests(self):
+        from peripheral_controller.consts import (
+            START_DEVICE_MONITORING, GO_HOME, MOVE_UP, MOVE_DOWN,
+            SET_POSITION, RETRY_CONNECTION, UPDATE_CONFIG,
+        )
+        assert ZStageTopics.Requests.START_DEVICE_MONITORING == START_DEVICE_MONITORING
+        assert ZStageTopics.Requests.GO_HOME == GO_HOME
+        assert ZStageTopics.Requests.MOVE_UP == MOVE_UP
+        assert ZStageTopics.Requests.MOVE_DOWN == MOVE_DOWN
+        assert ZStageTopics.Requests.SET_POSITION == SET_POSITION
+        assert ZStageTopics.Requests.RETRY_CONNECTION == RETRY_CONNECTION
+        assert ZStageTopics.Requests.UPDATE_CONFIG == UPDATE_CONFIG
+
+    def test_errors(self):
+        from peripheral_controller.consts import ERROR
+        assert ZStageTopics.Errors.ERROR == ERROR
+
+
+class TestSSHTopicsMatchConsts:
+
+    def test_requests(self):
+        from ssh_controls.consts import GENERATE_KEYPAIR, KEY_UPLOAD
+        assert SSHTopics.Requests.GENERATE_KEYPAIR == GENERATE_KEYPAIR
+        assert SSHTopics.Requests.KEY_UPLOAD == KEY_UPLOAD
+
+    def test_success(self):
+        from ssh_controls.consts import SSH_KEYGEN_SUCCESS, SSH_KEY_UPLOAD_SUCCESS
+        assert SSHTopics.Success.SSH_KEYGEN_SUCCESS == SSH_KEYGEN_SUCCESS
+        assert SSHTopics.Success.SSH_KEY_UPLOAD_SUCCESS == SSH_KEY_UPLOAD_SUCCESS
+
+    def test_warnings(self):
+        from ssh_controls.consts import SSH_KEYGEN_WARNING
+        assert SSHTopics.Warnings.SSH_KEYGEN_WARNING == SSH_KEYGEN_WARNING
+
+    def test_errors(self):
+        from ssh_controls.consts import SSH_KEYGEN_ERROR, SSH_KEY_UPLOAD_ERROR
+        assert SSHTopics.Errors.SSH_KEYGEN_ERROR == SSH_KEYGEN_ERROR
+        assert SSHTopics.Errors.SSH_KEY_UPLOAD_ERROR == SSH_KEY_UPLOAD_ERROR
+
+
+class TestOpenDropTopicsMatchConsts:
+
+    def test_signals(self):
+        from opendrop_controller.consts import (
+            OPENDROP_TEMPERATURES_UPDATED, OPENDROP_FEEDBACK_UPDATED,
+            OPENDROP_BOARD_INFO,
+        )
+        assert OpenDropTopics.Signals.TEMPERATURES_UPDATED == OPENDROP_TEMPERATURES_UPDATED
+        assert OpenDropTopics.Signals.FEEDBACK_UPDATED == OPENDROP_FEEDBACK_UPDATED
+        assert OpenDropTopics.Signals.BOARD_INFO == OPENDROP_BOARD_INFO
+
+    def test_requests(self):
+        from opendrop_controller.consts import (
+            RETRY_CONNECTION, SET_FEEDBACK, SET_TEMPERATURES,
+            SET_TEMPERATURE_1, SET_TEMPERATURE_2, SET_TEMPERATURE_3,
+            CHANGE_SETTINGS,
+        )
+        assert OpenDropTopics.Requests.RETRY_CONNECTION == RETRY_CONNECTION
+        assert OpenDropTopics.Requests.SET_FEEDBACK == SET_FEEDBACK
+        assert OpenDropTopics.Requests.SET_TEMPERATURES == SET_TEMPERATURES
+        assert OpenDropTopics.Requests.SET_TEMPERATURE_1 == SET_TEMPERATURE_1
+        assert OpenDropTopics.Requests.SET_TEMPERATURE_2 == SET_TEMPERATURE_2
+        assert OpenDropTopics.Requests.SET_TEMPERATURE_3 == SET_TEMPERATURE_3
+        assert OpenDropTopics.Requests.CHANGE_SETTINGS == CHANGE_SETTINGS
+
+
+class TestMockDropbotTopicsMatchConsts:
+
+    def test_requests(self):
+        from mock_dropbot_controller.consts import (
+            MOCK_CHANGE_SIM_SETTINGS, MOCK_SIMULATE_CONNECT,
+            MOCK_SIMULATE_DISCONNECT, MOCK_SIMULATE_CHIP_INSERT,
+            MOCK_SIMULATE_SHORTS, MOCK_SIMULATE_HALT,
+        )
+        assert MockDropbotTopics.Requests.CHANGE_SIM_SETTINGS == MOCK_CHANGE_SIM_SETTINGS
+        assert MockDropbotTopics.Requests.SIMULATE_CONNECT == MOCK_SIMULATE_CONNECT
+        assert MockDropbotTopics.Requests.SIMULATE_DISCONNECT == MOCK_SIMULATE_DISCONNECT
+        assert MockDropbotTopics.Requests.SIMULATE_CHIP_INSERT == MOCK_SIMULATE_CHIP_INSERT
+        assert MockDropbotTopics.Requests.SIMULATE_SHORTS == MOCK_SIMULATE_SHORTS
+        assert MockDropbotTopics.Requests.SIMULATE_HALT == MOCK_SIMULATE_HALT
+
+    def test_signals(self):
+        from mock_dropbot_controller.consts import (
+            MOCK_ACTUATED_CHANNELS_UPDATED, MOCK_STREAM_STATUS_UPDATED,
+        )
+        assert MockDropbotTopics.Signals.ACTUATED_CHANNELS_UPDATED == MOCK_ACTUATED_CHANNELS_UPDATED
+        assert MockDropbotTopics.Signals.STREAM_STATUS_UPDATED == MOCK_STREAM_STATUS_UPDATED
+
+
+class TestPGVATopicsMatchConsts:
+
+    def test_signals(self):
+        from pgva_controller_plugin.consts import (
+            PGVA_CONNECTED, PGVA_DISCONNECTED, PGVA_PRESSURE_UPDATED,
+            PGVA_VACUUM_UPDATED, PGVA_OUTPUT_PRESSURE_UPDATED,
+            PGVA_STATUS_UPDATED, PGVA_WARNINGS_UPDATED,
+            PGVA_ERRORS_UPDATED, PGVA_COMPREHENSIVE_STATUS_UPDATED,
+            PGVA_HEALTH_CHECK_UPDATED, PGVA_DEVICE_INFO_UPDATED,
+            PGVA_ERROR_SIGNAL,
+        )
+        assert PGVATopics.Signals.CONNECTED == PGVA_CONNECTED
+        assert PGVATopics.Signals.DISCONNECTED == PGVA_DISCONNECTED
+        assert PGVATopics.Signals.PRESSURE_UPDATED == PGVA_PRESSURE_UPDATED
+        assert PGVATopics.Signals.VACUUM_UPDATED == PGVA_VACUUM_UPDATED
+        assert PGVATopics.Signals.OUTPUT_PRESSURE_UPDATED == PGVA_OUTPUT_PRESSURE_UPDATED
+        assert PGVATopics.Signals.STATUS_UPDATED == PGVA_STATUS_UPDATED
+        assert PGVATopics.Signals.WARNINGS_UPDATED == PGVA_WARNINGS_UPDATED
+        assert PGVATopics.Signals.ERRORS_UPDATED == PGVA_ERRORS_UPDATED
+        assert PGVATopics.Signals.COMPREHENSIVE_STATUS_UPDATED == PGVA_COMPREHENSIVE_STATUS_UPDATED
+        assert PGVATopics.Signals.HEALTH_CHECK_UPDATED == PGVA_HEALTH_CHECK_UPDATED
+        assert PGVATopics.Signals.DEVICE_INFO_UPDATED == PGVA_DEVICE_INFO_UPDATED
+        assert PGVATopics.Signals.ERROR == PGVA_ERROR_SIGNAL
+
+    def test_requests(self):
+        from pgva_controller_plugin.consts import (
+            SET_PRESSURE, SET_VACUUM, SET_OUTPUT_PRESSURE,
+            GET_PRESSURE, GET_VACUUM, GET_OUTPUT_PRESSURE,
+            GET_STATUS, GET_WARNINGS, GET_ERRORS,
+            GET_COMPREHENSIVE_STATUS, GET_HEALTH_CHECK, GET_DEVICE_INFO,
+            ENABLE_PGVA, DISABLE_PGVA, RESET_PGVA, TRIGGER_MANUAL,
+            STORE_TO_EEPROM, CONNECT_PGVA, DISCONNECT_PGVA,
+        )
+        assert PGVATopics.Requests.SET_PRESSURE == SET_PRESSURE
+        assert PGVATopics.Requests.SET_VACUUM == SET_VACUUM
+        assert PGVATopics.Requests.SET_OUTPUT_PRESSURE == SET_OUTPUT_PRESSURE
+        assert PGVATopics.Requests.GET_PRESSURE == GET_PRESSURE
+        assert PGVATopics.Requests.GET_VACUUM == GET_VACUUM
+        assert PGVATopics.Requests.GET_OUTPUT_PRESSURE == GET_OUTPUT_PRESSURE
+        assert PGVATopics.Requests.GET_STATUS == GET_STATUS
+        assert PGVATopics.Requests.GET_WARNINGS == GET_WARNINGS
+        assert PGVATopics.Requests.GET_ERRORS == GET_ERRORS
+        assert PGVATopics.Requests.GET_COMPREHENSIVE_STATUS == GET_COMPREHENSIVE_STATUS
+        assert PGVATopics.Requests.GET_HEALTH_CHECK == GET_HEALTH_CHECK
+        assert PGVATopics.Requests.GET_DEVICE_INFO == GET_DEVICE_INFO
+        assert PGVATopics.Requests.ENABLE == ENABLE_PGVA
+        assert PGVATopics.Requests.DISABLE == DISABLE_PGVA
+        assert PGVATopics.Requests.RESET == RESET_PGVA
+        assert PGVATopics.Requests.TRIGGER_MANUAL == TRIGGER_MANUAL
+        assert PGVATopics.Requests.STORE_TO_EEPROM == STORE_TO_EEPROM
+        assert PGVATopics.Requests.CONNECT == CONNECT_PGVA
+        assert PGVATopics.Requests.DISCONNECT == DISCONNECT_PGVA
+
+
+# ===================================================================
+# 3. get_all_topics() introspection helper
+# ===================================================================
+
+class TestGetAllTopics:
+
+    def test_returns_dict(self):
+        result = get_all_topics()
+        assert isinstance(result, dict)
+
+    def test_all_domains_present(self):
+        result = get_all_topics()
+        expected_domains = {
+            "dropbot", "hardware", "ui", "application",
+            "zstage", "ssh", "opendrop", "pgva", "mock_dropbot",
+        }
+        assert expected_domains == set(result.keys())
+
+    def test_dropbot_domain_has_topics(self):
+        result = get_all_topics()
+        dropbot_topics = result["dropbot"]
+        assert len(dropbot_topics) > 0
+        # Spot-check a couple of known topics
+        assert "dropbot/requests/set_voltage" in dropbot_topics
+        assert "dropbot/signals/halted" in dropbot_topics
+
+    def test_all_values_are_strings_with_slashes(self):
+        result = get_all_topics()
+        for domain, topics in result.items():
+            for topic in topics:
+                assert isinstance(topic, str), f"{domain}: {topic} is not a string"
+                assert "/" in topic, f"{domain}: {topic} does not contain '/'"
+
+    def test_topics_are_sorted(self):
+        result = get_all_topics()
+        for domain, topics in result.items():
+            assert topics == sorted(topics), f"Topics in {domain} are not sorted"
+
+
+# ===================================================================
+# 4. Wildcard patterns are well-formed
+# ===================================================================
+
+class TestWildcardPatterns:
+
+    def test_all_patterns_end_with_hash(self):
+        for name in dir(WildcardPatterns):
+            if name.startswith("_"):
+                continue
+            value = getattr(WildcardPatterns, name)
+            assert value.endswith("#"), f"{name} = {value!r} does not end with '#'"
+
+    def test_patterns_are_strings(self):
+        for name in dir(WildcardPatterns):
+            if name.startswith("_"):
+                continue
+            value = getattr(WildcardPatterns, name)
+            assert isinstance(value, str)

--- a/microdrop_utils/api.py
+++ b/microdrop_utils/api.py
@@ -1,0 +1,418 @@
+"""
+Microdrop Messaging API
+=======================
+
+Centralized access to all Dramatiq pub/sub message topics, publishing utilities,
+and subscription helpers used throughout the MicroDrop application.
+
+This module serves as the single import point for any code that needs to publish
+or subscribe to messages. It re-exports every topic constant from the individual
+plugin ``consts.py`` modules and the core messaging primitives from
+``dramatiq_pub_sub_helpers``.
+
+Topic Naming Conventions
+------------------------
+Topics follow MQTT-style hierarchical naming with ``/`` delimiters::
+
+    <domain>/signals/<event_name>   -- emitted when something happens (backend -> frontend)
+    <domain>/requests/<action_name> -- request an action be performed   (frontend -> backend)
+    <domain>/error                  -- error notification
+
+MQTT wildcards are supported for subscriptions only (not publishing):
+
+- ``+`` matches a single level  (e.g. ``dropbot/signals/+``)
+- ``#`` matches all sub-levels  (e.g. ``dropbot/signals/#``)
+
+Quick Start
+-----------
+Publishing a simple message::
+
+    from microdrop_utils.api import publish_message, DropbotTopics
+    publish_message(message="100", topic=DropbotTopics.Requests.SET_VOLTAGE)
+
+Publishing with Pydantic validation::
+
+    from microdrop_utils.api import ValidatedTopicPublisher
+    from electrode_controller.models import ElectrodeChannelsRequest
+
+    publisher = ValidatedTopicPublisher(
+        topic="hardware/requests/electrodes_state_change",
+        validator_class=ElectrodeChannelsRequest,
+    )
+    publisher.publish({"channels": {1, 2, 3}}, validation_context={"max_channels": 120})
+
+Handler Naming
+--------------
+Frontend handlers (``DramatiqControllerBase``):
+    Methods named ``_on_{last_topic_segment}_triggered()`` are called reflectively.
+
+Backend handlers (``DropbotControllerBase``):
+    Methods named ``on_{last_topic_segment}_request()`` or ``on_{last_topic_segment}_signal()``.
+"""
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Core messaging primitives
+# ---------------------------------------------------------------------------
+from microdrop_utils.dramatiq_pub_sub_helpers import (  # noqa: E402
+    publish_message,
+    ValidatedTopicPublisher,
+    MessageRouterActor,
+    MessageRouterData,
+    MQTTMatcher,
+)
+from microdrop_utils.dramatiq_controller_base import (  # noqa: E402
+    DramatiqControllerBase,
+    basic_listener_actor_routine,
+    generate_class_method_dramatiq_listener_actor,
+)
+
+
+# ===================================================================
+# Topic Constants -- organised by domain / plugin
+# ===================================================================
+
+# ---------------------------------------------------------------------------
+# Dropbot Controller  (dropbot_controller/consts.py)
+# ---------------------------------------------------------------------------
+
+class DropbotTopics:
+    """All topics owned by the DropBot controller plugin."""
+
+    class Signals:
+        """Topics emitted by the backend when hardware events occur."""
+        CAPACITANCE_UPDATED     = "dropbot/signals/capacitance_updated"
+        SHORTS_DETECTED         = "dropbot/signals/shorts_detected"
+        HALTED                  = "dropbot/signals/halted"
+        CHIP_INSERTED           = "dropbot/signals/chip_inserted"
+        CHIP_NOT_INSERTED       = "dropbot/signals/chip_not_inserted"
+        SELF_TESTS_PROGRESS     = "dropbot/signals/self_tests_progress"
+        DROPLETS_DETECTED       = "dropbot/signals/drops_detected"
+
+    class Warnings:
+        """Warning-level signals published by the backend."""
+        NO_DROPBOT_AVAILABLE    = "dropbot/signals/warnings/no_dropbot_available"
+        NO_POWER                = "dropbot/signals/warnings/no_power"
+
+    class Requests:
+        """Topics consumed by the backend -- send these to request an action."""
+        START_DEVICE_MONITORING             = "dropbot/requests/start_device_monitoring"
+        DETECT_SHORTS                       = "dropbot/requests/detect_shorts"
+        RETRY_CONNECTION                    = "dropbot/requests/retry_connection"
+        HALT                                = "dropbot/requests/halt"
+        SET_VOLTAGE                         = "dropbot/requests/set_voltage"
+        SET_FREQUENCY                       = "dropbot/requests/set_frequency"
+        RUN_ALL_TESTS                       = "dropbot/requests/run_all_tests"
+        TEST_VOLTAGE                        = "dropbot/requests/test_voltage"
+        TEST_ON_BOARD_FEEDBACK_CALIBRATION  = "dropbot/requests/test_on_board_feedback_calibration"
+        TEST_SHORTS                         = "dropbot/requests/test_shorts"
+        TEST_CHANNELS                       = "dropbot/requests/test_channels"
+        CHIP_CHECK                          = "dropbot/requests/chip_check"
+        SELF_TEST_CANCEL                    = "dropbot/requests/self_test_cancel"
+        DETECT_DROPLETS                     = "dropbot/requests/detect_droplets"
+        CHANGE_SETTINGS                     = "dropbot/requests/change_settings"
+
+    class Errors:
+        """Error topics for the DropBot domain."""
+        DROPBOT_ERROR           = "dropbot/error"
+
+
+# ---------------------------------------------------------------------------
+# Hardware Topics  (shared across dropbot_controller & electrode_controller)
+# ---------------------------------------------------------------------------
+
+class HardwareTopics:
+    """Cross-cutting hardware topics used by multiple controller plugins."""
+
+    class Signals:
+        """Signals emitted by hardware backends."""
+        CONNECTED               = "hardware/signals/connected"
+        DISCONNECTED            = "hardware/signals/disconnected"
+        REALTIME_MODE_UPDATED   = "hardware/signals/realtime_mode_updated"
+        DISABLED_CHANNELS_CHANGED = "hardware/signals/disabled_channels_changed"
+
+    class Requests:
+        """Requests accepted by hardware backends."""
+        ELECTRODES_STATE_CHANGE = "hardware/requests/electrodes_state_change"
+        ELECTRODES_DISABLE      = "hardware/requests/electrodes_disable"
+        SET_REALTIME_MODE       = "hardware/requests/set_realtime_mode"
+
+
+# ---------------------------------------------------------------------------
+# UI Topics  (protocol_grid/consts.py, device_viewer)
+# ---------------------------------------------------------------------------
+
+class UITopics:
+    """Topics for UI state synchronisation between frontend plugins."""
+
+    DEVICE_VIEWER_STATE_CHANGED = "ui/device_viewer/state_changed"
+    PROTOCOL_GRID_DISPLAY_STATE = "ui/protocol_grid/display_state"
+    CALIBRATION_DATA            = "ui/calibration_data"
+    DEVICE_VIEWER_SCREEN_CAPTURE    = "ui/device_viewer/screen_capture"
+    DEVICE_VIEWER_SCREEN_RECORDING  = "ui/device_viewer/screen_recording"
+    DEVICE_VIEWER_CAMERA_ACTIVE     = "ui/device_viewer/camera_active"
+    DEVICE_VIEWER_MEDIA_CAPTURED    = "ui/device_viewer/camera/media_captured"
+    DEVICE_VIEWER_RECORDING_STATE   = "ui/device_viewer/recording_state"
+    ROUTES_EXECUTING                = "ui/device_viewer/routes_executing"
+
+
+# ---------------------------------------------------------------------------
+# Application-level Topics  (microdrop_application/consts.py)
+# ---------------------------------------------------------------------------
+
+class ApplicationTopics:
+    """Application-wide topics published by the core MicroDrop plugin."""
+    ADVANCED_MODE_CHANGE    = "microdrop/advanced_mode_change"
+    PROTOCOL_RUNNING        = "microdrop/protocol_running"
+
+
+# ---------------------------------------------------------------------------
+# Peripheral / ZStage Controller  (peripheral_controller/consts.py)
+# ---------------------------------------------------------------------------
+
+class ZStageTopics:
+    """Topics for the ZStage peripheral (MR-Box magnets / z-stage)."""
+
+    DEVICE_NAME = "ZStage"
+
+    class Signals:
+        """Signals emitted by the ZStage backend."""
+        CONNECTED           = "ZStage/signals/connected"
+        DISCONNECTED        = "ZStage/signals/disconnected"
+        POSITION_UPDATED    = "ZStage/signals/position_updated"
+
+    class Requests:
+        """Requests accepted by the ZStage backend."""
+        START_DEVICE_MONITORING = "ZStage/requests/start_device_monitoring"
+        GO_HOME                 = "ZStage/requests/go_home"
+        MOVE_UP                 = "ZStage/requests/move_up"
+        MOVE_DOWN               = "ZStage/requests/move_down"
+        SET_POSITION            = "ZStage/requests/set_position"
+        RETRY_CONNECTION        = "ZStage/requests/retry_connection"
+        UPDATE_CONFIG           = "ZStage/requests/update_config"
+
+    class Errors:
+        """Error topics for the ZStage domain."""
+        ERROR               = "ZStage/error"
+
+
+# ---------------------------------------------------------------------------
+# SSH Controls  (ssh_controls/consts.py)
+# ---------------------------------------------------------------------------
+
+class SSHTopics:
+    """Topics for the SSH key management service."""
+
+    class Requests:
+        """Requests accepted by the SSH controls backend."""
+        GENERATE_KEYPAIR    = "ssh_service/request/generate_keypair"
+        KEY_UPLOAD          = "ssh_service/request/key_upload"
+
+    class Success:
+        """Success signals published by the SSH controls backend."""
+        SSH_KEYGEN_SUCCESS      = "ssh_service/success/ssh_keygen_success"
+        SSH_KEY_UPLOAD_SUCCESS  = "ssh_service/success/ssh_key_upload_success"
+
+    class Warnings:
+        """Warning signals published by the SSH controls backend."""
+        SSH_KEYGEN_WARNING  = "ssh_service/warning/ssh_keygen_warning"
+
+    class Errors:
+        """Error signals published by the SSH controls backend."""
+        SSH_KEYGEN_ERROR        = "ssh_service/error/ssh_keygen_error"
+        SSH_KEY_UPLOAD_ERROR    = "ssh_service/error/ssh_key_upload_error"
+
+
+# ---------------------------------------------------------------------------
+# OpenDrop Controller  (opendrop_controller/consts.py)
+# ---------------------------------------------------------------------------
+
+class OpenDropTopics:
+    """Topics owned by the OpenDrop controller plugin."""
+
+    class Signals:
+        """Signals emitted by the OpenDrop backend."""
+        TEMPERATURES_UPDATED    = "opendrop/signals/temperatures_updated"
+        FEEDBACK_UPDATED        = "opendrop/signals/feedback_updated"
+        BOARD_INFO              = "opendrop/signals/board_info"
+
+    class Requests:
+        """Requests accepted by the OpenDrop backend."""
+        RETRY_CONNECTION    = "opendrop/requests/retry_connection"
+        SET_FEEDBACK        = "opendrop/requests/set_feedback"
+        SET_TEMPERATURES    = "opendrop/requests/set_temperatures"
+        SET_TEMPERATURE_1   = "opendrop/requests/set_temperature_1"
+        SET_TEMPERATURE_2   = "opendrop/requests/set_temperature_2"
+        SET_TEMPERATURE_3   = "opendrop/requests/set_temperature_3"
+        CHANGE_SETTINGS     = "opendrop/requests/change_settings"
+
+
+# ---------------------------------------------------------------------------
+# PGVA Controller  (pgva_controller_plugin/consts.py)
+# ---------------------------------------------------------------------------
+
+class PGVATopics:
+    """Topics owned by the PGVA (Pressure/Vacuum) controller plugin."""
+
+    class Signals:
+        """Signals emitted by the PGVA backend."""
+        CONNECTED                   = "pgva/signals/connected"
+        DISCONNECTED                = "pgva/signals/disconnected"
+        PRESSURE_UPDATED            = "pgva/signals/pressure_updated"
+        VACUUM_UPDATED              = "pgva/signals/vacuum_updated"
+        OUTPUT_PRESSURE_UPDATED     = "pgva/signals/output_pressure_updated"
+        STATUS_UPDATED              = "pgva/signals/status_updated"
+        WARNINGS_UPDATED            = "pgva/signals/warnings_updated"
+        ERRORS_UPDATED              = "pgva/signals/errors_updated"
+        COMPREHENSIVE_STATUS_UPDATED = "pgva/signals/comprehensive_status_updated"
+        HEALTH_CHECK_UPDATED        = "pgva/signals/health_check_updated"
+        DEVICE_INFO_UPDATED         = "pgva/signals/device_info_updated"
+        ERROR                       = "pgva/signals/error"
+
+    class Requests:
+        """Requests accepted by the PGVA backend."""
+        SET_PRESSURE            = "pgva/requests/set_pressure"
+        SET_VACUUM              = "pgva/requests/set_vacuum"
+        SET_OUTPUT_PRESSURE     = "pgva/requests/set_output_pressure"
+        GET_PRESSURE            = "pgva/requests/get_pressure"
+        GET_VACUUM              = "pgva/requests/get_vacuum"
+        GET_OUTPUT_PRESSURE     = "pgva/requests/get_output_pressure"
+        GET_STATUS              = "pgva/requests/get_status"
+        GET_WARNINGS            = "pgva/requests/get_warnings"
+        GET_ERRORS              = "pgva/requests/get_errors"
+        GET_COMPREHENSIVE_STATUS = "pgva/requests/get_comprehensive_status"
+        GET_HEALTH_CHECK        = "pgva/requests/get_health_check"
+        GET_DEVICE_INFO         = "pgva/requests/get_device_info"
+        ENABLE                  = "pgva/requests/enable"
+        DISABLE                 = "pgva/requests/disable"
+        RESET                   = "pgva/requests/reset"
+        TRIGGER_MANUAL          = "pgva/requests/trigger_manual"
+        STORE_TO_EEPROM         = "pgva/requests/store_to_eeprom"
+        CONNECT                 = "pgva/requests/connect"
+        DISCONNECT              = "pgva/requests/disconnect"
+
+
+# ---------------------------------------------------------------------------
+# Mock DropBot Controller  (mock_dropbot_controller/consts.py)
+# ---------------------------------------------------------------------------
+
+class MockDropbotTopics:
+    """Topics owned by the mock DropBot controller (for testing without hardware)."""
+
+    class Requests:
+        """Requests accepted by the mock DropBot backend."""
+        CHANGE_SIM_SETTINGS     = "mock_dropbot/requests/change_simulation_settings"
+        SIMULATE_CONNECT        = "mock_dropbot/requests/simulate_connect"
+        SIMULATE_DISCONNECT     = "mock_dropbot/requests/simulate_disconnect"
+        SIMULATE_CHIP_INSERT    = "mock_dropbot/requests/simulate_chip_insert"
+        SIMULATE_SHORTS         = "mock_dropbot/requests/simulate_shorts"
+        SIMULATE_HALT           = "mock_dropbot/requests/simulate_halt"
+
+    class Signals:
+        """Signals emitted by the mock DropBot backend."""
+        ACTUATED_CHANNELS_UPDATED   = "mock_dropbot/signals/actuated_channels_updated"
+        STREAM_STATUS_UPDATED       = "mock_dropbot/signals/stream_status_updated"
+
+
+# ===================================================================
+# Wildcard subscription patterns
+# ===================================================================
+
+class WildcardPatterns:
+    """Pre-built wildcard subscription patterns commonly used by plugins.
+
+    These are convenience constants for the MQTT-style wildcard subscriptions
+    accepted by ``MessageRouterData.add_subscriber_to_topic``.
+    """
+    ALL_DROPBOT_SIGNALS     = "dropbot/signals/#"
+    ALL_DROPBOT_REQUESTS    = "dropbot/requests/#"
+    ALL_HARDWARE_SIGNALS    = "hardware/signals/#"
+    ALL_HARDWARE_REQUESTS   = "hardware/requests/#"
+    ALL_OPENDROP_SIGNALS    = "opendrop/signals/#"
+    ALL_OPENDROP_REQUESTS   = "opendrop/requests/#"
+    ALL_PGVA_SIGNALS        = "pgva/signals/#"
+    ALL_PGVA_REQUESTS       = "pgva/requests/#"
+    ALL_MOCK_DROPBOT_SIGNALS    = "mock_dropbot/signals/#"
+    ALL_MOCK_DROPBOT_REQUESTS   = "mock_dropbot/requests/#"
+    ALL_ZSTAGE_SIGNALS      = "ZStage/signals/#"
+    ALL_ZSTAGE_REQUESTS     = "ZStage/requests/#"
+
+
+# ===================================================================
+# Convenience helpers
+# ===================================================================
+
+def get_all_topics() -> dict[str, list[str]]:
+    """Return a dictionary mapping each domain to its list of topic strings.
+
+    Useful for debugging, documentation generation, or runtime introspection
+    of all available topics in the system.
+
+    Returns:
+        dict mapping domain name (str) to list of topic strings.
+    """
+    topics: dict[str, list[str]] = {}
+
+    topic_classes = [
+        ("dropbot", DropbotTopics),
+        ("hardware", HardwareTopics),
+        ("ui", UITopics),
+        ("application", ApplicationTopics),
+        ("zstage", ZStageTopics),
+        ("ssh", SSHTopics),
+        ("opendrop", OpenDropTopics),
+        ("pgva", PGVATopics),
+        ("mock_dropbot", MockDropbotTopics),
+    ]
+
+    for domain, cls in topic_classes:
+        domain_topics = []
+        _collect_string_attrs(cls, domain_topics)
+        topics[domain] = sorted(domain_topics)
+
+    return topics
+
+
+def _collect_string_attrs(cls, result: list[str]) -> None:
+    """Recursively collect all string class attributes from *cls* and its nested classes."""
+    for name in dir(cls):
+        if name.startswith("_"):
+            continue
+        value = getattr(cls, name)
+        if isinstance(value, str) and "/" in value:
+            result.append(value)
+        elif isinstance(value, type):
+            _collect_string_attrs(value, result)
+
+
+# ===================================================================
+# Public API
+# ===================================================================
+
+__all__ = [
+    # Core messaging primitives
+    "publish_message",
+    "ValidatedTopicPublisher",
+    "MessageRouterActor",
+    "MessageRouterData",
+    "MQTTMatcher",
+    "DramatiqControllerBase",
+    "basic_listener_actor_routine",
+    "generate_class_method_dramatiq_listener_actor",
+    # Topic namespaces
+    "DropbotTopics",
+    "HardwareTopics",
+    "UITopics",
+    "ApplicationTopics",
+    "ZStageTopics",
+    "SSHTopics",
+    "OpenDropTopics",
+    "PGVATopics",
+    "MockDropbotTopics",
+    "WildcardPatterns",
+    # Helpers
+    "get_all_topics",
+]


### PR DESCRIPTION
Closes #282. Adds microdrop_utils/api.py as a centralized API module exposing all pub/sub topics and dramatiq controls. Includes test suite.