### PR TITLE
Per-step Lin Reps: replace global preference with grid column

### DIFF
--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -44,6 +44,11 @@ class DeviceViewMainModel(HasTraits):
     # `object.routes.commit_enabled` don't re-evaluate reliably in enabled_when.
     routes_commit_enabled = DelegatesTo("routes", prefix="commit_enabled")
 
+    # Mirror of routes.repeats_frozen at the top level so the sidebar's
+    # Repetitions / Repeat Duration spinners re-evaluate `enabled_when`
+    # reliably when a loop is added/removed or Lin Reps is toggled.
+    routes_repeats_frozen = DelegatesTo("routes", prefix="repeats_frozen")
+
     # route Execution status display
     execution_status = Str("")
 

--- a/device_viewer/models/route.py
+++ b/device_viewer/models/route.py
@@ -227,6 +227,15 @@ class RouteLayerManager(HasTraits):
     soft_terminate = Bool(False)
     linear_repeats = Bool(False)
 
+    # True when linear_repeats is off AND no layer contains a loop route —
+    # Repetitions / Repeat Duration are meaningless in that mode, so the
+    # sidebar spinners are disabled and the values are pinned to 1 / 0.
+    # Mirrored to DeviceViewMainModel.routes_repeats_frozen so the view's
+    # `enabled_when` binding picks it up (nested paths don't re-evaluate).
+    repeats_frozen = Property(
+        observe="linear_repeats,layers.items.route.route.items"
+    )
+
     # -------- Step-params commit state --------
     # Empty dict means no step is currently selected — commit button disabled.
     _committed_params_baseline = Dict()
@@ -317,6 +326,24 @@ class RouteLayerManager(HasTraits):
     def _get_max_trail_overlay(self):
         """Computed upper bound for trail_overlay, recalculated when trail_length changes."""
         return self.trail_length - 1
+
+    def _get_repeats_frozen(self):
+        if self.linear_repeats:
+            return False
+        return not any(layer.route.is_loop() for layer in self.layers)
+
+    @observe("repeats_frozen")
+    def _repeats_frozen_changed(self, event):
+        """Reset Repetitions / Repeat Duration when the freeze kicks in.
+
+        When Lin Reps goes off on a linear-only layer set, the two controls
+        have no effect, so pin them to 1 / 0. The view disables the spinners
+        for the duration via ``enabled_when="not routes_repeats_frozen"``.
+        """
+        if not self.repeats_frozen:
+            return
+        with self._suppress_repeat_exclusion():
+            self.trait_set(repetitions=1, repeat_duration=0)
 
     # --------------------------- Model Helpers --------------------------
 

--- a/device_viewer/models/route.py
+++ b/device_viewer/models/route.py
@@ -225,6 +225,7 @@ class RouteLayerManager(HasTraits):
 
     soft_start = Bool(False)
     soft_terminate = Bool(False)
+    linear_repeats = Bool(False)
 
     # -------- Step-params commit state --------
     # Empty dict means no step is currently selected — commit button disabled.
@@ -244,7 +245,7 @@ class RouteLayerManager(HasTraits):
         observe=(
             "_committed_params_baseline.items,"
             "duration,repetitions,repeat_duration,"
-            "trail_length,trail_overlay,soft_start,soft_terminate"
+            "trail_length,trail_overlay,soft_start,soft_terminate,linear_repeats"
         )
     )
 
@@ -263,6 +264,7 @@ class RouteLayerManager(HasTraits):
             "trail_overlay": int(self.trail_overlay),
             "soft_start": bool(self.soft_start),
             "soft_terminate": bool(self.soft_terminate),
+            "linear_repeats": bool(self.linear_repeats),
         }
 
     def apply_execution_params(self, params: dict) -> None:
@@ -281,6 +283,7 @@ class RouteLayerManager(HasTraits):
                 trail_overlay=params["trail_overlay"],
                 soft_start=params["soft_start"],
                 soft_terminate=params["soft_terminate"],
+                linear_repeats=params["linear_repeats"],
             )
         self.mark_params_committed()
 

--- a/device_viewer/services/route_execution_service.py
+++ b/device_viewer/services/route_execution_service.py
@@ -84,10 +84,9 @@ class RouteExecutionService(HasTraits):
             if channel in self.model.electrodes.channels_electrode_ids_map:
                 activated_electrode_ids.extend(self.model.electrodes.channels_electrode_ids_map[channel])
 
-        # Read the linear-repeats preference once so the plan and the
-        # rep/phase counters below agree on the mode.
-        from protocol_grid.preferences import ProtocolPreferences
-        linear_repeats = bool(ProtocolPreferences().linear_repeats)
+        # Source linear-repeats from the live RoutesModel (mirrors how
+        # soft_start / soft_terminate are sourced below).
+        linear_repeats = bool(self.model.routes.linear_repeats)
 
         # Build execution plan using PathExecutionService with raw params
         plan = PathExecutionService.calculate_execution_plan_from_params(

--- a/device_viewer/views/route_selection_view/route_selection_view.py
+++ b/device_viewer/views/route_selection_view/route_selection_view.py
@@ -100,9 +100,11 @@ UItem('object.routes.trail_overlay',
       tooltip="electrodes actuated from one step to overlay onto next step"),
 UItem('object.routes.repetitions',
       editor=RangeEditor(low=1, high=10000, mode='spinner'),
+      enabled_when="not object.routes_repeats_frozen",
       tooltip="Times to repeat loops execution"),
 UItem('object.routes.repeat_duration',
       editor=RangeEditor(low=0, high=10000, mode='spinner'),
+      enabled_when="not object.routes_repeats_frozen",
       tooltip="Seconds to repeat path executions. Idle time in end if loop cannot be completed"),
 )
 

