### PR TITLE
Linear Repeats — repeat linear routes + status bar toggle (#341)

### DIFF
--- a/device_viewer/services/route_execution_service.py
+++ b/device_viewer/services/route_execution_service.py
@@ -84,6 +84,11 @@ class RouteExecutionService(HasTraits):
             if channel in self.model.electrodes.channels_electrode_ids_map:
                 activated_electrode_ids.extend(self.model.electrodes.channels_electrode_ids_map[channel])
 
+        # Read the linear-repeats preference once so the plan and the
+        # rep/phase counters below agree on the mode.
+        from protocol_grid.preferences import ProtocolPreferences
+        linear_repeats = bool(ProtocolPreferences().linear_repeats)
+
         # Build execution plan using PathExecutionService with raw params
         plan = PathExecutionService.calculate_execution_plan_from_params(
             duration=self.model.routes.duration,
@@ -95,6 +100,7 @@ class RouteExecutionService(HasTraits):
             activated_electrodes=activated_electrode_ids,
             soft_start=self.model.routes.soft_start,
             soft_terminate=self.model.routes.soft_terminate,
+            linear_repeats=linear_repeats,
         )
 
         if not plan:
@@ -140,8 +146,21 @@ class RouteExecutionService(HasTraits):
             # One rep = one full cycle of the longest loop path
             self._phases_per_rep = max(max_cycle_length, 1)
             self._total_reps = max_effective_reps
+        elif linear_repeats:
+            # Open-only paths with linear_repeats on: longest path's single
+            # traversal = one rep; total reps = the raw Repetitions count.
+            max_open_cycle = 0
+            for path in paths:
+                cycle_phases = PathExecutionService.calculate_trail_phases_for_path(
+                    path, self.model.routes.trail_length, self.model.routes.trail_overlay,
+                    soft_start=self.model.routes.soft_start,
+                    soft_terminate=self.model.routes.soft_terminate,
+                )
+                max_open_cycle = max(max_open_cycle, len(cycle_phases))
+            self._phases_per_rep = max(max_open_cycle, 1)
+            self._total_reps = max(int(self.model.routes.repetitions), 1)
         else:
-            # Open paths only — no repetitions, entire plan is one rep
+            # Open paths only, no linear repeats — entire plan is one rep
             self._phases_per_rep = max(len(plan), 1)
             self._total_reps = 1
 

--- a/protocol_grid/extra_ui_elements.py
+++ b/protocol_grid/extra_ui_elements.py
@@ -359,14 +359,27 @@ class StatusBar(QScrollArea):
         self.lbl_next_step.setFixedWidth(180)
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        for widget in [self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress, 
-                      self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step]:
+        # Live indicator for the "Linear Repeats" preference.
+        # Uses setText / setStyleSheet via set_linear_repeats(bool).
+        self.lbl_linear_repeats = QLabel()
+        self.lbl_linear_repeats.setFixedWidth(100)
+        self.lbl_linear_repeats.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.lbl_linear_repeats.setToolTip(
+            "Linear Repeats preference — when enabled, linear paths are "
+            "replayed by the Repetitions count just like loops."
+        )
+        self.set_linear_repeats(False)
+
+        for widget in [self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress,
+                      self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
+                      self.lbl_linear_repeats]:
             widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             widget.setFixedHeight(20)
 
         layout.addWidget(self.lbl_total_time)
         layout.addWidget(self.lbl_step_time)
         layout.addWidget(repeat_widget)
+        layout.addWidget(self.lbl_linear_repeats)
         layout.addWidget(self.lbl_step_progress)
         layout.addWidget(self.lbl_step_repetition)
         layout.addWidget(self.lbl_recent_step)
@@ -393,6 +406,18 @@ class StatusBar(QScrollArea):
 
         QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)
     
+    def set_linear_repeats(self, enabled: bool):
+        """Update the Lin-Reps indicator to reflect the current preference.
+
+        ``✓ Lin-Reps`` in green when on; ``✗ Lin-Reps`` in red when off.
+        """
+        if enabled:
+            self.lbl_linear_repeats.setText("✓ Lin-Reps")
+            self.lbl_linear_repeats.setStyleSheet("QLabel { color: #2e7d32; font-weight: bold; }")
+        else:
+            self.lbl_linear_repeats.setText("✗ Lin-Reps")
+            self.lbl_linear_repeats.setStyleSheet("QLabel { color: #c62828; font-weight: bold; }")
+
     def _apply_styling(self):
         """Apply theme-specific styling to all labels and input fields."""
         if is_dark_mode():
