### PR TITLE
Fix: stop button unusable during Run Step

### DIFF
--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -1383,8 +1383,10 @@ class PGCWidget(QWidget):
 
         self.navigation_bar.btn_play.setText(ICON_PAUSE)
         self.navigation_bar.btn_play.setToolTip("Pause Protocol")
+        self.navigation_bar.btn_stop.setEnabled(True)
 
         self._update_navigation_buttons_state()
+        self._update_ui_enabled_state()
 
         self.tree.clearSelection()
         self._last_selected_step_id = None


### PR DESCRIPTION
## Summary
- `run_selected_step` (right-click → **Run Step**) forgot to enable `btn_stop` and refresh the UI enabled state, so once the user hit pause during a single-step run they were stuck watching the whole step — the stop button never became clickable.
- Added the two calls (`btn_stop.setEnabled(True)` and `_update_ui_enabled_state()`) that the regular protocol-start path already makes.

## Test plan
- [x] Right-click a step in the protocol grid → **Run Step** → click pause → verify the stop button is enabled and cancels the step.
- [x] Regression: normal **Play Protocol** flow still enables/stops correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)