--- a/device_viewer/views/route_selection_view/route_selection_view.py
+++ b/device_viewer/views/route_selection_view/route_selection_view.py
@@ -117,10 +117,12 @@ Label("Rep Duration", tooltip="Seconds to repeat path executions. Idle time in e
 soft_transition_settings = (
 UItem('object.routes.soft_start', tooltip="Ramp up overlay at start"),
 UItem('object.routes.soft_terminate', tooltip="Ramp down overlay at end"),
+UItem('object.routes.linear_repeats', tooltip="Replay linear paths Repetitions times"),
 )
 soft_transition_settings_header = (
 Label("Ramp Up", tooltip="Ramp up overlay at start"),
 Label("Ramp Dn", tooltip="Ramp down overlay at end"),
+Label("Lin Reps", tooltip="Replay linear paths Repetitions times"),
 )
 
 
@@ -137,6 +139,7 @@ protocol_execution_settings_group = VGroup(
     HGroup(
         VGroup(soft_transition_settings_header[0], soft_transition_settings[0]),
         VGroup(soft_transition_settings_header[1], soft_transition_settings[1]),
+        VGroup(soft_transition_settings_header[2], soft_transition_settings[2]),
     ),
     # enabled_when='free_mode',
 )

--- a/protocol_grid/consts.py
+++ b/protocol_grid/consts.py
@@ -60,17 +60,17 @@ ROW_TYPE_ROLE = Qt.UserRole + 1
 REPEAT_DURATION_CONTROLS_ROLE = Qt.UserRole + 3
 
 protocol_grid_fields = [
-    "Description", "ID", "Repetitions", 
-    "Duration", "Voltage", "Force", "Frequency", 
+    "Description", "ID", "Repetitions",
+    "Duration", "Voltage", "Force", "Frequency",
     "Message", "Repeat Duration",
     "Trail Length", "Trail Overlay",
-    "Ramp Up", "Ramp Dn",
+    "Ramp Up", "Ramp Dn", "Lin Reps",
     "Video", "Capture", "Record",
     "Volume Threshold", "Magnet", "Magnet Height (mm)",
     "Max. Path Length", "Run Time"
 ]
 protocol_grid_column_widths = [
-    120, 70, 80, 70, 70, 70, 90, 80, 130, 100, 100, 80, 80, 50, 140, 70, 110, 140, 90
+    120, 70, 80, 70, 70, 70, 90, 80, 130, 100, 100, 80, 80, 80, 50, 140, 70, 110, 140, 90
 ]
 hidden_fields = ["UID"]
 all_fields = protocol_grid_fields + hidden_fields
@@ -80,10 +80,10 @@ field_groupings = [
                 "Repeat Duration", "Repetitions",
                 "Trail Length", "Video", "Capture", "Record", "Volume Threshold",
                 "Magnet", "Magnet Height (mm)", "Trail Overlay",
-                "Ramp Up", "Ramp Dn"
+                "Ramp Up", "Ramp Dn", "Lin Reps"
             ] and f not in fixed_fields]),
             ("Device Viewer:", ["Repeat Duration", "Repetitions", "Trail Length",
-                                "Trail Overlay", "Ramp Up", "Ramp Dn",
+                                "Trail Overlay", "Ramp Up", "Ramp Dn", "Lin Reps",
                                 "Video", "Capture", "Record"]),
             ("Dropbot:", ["Volume Threshold"]),
             ("Magnet:", ["Magnet", "Magnet Height (mm)"]),
