### PR TITLE
Paint read-only grid cells with a light-grey background (#359)

### DIFF
--- a/protocol_grid/protocol_grid_helpers.py
+++ b/protocol_grid/protocol_grid_helpers.py
@@ -8,7 +8,9 @@ from PySide6.QtWidgets import (
     QAbstractItemView,
 )
 
-from PySide6.QtGui import QStandardItem
+from PySide6.QtGui import QStandardItem, QBrush, QColor
+
+from microdrop_style.helpers import is_dark_mode
 
 from dropbot_controller.consts import SET_VOLTAGE, SET_FREQUENCY
 from dropbot_preferences_ui.models import VoltageFrequencyRangePreferences
@@ -54,6 +56,27 @@ class ProtocolGridDelegate(QStyledItemDelegate):
                 self._voltage_frequency_range_prefs = VoltageFrequencyRangePreferences()
         else:
             self._voltage_frequency_range_prefs = VoltageFrequencyRangePreferences()
+
+    # Light-grey fill for read-only cells so they visually match the column
+    # header row (issue #359). A cell is "read-only" here when the item is not
+    # editable AND not user-checkable — checkbox cells are non-editable by
+    # design but remain interactive, so we leave them alone.
+    _READ_ONLY_BG_LIGHT = QColor("#E8E8E8")
+    _READ_ONLY_BG_DARK = QColor("#3A3A3A")
+
+    @classmethod
+    def _read_only_brush(cls):
+        return QBrush(cls._READ_ONLY_BG_DARK if is_dark_mode() else cls._READ_ONLY_BG_LIGHT)
+
+    def initStyleOption(self, option, index):
+        super().initStyleOption(option, index)
+        model = index.model()
+        item = model.itemFromIndex(index) if hasattr(model, "itemFromIndex") else None
+        if item is None:
+            return
+        flags = item.flags()
+        if not (flags & Qt.ItemIsEditable) and not (flags & Qt.ItemIsUserCheckable):
+            option.backgroundBrush = self._read_only_brush()
 
     def paint(self, painter, option, index):
         """


### PR DESCRIPTION
## Summary

Closes #359.

Read-only cells in the protocol grid (`Max. Path Length`, `Run Time`, `Force`, step `ID`, frozen `Repetitions` / `Repeat Duration`, group-row placeholders, …) previously looked identical to editable cells. They now render with a light-grey fill that matches the column-header style, making "read-only" visually clear at a glance.

## Implementation

Implemented in `ProtocolGridDelegate.initStyleOption` (`protocol_grid/protocol_grid_helpers.py`), so the item's `Qt.ItemIsEditable` flag is the single source of truth:

- If the flag is cleared AND the item isn't `Qt.ItemIsUserCheckable`, the delegate sets `option.backgroundBrush` to the read-only colour.
- Checkbox cells (non-editable by design but still interactive) are explicitly excluded.
- Colour adapts to theme via `microdrop_style.helpers.is_dark_mode` — `#E8E8E8` in light mode, `#3A3A3A` in dark.

No need to also set `Qt.BackgroundRole` on items or keep a parallel style in sync when a cell flips editable (e.g. Magnet Height toggle, Lin Reps freeze) — the delegate re-evaluates on every paint.

## Test plan

- [x] Launch the app (`python examples/run_device_viewer_pluggable.py`, Redis running).
- [x] `Max. Path Length` and `Run Time` cells on step rows render light grey.
- [x] `Force` cells render light grey.
- [x] Step `ID` cells render light grey.
- [x] Group rows: non-editable placeholder cells render light grey.
- [x] Editable cells (Description, Duration, Voltage, Frequency, Message, Trail Length, Trail Overlay, Repetitions, Repeat Duration, Volume Threshold) stay on the normal background.
- [x] Checkbox cells (Ramp Up, Ramp Dn, Lin Reps, Video, Capture, Record, Magnet) stay on the normal background and remain clickable.
- [x] On a linear-only step with Lin Reps off: `Repetitions` / `Repeat Duration` cells flip to light grey (frozen); checking Lin Reps or adding a loop route restores the normal background.
- [x] `Magnet Height (mm)` cell: greyed when Magnet is off, normal when Magnet is on.
- [x] Dark mode: same cells render with the darker grey shade, stay readable.
- [x] Selection highlight still visible on greyed cells.

🤖 Generated with [Claude Code](https://claude.com/claude-code)