@@ -417,19 +442,21 @@ class StatusBar(QScrollArea):
                     padding: 2px;
                 }}
             """
-        
+
         label_style = f"QLabel {{ color: {text_color}; }}"
-        
-        # Apply styling to all labels
+
+        # Apply styling to all labels. `lbl_linear_repeats` keeps its own
+        # coloured stylesheet (set by `set_linear_repeats`), independent of
+        # the light/dark text color.
         all_labels = [
             self.lbl_total_time, self.lbl_step_time, self.lbl_repeat_protocol,
             self.lbl_repeat_protocol_status, self.lbl_step_progress,
             self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step
         ]
-        
+
         for label in all_labels:
             label.setStyleSheet(label_style)
-        
+
         # Apply styling to input field
         self.edit_repeat_protocol.setStyleSheet(input_style)
 

--- a/protocol_grid/extra_ui_elements.py
+++ b/protocol_grid/extra_ui_elements.py
@@ -374,13 +374,8 @@ class StatusBar(QScrollArea):
         # Live indicator for the "Linear Repeats" preference.
         # Clickable — emits `clicked` so the widget can toggle the pref.
         self.lbl_linear_repeats = _ClickableLabel()
-        self.lbl_linear_repeats.setFixedWidth(100)
-        self.lbl_linear_repeats.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.lbl_linear_repeats.setCursor(Qt.PointingHandCursor)
-        self.lbl_linear_repeats.setToolTip(
-            "Linear Repeats preference — when enabled, linear paths are "
-            "replayed by the Repetitions count just like loops. Click to toggle."
-        )
+        self.lbl_linear_repeats.setToolTip("Loop linear paths")
         self.set_linear_repeats(False)
 
         for widget in [self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress,

--- a/protocol_grid/extra_ui_elements.py
+++ b/protocol_grid/extra_ui_elements.py
@@ -24,6 +24,18 @@ from microdrop_style.colors import (WHITE, BLACK)
 from microdrop_style.button_styles import BUTTON_SPACING, get_button_style
 
 
+class _ClickableLabel(QLabel):
+    """Minimal QLabel that emits `clicked` on left-click."""
+    clicked = Signal()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit()
+            event.accept()
+        else:
+            super().mousePressEvent(event)
+
+
 class ExperimentLabel(QLabel):
     """shows experiment info - clickable label"""
     clicked = Signal()
@@ -360,13 +372,14 @@ class StatusBar(QScrollArea):
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         # Live indicator for the "Linear Repeats" preference.
-        # Uses setText / setStyleSheet via set_linear_repeats(bool).
-        self.lbl_linear_repeats = QLabel()
+        # Clickable — emits `clicked` so the widget can toggle the pref.
+        self.lbl_linear_repeats = _ClickableLabel()
         self.lbl_linear_repeats.setFixedWidth(100)
         self.lbl_linear_repeats.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.lbl_linear_repeats.setCursor(Qt.PointingHandCursor)
         self.lbl_linear_repeats.setToolTip(
             "Linear Repeats preference — when enabled, linear paths are "
-            "replayed by the Repetitions count just like loops."
+            "replayed by the Repetitions count just like loops. Click to toggle."
         )
         self.set_linear_repeats(False)
 

--- a/protocol_grid/preferences.py
+++ b/protocol_grid/preferences.py
@@ -3,7 +3,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import List, Enum, Directory
+from traits.api import List, Enum, Directory, Bool
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import View, Item
 from envisage.ui.tasks.api import PreferencesCategory
@@ -60,6 +60,11 @@ class ProtocolPreferences(PreferencesHelper):
 
     capture_time = Enum(StepTime.START, StepTime.END, value=StepTime.START)
 
+    # When enabled, linear (non-loop) paths are also replayed `Repetitions`
+    # times. When disabled (default), only loop paths honor the Repetitions
+    # count and linear paths play exactly once.
+    linear_repeats = Bool(False)
+
     PROTOCOL_REPO_DIR = Directory()
 
     def _PROTOCOL_REPO_DIR_default(self) -> Path:
@@ -103,6 +108,14 @@ class ProtocolPreferencesPane(PreferencesPane):
         group_style_sheet=preferences_group_style_sheet,
     )
 
+    routes_execution_grid = create_grid_group(
+        ["linear_repeats"],
+        label_text=["Linear Repeats"],
+        group_label="Routes Execution Config",
+        group_show_border=True,
+        group_style_sheet=preferences_group_style_sheet,
+    )
+
     general_protocol_settings_grid = create_grid_group(
         items=["realtime_mode_settling_time_s", "logs_settling_time_s"],
         label_text = ["Realtime Mode Pre-Protocol (s)", "Logs Accepted Post-Protocol (s)"],
@@ -116,6 +129,8 @@ class ProtocolPreferencesPane(PreferencesPane):
         general_protocol_settings_grid,
         Item("_"),
         camera_settings_grid,
+        Item("_"),
+        routes_execution_grid,
         Item("_"),  # Separator to space this out from further contributions to the pane.
         resizable=True
     )

--- a/protocol_grid/services/path_execution_service.py
+++ b/protocol_grid/services/path_execution_service.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from device_viewer.models.messages import DeviceViewerMessageModel
 from protocol_grid.state.device_state import DeviceState
@@ -8,6 +8,16 @@ from protocol_grid.state.protocol_state import ProtocolStep
 from logger.logger_service import get_logger
 
 logger = get_logger(__name__)
+
+
+def _read_linear_repeats_preference() -> bool:
+    """Read the `linear_repeats` preference. Localized so the import is lazy
+    (avoids circular-import issues at module load time)."""
+    try:
+        from protocol_grid.preferences import ProtocolPreferences
+        return bool(ProtocolPreferences().linear_repeats)
+    except Exception:
+        return False
 
 class PathExecutionService:
 
@@ -363,13 +373,18 @@ class PathExecutionService:
     
     @staticmethod
     def calculate_step_execution_plan(step: ProtocolStep, device_state: DeviceState,
-                                      soft_start: bool = False, soft_terminate: bool = False) -> List[Dict[str, Any]]:
+                                      soft_start: bool = False, soft_terminate: bool = False,
+                                      linear_repeats: Optional[bool] = None) -> List[Dict[str, Any]]:
         """Build the full phase-by-phase execution plan for a protocol step.
 
         Each entry in the returned list describes one timed phase with its
         activated electrodes.  Respects "Repeat Duration Mode" to decide
         whether loop repetitions are time-capped (with idle padding) or
         count-based.  Soft start/terminate add ramp phases on top.