@@ -102,6 +102,7 @@ step_defaults = {
     "Trail Overlay": "0",
     "Ramp Up": "0",
     "Ramp Dn": "0",
+    "Lin Reps": "0",
     "Video": "0",
     "Capture": "0",
     "Record": "0",
@@ -136,6 +137,7 @@ copy_fields_for_new_step = [
     "Trail Overlay",
     "Ramp Up",
     "Ramp Dn",
+    "Lin Reps",
     "Video",
     "Capture",
     "Record",
@@ -146,7 +148,7 @@ copy_fields_for_new_step = [
     "Run Time"
 ]
 
-CHECKBOX_COLS = ("Video", "Capture", "Record", "Magnet", "Ramp Up", "Ramp Dn")
+CHECKBOX_COLS = ("Video", "Capture", "Record", "Magnet", "Ramp Up", "Ramp Dn", "Lin Reps")
 
 ALLOWED_group_fields = {
     "Description",

--- a/protocol_grid/extra_ui_elements.py
+++ b/protocol_grid/extra_ui_elements.py
@@ -371,23 +371,14 @@ class StatusBar(QScrollArea):
         self.lbl_next_step.setFixedWidth(180)
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        # Live indicator for the "Linear Repeats" preference.
-        # Clickable — emits `clicked` so the widget can toggle the pref.
-        self.lbl_linear_repeats = _ClickableLabel()
-        self.lbl_linear_repeats.setCursor(Qt.PointingHandCursor)
-        self.lbl_linear_repeats.setToolTip("Loop linear paths")
-        self.set_linear_repeats(False)
-
         for widget in [self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress,
-                      self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
-                      self.lbl_linear_repeats]:
+                      self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step]:
             widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             widget.setFixedHeight(20)
 
         layout.addWidget(self.lbl_total_time)
         layout.addWidget(self.lbl_step_time)
         layout.addWidget(repeat_widget)
-        layout.addWidget(self.lbl_linear_repeats)
         layout.addWidget(self.lbl_step_progress)
         layout.addWidget(self.lbl_step_repetition)
         layout.addWidget(self.lbl_recent_step)
@@ -414,18 +405,6 @@ class StatusBar(QScrollArea):
 
         QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)
     
-    def set_linear_repeats(self, enabled: bool):
-        """Update the Lin-Reps indicator to reflect the current preference.
-
-        ``✓ Lin-Reps`` in green when on; ``✗ Lin-Reps`` in red when off.
-        """
-        if enabled:
-            self.lbl_linear_repeats.setText("✓ Lin-Reps")
-            self.lbl_linear_repeats.setStyleSheet("QLabel { color: #2e7d32; font-weight: bold; }")
-        else:
-            self.lbl_linear_repeats.setText("✗ Lin-Reps")
-            self.lbl_linear_repeats.setStyleSheet("QLabel { color: #c62828; font-weight: bold; }")
-
     def _apply_styling(self):
         """Apply theme-specific styling to all labels and input fields."""
         if is_dark_mode():
@@ -453,9 +432,7 @@ class StatusBar(QScrollArea):
 
         label_style = f"QLabel {{ color: {text_color}; }}"
 
-        # Apply styling to all labels. `lbl_linear_repeats` keeps its own
-        # coloured stylesheet (set by `set_linear_repeats`), independent of
-        # the light/dark text color.
+        # Apply styling to all labels.
         all_labels = [
             self.lbl_total_time, self.lbl_step_time, self.lbl_repeat_protocol,
             self.lbl_repeat_protocol_status, self.lbl_step_progress,

--- a/protocol_grid/models/step_params_commit.py
+++ b/protocol_grid/models/step_params_commit.py
@@ -10,6 +10,7 @@ class StepParamsCommitMessage(BaseModel):
     trail_overlay: int
     soft_start: bool
     soft_terminate: bool
+    linear_repeats: bool
 
     def serialize(self) -> str:
         return self.model_dump_json()

--- a/protocol_grid/preferences.py
+++ b/protocol_grid/preferences.py
@@ -3,7 +3,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import List, Enum, Directory, Bool
+from traits.api import List, Enum, Directory
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import View, Item
 from envisage.ui.tasks.api import PreferencesCategory
@@ -60,11 +60,6 @@ class ProtocolPreferences(PreferencesHelper):
 
     capture_time = Enum(StepTime.START, StepTime.END, value=StepTime.START)
 
-    # When enabled, linear (non-loop) paths are also replayed `Repetitions`
-    # times. When disabled (default), only loop paths honor the Repetitions
-    # count and linear paths play exactly once.
-    linear_repeats = Bool(False)
-
     PROTOCOL_REPO_DIR = Directory()
 
     def _PROTOCOL_REPO_DIR_default(self) -> Path:
@@ -108,14 +103,6 @@ class ProtocolPreferencesPane(PreferencesPane):
         group_style_sheet=preferences_group_style_sheet,
     )
 
-    routes_execution_grid = create_grid_group(
-        ["linear_repeats"],
-        label_text=["Linear Repeats"],
-        group_label="Routes Execution Config",
-        group_show_border=True,
-        group_style_sheet=preferences_group_style_sheet,
-    )
-
     general_protocol_settings_grid = create_grid_group(
         items=["realtime_mode_settling_time_s", "logs_settling_time_s"],
         label_text = ["Realtime Mode Pre-Protocol (s)", "Logs Accepted Post-Protocol (s)"],
@@ -129,8 +116,6 @@ class ProtocolPreferencesPane(PreferencesPane):
         general_protocol_settings_grid,
         Item("_"),
         camera_settings_grid,
-        Item("_"),
-        routes_execution_grid,
         Item("_"),  # Separator to space this out from further contributions to the pane.
         resizable=True
     )

--- a/protocol_grid/protocol_grid_helpers.py
+++ b/protocol_grid/protocol_grid_helpers.py
@@ -426,6 +426,7 @@ _EXEC_PARAM_FIELD_MAP = {
     "trail_overlay":   ("Trail Overlay",   int),
     "soft_start":      ("Ramp Up",         lambda s: str(s).strip() in ("1", "true", "True")),
     "soft_terminate":  ("Ramp Dn",         lambda s: str(s).strip() in ("1", "true", "True")),
+    "linear_repeats":  ("Lin Reps",        lambda s: str(s).strip() in ("1", "true", "True")),
 }
 
 

--- a/protocol_grid/services/path_execution_service.py
+++ b/protocol_grid/services/path_execution_service.py
@@ -275,7 +275,8 @@ class PathExecutionService:
         on top.
 
         When ``linear_repeats`` is True, linear (non-loop) paths are replayed
-        ``Repetitions`` times. None (default) reads from ``ProtocolPreferences``.
+        ``Repetitions`` times. None (default) reads the per-step ``Lin Reps``
+        cell from the supplied ``step``.
         """
         duration = float(step.parameters.get("Duration", "1.0"))
         repetitions = int(step.parameters.get("Repetitions", "1"))
@@ -412,8 +413,8 @@ class PathExecutionService:
         count-based.  Soft start/terminate add ramp phases on top.
 
         When ``linear_repeats`` is True, linear (non-loop) paths are replayed
-        ``Repetitions`` times. When None (default), the preference is read
-        from ``ProtocolPreferences``.
+        ``Repetitions`` times. None (default) reads the per-step ``Lin Reps``
+        cell from the supplied ``step``.
         """
         duration = float(step.parameters.get("Duration", "1.0"))
         repetitions = int(step.parameters.get("Repetitions", "1"))

--- a/protocol_grid/services/path_execution_service.py
+++ b/protocol_grid/services/path_execution_service.py
@@ -10,14 +10,17 @@ from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
 
-def _read_linear_repeats_preference() -> bool:
-    """Read the `linear_repeats` preference. Localized so the import is lazy
-    (avoids circular-import issues at module load time)."""
+def _read_linear_repeats_from_step(step: "ProtocolStep") -> bool:
+    """Read the per-step `Lin Reps` cell value (parsed bool).
+
+    Falls back to False if the field is missing (legacy protocol JSON without
+    the column).
+    """
+    raw = step.parameters.get("Lin Reps", "0")
     try:
-        from protocol_grid.preferences import ProtocolPreferences
-        return bool(ProtocolPreferences().linear_repeats)
-    except Exception:
-        return False
+        return bool(int(raw))
+    except (TypeError, ValueError):
+        return str(raw).strip().lower() in ("1", "true", "yes", "on")
 
 class PathExecutionService:
 
@@ -282,7 +285,7 @@ class PathExecutionService:
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
 
         if linear_repeats is None:
-            linear_repeats = _read_linear_repeats_preference()
+            linear_repeats = _read_linear_repeats_from_step(step)
 
         if not device_state.has_paths():
             return duration
@@ -354,7 +357,7 @@ class PathExecutionService:
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
 
         if linear_repeats is None:
-            linear_repeats = _read_linear_repeats_preference()
+            linear_repeats = _read_linear_repeats_from_step(step)
 
         if not device_state.has_paths():
             return {"max_cycle_length": 1, "max_effective_repetitions": 1}
@@ -420,7 +423,7 @@ class PathExecutionService:
         trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
 
         if linear_repeats is None:
-            linear_repeats = _read_linear_repeats_preference()
+            linear_repeats = _read_linear_repeats_from_step(step)
 
         step_uid = step.parameters.get("UID", "")
         step_id = step.parameters.get("ID", "")

--- a/protocol_grid/state/device_state.py
+++ b/protocol_grid/state/device_state.py
@@ -29,7 +29,7 @@ class DeviceState:
     def calculated_duration(self, step_duration: float, repetitions: int,
                             repeat_duration: float = 1.0, trail_length: int = 1, trail_overlay: int = 0,
                             soft_start: bool = False, soft_end: bool = False,
-                            linear_repeats: bool = None):
+                            linear_repeats: bool = False):
         """Calculate the total duration for this step including idle/balance phases.
 
         When repeat_duration > 0 and the step has loops, each loop independently
@@ -38,14 +38,10 @@ class DeviceState:
         The total step duration is driven by the longest loop.
 
         When ``linear_repeats`` is True, open paths also play ``repetitions``
-        times. None reads from ``ProtocolPreferences``.
+        times. Callers are expected to pass the per-step value explicitly; the
+        default of False is only a safety net for test fixtures that don't care.
         """
