### PR TITLE
Free-mode captures & recordings go to experiment folder (#342)

### DIFF
--- a/device_viewer/views/camera_control_view/widget.py
+++ b/device_viewer/views/camera_control_view/widget.py
@@ -4,7 +4,6 @@ from PySide6.QtCore import (
     Signal,
     Slot,
     QTimer,
-    QStandardPaths,
 )
 from PySide6.QtGui import QImage
 from PySide6.QtMultimedia import QMediaCaptureSession, QCamera, QMediaDevices, QCameraDevice, QCameraFormat
@@ -22,6 +21,7 @@ from PySide6.QtWidgets import (
 from apptools.preferences.api import Preferences
 
 from microdrop_application.dialogs.pyface_wrapper import error, warning, YES, OK, disclaimer
+from microdrop_application.helpers import get_current_experiment_directory
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from microdrop_utils.pyside_helpers import MarqueeComboBox
 from microdrop_utils.v4l2_fps_getter import get_video_inputs, LinuxCameraDeviceContainer
@@ -578,14 +578,9 @@ class CameraControlWidget(QWidget):
 
         # 4. Generate Path
         filename = self._generate_capture_filename(step_description, step_id)
-        if directory:
-            save_path = Path(directory) / "captures" / filename
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-        else:
-            save_path = (
-                Path(QStandardPaths.writableLocation(QStandardPaths.StandardLocation.PicturesLocation))
-                / filename
-            )
+        base_dir = Path(directory) if directory else get_current_experiment_directory()
+        save_path = base_dir / "captures" / filename
+        save_path.parent.mkdir(parents=True, exist_ok=True)
 
         worker = ImageSaver(image.copy(), str(save_path))
 
@@ -626,7 +621,7 @@ class CameraControlWidget(QWidget):
         elif step_id:
             return f"step_{step_id}_{timestamp}{file_extension}"
         else:
-            return f"captured_media_{timestamp}{file_extension}"
+            return f"free_mode_{timestamp}{file_extension}"
 
     def _generate_capture_filename(self, step_description=None, step_id=None):
         return self._generate_media_filename(step_description, step_id, ".png")
@@ -725,15 +720,10 @@ class CameraControlWidget(QWidget):
             self._camera_state_pre_recording = True
 
         filename = self._generate_recording_filename(step_description, step_id)
-        if directory:
-            path = Path(directory) / "recordings" / filename
-            path.parent.mkdir(parents=True, exist_ok=True)
-            _recording_file_path = str(path)
-        else:
-            _recording_file_path = str(
-                Path(QStandardPaths.writableLocation(QStandardPaths.StandardLocation.MoviesLocation))
-                / filename
-            )
+        base_dir = Path(directory) if directory else get_current_experiment_directory()
+        path = base_dir / "recordings" / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _recording_file_path = str(path)
 
         self.show_media_capture_dialog_for_video = show_dialog
 

--- a/microdrop_application/helpers.py
+++ b/microdrop_application/helpers.py
@@ -1,6 +1,29 @@
-from microdrop_application.consts import APP_GLOBALS_REDIS_HASH
+from pathlib import Path
+
+from microdrop_application.consts import APP_GLOBALS_REDIS_HASH, EXPERIMENT_DIR
 from microdrop_utils.redis_manager import get_redis_hash_proxy
 from dramatiq import get_broker
 
 def get_microdrop_redis_globals_manager():
     return get_redis_hash_proxy(redis_client=get_broker().client, hash_name=APP_GLOBALS_REDIS_HASH)
+
+
+def get_current_experiment_directory() -> Path:
+    """Return the currently-active experiment folder.
+
+    Usable from plugins/widgets that don't have direct access to the Envisage
+    application instance. Mirrors MicrodropApplication._get_current_experiment_directory
+    / MicrodropBackendApplication._get_current_experiment_directory.
+    """
+    # Avoid importing MicrodropPreferences at module load — it pulls Traits
+    # machinery that may not be ready when helpers.py is first imported.
+    from microdrop_application.preferences import MicrodropPreferences
+
+    globals_manager = get_microdrop_redis_globals_manager()
+    current_exp_dir = globals_manager.get("experiment_directory", None)
+    if current_exp_dir is None:
+        current_exp_dir = EXPERIMENT_DIR
+        globals_manager["experiment_directory"] = EXPERIMENT_DIR
+
+    experiments_root = Path(MicrodropPreferences().EXPERIMENTS_DIR)
+    return experiments_root / current_exp_dir


### PR DESCRIPTION
## Summary
- Free-mode image captures and video recordings used to land in the OS Pictures / Movies directory (via `QStandardPaths`). Now every piece of experimental media — protocol run or free mode — lives under the active experiment folder.
- Added `microdrop_application.helpers.get_current_experiment_directory()` as a single source of truth so any plugin can resolve the active experiment folder without needing the Envisage application instance.
- `CameraControlWidget` now falls back to `<experiment>/captures/` and `<experiment>/recordings/`; free-mode filename prefix is `free_mode_{timestamp}` instead of `captured_media_{timestamp}`.

Closes #342

## Test plan
- [x] With no protocol running, press the capture button — verify the PNG shows up in `<experiment>/captures/free_mode_<ts>.png` and not in the user's Pictures folder.
- [x] With no protocol running, record a video — verify the MKV shows up in `<experiment>/recordings/free_mode_<ts>.mkv` and not in the user's Movies folder.
- [x] Regression: run a protocol step with a capture action — file should still save to `<experiment>/captures/<step_description>_<step_id>_<ts>.png` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)