+
+        When ``linear_repeats`` is True, linear (non-loop) paths are replayed
+        ``Repetitions`` times. When None (default), the preference is read
+        from ``ProtocolPreferences``.
         """
         duration = float(step.parameters.get("Duration", "1.0"))
         repetitions = int(step.parameters.get("Repetitions", "1"))
@@ -377,6 +392,9 @@ class PathExecutionService:
         repeat_duration = int(float(step.parameters.get("Repeat Duration", "1"))) if repeat_duration_mode else 0
         trail_length = int(step.parameters.get("Trail Length", "1"))
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
+
+        if linear_repeats is None:
+            linear_repeats = _read_linear_repeats_preference()
 
         step_uid = step.parameters.get("UID", "")
         step_id = step.parameters.get("ID", "")
@@ -438,16 +456,18 @@ class PathExecutionService:
                     + len(soft_terminate_phases)
                 )
             else:  # open path
-                path_repetitions[i] = 1
+                open_reps = repetitions if linear_repeats else 1
+                path_repetitions[i] = open_reps
                 # For open paths, soft start/terminate phases are baked into the trail phases
                 cycle_phases = PathExecutionService.calculate_trail_phases_for_path(
                     path, trail_length, trail_overlay,
                     soft_start=soft_start, soft_terminate=soft_terminate
                 )
                 cycle_length = len(cycle_phases)
-                max_open_path_length = max(max_open_path_length, cycle_length)
-                loop_total_phases = cycle_length
-                active_phases = cycle_length
+                total_open_phases = cycle_length * open_reps
+                max_open_path_length = max(max_open_path_length, total_open_phases)
+                loop_total_phases = total_open_phases
+                active_phases = total_open_phases
                 idle_phases = 0
                 soft_start_phases = []
                 soft_terminate_phases = []
@@ -571,9 +591,13 @@ class PathExecutionService:
                                     electrode_id = path[electrode_idx]
                                     phase_electrodes.add(electrode_id)
                 else:
-                    if phase_idx < cycle_length:
-                        if phase_idx < len(cycle_phases):
-                            electrode_indices = cycle_phases[phase_idx]
+                    # Open path: with linear_repeats, total active phases =
+                    # cycle_length * repetitions; we wrap phase_idx around the
+                    # cycle so the trail replays from the start each rep.
+                    if phase_idx < path_total_phases:
+                        phase_in_cycle = phase_idx % cycle_length if cycle_length > 0 else 0
+                        if phase_in_cycle < len(cycle_phases):
+                            electrode_indices = cycle_phases[phase_in_cycle]
                             for electrode_idx in electrode_indices:
                                 if electrode_idx < len(path):
                                     electrode_id = path[electrode_idx]
@@ -605,6 +629,7 @@ class PathExecutionService:
         repeat_duration_mode: bool = True,
         soft_start: bool = False,
         soft_terminate: bool = False,
+        linear_repeats: Optional[bool] = None,
     ) -> List[Dict[str, Any]]:
         """Calculate execution plan from raw parameters without needing ProtocolStep or DeviceState.
 