-        from protocol_grid.services.path_execution_service import (
-            PathExecutionService, _read_linear_repeats_preference,
-        )
-
-        if linear_repeats is None:
-            linear_repeats = _read_linear_repeats_preference()
+        from protocol_grid.services.path_execution_service import PathExecutionService
 
         if not self.has_paths():
             calculated_time = step_duration * repetitions

--- a/protocol_grid/state/protocol_state.py
+++ b/protocol_grid/state/protocol_state.py
@@ -15,7 +15,7 @@ class ProtocolStep:
             self.parameters["Force"] = ""
         
         # normalize checkbox fields for consistent storage
-        for field in ("Magnet", "Video", "Capture", "Record", "Ramp Up", "Ramp Dn"):
+        for field in ("Magnet", "Video", "Capture", "Record", "Ramp Up", "Ramp Dn", "Lin Reps"):
             if field in self.parameters:
                 val = self.parameters[field]
                 if isinstance(val, bool):

--- a/protocol_grid/tests/test_message_listener_step_params.py
+++ b/protocol_grid/tests/test_message_listener_step_params.py
@@ -19,7 +19,7 @@ def test_listener_emits_step_params_commit_received(listener):
         step_id="uid-1",
         duration=2.0, repetitions=3, repeat_duration=0,
         trail_length=2, trail_overlay=1,
-        soft_start=True, soft_terminate=False,
+        soft_start=True, soft_terminate=False, linear_repeats=False,
     )
 
     received = []

--- a/protocol_grid/tests/test_step_params_commit.py
+++ b/protocol_grid/tests/test_step_params_commit.py
@@ -43,6 +43,7 @@ def test_extract_execution_params_happy_path():
         "Trail Overlay": "1",
         "Ramp Up": "1",
         "Ramp Dn": "0",
+        "Lin Reps": "1",
         "Voltage": "100",  # should be ignored
     }
     result = extract_execution_params(parameters)
@@ -54,6 +55,7 @@ def test_extract_execution_params_happy_path():
         "trail_overlay": 1,
         "soft_start": True,
         "soft_terminate": False,
+        "linear_repeats": True,
     }
 
 
@@ -75,6 +77,7 @@ def test_extract_execution_params_missing_keys_use_defaults():
     assert result["trail_overlay"] == 0
     assert result["soft_start"] is False
     assert result["soft_terminate"] is False
+    assert result["linear_repeats"] is False
 
 
 from protocol_grid.state.device_state import (
@@ -92,6 +95,7 @@ def test_device_state_message_carries_execution_params():
         "trail_overlay": 2,
         "soft_start": True,
         "soft_terminate": False,
+        "linear_repeats": False,
     }
     state = DeviceState()
     msg = device_state_to_device_viewer_message(

--- a/protocol_grid/tests/test_step_params_commit.py
+++ b/protocol_grid/tests/test_step_params_commit.py
@@ -14,6 +14,7 @@ def _valid_kwargs():
         trail_overlay=1,
         soft_start=True,
         soft_terminate=False,
+        linear_repeats=True,
     )
 
 
@@ -104,3 +105,10 @@ def test_device_state_message_execution_params_defaults_none():
     state = DeviceState()
     msg = device_state_to_device_viewer_message(state, step_uid="u1")
     assert msg.execution_params is None
+
+
+def test_step_params_commit_carries_linear_repeats():
+    msg = StepParamsCommitMessage(**_valid_kwargs())
+    assert msg.linear_repeats is True
+    rebuilt = StepParamsCommitMessage.deserialize(msg.serialize())
+    assert rebuilt.linear_repeats is True

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -745,6 +745,7 @@ class PGCWidget(QWidget):
             "Trail Overlay":   str(commit_msg.trail_overlay),
             "Ramp Up":         "1" if commit_msg.soft_start else "0",
             "Ramp Dn":         "1" if commit_msg.soft_terminate else "0",
+            "Lin Reps":        "1" if commit_msg.linear_repeats else "0",
         }
 
         self._programmatic_change = True

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -2685,8 +2685,8 @@ class PGCWidget(QWidget):
         if field in CHECKBOX_COLS:
             self._handle_checkbox_change(parent, row, field)
 
-            # Ramp Up/Dn affect Run Time — trigger recalculation
-            if field in ("Ramp Up", "Ramp Dn"):
+            # Ramp Up/Dn and Lin Reps affect Run Time — trigger recalculation
+            if field in ("Ramp Up", "Ramp Dn", "Lin Reps"):
                 desc_item = parent.child(row, 0)
                 if desc_item and desc_item.data(ROW_TYPE_ROLE) == STEP_TYPE:
                     self.update_single_step_dev_fields(desc_item, changed_field=field)

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -1922,7 +1922,7 @@ class PGCWidget(QWidget):
         return "1" if self._is_checkbox_checked(value) else "0"
 
     def _handle_checkbox_change(self, parent, row, field):
-        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn"):
+        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn", "Lin Reps"):
             col = protocol_grid_fields.index(field)
             item = parent.child(row, col)
             if item:
@@ -3074,6 +3074,12 @@ class PGCWidget(QWidget):
         else:
             repetitions_item.setFlags(repetitions_item.flags() | Qt.ItemIsEditable)
             repeat_duration_item.setFlags(repeat_duration_item.flags() | Qt.ItemIsEditable)
+
+        # setFlags alone doesn't always cause the view to repaint the cell's
+        # editability state — emit dataChanged explicitly so delegates pick up
+        # the change immediately.
+        for cell in (repetitions_item, repeat_duration_item):
+            self.model.dataChanged.emit(cell.index(), cell.index(), [Qt.EditRole])
 
     def update_single_step_dev_fields(self, desc_item, changed_field=None):
         """Recalculate derived columns (Max. Path Length, Run Time, etc.) for one step row.

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -706,6 +706,8 @@ class PGCWidget(QWidget):
                     device_state.to_dict()
                 )  # apply new device states to selected step
 
+                self._reconcile_step_freeze_state(target_item)
+
                 self.model_to_state()
                 self.load_from_state()
 
@@ -3089,6 +3091,61 @@ class PGCWidget(QWidget):
                         "(start and end on the same electrode).",
             )
 
+    def _reconcile_step_freeze_state(self, desc_item):
+        """Freeze Repetitions / Repeat Duration on linear-only steps with Lin Reps off.
+
+        A step is "frozen" when it has no loop path AND its ``Lin Reps`` cell is
+        off — in that mode, Repetitions > 1 is meaningless, so we pin the two
+        cells to ``"1"`` / ``"0"`` and disable editing. The cells become
+        editable again as soon as either condition flips (a loop route is added
+        or ``Lin Reps`` is toggled on).
+        """
+        if not desc_item or desc_item.data(ROW_TYPE_ROLE) != STEP_TYPE:
+            return
+
+        parent = desc_item.parent() or self.model.invisibleRootItem()
+        row = desc_item.row()
+
+        try:
+            lin_reps_col = protocol_grid_fields.index("Lin Reps")
+            repetitions_col = protocol_grid_fields.index("Repetitions")
+            repeat_duration_col = protocol_grid_fields.index("Repeat Duration")
+        except ValueError:
+            return
+
+        lin_reps_item = parent.child(row, lin_reps_col)
+        repetitions_item = parent.child(row, repetitions_col)
+        repeat_duration_item = parent.child(row, repeat_duration_col)
+        if not (lin_reps_item and repetitions_item and repeat_duration_item):
+            return
+
+        lin_reps_on = lin_reps_item.data(Qt.CheckStateRole) == Qt.Checked
+        device_state = desc_item.data(Qt.UserRole + 100)
+        has_loop = bool(
+            device_state
+            and device_state.has_paths()
+            and any(
+                len(path) >= 2 and path[0] == path[-1]
+                for path in device_state.paths
+            )
+        )
+        frozen = (not has_loop) and (not lin_reps_on)
+
+        if frozen:
+            self._programmatic_change = True
+            try:
+                if repetitions_item.text() != "1":
+                    repetitions_item.setText("1")
+                if repeat_duration_item.text() != "0":
+                    repeat_duration_item.setText("0")
+            finally:
+                self._programmatic_change = False
+            repetitions_item.setFlags(repetitions_item.flags() & ~Qt.ItemIsEditable)
+            repeat_duration_item.setFlags(repeat_duration_item.flags() & ~Qt.ItemIsEditable)
+        else:
+            repetitions_item.setFlags(repetitions_item.flags() | Qt.ItemIsEditable)
+            repeat_duration_item.setFlags(repeat_duration_item.flags() | Qt.ItemIsEditable)
+
     def update_single_step_dev_fields(self, desc_item, changed_field=None):
         """Recalculate derived columns (Max. Path Length, Run Time, etc.) for one step row.
 