@@ -632,7 +657,9 @@ class PathExecutionService:
             paths=paths,
         )
         return PathExecutionService.calculate_step_execution_plan(
-            step, device_state, soft_start=soft_start, soft_terminate=soft_terminate
+            step, device_state,
+            soft_start=soft_start, soft_terminate=soft_terminate,
+            linear_repeats=linear_repeats,
         )
 
     @staticmethod

--- a/protocol_grid/services/path_execution_service.py
+++ b/protocol_grid/services/path_execution_service.py
@@ -261,7 +261,8 @@ class PathExecutionService:
 
     @staticmethod
     def calculate_step_execution_time(step: ProtocolStep, device_state: DeviceState,
-                                      soft_start: bool = False, soft_terminate: bool = False) -> float:
+                                      soft_start: bool = False, soft_terminate: bool = False,
+                                      linear_repeats: Optional[bool] = None) -> float:
         """Return the total execution time (seconds) for a single protocol step.
 
         When "Repeat Duration Mode" is "1", repeat_duration caps loop
@@ -269,6 +270,9 @@ class PathExecutionService:
         repeat_duration is ignored (treated as 0) and loops run exactly
         ``repetitions`` times.  Soft start/terminate add ramp phases
         on top.
+
+        When ``linear_repeats`` is True, linear (non-loop) paths are replayed
+        ``Repetitions`` times. None (default) reads from ``ProtocolPreferences``.
         """
         duration = float(step.parameters.get("Duration", "1.0"))
         repetitions = int(step.parameters.get("Repetitions", "1"))
@@ -276,6 +280,9 @@ class PathExecutionService:
         repeat_duration = int(float(step.parameters.get("Repeat Duration", "1"))) if repeat_duration_mode else 0
         trail_length = int(step.parameters.get("Trail Length", "1"))
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
+
+        if linear_repeats is None:
+            linear_repeats = _read_linear_repeats_preference()
 
         if not device_state.has_paths():
             return duration
@@ -318,7 +325,8 @@ class PathExecutionService:
                     soft_start=soft_start, soft_terminate=soft_terminate
                 )
                 cycle_length = len(cycle_phases)
-                max_open_path_length = max(max_open_path_length, cycle_length)
+                open_reps = repetitions if linear_repeats else 1
+                max_open_path_length = max(max_open_path_length, cycle_length * open_reps)
 
         # calculate total phases based on the longest duration needed
         total_phases = max(max_loop_total_phases, max_open_path_length)
@@ -327,12 +335,16 @@ class PathExecutionService:
         return total_time
     
     @staticmethod
-    def calculate_step_repetition_info(step: ProtocolStep, device_state: DeviceState) -> Dict[str, int]:
+    def calculate_step_repetition_info(step: ProtocolStep, device_state: DeviceState,
+                                       linear_repeats: Optional[bool] = None) -> Dict[str, int]:
         """Calculate repetition information for status bar display.
 
         Respects "Repeat Duration Mode": when enabled, effective
         repetitions are derived from Repeat Duration; when disabled,
         the raw Repetitions value is used.
+
+        When ``linear_repeats`` is True, open paths contribute their cycle
+        length and ``Repetitions`` count to the info dict.
         """
         duration = float(step.parameters.get("Duration", "1.0"))
         repetitions = int(step.parameters.get("Repetitions", "1"))