@@ -3113,6 +3170,8 @@ class PGCWidget(QWidget):
         """
         if not desc_item or desc_item.data(ROW_TYPE_ROLE) != STEP_TYPE:
             return
+
+        self._reconcile_step_freeze_state(desc_item)
 
         parent = desc_item.parent() or self.model.invisibleRootItem()
         row = desc_item.row()

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -2659,6 +2659,14 @@ class PGCWidget(QWidget):
         if field in CHECKBOX_COLS:
             self._handle_checkbox_change(parent, row, field)
 
+            # Turning Lin Reps off on a linear-only step will revert any custom
+            # Repetitions / Repeat Duration to 1 / 0 — confirm before proceeding.
+            if field == "Lin Reps":
+                desc_item = parent.child(row, 0)
+                if desc_item and not self._confirm_lin_reps_toggle_off(desc_item, parent, row):
+                    QTimer.singleShot(0, self._reset_undo_snapshotted)
+                    return
+
             # Ramp Up/Dn and Lin Reps affect Run Time — trigger recalculation
             if field in ("Ramp Up", "Ramp Dn", "Lin Reps"):
                 desc_item = parent.child(row, 0)
@@ -3019,6 +3027,93 @@ class PGCWidget(QWidget):
         # Switch back: clear flag, recalculate repeat duration as perfect multiple
         desc_item.setData(False, REPEAT_DURATION_CONTROLS_ROLE)
         return True
+
+    def _confirm_lin_reps_toggle_off(self, desc_item, parent, row):
+        """Warn before turning Lin Reps off on a linear-only step with custom reps.
+
+        When the step has no loop path, ``_reconcile_step_freeze_state`` will
+        reset ``Repetitions`` to 1 and ``Repeat Duration`` to 0 once Lin Reps
+        goes off. If the user had set custom values there, this is silent data
+        loss — so we prompt first and revert the checkbox click on cancel.
+
+        Returns True if the toggle should proceed, False if it was reverted.
+        """
+        if desc_item.data(ROW_TYPE_ROLE) != STEP_TYPE:
+            return True
+        if getattr(self, "_loading_from_file", False):
+            return True
+        if self._programmatic_change:
+            return True
+
+        try:
+            lin_reps_col = protocol_grid_fields.index("Lin Reps")
+            repetitions_col = protocol_grid_fields.index("Repetitions")
+            repeat_duration_col = protocol_grid_fields.index("Repeat Duration")
+        except ValueError:
+            return True
+
+        lin_reps_item = parent.child(row, lin_reps_col)
+        repetitions_item = parent.child(row, repetitions_col)
+        repeat_duration_item = parent.child(row, repeat_duration_col)
+        if not (lin_reps_item and repetitions_item and repeat_duration_item):
+            return True
+
+        # Only warn when the user just turned Lin Reps OFF.
+        if lin_reps_item.data(Qt.CheckStateRole) == Qt.Checked:
+            return True
+
+        device_state = desc_item.data(Qt.UserRole + 100)
+        has_loop = bool(
+            device_state
+            and device_state.has_paths()
+            and any(
+                len(path) >= 2 and path[0] == path[-1]
+                for path in device_state.paths
+            )
+        )
+        # If the step has a loop path, turning Lin Reps off doesn't freeze
+        # anything — no data loss, no prompt needed.
+        if has_loop:
+            return True
+
+        try:
+            current_reps = int(repetitions_item.text() or "1")
+        except ValueError:
+            current_reps = 1
+        try:
+            current_repeat_dur = int(repeat_duration_item.text() or "0")
+        except ValueError:
+            current_repeat_dur = 0
+
+        if current_reps <= 1 and current_repeat_dur <= 0:
+            return True
+
+        result = confirm(
+            self,
+            "Turning Lin Reps off on a step with no loop path will reset "
+            "Repetitions and Repeat Duration to their defaults.",
+            title="Reset Repetitions?",
+            informative=(
+                f"This step currently has Repetitions = {current_reps} and "
+                f"Repeat Duration = {current_repeat_dur}. Without Lin Reps "
+                "and no loop path, these values have no effect and will be "
+                "reset to 1 and 0 respectively.<br><br>"
+                "Do you want to continue?"
+            ),
+            yes_label="Continue",
+            no_label="Cancel",
+        )
+        if result == YES:
+            return True
+
+        # Revert the checkbox click programmatically.
+        self._programmatic_change = True
+        try:
+            lin_reps_item.setData(Qt.Checked, Qt.CheckStateRole)
+            lin_reps_item.emitDataChanged()
+        finally:
+            self._programmatic_change = False
+        return False
 
     def _reconcile_step_freeze_state(self, desc_item):
         """Freeze Repetitions / Repeat Duration on linear-only steps with Lin Reps off.

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -1922,7 +1922,7 @@ class PGCWidget(QWidget):
         return "1" if self._is_checkbox_checked(value) else "0"
 
     def _handle_checkbox_change(self, parent, row, field):
-        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn", "Lin Reps"):
+        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn"):
             col = protocol_grid_fields.index(field)
             item = parent.child(row, col)
             if item:
@@ -3060,26 +3060,25 @@ class PGCWidget(QWidget):
         )
         frozen = (not has_loop) and (not lin_reps_on)
 
-        if frozen:
-            self._programmatic_change = True
-            try:
+        # All cell mutations below run as programmatic changes so the
+        # itemChanged re-entry from setText/setFlags doesn't trigger
+        # on_item_changed → update_single_step_dev_fields →
+        # _reconcile_step_freeze_state recursion.
+        prior_programmatic = self._programmatic_change
+        self._programmatic_change = True
+        try:
+            if frozen:
                 if repetitions_item.text() != "1":
                     repetitions_item.setText("1")
                 if repeat_duration_item.text() != "0":
                     repeat_duration_item.setText("0")