@@ -340,13 +352,27 @@ class PathExecutionService:
         repeat_duration = int(float(step.parameters.get("Repeat Duration", "1"))) if repeat_duration_mode else 0
         trail_length = int(step.parameters.get("Trail Length", "1"))
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
-        
+
+        if linear_repeats is None:
+            linear_repeats = _read_linear_repeats_preference()
+
         if not device_state.has_paths():
             return {"max_cycle_length": 1, "max_effective_repetitions": 1}
-        
+
         has_loops = PathExecutionService.has_any_loops(device_state)
-        
+
         if not has_loops:
+            if linear_repeats:
+                max_open_cycle = 0
+                for path in device_state.paths:
+                    cycle_phases = PathExecutionService.calculate_trail_phases_for_path(
+                        path, trail_length, trail_overlay,
+                    )
+                    max_open_cycle = max(max_open_cycle, len(cycle_phases))
+                return {
+                    "max_cycle_length": max(max_open_cycle, 1),
+                    "max_effective_repetitions": max(repetitions, 1),
+                }
             return {"max_cycle_length": 1, "max_effective_repetitions": 1}
         
         max_cycle_length = 0

--- a/protocol_grid/state/device_state.py
+++ b/protocol_grid/state/device_state.py
@@ -28,15 +28,24 @@ class DeviceState:
 
     def calculated_duration(self, step_duration: float, repetitions: int,
                             repeat_duration: float = 1.0, trail_length: int = 1, trail_overlay: int = 0,
-                            soft_start: bool = False, soft_end: bool = False):
+                            soft_start: bool = False, soft_end: bool = False,
+                            linear_repeats: bool = None):
         """Calculate the total duration for this step including idle/balance phases.
 
         When repeat_duration > 0 and the step has loops, each loop independently
         calculates how many full cycles fit within repeat_duration. Idle phases
         pad the remaining balance time.  Soft start/end add ramp phases on top.
         The total step duration is driven by the longest loop.
+
+        When ``linear_repeats`` is True, open paths also play ``repetitions``
+        times. None reads from ``ProtocolPreferences``.
         """
-        from protocol_grid.services.path_execution_service import PathExecutionService
+        from protocol_grid.services.path_execution_service import (
+            PathExecutionService, _read_linear_repeats_preference,
+        )
+
+        if linear_repeats is None:
+            linear_repeats = _read_linear_repeats_preference()
 
         if not self.has_paths():
             calculated_time = step_duration * repetitions
@@ -81,7 +90,8 @@ class DeviceState:
                         soft_start=soft_start, soft_terminate=soft_end,
                     )
                     cycle_length = len(cycle_phases)
-                    max_open_path_length = max(max_open_path_length, cycle_length)
+                    open_reps = repetitions if linear_repeats else 1
+                    max_open_path_length = max(max_open_path_length, cycle_length * open_reps)
 
             # calculate total phases based on the longest duration needed
             total_phases = max(max_loop_total_phases, max_open_path_length)

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -901,7 +901,13 @@ class PGCWidget(QWidget):
         self.status_bar.set_linear_repeats(enabled)
 
     def _toggle_linear_repeats_preference(self):
-        """Flip the Linear Repeats preference and refresh the indicator."""
+        """Flip the Linear Repeats preference and refresh the indicator.
+
+        Recomputes every step's derived columns (Run Time, etc.) and any
+        parent group aggregations so totals reflect the new mode
+        immediately — linear paths that now repeat add to Run Time, and
+        vice-versa when disabling.
+        """
         try:
             from protocol_grid.preferences import ProtocolPreferences
             prefs = ProtocolPreferences()
@@ -910,6 +916,8 @@ class PGCWidget(QWidget):
             logger.error(f"Failed to toggle Linear Repeats preference: {e}", exc_info=True)
             return
         self._refresh_linear_repeats_indicator()
+        self.update_step_dev_fields()
+        self.update_all_group_aggregations()
 
     def update_status_bar(self, status):
         self._refresh_linear_repeats_indicator()
@@ -3038,13 +3046,24 @@ class PGCWidget(QWidget):
         return True
 
     def _enforce_step_repetition_requires_loop(self, desc_item, repetitions_item):
-        """Revert Repetitions to 1 if the step has no looping route"""
+        """Revert Repetitions to 1 if the step has no looping route.
+
+        Skipped when the Linear Repeats preference is on — in that mode,
+        linear paths honor Repetitions too, so the guard would be incorrect.
+        """
         try:
             reps = int(repetitions_item.text() or "1")
         except ValueError:
             return
         if reps <= 1:
             return