-            finally:
-                self._programmatic_change = False
-            repetitions_item.setFlags(repetitions_item.flags() & ~Qt.ItemIsEditable)
-            repeat_duration_item.setFlags(repeat_duration_item.flags() & ~Qt.ItemIsEditable)
-        else:
-            repetitions_item.setFlags(repetitions_item.flags() | Qt.ItemIsEditable)
-            repeat_duration_item.setFlags(repeat_duration_item.flags() | Qt.ItemIsEditable)
-
-        # setFlags alone doesn't always cause the view to repaint the cell's
-        # editability state — emit dataChanged explicitly so delegates pick up
-        # the change immediately.
-        for cell in (repetitions_item, repeat_duration_item):
-            self.model.dataChanged.emit(cell.index(), cell.index(), [Qt.EditRole])
+                repetitions_item.setFlags(repetitions_item.flags() & ~Qt.ItemIsEditable)
+                repeat_duration_item.setFlags(repeat_duration_item.flags() & ~Qt.ItemIsEditable)
+            else:
+                repetitions_item.setFlags(repetitions_item.flags() | Qt.ItemIsEditable)
+                repeat_duration_item.setFlags(repeat_duration_item.flags() | Qt.ItemIsEditable)
+        finally:
+            self._programmatic_change = prior_programmatic
 
     def update_single_step_dev_fields(self, desc_item, changed_field=None):
         """Recalculate derived columns (Max. Path Length, Run Time, etc.) for one step row.

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -2035,6 +2035,7 @@ class PGCWidget(QWidget):
             new_step.parameters["Trail Overlay"]   = str(dv_msg.execution_params["trail_overlay"])
             new_step.parameters["Ramp Up"]         = "1" if dv_msg.execution_params["soft_start"] else "0"
             new_step.parameters["Ramp Dn"]         = "1" if dv_msg.execution_params["soft_terminate"] else "0"
+            new_step.parameters["Lin Reps"]        = "1" if dv_msg.execution_params["linear_repeats"] else "0"
 
         new_step.device_state.from_dict(device_state.to_dict())
 

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -706,6 +706,10 @@ class PGCWidget(QWidget):
                     device_state.to_dict()
                 )  # apply new device states to selected step
 
+                # Reconcile before model_to_state() reads cell text — otherwise a
+                # newly-linear-only step would persist its stale Repetitions /
+                # Repeat Duration into state.sequence before load_from_state()
+                # rebuilds the cells.
                 self._reconcile_step_freeze_state(target_item)
 
                 self.model_to_state()

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from dropbot_preferences_ui.models import VoltageFrequencyRangePreferences
 from electrode_controller.consts import electrode_state_change_publisher
-from microdrop_application.dialogs.pyface_wrapper import confirm, NO, YES, success, error, warning, information
+from microdrop_application.dialogs.pyface_wrapper import confirm, NO, YES, success, error, information
 
 from PySide6.QtWidgets import (
     QWidget,
@@ -2714,7 +2714,6 @@ class PGCWidget(QWidget):
             # Mode-switch handlers return False (and revert the edit) when the
             # user cancels the confirmation dialog, so we bail out early.
             if field == "Repetitions":
-                self._enforce_step_repetition_requires_loop(desc_item, item)
                 if not self._handle_repetitions_mode_switch(desc_item, item):
                     return
             elif field == "Repeat Duration":
@@ -3052,48 +3051,6 @@ class PGCWidget(QWidget):
         # Switch back: clear flag, recalculate repeat duration as perfect multiple
         desc_item.setData(False, REPEAT_DURATION_CONTROLS_ROLE)
         return True
-
-    def _enforce_step_repetition_requires_loop(self, desc_item, repetitions_item):
-        """Revert Repetitions to 1 if the step has no looping route.
-
-        Skipped when the Linear Repeats preference is on — in that mode,
-        linear paths honor Repetitions too, so the guard would be incorrect.
-        """
-        try:
-            reps = int(repetitions_item.text() or "1")
-        except ValueError:
-            return
-        if reps <= 1:
-            return
-
-        try:
-            from protocol_grid.preferences import ProtocolPreferences
-            if bool(ProtocolPreferences().linear_repeats):
-                return
-        except Exception:
-            pass
-
-        device_state = desc_item.data(Qt.UserRole + 100)
-        has_loop = (
-            device_state
-            and device_state.has_paths()
-            and any(
-                len(path) >= 2 and path[0] == path[-1]
-                for path in device_state.paths
-            )
-        )
-        if not has_loop:
-            self._programmatic_change = True
-            try:
-                repetitions_item.setText("1")
-            finally:
-                self._programmatic_change = False
-            warning(
-                None,
-                title="Repetitions Not Supported",
-                message="Repetitions > 1 require a route that forms a loop "
-                        "(start and end on the same electrode).",
-            )
 
     def _reconcile_step_freeze_state(self, desc_item):
         """Freeze Repetitions / Repeat Duration on linear-only steps with Lin Reps off.

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -3168,6 +3168,10 @@ class PGCWidget(QWidget):
             is_soft_start = soft_start_item and soft_start_item.data(Qt.CheckStateRole) == Qt.Checked
             is_soft_end = soft_end_item and soft_end_item.data(Qt.CheckStateRole) == Qt.Checked
 
+            lin_reps_col = protocol_grid_fields.index("Lin Reps")
+            lin_reps_item = parent.child(row, lin_reps_col)
+            is_linear_repeats = bool(lin_reps_item and lin_reps_item.data(Qt.CheckStateRole) == Qt.Checked)
+
             estimated_repeat_duration = self._calculate_estimated_repeat_duration(
                 device_state, repetitions, duration, trail_length, trail_overlay
             )
@@ -3197,6 +3201,7 @@ class PGCWidget(QWidget):
                 trail_overlay,
                 soft_start=is_soft_start,
                 soft_end=is_soft_end,
+                linear_repeats=is_linear_repeats,
             )
 
             self._programmatic_change = True

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -366,8 +366,6 @@ class PGCWidget(QWidget):
         self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
 
         self.status_bar = StatusBar(self)
-        self.status_bar.lbl_linear_repeats.clicked.connect(self._toggle_linear_repeats_preference)
-        self._refresh_linear_repeats_indicator()
 
         layout = QVBoxLayout()
 
@@ -898,36 +896,7 @@ class PGCWidget(QWidget):
 
         clear_recursive(self.model.invisibleRootItem())
 
-    def _refresh_linear_repeats_indicator(self):
-        """Re-read the Linear Repeats preference and update the status bar."""
-        try:
-            from protocol_grid.preferences import ProtocolPreferences
-            enabled = bool(ProtocolPreferences().linear_repeats)
-        except Exception:
-            enabled = False
-        self.status_bar.set_linear_repeats(enabled)
-
-    def _toggle_linear_repeats_preference(self):
-        """Flip the Linear Repeats preference and refresh the indicator.
-
-        Recomputes every step's derived columns (Run Time, etc.) and any
-        parent group aggregations so totals reflect the new mode
-        immediately — linear paths that now repeat add to Run Time, and
-        vice-versa when disabling.
-        """
-        try:
-            from protocol_grid.preferences import ProtocolPreferences
-            prefs = ProtocolPreferences()
-            prefs.linear_repeats = not bool(prefs.linear_repeats)
-        except Exception as e:
-            logger.error(f"Failed to toggle Linear Repeats preference: {e}", exc_info=True)
-            return
-        self._refresh_linear_repeats_indicator()
-        self.update_step_dev_fields()
-        self.update_all_group_aggregations()
-
     def update_status_bar(self, status):
-        self._refresh_linear_repeats_indicator()
         self.status_bar.lbl_total_time.setText(
             f"Total Time: {int(status['total_time'])} s"
         )
@@ -1457,7 +1426,6 @@ class PGCWidget(QWidget):
         self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
         self.status_bar.lbl_next_step.setText("Next Step: -")
         self.status_bar.lbl_repeat_protocol_status.setText("0/")
-        self._refresh_linear_repeats_indicator()
 
     def _update_ui_enabled_state(self):
         enabled = not self._protocol_running

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -1922,7 +1922,7 @@ class PGCWidget(QWidget):
         return "1" if self._is_checkbox_checked(value) else "0"
 
     def _handle_checkbox_change(self, parent, row, field):