+
+        try:
+            from protocol_grid.preferences import ProtocolPreferences
+            if bool(ProtocolPreferences().linear_repeats):
+                return
+        except Exception:
+            pass
 
         device_state = desc_item.data(Qt.UserRole + 100)
         has_loop = (

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -366,6 +366,7 @@ class PGCWidget(QWidget):
         self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
 
         self.status_bar = StatusBar(self)
+        self.status_bar.lbl_linear_repeats.clicked.connect(self._toggle_linear_repeats_preference)
         self._refresh_linear_repeats_indicator()
 
         layout = QVBoxLayout()
@@ -898,6 +899,17 @@ class PGCWidget(QWidget):
         except Exception:
             enabled = False
         self.status_bar.set_linear_repeats(enabled)
+
+    def _toggle_linear_repeats_preference(self):
+        """Flip the Linear Repeats preference and refresh the indicator."""
+        try:
+            from protocol_grid.preferences import ProtocolPreferences
+            prefs = ProtocolPreferences()
+            prefs.linear_repeats = not bool(prefs.linear_repeats)
+        except Exception as e:
+            logger.error(f"Failed to toggle Linear Repeats preference: {e}", exc_info=True)
+            return
+        self._refresh_linear_repeats_indicator()
 
     def update_status_bar(self, status):
         self._refresh_linear_repeats_indicator()

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -366,6 +366,7 @@ class PGCWidget(QWidget):
         self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
 
         self.status_bar = StatusBar(self)
+        self._refresh_linear_repeats_indicator()
 
         layout = QVBoxLayout()
 
@@ -889,7 +890,17 @@ class PGCWidget(QWidget):
 
         clear_recursive(self.model.invisibleRootItem())
 
+    def _refresh_linear_repeats_indicator(self):
+        """Re-read the Linear Repeats preference and update the status bar."""
+        try:
+            from protocol_grid.preferences import ProtocolPreferences
+            enabled = bool(ProtocolPreferences().linear_repeats)
+        except Exception:
+            enabled = False
+        self.status_bar.set_linear_repeats(enabled)
+
     def update_status_bar(self, status):
+        self._refresh_linear_repeats_indicator()
         self.status_bar.lbl_total_time.setText(
             f"Total Time: {int(status['total_time'])} s"
         )
@@ -1419,6 +1430,7 @@ class PGCWidget(QWidget):
         self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
         self.status_bar.lbl_next_step.setText("Next Step: -")
         self.status_bar.lbl_repeat_protocol_status.setText("0/")
+        self._refresh_linear_repeats_indicator()
 
     def _update_ui_enabled_state(self):
         enabled = not self._protocol_running


### PR DESCRIPTION
## Summary
- New "Routes Execution Config" group in Protocol Settings with a **Linear Repeats** checkbox. When on, linear (non-loop) routes are replayed by the step's `Repetitions` count, just like loops.
- Status bar badge ✓/✗ **Lin-Reps** (green/red) sits beside Step Time / Repeat Protocol. Reflects the current preference and is clickable to toggle it in place.
- Toggling immediately recomputes every step's `Run Time` and parent-group aggregations. The "Repetitions Not Supported" dialog is suppressed while Lin-Reps is on.
- Execution engine threads `linear_repeats` through every place that matters: `calculate_step_execution_plan`, `calculate_step_execution_time` (step timeout), `calculate_step_repetition_info` (status counter), `DeviceState.calculated_duration`, and the device viewer's `RouteExecutionService` (so its internal rep counter ticks correctly for open-only paths).

Closes #341

## Test plan
- [x] Enable Lin-Reps (preferences pane *or* click the status-bar badge); verify the badge flips ✓ green.
- [x] Build a step with a single linear path, Repetitions = 3, and run the protocol — the path replays 3 times before the step ends.
- [x] Edit the same step's Repetitions to >1 with Lin-Reps on — no "Repetitions Not Supported" dialog.
- [x] Toggle Lin-Reps off — the same step now plays once; the dialog reappears if you try Repetitions > 1.
- [x] During execution, the "Repetition X/Y" status bar counter ticks from 1/3 → 2/3 → 3/3 for the linear step.
- [x] Toggling the badge recomputes `Run Time` and the parent-group `Duration` in the grid without requiring any other edit.
- [x] Regression: a step with a loop path still honors Repetitions / Repeat Duration correctly regardless of the Lin-Reps state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)