-        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn"):
+        if field in ("Video", "Capture", "Record", "Ramp Up", "Ramp Dn", "Lin Reps"):
             col = protocol_grid_fields.index(field)
             item = parent.child(row, col)
             if item:


### PR DESCRIPTION
## Summary

- Replace the global `ProtocolPreferences.linear_repeats` toggle with a per-step **`Lin Reps`** checkbox column on the protocol grid (under the "Device Viewer:" group, alongside `Ramp Up` / `Ramp Dn`).
- Add a matching `linear_repeats` toggle in the Device Viewer route-selection sidebar; live ad-hoc route execution now sources from `RoutesModel.linear_repeats`. The sync / commit-to-step button round-trips the value through the existing `StepParamsCommitMessage` plumbing (mirrors `soft_start` / `soft_terminate`).
- Replace the old "Repetitions Not Supported" warning dialog with a per-step **freeze** in the protocol grid: when a step has only linear (non-loop) paths AND `Lin Reps` is off, `Repetitions` and `Repeat Duration` are pinned to `1` / `0` and the cells are made non-editable. They become editable again as soon as a loop route is added or `Lin Reps` is checked. `Run Time` recalculation is localized to the touched step.
- Mirror that freeze in the **Device Viewer sidebar**: `Repetitions` / `Repeat Duration` spinners are disabled when `RoutesModel.linear_repeats` is off and no layer is a loop, and the values are pinned to `1` / `0` while frozen. Adding a loop route or checking `Lin Reps` re-enables the spinners.
- `Lin Reps` click on a grid row now refreshes the freeze and `Run Time` immediately — `_handle_checkbox_change` previously omitted `"Lin Reps"` from its `CheckStateRole` sync tuple, so the freeze/Run Time only updated when the row was next rebuilt (e.g. adding a step).
- Turning `Lin Reps` off on a linear-only grid step with non-default `Repetitions` / `Repeat Duration` now shows a confirmation dialog (via the project's `confirm(...)` wrapper) listing the current values; cancelling reverts the checkbox click.
- Remove the global preference, the preferences-pane entry, and the clickable `✓ Lin-Reps` / `✗ Lin-Reps` status-bar indicator.

## Architecture notes

The new `Lin Reps` column is plumbed end-to-end exactly like the existing `Ramp Up` / `Ramp Dn` (`soft_start` / `soft_terminate`) pattern — every site in that pipeline has a parallel addition for `linear_repeats`:

1. `RoutesModel.linear_repeats` Bool trait + dirty-tracker entry + `_current_params` / `apply_execution_params`
2. Sidebar `UItem` + `Label`
3. `StepParamsCommitMessage.linear_repeats: bool`
4. `_EXEC_PARAM_FIELD_MAP` entry mapping `"linear_repeats" ↔ "Lin Reps"`
5. Sync-button commit handler writes the cell
6. New-step-from-DV path seeds the cell
7. `ProtocolStep.__init__` checkbox normalization
8. Display reader passes the per-step value into `device_state.calculated_duration`
9. Live route execution sources from `RoutesModel.linear_repeats`

A new `_reconcile_step_freeze_state(desc_item)` helper enforces the grid freeze invariant; it is called at the top of `update_single_step_dev_fields` (covers file load, step add/copy, refresh after `Lin Reps` toggle) and immediately after the device-viewer state push (covers loop-route add/remove).

A new `_confirm_lin_reps_toggle_off(desc_item, parent, row)` helper intercepts the Lin-Reps-off grid click before the freeze runs, prompts via `confirm(...)` (same wrapper used for the Repetitions / Repeat-Duration mode switches), and reverts the `CheckStateRole` under `_programmatic_change` on cancel.

The sidebar freeze uses the same invariant, expressed as a Traits Property on `RouteLayerManager`:

- `RouteLayerManager.repeats_frozen = Property(observe="linear_repeats,layers.items.route.route.items")` — True iff `linear_repeats` is off AND no layer is a loop.
- `_repeats_frozen_changed` observer pins `repetitions=1` / `repeat_duration=0` when the freeze flips True (wrapped in `_suppress_repeat_exclusion()` so the mutual-exclusion observers don't interfere).
- `DeviceViewMainModel.routes_repeats_frozen = DelegatesTo("routes", prefix="repeats_frozen")` mirrors it to the top level so the view's `enabled_when` re-evaluates reliably — TraitsUI does not track nested paths in `enabled_when`.
- The two sidebar `RangeEditor` spinners gain `enabled_when="not object.routes_repeats_frozen"`.

**Spec:** `docs/superpowers/specs/2026-04-21-per-step-linear-repeats-design.md` (untracked in this branch — local design note)
**Plan:** `docs/superpowers/plans/2026-04-21-per-step-linear-repeats.md` (untracked in this branch — local plan note)

## Behavioural notes

- **Default off** for new steps; missing `Lin Reps` field on legacy protocol JSON falls back to `"0"` via `step.parameters.get("Lin Reps", "0")`.
- **Silent rewrite on legacy load:** a legacy step with `Repetitions > 1` but only linear paths will be silently rewritten to `Repetitions=1` / `Repeat Duration=0` the first time the step is rendered (this is the new invariant). Setting `Lin Reps` on for that step before/on load preserves the legacy value.
- **In-session grid edits are NOT silent:** toggling `Lin Reps` off through the grid UI on a step where `Repetitions > 1` or `Repeat Duration > 0` pops a confirm dialog before the reset, so users lose values only after an explicit "Continue".
- **Sidebar freeze IS silent:** the sidebar represents live ad-hoc state (not a saved step), so toggling `Lin Reps` off there just pins the spinners to `1` / `0` and disables them without a dialog — toggling `Lin Reps` back on or drawing a loop route restores them.
- 14 production files modified, 2 test files updated, 1 helper deleted (`_enforce_step_repetition_requires_loop`), 2 status-bar methods deleted (`_refresh_linear_repeats_indicator`, `_toggle_linear_repeats_preference`), 1 status-bar label deleted (`lbl_linear_repeats`).
- Across 24 small, reviewed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)