### PR TITLE
[PPT-2] Executor + StepContext.wait_for + pause/stop

### DIFF
--- a/docs/superpowers/plans/2026-04-22-ppt-2-executor.md
+++ b/docs/superpowers/plans/2026-04-22-ppt-2-executor.md
@@ -1,0 +1,2885 @@
+# PPT-2: Executor + StepContext.wait_for + pause/stop — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the protocol-execution layer for the new pluggable protocol tree: a `ProtocolExecutor` that runs a `RowManager`'s rows, fires the five `IColumnHandler` hooks per step in priority-bucket order, and lets handlers block on `ctx.wait_for(topic)` for asynchronous Dramatiq replies — with pause/stop/error semantics doing the right thing in every case.
+
+**Architecture:** Three-layer split inside a new `execution/` subpackage.
+1. **Plumbing** — small types: `AbortError`, `PauseEvent`, `ExecutorSignals` (QObject), `Mailbox`, `wait_first` helper. Each one-job, one-file.
+2. **Context** — `ProtocolContext` and `StepContext`. Per-step mailboxes are *pre-registered* before any hook publishes, so the publish-then-ack race never bites. A single Dramatiq listener actor holds an "active-step" pointer and routes incoming messages into the active step's mailboxes.
+3. **Executor** — `ProtocolExecutor` (HasTraits, hosted on its own `QThread`). Walks `iter_execution_steps`, fans hooks across priority buckets (sequential between buckets, parallel within), distinguishes `protocol_finished` / `protocol_aborted` / `protocol_error` by checking `_error` then `stop_event` in one place.
+
+**Tech Stack:** PySide6 / Qt6, Pyface, Traits/HasTraits, Dramatiq + Redis (the existing message router), `concurrent.futures.ThreadPoolExecutor` for in-bucket parallelism, `queue.SimpleQueue` + `threading.Event` for mailboxes, pytest (+ pytest gates for the Redis integration test).
+
+**Spec:** `src/docs/superpowers/specs/2026-04-22-ppt-2-executor-design.md`
+
+**Issue:** Closes #364 (sub-issue) — part of umbrella #361.
+
+**Branch:** `feat/ppt-2-executor` (already created when the spec was committed).
+
+---
+
+## File structure
+
+New files in this PR:
+
+```
+src/pluggable_protocol_tree/
+├── execution/
+│   ├── __init__.py
+│   ├── exceptions.py         # AbortError
+│   ├── events.py             # PauseEvent
+│   ├── signals.py            # ExecutorSignals(QObject)
+│   ├── step_context.py       # wait_first + Mailbox + ProtocolContext + StepContext
+│   ├── listener.py           # active-step pointer + Dramatiq executor_listener actor
+│   └── executor.py           # ProtocolExecutor
+├── builtins/
+│   └── repetitions_column.py     # 5th always-on built-in
+├── demos/
+│   └── message_column.py     # toy column for the demo
+└── tests/
+    ├── test_step_context.py
+    ├── test_executor.py
+    └── tests_with_redis_server_need/
+        ├── __init__.py
+        └── test_executor_redis_integration.py
+```
+
+Modified files:
+
+```
+src/pluggable_protocol_tree/
+├── plugin.py                 # _assemble_columns adds repetitions; start() registers subscriptions
+├── demos/run_widget.py       # adds Run/Pause/Stop toolbar + signal wiring
+└── tests/test_builtins.py    # adds repetitions tests
+```
+
+Each `execution/` file has one clear responsibility. The `step_context.py` file groups `Mailbox`, `wait_first`, `ProtocolContext`, and `StepContext` together because they form one cohesive unit (mailbox lifetime is bound to step context lifetime, and `wait_for` is the public method that ties them together) — splitting them across files would scatter their tight coupling for no payoff.
+
+---
+
+## Working directory and conventions
+
+All commands run from the **outer repo** at `C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py` (this is where `pixi.toml` lives). Pixi is required — never invoke `python` or `pytest` directly. The standard form is:
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest <args>"
+```
+
+All `git` operations run from the **submodule** at `C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src` on branch `feat/ppt-2-executor`. The pre-existing modification to `protocol_grid/preferences.py` must remain unstaged throughout — do not stage or modify it.
+
+Commit messages all start with `[PPT-2]` and end with the standard `Co-Authored-By:` trailer.
+
+---
+
+## Task 0: Verify branch + issue state
+
+**Files:** none (git/gh only)
+
+- [ ] **Step 1: Verify the working branch and clean tree (other than preferences.py)**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && git rev-parse --abbrev-ref HEAD && git status --short
+```
+
+Expected: `feat/ppt-2-executor` and only ` M protocol_grid/preferences.py` (or possibly nothing if the file is untouched in your local clone). Anything else means there's stray work — investigate before continuing.
+
+- [ ] **Step 2: Verify issue #364 is open and the spec commit is on the branch**
+
+```bash
+gh issue view 364 --repo Blue-Ocean-Technologies-Inc/Microdrop --json state,title
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && git log --oneline -3
+```
+
+Expected: issue state `OPEN`, title `[PPT-2] Executor + StepContext.wait_for + pause/stop`. Most recent commit on the branch is `[Spec] PPT-2 executor — design doc`.
+
+---
+
+## Task 1: Package scaffolding for `execution/`
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/__init__.py`
+
+- [ ] **Step 1: Create the directory and empty package init**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  mkdir -p pluggable_protocol_tree/execution
+```
+
+Then create `src/pluggable_protocol_tree/execution/__init__.py` as an **empty file** (no content).
+
+- [ ] **Step 2: Smoke-test the package is importable**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c 'import pluggable_protocol_tree.execution; print(pluggable_protocol_tree.execution.__name__)'"
+```
+
+Expected: `pluggable_protocol_tree.execution`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/__init__.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Package scaffolding for execution subpackage
+
+Empty __init__.py so subsequent tasks can land focused modules
+(exceptions, events, signals, step_context, listener, executor)
+without touching package import shape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `AbortError` exception
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/exceptions.py`
+- Create: `src/pluggable_protocol_tree/tests/test_step_context.py` (just the imports + first test for now)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_step_context.py`:
+
+```python
+"""Tests for execution.exceptions, .events, .step_context.
+
+Pure-Python unit tests — no Qt application, no Dramatiq broker.
+Behavioral tests for Mailbox / ProtocolContext / StepContext / wait_for
+get appended in later tasks; this file starts with the smallest
+foundational types."""
+
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def test_abort_error_is_exception():
+    assert issubclass(AbortError, Exception)
+
+
+def test_abort_error_carries_message():
+    e = AbortError("stop pressed")
+    assert str(e) == "stop pressed"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.exceptions`.
+
+- [ ] **Step 3: Implement `AbortError`**
+
+Create `src/pluggable_protocol_tree/execution/exceptions.py`:
+
+```python
+"""Execution-layer exceptions."""
+
+
+class AbortError(Exception):
+    """Raised inside ctx.wait_for() when the executor's stop_event fires.
+
+    Hooks should let it propagate; the executor catches it at the bucket
+    boundary, sets stop_event (idempotent), drains other in-flight hooks,
+    and routes to the protocol_aborted or protocol_error terminal signal
+    via _emit_terminal_signal().
+    """
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/exceptions.py pluggable_protocol_tree/tests/test_step_context.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] AbortError exception
+
+Marker exception raised by ctx.wait_for() when the executor's stop_event
+fires mid-wait. Lets handlers stay agnostic about cooperative shutdown
+while the executor handles the routing decision (aborted vs error) at
+the bucket boundary.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `PauseEvent`
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/events.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_step_context.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_step_context.py`:
+
+```python
+# --- PauseEvent ---
+
+import threading
+import time
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+
+
+def test_pause_event_starts_unset_and_cleared():
+    p = PauseEvent()
+    assert p.is_set() is False
+
+
+def test_pause_event_set_and_clear_round_trip():
+    p = PauseEvent()
+    p.set()
+    assert p.is_set() is True
+    p.clear()
+    assert p.is_set() is False
+
+
+def test_pause_event_wait_cleared_returns_immediately_when_unset():
+    p = PauseEvent()
+    # Already cleared; should not block.
+    start = time.monotonic()
+    p.wait_cleared(timeout=0.5)
+    assert time.monotonic() - start < 0.1
+
+
+def test_pause_event_wait_cleared_blocks_until_clear():
+    p = PauseEvent()
+    p.set()
+    woken = threading.Event()
+
+    def waiter():
+        p.wait_cleared(timeout=2.0)
+        woken.set()
+
+    t = threading.Thread(target=waiter, daemon=True)
+    t.start()
+    # waiter should still be blocked
+    assert woken.wait(timeout=0.1) is False
+    p.clear()
+    assert woken.wait(timeout=1.0) is True
+    t.join(timeout=1.0)
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.events`.
+
+- [ ] **Step 3: Implement `PauseEvent`**
+
+Create `src/pluggable_protocol_tree/execution/events.py`:
+
+```python
+"""Synchronization primitives used by the executor."""
+
+import threading
+
+
+class PauseEvent:
+    """A pause/resume primitive built on two ``threading.Event``s.
+
+    ``threading.Event`` itself doesn't have a ``wait_cleared()`` method,
+    but the executor's main loop needs to block at a step boundary until
+    the user resumes — a single Event would only let it block until
+    *something* is set, not until the existing 'set' state goes away.
+    Implementing it as two events (one fires on set, the other on clear)
+    keeps each side a simple Event.wait() under the hood.
+    """
+
+    def __init__(self):
+        self._set = threading.Event()
+        self._cleared = threading.Event()
+        self._cleared.set()       # initial state: not paused
+
+    def set(self):
+        """Mark paused. wait_cleared() will block until clear() is called."""
+        self._set.set()
+        self._cleared.clear()
+
+    def clear(self):
+        """Mark unpaused. Wakes any thread blocked in wait_cleared()."""
+        self._set.clear()
+        self._cleared.set()
+
+    def is_set(self) -> bool:
+        return self._set.is_set()
+
+    def wait_cleared(self, timeout: float = None) -> bool:
+        """Block until the event is cleared (i.e., not paused).
+
+        Returns True if the event was cleared, False on timeout.
+        Returns immediately if already clear.
+        """
+        return self._cleared.wait(timeout)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: 6 passed (2 from Task 2 + 4 here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/events.py pluggable_protocol_tree/tests/test_step_context.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] PauseEvent: pause/resume primitive
+
+Two-Event composition (set / cleared) so the executor's main loop can
+block at a step boundary via wait_cleared() until the user resumes.
+threading.Event alone has wait() (block-until-set) but no symmetric
+"block until cleared", which is what pause/resume actually needs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `ExecutorSignals` (QObject)
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/signals.py`
+- Create: `src/pluggable_protocol_tree/tests/test_executor.py` (just imports + signals tests for now)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/pluggable_protocol_tree/tests/test_executor.py`:
+
+```python
+"""Tests for execution.executor and .signals.
+
+Most tests do NOT require a QApplication — Qt direct-connect signals work
+without an event loop when sender and receiver share a thread. Tests that
+need cross-thread signal delivery construct a QApplication via fixture.
+"""
+
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+
+
+def test_executor_signals_constructible_without_qapplication():
+    s = ExecutorSignals()
+    # All seven expected signals are present as attributes.
+    for name in (
+        "protocol_started", "step_started", "step_finished",
+        "protocol_paused", "protocol_resumed",
+        "protocol_finished", "protocol_aborted", "protocol_error",
+    ):
+        assert hasattr(s, name), f"missing signal: {name}"
+
+
+def test_executor_signals_direct_connect_invokes_slot():
+    s = ExecutorSignals()
+    received = []
+    s.protocol_finished.connect(lambda: received.append("finished"))
+    s.protocol_finished.emit()
+    assert received == ["finished"]
+
+
+def test_executor_signals_step_started_carries_row():
+    s = ExecutorSignals()
+    received = []
+    s.step_started.connect(lambda row: received.append(row))
+    sentinel = object()
+    s.step_started.emit(sentinel)
+    assert received == [sentinel]
+
+
+def test_executor_signals_protocol_error_carries_message():
+    s = ExecutorSignals()
+    received = []
+    s.protocol_error.connect(lambda msg: received.append(msg))
+    s.protocol_error.emit("oops")
+    assert received == ["oops"]
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.signals`.
+
+- [ ] **Step 3: Implement `ExecutorSignals`**
+
+Create `src/pluggable_protocol_tree/execution/signals.py`:
+
+```python
+"""QObject carrying the executor's UI-facing signals.
+
+Lives on a QObject (not the Traits-based ProtocolExecutor) so Qt's
+queued-connection machinery can marshal emissions from the executor's
+worker thread to slots living on the GUI thread automatically.
+
+UI consumers connect directly:
+    executor.qsignals.step_started.connect(tree_model.set_active_node)
+"""
+
+from pyface.qt.QtCore import QObject, Signal
+
+
+class ExecutorSignals(QObject):
+    # Lifecycle
+    protocol_started   = Signal()
+    protocol_paused    = Signal()
+    protocol_resumed   = Signal()
+    protocol_finished  = Signal()           # ran to completion
+    protocol_aborted   = Signal()           # user pressed Stop
+    protocol_error     = Signal(str)        # exception raised in a hook
+
+    # Per-step
+    step_started       = Signal(object)     # row
+    step_finished      = Signal(object)     # row
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/signals.py pluggable_protocol_tree/tests/test_executor.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] ExecutorSignals — UI-facing Qt signal bundle
+
+Eight signals split across protocol-lifecycle and per-step. Lives on a
+QObject (not the Traits ProtocolExecutor) so Qt can marshal emissions
+from the executor's worker thread to GUI-thread slots via queued
+connections automatically.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `Mailbox` + `wait_first`
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/step_context.py` (with just the helpers for now)
+- Modify: `src/pluggable_protocol_tree/tests/test_step_context.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_step_context.py`:
+
+```python
+# --- wait_first ---
+
+from pluggable_protocol_tree.execution.step_context import wait_first
+
+
+def test_wait_first_returns_event_that_fires_first():
+    a = threading.Event()
+    b = threading.Event()
+    threading.Timer(0.05, b.set).start()
+    fired = wait_first([a, b], timeout=1.0)
+    assert fired is b
+
+
+def test_wait_first_returns_none_on_timeout():
+    a = threading.Event()
+    b = threading.Event()
+    fired = wait_first([a, b], timeout=0.05)
+    assert fired is None
+
+
+def test_wait_first_returns_immediately_when_event_already_set():
+    a = threading.Event()
+    a.set()
+    start = time.monotonic()
+    fired = wait_first([a], timeout=1.0)
+    assert fired is a
+    assert time.monotonic() - start < 0.1
+
+
+# --- Mailbox ---
+
+from pluggable_protocol_tree.execution.step_context import Mailbox
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def test_mailbox_drain_one_returns_pre_deposited_immediately():
+    mb = Mailbox()
+    mb.deposit({"v": 1})
+    stop = threading.Event()
+    start = time.monotonic()
+    item = mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+    assert item == {"v": 1}
+    assert time.monotonic() - start < 0.1
+
+
+def test_mailbox_drain_one_blocks_then_wakes_on_deposit():
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, lambda: mb.deposit("hello")).start()
+    item = mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+    assert item == "hello"
+
+
+def test_mailbox_drain_one_raises_timeout_when_nothing_arrives():
+    mb = Mailbox()
+    stop = threading.Event()
+    with __import__("pytest").raises(TimeoutError):
+        mb.drain_one(predicate=None, timeout=0.05, stop_event=stop)
+
+
+def test_mailbox_drain_one_raises_abort_when_stop_pre_set():
+    mb = Mailbox()
+    stop = threading.Event()
+    stop.set()
+    with __import__("pytest").raises(AbortError):
+        mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+
+
+def test_mailbox_drain_one_raises_abort_when_stop_fires_mid_wait():
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, stop.set).start()
+    start = time.monotonic()
+    with __import__("pytest").raises(AbortError):
+        mb.drain_one(predicate=None, timeout=2.0, stop_event=stop)
+    # Must abort promptly, not wait out the 2s timeout.
+    assert time.monotonic() - start < 0.5
+
+
+def test_mailbox_predicate_rejects_then_accepts():
+    mb = Mailbox()
+    stop = threading.Event()
+    mb.deposit({"ready": False})
+    mb.deposit({"ready": True})
+    item = mb.drain_one(
+        predicate=lambda p: p.get("ready"),
+        timeout=1.0,
+        stop_event=stop,
+    )
+    assert item == {"ready": True}
+
+
+def test_mailbox_predicate_rejects_all_pre_deposited_then_blocks():
+    mb = Mailbox()
+    stop = threading.Event()
+    mb.deposit({"ready": False})
+    mb.deposit({"ready": False})
+    threading.Timer(0.05, lambda: mb.deposit({"ready": True})).start()
+    item = mb.drain_one(
+        predicate=lambda p: p.get("ready"),
+        timeout=1.0,
+        stop_event=stop,
+    )
+    assert item == {"ready": True}
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.step_context`.
+
+- [ ] **Step 3: Implement `wait_first` and `Mailbox`**
+
+Create `src/pluggable_protocol_tree/execution/step_context.py`:
+
+```python
+"""Per-protocol and per-step contexts plus the mailbox machinery that
+backs ctx.wait_for().
+
+This file groups Mailbox, wait_first, ProtocolContext, and StepContext
+together because they form one cohesive unit — a Mailbox's lifetime is
+bound to a StepContext's lifetime, and wait_for is the public method
+that ties them together. Splitting them across files would scatter
+their tight coupling for no payoff.
+
+ProtocolContext / StepContext land in Task 6 — this task ships only the
+two primitives Mailbox depends on.
+"""
+
+import queue
+import threading
+import time
+from typing import Callable, Optional
+
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def wait_first(events: list, timeout: float) -> Optional[threading.Event]:
+    """Block until any of `events` fires, or the timeout elapses.
+
+    Returns the Event that fired, or None on timeout. Implemented by
+    polling each event with a short slice — Python's stdlib does not
+    expose a kqueue/epoll-style multi-event wait, and rolling a
+    waker-channel implementation is more code than the executor needs.
+
+    The poll interval is small enough that responsiveness is dominated
+    by the OS scheduler, not by the polling cadence.
+    """
+    deadline = time.monotonic() + timeout
+    poll_interval = 0.01      # 10ms
+    while True:
+        for e in events:
+            if e.is_set():
+                return e
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        time.sleep(min(poll_interval, remaining))
+
+
+class Mailbox:
+    """A SimpleQueue-backed buffer with a wake event.
+
+    One Mailbox per (active step, topic) pair. The dramatiq listener
+    deposits payloads; ``drain_one`` blocks until a satisfying item is
+    available, the stop_event fires, or the timeout expires.
+    """
+
+    def __init__(self):
+        self._queue = queue.SimpleQueue()
+        self._wake = threading.Event()
+
+    def deposit(self, payload):
+        """Push a payload onto the queue and wake any blocked waiter."""
+        self._queue.put(payload)
+        self._wake.set()
+
+    def drain_one(self, predicate: Optional[Callable], timeout: float,
+                  stop_event: threading.Event):
+        """Return the first queued item satisfying ``predicate``.
+
+        Discards predicate-rejected items (they are not requeued).
+        Raises ``TimeoutError`` if the deadline elapses with no match.
+        Raises ``AbortError`` if ``stop_event`` is set, either before
+        the call or while the call is blocked.
+        """
+        if stop_event.is_set():
+            raise AbortError("stop_event set before wait_for")
+        deadline = time.monotonic() + timeout
+        while True:
+            # 1) Drain any currently-queued items.
+            while True:
+                try:
+                    item = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if predicate is None or predicate(item):
+                    return item
+                # else discard and continue
+            # 2) Block for more.
+            self._wake.clear()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"wait_for timed out after {timeout}s"
+                )
+            triggered = wait_first(
+                [self._wake, stop_event], timeout=remaining
+            )
+            if triggered is None:
+                raise TimeoutError(
+                    f"wait_for timed out after {timeout}s"
+                )
+            if triggered is stop_event:
+                raise AbortError("stop_event fired while waiting")
+            # else self._wake fired; loop back and try to drain.
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: 16 passed (2 + 4 + 3 + 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/step_context.py pluggable_protocol_tree/tests/test_step_context.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Mailbox + wait_first helper
+
+Mailbox buffers payloads from the dramatiq listener until the active
+hook's ctx.wait_for() drains them. Predicate-rejected items are
+discarded; TimeoutError on deadline; AbortError when stop_event fires
+(immediately if pre-set, promptly if mid-wait — without waiting out
+the timeout).
+
+wait_first polls a list of Events for the first to fire (10ms slice),
+since stdlib doesn't expose a cross-event multi-wait. Used by Mailbox
+to break out of a long-timeout wait the moment Stop is pressed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `ProtocolContext` + `StepContext` + `wait_for`
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/execution/step_context.py` (append)
+- Modify: `src/pluggable_protocol_tree/tests/test_step_context.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_step_context.py`:
+
+```python
+# --- ProtocolContext + StepContext + wait_for ---
+
+from pluggable_protocol_tree.execution.step_context import (
+    ProtocolContext, StepContext,
+)
+from pluggable_protocol_tree.models.row import BaseRow
+
+
+def _make_step_ctx(topics: list[str]) -> StepContext:
+    """Helper: build a StepContext with mailboxes pre-opened for `topics`."""
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    for t in topics:
+        step.open_mailbox(t)
+    return step
+
+
+def test_wait_for_returns_payload_after_deposit():
+    step = _make_step_ctx(["t/foo"])
+    threading.Timer(
+        0.05, lambda: step.deposit("t/foo", {"v": 1})
+    ).start()
+    payload = step.wait_for("t/foo", timeout=1.0)
+    assert payload == {"v": 1}
+
+
+def test_wait_for_returns_pre_deposited_immediately():
+    """The race-fix that justifies the per-step pre-registration model."""
+    step = _make_step_ctx(["t/ack"])
+    step.deposit("t/ack", {"ok": True})
+    start = time.monotonic()
+    payload = step.wait_for("t/ack", timeout=1.0)
+    assert payload == {"ok": True}
+    assert time.monotonic() - start < 0.1
+
+
+def test_wait_for_unknown_topic_raises_keyerror():
+    """Unopened topics indicate a missing wait_for_topics declaration."""
+    step = _make_step_ctx(["t/known"])
+    import pytest
+    with pytest.raises(KeyError):
+        step.wait_for("t/unknown", timeout=0.1)
+
+
+def test_wait_for_timeout():
+    step = _make_step_ctx(["t/never"])
+    import pytest
+    with pytest.raises(TimeoutError):
+        step.wait_for("t/never", timeout=0.05)
+
+
+def test_wait_for_abort_when_stop_event_fires():
+    step = _make_step_ctx(["t/never"])
+    threading.Timer(0.05, step.protocol.stop_event.set).start()
+    import pytest
+    with pytest.raises(AbortError):
+        step.wait_for("t/never", timeout=2.0)
+
+
+def test_wait_for_predicate_filters_payloads():
+    step = _make_step_ctx(["t/status"])
+    step.deposit("t/status", {"ready": False})
+    step.deposit("t/status", {"ready": True})
+    payload = step.wait_for(
+        "t/status", timeout=1.0,
+        predicate=lambda p: p.get("ready") is True,
+    )
+    assert payload == {"ready": True}
+
+
+def test_protocol_context_scratch_is_per_protocol():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    proto.scratch["k"] = "v"
+    assert proto.scratch["k"] == "v"
+
+
+def test_step_context_scratch_is_per_step_and_independent():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    a = StepContext(row=BaseRow(name="a"), protocol=proto)
+    b = StepContext(row=BaseRow(name="b"), protocol=proto)
+    a.scratch["k"] = "av"
+    b.scratch["k"] = "bv"
+    assert a.scratch["k"] == "av"
+    assert b.scratch["k"] == "bv"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: ImportError on `ProtocolContext` / `StepContext`.
+
+- [ ] **Step 3: Append `ProtocolContext` + `StepContext` to `step_context.py`**
+
+Append to `src/pluggable_protocol_tree/execution/step_context.py`:
+
+```python
+# --- contexts ---
+
+from traits.api import Any, Dict, HasTraits, Instance, Str, List
+
+from pluggable_protocol_tree.interfaces.i_column import IColumn
+from pluggable_protocol_tree.models.row import BaseRow
+
+
+class ProtocolContext(HasTraits):
+    """Spans one protocol run.
+
+    Hooks reach this from a StepContext via ``ctx.protocol``. Use
+    ``scratch`` for cross-step state (e.g. cumulative stats). The
+    ``stop_event`` lets long-running CPU hooks check for Stop without
+    going through ctx.wait_for; e.g.
+    ``while not ctx.protocol.stop_event.is_set(): ...``.
+    """
+    columns    = List(Instance(IColumn))
+    scratch    = Dict(Str, Any,
+                      desc="protocol-scoped scratch (cleared on each run)")
+    stop_event = Instance(threading.Event)
+
+
+class StepContext(HasTraits):
+    """Spans one row's execution.
+
+    Hooks call ``wait_for(topic, ...)`` on this. Mailboxes are opened by
+    the executor before any hook runs (so a hook can publish a request
+    and immediately wait for the ack without losing fast replies).
+    """
+    row       = Instance(BaseRow)
+    protocol  = Instance(ProtocolContext)
+    scratch   = Dict(Str, Any,
+                     desc="step-scoped scratch (cleared per step)")
+    _mailboxes = Dict(Str, Instance(Mailbox))
+
+    def open_mailbox(self, topic: str) -> None:
+        """Pre-register a mailbox for ``topic``. Called by the executor
+        at step start for every topic in the union of all handlers'
+        wait_for_topics. Idempotent."""
+        if topic not in self._mailboxes:
+            self._mailboxes[topic] = Mailbox()
+
+    def deposit(self, topic: str, payload) -> None:
+        """Called by the dramatiq listener for any message on a topic
+        the active step has a mailbox for. Drops messages for topics
+        without an open mailbox (handler didn't declare wait_for)."""
+        box = self._mailboxes.get(topic)
+        if box is not None:
+            box.deposit(payload)
+
+    def wait_for(self, topic: str, timeout: float = 5.0,
+                 predicate: Optional[Callable] = None):
+        """Block until a message on ``topic`` satisfying ``predicate``
+        arrives, or the timeout/stop fires.
+
+        Returns the payload. Raises:
+          * ``KeyError`` if ``topic`` was not declared in any handler's
+            ``wait_for_topics`` (the executor would not have opened a
+            mailbox; waiting would block forever).
+          * ``TimeoutError`` after ``timeout`` seconds.
+          * ``AbortError`` if the protocol's stop_event fires.
+        """
+        try:
+            box = self._mailboxes[topic]
+        except KeyError:
+            raise KeyError(
+                f"wait_for({topic!r}) called but topic not in any handler's "
+                f"wait_for_topics; declare it on the IColumnHandler."
+            )
+        return box.drain_one(
+            predicate=predicate,
+            timeout=timeout,
+            stop_event=self.protocol.stop_event,
+        )
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: 24 passed (16 + 8).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/step_context.py pluggable_protocol_tree/tests/test_step_context.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] ProtocolContext + StepContext + ctx.wait_for
+
+ProtocolContext spans the protocol run; StepContext spans one row.
+Mailboxes are pre-opened by the executor at step start (covering the
+union of all handlers' wait_for_topics), so a hook can publish a
+request and immediately wait for the reply without the publish-then-
+register race losing fast acks.
+
+ctx.wait_for(topic) raises KeyError if the topic isn't pre-opened,
+making the missing-wait_for_topics declaration a clear error rather
+than a silent forever-block. TimeoutError on deadline, AbortError on
+stop_event — both handled by Mailbox.drain_one already.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Listener — Dramatiq actor + active-step pointer
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/listener.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_step_context.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_step_context.py`:
+
+```python
+# --- listener active-step pointer ---
+
+from pluggable_protocol_tree.execution import listener as _listener
+
+
+def test_listener_active_step_initially_none():
+    _listener.clear_active_step()
+    assert _listener.get_active_step() is None
+
+
+def test_listener_set_then_get_returns_step():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    _listener.set_active_step(step)
+    try:
+        assert _listener.get_active_step() is step
+    finally:
+        _listener.clear_active_step()
+
+
+def test_listener_clear_resets_to_none():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    _listener.set_active_step(step)
+    _listener.clear_active_step()
+    assert _listener.get_active_step() is None
+
+
+def test_listener_route_to_active_step_deposits_into_mailbox():
+    """Direct route() helper bypasses Dramatiq for unit testing."""
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    step.open_mailbox("t/foo")
+    _listener.set_active_step(step)
+    try:
+        _listener.route_to_active_step("t/foo", {"v": 42})
+        item = step.wait_for("t/foo", timeout=0.1)
+        assert item == {"v": 42}
+    finally:
+        _listener.clear_active_step()
+
+
+def test_listener_route_with_no_active_step_drops_silently():
+    _listener.clear_active_step()
+    # No exception, no observable side effect.
+    _listener.route_to_active_step("t/foo", {"v": 1})
+
+
+def test_listener_route_for_unopened_topic_drops_silently():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    step.open_mailbox("t/known")
+    _listener.set_active_step(step)
+    try:
+        # No exception — the listener simply has nowhere to put it.
+        _listener.route_to_active_step("t/unknown", {"v": 1})
+    finally:
+        _listener.clear_active_step()
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.listener`.
+
+- [ ] **Step 3: Implement the listener**
+
+Create `src/pluggable_protocol_tree/execution/listener.py`:
+
+```python
+"""Dramatiq listener actor + active-step pointer.
+
+The actor itself receives every message published on any topic the
+plugin's start() method aggregated from contributed handlers'
+wait_for_topics. It routes payloads into the active step's mailbox via
+``route_to_active_step`` — the same function tests can call directly to
+bypass Dramatiq.
+
+Only one protocol runs at a time, so a single module-level pointer is
+enough. set/clear are guarded by a lock so the listener thread and the
+executor's main loop don't see a torn read on the pointer transition
+between steps.
+"""
+
+import threading
+from typing import Optional
+
+import dramatiq
+
+from pluggable_protocol_tree.execution.step_context import StepContext
+
+
+_active_step_ctx: Optional[StepContext] = None
+_active_lock = threading.Lock()
+
+
+def set_active_step(step_ctx: StepContext) -> None:
+    """Called by the executor at the start of each step (before any
+    hook runs)."""
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = step_ctx
+
+
+def clear_active_step() -> None:
+    """Called by the executor at the end of each step. Subsequent
+    incoming messages on what *was* the step's topics are dropped
+    silently until the next set_active_step()."""
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = None
+
+
+def get_active_step() -> Optional[StepContext]:
+    """For tests + the dramatiq actor."""
+    with _active_lock:
+        return _active_step_ctx
+
+
+def route_to_active_step(topic: str, payload) -> None:
+    """Deposit a payload into the active step's mailbox for ``topic``.
+    Drops silently if no protocol is running, or if the active step
+    didn't pre-open a mailbox for ``topic``.
+
+    Direct entry point for both the dramatiq actor and unit tests.
+    """
+    ctx = get_active_step()
+    if ctx is None:
+        return
+    ctx.deposit(topic, payload)
+
+
+@dramatiq.actor(actor_name="pluggable_protocol_tree_executor_listener",
+                queue_name="default")
+def executor_listener(message: dict) -> None:
+    """Receives every message on any topic in the aggregated
+    wait_for_topics set. Conforms to the project's message-router
+    payload shape: ``{"topic": ..., "message": ...}`` (the message
+    router's publish_message wraps user payloads in this envelope)."""
+    topic = message.get("topic")
+    payload = message.get("message")
+    if topic is None:
+        return
+    route_to_active_step(topic, payload)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_step_context.py -v"
+```
+
+Expected: 30 passed (24 + 6).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/listener.py pluggable_protocol_tree/tests/test_step_context.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Dramatiq executor_listener + active-step pointer
+
+Single Dramatiq actor "pluggable_protocol_tree_executor_listener"
+receives every message published on any topic the plugin aggregated
+from contributed handlers' wait_for_topics. The active-step pointer
+(module-level, lock-guarded) gates routing — only one protocol runs at
+a time, so a singleton is enough. set/clear bracketed by the
+executor's per-step lifecycle, so cross-step messages on shared topics
+get dropped during the gap (intentional; avoids cross-contamination).
+
+route_to_active_step() is the same function the actor uses, so unit
+tests can drive the routing logic without spinning up Dramatiq.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `ProtocolExecutor` scaffolding + public control API
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/execution/executor.py` (skeleton + public API only)
+- Modify: `src/pluggable_protocol_tree/tests/test_executor.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_executor.py`:
+
+```python
+# --- ProtocolExecutor public API ---
+
+import threading
+
+import pytest
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+
+
+def _make_executor():
+    """Bare-bones executor with the four PPT-1 built-in columns."""
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), make_duration_column()]
+    rm = RowManager(columns=cols)
+    return ProtocolExecutor(
+        row_manager=rm,
+        qsignals=ExecutorSignals(),
+        pause_event=PauseEvent(),
+        stop_event=threading.Event(),
+    )
+
+
+def test_executor_constructible_with_required_traits():
+    ex = _make_executor()
+    assert ex.row_manager is not None
+    assert ex.qsignals is not None
+    assert ex.pause_event is not None
+    assert ex.stop_event is not None
+
+
+def test_executor_pause_emits_protocol_paused():
+    ex = _make_executor()
+    received = []
+    ex.qsignals.protocol_paused.connect(lambda: received.append("paused"))
+    ex.pause()
+    assert ex.pause_event.is_set() is True
+    assert received == ["paused"]
+
+
+def test_executor_resume_emits_protocol_resumed():
+    ex = _make_executor()
+    received = []
+    ex.qsignals.protocol_resumed.connect(lambda: received.append("resumed"))
+    ex.pause()
+    ex.resume()
+    assert ex.pause_event.is_set() is False
+    assert received == ["resumed"]
+
+
+def test_executor_stop_sets_stop_event_and_clears_pause():
+    """stop() must also clear pause_event so a Stop-while-paused doesn't
+    deadlock the main loop in wait_cleared()."""
+    ex = _make_executor()
+    ex.pause()
+    assert ex.pause_event.is_set() is True
+    ex.stop()
+    assert ex.stop_event.is_set() is True
+    assert ex.pause_event.is_set() is False
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: ImportError on `pluggable_protocol_tree.execution.executor`.
+
+- [ ] **Step 3: Implement the executor scaffolding**
+
+Create `src/pluggable_protocol_tree/execution/executor.py`:
+
+```python
+"""Protocol executor — runs a RowManager's rows on a QThread.
+
+Responsibilities:
+  * Walk row_manager.iter_execution_steps() in order.
+  * For each row, fan the five hooks across priority buckets (sequential
+    between buckets, parallel within).
+  * Distinguish protocol_finished / protocol_aborted / protocol_error in
+    one place (_emit_terminal_signal).
+  * Cooperate with stop/pause/error: stop_event short-circuits the loop
+    and propagates into ctx.wait_for; pause_event blocks at step
+    boundaries only; first hook exception aborts the step and routes to
+    protocol_error.
+
+This task ships only the scaffolding + public control API. The run loop,
+hook fan-out, and conflict assertion land in subsequent tasks.
+"""
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Optional
+
+from pyface.qt.QtCore import QThread
+from traits.api import Any, Callable as CallableTrait, HasTraits, Instance
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProtocolExecutor(HasTraits):
+    """One executor per RowManager. Reused across runs."""
+
+    row_manager = Instance(RowManager)
+    qsignals    = Instance(ExecutorSignals)
+
+    pause_event = Instance(PauseEvent)
+    stop_event  = Instance(threading.Event)
+
+    # Internal — set by start() / cleared by run()'s finally.
+    _thread = Any
+    _error  = Any
+
+    # Injectable for tests (e.g. a synchronous executor for determinism).
+    bucket_pool_factory = CallableTrait
+
+    def _bucket_pool_factory_default(self):
+        return ThreadPoolExecutor
+
+    # ------- public control API (called from the GUI thread) -------
+
+    def start(self) -> None:
+        """Spawn a QThread and call run() on it. Idempotent — a second
+        call while already running is ignored."""
+        if self._thread is not None and self._thread.isRunning():
+            return
+        self.pause_event.clear()
+        self.stop_event.clear()
+        self._error = None
+        self._thread = QThread()
+        self.moveToThread(self._thread)
+        self._thread.started.connect(self.run)
+        self._thread.start()
+
+    def pause(self) -> None:
+        """Set pause_event. Effective at the next step boundary."""
+        self.pause_event.set()
+        self.qsignals.protocol_paused.emit()
+
+    def resume(self) -> None:
+        """Clear pause_event so the main loop unblocks."""
+        self.pause_event.clear()
+        self.qsignals.protocol_resumed.emit()
+
+    def stop(self) -> None:
+        """Set stop_event AND clear pause_event so a Stop-while-paused
+        doesn't deadlock the main loop in pause_event.wait_cleared()."""
+        self.stop_event.set()
+        self.pause_event.clear()
+
+    # ------- main loop (overridden in Task 9) -------
+
+    def run(self) -> None:
+        """Stub — fully implemented in Task 9."""
+        raise NotImplementedError("run() lands in Task 9")
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: 8 passed (4 from Task 4 + 4 here).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/executor.py pluggable_protocol_tree/tests/test_executor.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] ProtocolExecutor scaffolding + public control API
+
+HasTraits class with row_manager / qsignals / pause_event / stop_event
+traits, plus start/pause/resume/stop public methods. Run loop is a stub
+that raises NotImplementedError; lands in Task 9.
+
+The non-obvious bit: stop() also clears pause_event. Without this,
+pressing Stop while paused leaves the main loop blocked in
+pause_event.wait_cleared() forever — stop_event going True is invisible
+to a thread that's only watching pause_event.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: `ProtocolExecutor.run()` main loop + terminal signals
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/execution/executor.py` (replace the `run` stub + add helpers)
+- Modify: `src/pluggable_protocol_tree/tests/test_executor.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_executor.py`:
+
+```python
+# --- ProtocolExecutor.run() — main loop ---
+
+import time
+
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+
+
+class _SignalSpy:
+    """Collects signal emissions into a list for assertion."""
+    def __init__(self, sigs: ExecutorSignals):
+        self.events = []
+        sigs.protocol_started.connect(lambda: self.events.append(("protocol_started",)))
+        sigs.step_started.connect(lambda r: self.events.append(("step_started", r.name)))
+        sigs.step_finished.connect(lambda r: self.events.append(("step_finished", r.name)))
+        sigs.protocol_finished.connect(lambda: self.events.append(("protocol_finished",)))
+        sigs.protocol_aborted.connect(lambda: self.events.append(("protocol_aborted",)))
+        sigs.protocol_error.connect(lambda m: self.events.append(("protocol_error", m)))
+
+
+def test_run_empty_protocol_emits_started_then_finished():
+    ex = _make_executor()
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()       # synchronous; bypasses start()/QThread
+    assert spy.events[0] == ("protocol_started",)
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_run_three_steps_emits_step_signals_in_order():
+    ex = _make_executor()
+    a = ex.row_manager.add_step(values={"name": "A"})
+    b = ex.row_manager.add_step(values={"name": "B"})
+    c = ex.row_manager.add_step(values={"name": "C"})
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    step_events = [e for e in spy.events if e[0] in ("step_started", "step_finished")]
+    assert step_events == [
+        ("step_started", "A"), ("step_finished", "A"),
+        ("step_started", "B"), ("step_finished", "B"),
+        ("step_started", "C"), ("step_finished", "C"),
+    ]
+
+
+def test_run_stop_pre_set_aborts_immediately():
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.row_manager.add_step(values={"name": "B"})
+    ex.stop_event.set()
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    # No step events; terminal is aborted, not finished.
+    assert ("step_started", "A") not in spy.events
+    assert spy.events[-1] == ("protocol_aborted",)
+
+
+def test_run_pause_then_resume_blocks_then_continues():
+    """Set pause_event before calling run() so iter_execution_steps's
+    first iteration hits wait_cleared(). Then clear it from another
+    thread to release."""
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.pause_event.set()
+    spy = _SignalSpy(ex.qsignals)
+
+    def resumer():
+        time.sleep(0.05)
+        ex.pause_event.clear()
+
+    threading.Thread(target=resumer, daemon=True).start()
+    start = time.monotonic()
+    ex.run()
+    elapsed = time.monotonic() - start
+    # We waited ~50ms before resume; protocol then completed quickly.
+    assert elapsed >= 0.05
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_run_stop_while_paused_breaks_out():
+    """Regression for the deadlock-avoidance code in stop()."""
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.pause_event.set()
+    spy = _SignalSpy(ex.qsignals)
+
+    def stopper():
+        time.sleep(0.05)
+        ex.stop()
+
+    threading.Thread(target=stopper, daemon=True).start()
+    ex.run()
+    assert spy.events[-1] == ("protocol_aborted",)
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: NotImplementedError from `run()` stub on each of the new tests.
+
+- [ ] **Step 3: Replace `run` stub with the real loop**
+
+Open `src/pluggable_protocol_tree/execution/executor.py` and replace the `run` method (the one that raises `NotImplementedError`) with this implementation. Also add the imports + helpers shown.
+
+Add to the top of the file (after the existing imports):
+
+```python
+from pluggable_protocol_tree.execution.listener import (
+    set_active_step, clear_active_step,
+)
+from pluggable_protocol_tree.execution.step_context import (
+    ProtocolContext, StepContext,
+)
+```
+
+Replace the `run()` stub with:
+
+```python
+    def run(self) -> None:
+        """Main loop. Runs synchronously when called directly (tests),
+        or on its QThread when entered via start()."""
+        cols = list(self.row_manager.columns)
+        proto_ctx = ProtocolContext(
+            columns=cols, stop_event=self.stop_event,
+        )
+        try:
+            self._run_hooks("on_protocol_start", cols, proto_ctx, row=None)
+            self.qsignals.protocol_started.emit()
+
+            for row in self.row_manager.iter_execution_steps():
+                if self.stop_event.is_set():
+                    break
+                if self.pause_event.is_set():
+                    self.pause_event.wait_cleared()
+                    if self.stop_event.is_set():
+                        break
+
+                step_ctx = self._build_step_ctx(row, cols, proto_ctx)
+                set_active_step(step_ctx)
+                try:
+                    self.qsignals.step_started.emit(row)
+                    self._run_hooks("on_pre_step",  cols, step_ctx, row)
+                    self._run_hooks("on_step",      cols, step_ctx, row)
+                    self._run_hooks("on_post_step", cols, step_ctx, row)
+                    self.qsignals.step_finished.emit(row)
+                finally:
+                    clear_active_step()
+
+            # on_protocol_end runs even on stop, as best-effort cleanup.
+            self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+
+        except Exception as e:
+            self._error = e
+            logger.exception("Protocol error")
+            try:
+                self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+            except Exception:
+                logger.exception("on_protocol_end raised during error cleanup")
+
+        finally:
+            self._emit_terminal_signal()
+            if self._thread is not None:
+                self._thread.quit()
+
+    # ------- helpers -------
+
+    def _emit_terminal_signal(self) -> None:
+        """Single source of truth for which lifecycle-end signal fires.
+
+        Order matters: an in-loop exception (recorded as self._error)
+        wins over user Stop, which wins over normal completion.
+        """
+        if self._error is not None:
+            self.qsignals.protocol_error.emit(str(self._error))
+        elif self.stop_event.is_set():
+            self.qsignals.protocol_aborted.emit()
+        else:
+            self.qsignals.protocol_finished.emit()
+
+    def _build_step_ctx(self, row, cols, proto_ctx) -> StepContext:
+        """Construct a fresh StepContext and pre-open one mailbox per
+        topic in the union of all handlers' wait_for_topics."""
+        step_ctx = StepContext(row=row, protocol=proto_ctx)
+        for col in cols:
+            for topic in (col.handler.wait_for_topics or []):
+                step_ctx.open_mailbox(topic)
+        return step_ctx
+
+    def _run_hooks(self, hook_name, cols, ctx, row) -> None:
+        """Stub — full priority-bucket implementation lands in Task 10.
+        Until then, run hooks sequentially in given order so the run-loop
+        tests can pass without depending on the bucket fan-out yet."""
+        for col in cols:
+            self._invoke_hook(col, hook_name, ctx, row)
+
+    def _invoke_hook(self, col, hook_name, ctx, row) -> None:
+        """Dispatch to the handler's named hook with the right signature.
+
+        Per-step hooks take (row, ctx); protocol-level take (ctx).
+        Default handlers from BaseColumnHandler are no-ops, so calling
+        them on every column is safe (and cheaper than introspecting
+        which columns override).
+        """
+        fn = getattr(col.handler, hook_name)
+        if hook_name in ("on_protocol_start", "on_protocol_end"):
+            fn(ctx)
+        else:
+            fn(row, ctx)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: 13 passed (8 + 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/executor.py pluggable_protocol_tree/tests/test_executor.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] ProtocolExecutor.run() main loop
+
+Walks iter_execution_steps and fires the five hooks per step. Three
+terminal-signal cases (finished / aborted / error) consolidated in
+_emit_terminal_signal so call sites don't have to remember which one
+to pick. Per-step StepContext opens mailboxes for the union of all
+handlers' wait_for_topics before any hook runs (the publish-then-ack
+race fix in concrete form).
+
+_run_hooks is a sequential stub here; the priority-bucket fan-out
+lands in Task 10.
+
+stop_event is checked twice per iteration: once before the pause
+boundary, once after wait_cleared returns. The post-pause check is
+what makes Stop-while-paused work — see the regression test
+test_run_stop_while_paused_breaks_out.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `_run_hooks` priority-bucket fan-out
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/execution/executor.py` (replace `_run_hooks` stub)
+- Modify: `src/pluggable_protocol_tree/tests/test_executor.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_executor.py`:
+
+```python
+# --- priority bucket fan-out ---
+
+from traits.api import HasTraits, Int, List, provides, Str
+
+from pluggable_protocol_tree.interfaces.i_column import IColumnHandler
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.views.columns.readonly_label import (
+    ReadOnlyLabelColumnView,
+)
+
+
+def _recording_handler(name, priority, log: list, barrier=None):
+    """Build a handler that appends (name, hook_name) to `log` on each
+    fire. Optional `barrier` makes the handler block on a threading
+    barrier inside on_step (used to prove parallel execution)."""
+    class _H(BaseColumnHandler):
+        def on_protocol_start(self, ctx):  log.append((name, "on_protocol_start"))
+        def on_pre_step(self, row, ctx):   log.append((name, "on_pre_step"))
+        def on_step(self, row, ctx):
+            log.append((name, "on_step"))
+            if barrier is not None:
+                barrier.wait(timeout=2.0)
+        def on_post_step(self, row, ctx):  log.append((name, "on_post_step"))
+        def on_protocol_end(self, ctx):    log.append((name, "on_protocol_end"))
+    h = _H()
+    h.priority = priority
+    return h
+
+
+def _make_recording_column(col_id, priority, log, barrier=None):
+    return Column(
+        model=BaseColumnModel(col_id=col_id, col_name=col_id, default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_recording_handler(col_id, priority, log, barrier),
+    )
+
+
+def _executor_with(cols):
+    """Build an executor on a fresh RowManager containing one step,
+    with the given extra columns layered on top of the four PPT-1
+    builtins (so iter_execution_steps yields one row)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    builtins = [make_type_column(), make_id_column(),
+                make_name_column(), make_duration_column()]
+    rm = RowManager(columns=builtins + list(cols))
+    rm.add_step(values={"name": "A"})
+    return ProtocolExecutor(
+        row_manager=rm,
+        qsignals=ExecutorSignals(),
+        pause_event=PauseEvent(),
+        stop_event=threading.Event(),
+    )
+
+
+def test_run_hooks_orders_buckets_by_priority():
+    log = []
+    low = _make_recording_column("low", priority=10, log=log)
+    high = _make_recording_column("high", priority=30, log=log)
+    ex = _executor_with([high, low])   # deliberately shuffled
+    ex.run()
+    on_step_calls = [name for (name, hook) in log if hook == "on_step"]
+    # All low (priority 10) before any high (priority 30)
+    assert on_step_calls.index("low") < on_step_calls.index("high")
+
+
+def test_run_hooks_fans_same_priority_in_parallel():
+    log = []
+    barrier = threading.Barrier(2)
+    a = _make_recording_column("a", priority=20, log=log, barrier=barrier)
+    b = _make_recording_column("b", priority=20, log=log, barrier=barrier)
+    ex = _executor_with([a, b])
+    # If they don't run in parallel the barrier never trips and the
+    # executor blocks until barrier timeout (2s) — test would take >2s.
+    start = time.monotonic()
+    ex.run()
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5, "same-priority hooks did not fan out in parallel"
+    on_step_names = [name for (name, hook) in log if hook == "on_step"]
+    assert sorted(on_step_names) == ["a", "b"]
+
+
+def test_run_hooks_uses_default_priority_50_for_unset():
+    """BaseColumnHandler defaults priority to 50 — no explicit set
+    needed for a column that doesn't care about ordering."""
+    log = []
+    no_pri = _make_recording_column("default", priority=50, log=log)
+    early = _make_recording_column("early", priority=10, log=log)
+    ex = _executor_with([no_pri, early])
+    ex.run()
+    on_step_calls = [name for (name, hook) in log if hook == "on_step"]
+    assert on_step_calls.index("early") < on_step_calls.index("default")
+
+
+def test_run_hooks_all_five_phases_fire_in_order_for_one_step():
+    log = []
+    col = _make_recording_column("c", priority=50, log=log)
+    ex = _executor_with([col])
+    ex.run()
+    # Filter to the recording column only (built-ins also fire but with
+    # no logging side effect — their handlers are BaseColumnHandler).
+    c_calls = [hook for (name, hook) in log if name == "c"]
+    assert c_calls == [
+        "on_protocol_start",
+        "on_pre_step", "on_step", "on_post_step",
+        "on_protocol_end",
+    ]
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: parallel test fails (sequential stub serialises so the barrier never trips → test times out around 2s). Other tests may pass coincidentally because the sequential stub respects iteration order for matching priorities.
+
+- [ ] **Step 3: Replace `_run_hooks` with priority-bucket fan-out**
+
+In `src/pluggable_protocol_tree/execution/executor.py`, add this import alongside the others:
+
+```python
+from collections import defaultdict
+from concurrent.futures import as_completed
+```
+
+Replace the `_run_hooks` method body (the sequential stub from Task 9) with:
+
+```python
+    def _run_hooks(self, hook_name, cols, ctx, row) -> None:
+        """Priority-bucket fan-out.
+
+        Lower priority runs first. Equal priorities run in parallel
+        (one ThreadPoolExecutor per bucket; the executor returns
+        only when every future in the bucket has resolved).
+
+        The first exception in any bucket wins: stop_event is set so
+        sibling hooks waiting on ctx.wait_for() return promptly via
+        AbortError, the pool drains, and the original exception is
+        re-raised out of this method.
+        """
+        buckets = defaultdict(list)
+        for col in cols:
+            buckets[col.handler.priority].append(col)
+
+        for priority in sorted(buckets):
+            bucket_cols = buckets[priority]
+            with self.bucket_pool_factory(
+                max_workers=max(1, len(bucket_cols)),
+            ) as pool:
+                futures = {
+                    pool.submit(self._invoke_hook, col, hook_name, ctx, row): col
+                    for col in bucket_cols
+                }
+                first_exc = None
+                for f in as_completed(futures):
+                    exc = f.exception()
+                    if exc is not None and first_exc is None:
+                        first_exc = exc
+                        # Set stop so sibling wait_for() calls return
+                        # promptly — pool.__exit__ will then wait for
+                        # those threads to drain naturally.
+                        self.stop_event.set()
+                if first_exc is not None:
+                    raise first_exc
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: 17 passed (13 + 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/executor.py pluggable_protocol_tree/tests/test_executor.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] _run_hooks priority-bucket fan-out
+
+Lower priority first; equal priority parallel via a per-bucket
+ThreadPoolExecutor. First exception in a bucket sets stop_event so
+sibling wait_for() calls return promptly via AbortError, the pool
+drains naturally (Python threads aren't cancellable), and the original
+exception re-raises out of _run_hooks.
+
+The parallel test uses a threading.Barrier to prove same-priority
+hooks actually run concurrently — the sequential stub from Task 9
+would have hung on it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Same-topic conflict assertion + error-propagation tests
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/execution/executor.py` (extend `_build_step_ctx`)
+- Modify: `src/pluggable_protocol_tree/tests/test_executor.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_executor.py`:
+
+```python
+# --- same-topic conflict + error propagation ---
+
+def _handler_with_topic(name, priority, topic, log):
+    class _H(BaseColumnHandler):
+        wait_for_topics = [topic]
+        def on_step(self, row, ctx):
+            log.append((name, "on_step"))
+    h = _H()
+    h.priority = priority
+    return h
+
+
+def _column_with_topic_handler(col_id, priority, topic, log):
+    return Column(
+        model=BaseColumnModel(col_id=col_id, col_name=col_id, default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_handler_with_topic(col_id, priority, topic, log),
+    )
+
+
+def test_same_topic_in_same_priority_bucket_raises():
+    """Two columns both declaring the same wait_for_topic at the same
+    priority would race for the mailbox. Detected at step start."""
+    log = []
+    a = _column_with_topic_handler("a", 20, "shared/topic", log)
+    b = _column_with_topic_handler("b", 20, "shared/topic", log)
+    ex = _executor_with([a, b])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    # Surfaces as a protocol_error (the _build_step_ctx assertion raises).
+    assert spy.events[-1][0] == "protocol_error"
+    assert "shared/topic" in spy.events[-1][1]
+
+
+def test_same_topic_different_priority_buckets_is_fine():
+    """Sequential — no race. Should not raise."""
+    log = []
+    a = _column_with_topic_handler("a", 10, "shared/topic", log)
+    b = _column_with_topic_handler("b", 30, "shared/topic", log)
+    ex = _executor_with([a, b])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_hook_exception_emits_protocol_error_not_finished():
+    log = []
+
+    class _Boom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("kaboom")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_Boom(),
+    )
+    ex = _executor_with([col])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    err_events = [e for e in spy.events if e[0] == "protocol_error"]
+    assert len(err_events) == 1
+    assert "kaboom" in err_events[0][1]
+    # Did NOT emit finished or aborted.
+    assert ("protocol_finished",) not in spy.events
+    assert ("protocol_aborted",) not in spy.events
+
+
+def test_on_protocol_end_runs_even_on_error():
+    """Best-effort cleanup: if on_step raises, on_protocol_end still
+    fires (in the except branch's fallback)."""
+    log = []
+
+    class _Boom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("kaboom")
+        def on_protocol_end(self, ctx):
+            log.append("end_ran")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_Boom(),
+    )
+    ex = _executor_with([col])
+    ex.run()
+    assert "end_ran" in log
+
+
+def test_on_protocol_end_raising_during_error_cleanup_is_swallowed():
+    """If both on_step AND on_protocol_end raise, the original error
+    wins (it's what surfaces as protocol_error) and the on_protocol_end
+    exception is logged but not re-raised."""
+    log = []
+
+    class _DoubleBoom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("first")
+        def on_protocol_end(self, ctx):
+            raise RuntimeError("second")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_DoubleBoom(),
+    )
+    ex = _executor_with([col])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    err_events = [e for e in spy.events if e[0] == "protocol_error"]
+    assert len(err_events) == 1
+    assert "first" in err_events[0][1]
+    assert "second" not in err_events[0][1]
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: `test_same_topic_in_same_priority_bucket_raises` fails (no assertion in `_build_step_ctx` yet — the topic just gets opened twice silently). The error-propagation tests should already pass from Task 9's `try/except` structure.
+
+- [ ] **Step 3: Add the conflict assertion**
+
+In `src/pluggable_protocol_tree/execution/executor.py`, replace `_build_step_ctx` with:
+
+```python
+    def _build_step_ctx(self, row, cols, proto_ctx) -> StepContext:
+        """Construct a fresh StepContext and pre-open one mailbox per
+        topic in the union of all handlers' wait_for_topics.
+
+        Raises ValueError if two columns *in the same priority bucket*
+        declare the same topic — they'd race for the mailbox under
+        parallel fan-out, and we don't yet have a use case for
+        broadcast-to-multiple-waiters semantics. Same topic in
+        different buckets is fine (sequential).
+        """
+        step_ctx = StepContext(row=row, protocol=proto_ctx)
+        # Detect within-bucket topic collisions before opening any boxes.
+        per_priority_topics: dict[int, dict[str, str]] = {}  # priority → topic → col_id
+        for col in cols:
+            topics = col.handler.wait_for_topics or []
+            bucket = per_priority_topics.setdefault(col.handler.priority, {})
+            for topic in topics:
+                if topic in bucket:
+                    raise ValueError(
+                        f"Topic conflict: columns {bucket[topic]!r} and "
+                        f"{col.model.col_id!r} both declare wait_for_topics={topic!r} "
+                        f"at the same priority bucket ({col.handler.priority}); "
+                        f"they would race for the mailbox."
+                    )
+                bucket[topic] = col.model.col_id
+                step_ctx.open_mailbox(topic)
+        return step_ctx
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_executor.py -v"
+```
+
+Expected: 22 passed (17 + 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/execution/executor.py pluggable_protocol_tree/tests/test_executor.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Same-topic conflict assertion + error-propagation tests
+
+_build_step_ctx now scans wait_for_topics per priority bucket and
+raises ValueError if two columns in the same bucket both declare the
+same topic. Different buckets is fine (sequential — no race). The
+error surfaces as protocol_error, not aborted.
+
+Also locks in the error semantics from Task 9's run loop:
+- Hook exception → protocol_error(message), NOT _finished or _aborted
+- on_protocol_end runs as best-effort cleanup
+- An on_protocol_end exception during cleanup is swallowed (logged) so
+  the original error wins
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: `repetitions` built-in column
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/builtins/repetitions_column.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_builtins.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_builtins.py`:
+
+```python
+# --- repetitions column ---
+
+from pluggable_protocol_tree.builtins.repetitions_column import (
+    make_repetitions_column,
+)
+
+
+def test_repetitions_column_default_one():
+    col = make_repetitions_column()
+    assert col.model.default_value == 1
+
+
+def test_repetitions_column_trait_is_int_with_default_one():
+    col = make_repetitions_column()
+    RowType = build_row_type([col], base=BaseRow)
+    r = RowType()
+    assert r.repetitions == 1
+
+
+def test_repetitions_column_view_uses_intspinbox_range():
+    col = make_repetitions_column()
+    assert col.view.low == 1
+    assert col.view.high == 1000
+
+
+def test_repetitions_column_drives_iter_execution_steps_expansion():
+    """Locks in the PPT-1 contract through a real column (not setattr)."""
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    cols = [make_type_column(), make_id_column(), make_name_column(),
+            make_repetitions_column(), make_duration_column()]
+    rm = RowManager(columns=cols)
+    rm.add_step(values={"name": "A", "repetitions": 3})
+    names = [r.name for r in rm.iter_execution_steps()]
+    assert names == ["A", "A", "A"]
+
+
+def test_repetitions_column_metadata():
+    col = make_repetitions_column()
+    assert col.model.col_id == "repetitions"
+    assert col.model.col_name == "Reps"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_builtins.py -v"
+```
+
+Expected: ImportError on `make_repetitions_column`.
+
+- [ ] **Step 3: Implement the column**
+
+Create `src/pluggable_protocol_tree/builtins/repetitions_column.py`:
+
+```python
+"""Repetitions column — number of times each row executes.
+
+Steps repeat their on_step N times. Groups expand their child subtree
+N times. Default 1.
+
+iter_execution_steps in RowManager already reads ``getattr(row,
+"repetitions", 1)`` (PPT-1 left the contract in place); this column
+populates the trait so that getattr fallback becomes vestigial for
+new protocols. The fallback is kept for safety against persisted
+protocols that pre-date the column.
+"""
+
+from traits.api import Int
+
+from pluggable_protocol_tree.models.column import BaseColumnModel, Column
+from pluggable_protocol_tree.views.columns.spinbox import IntSpinBoxColumnView
+
+
+class RepetitionsColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Int(1, desc="Number of times this row executes (groups "
+                            "expand subtree N×)")
+
+
+def make_repetitions_column():
+    return Column(
+        model=RepetitionsColumnModel(
+            col_id="repetitions", col_name="Reps", default_value=1,
+        ),
+        view=IntSpinBoxColumnView(low=1, high=1000),
+    )
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_builtins.py -v"
+```
+
+Expected: 18 passed (the existing 13 + 5 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/builtins/repetitions_column.py pluggable_protocol_tree/tests/test_builtins.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Repetitions built-in column (5th always-on)
+
+Int trait, default 1, IntSpinBox view (1–1000). Locks the PPT-1
+iter_execution_steps "repetitions attribute" contract behind a real
+column rather than the setattr cheat the original tests used.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Plugin updates — assemble repetitions + register subscriptions
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/plugin.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_plugin.py`
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_plugin.py`:
+
+```python
+# --- PPT-2 additions ---
+
+def test_assemble_columns_includes_repetitions():
+    p = PluggableProtocolTreePlugin()
+    cols = p._assemble_columns()
+    ids = [c.model.col_id for c in cols]
+    assert "repetitions" in ids
+
+
+def test_assemble_columns_canonical_order():
+    """Built-ins land in: type, id, name, repetitions, duration_s order."""
+    p = PluggableProtocolTreePlugin()
+    cols = p._assemble_columns()
+    builtin_ids = [c.model.col_id for c in cols
+                   if c.model.col_id in ("type", "id", "name",
+                                         "repetitions", "duration_s")]
+    assert builtin_ids == ["type", "id", "name", "repetitions", "duration_s"]
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_plugin.py -v"
+```
+
+Expected: 2 new tests fail because `repetitions` isn't in the assembled column list yet.
+
+- [ ] **Step 3: Add repetitions to `_assemble_columns` + add the start() subscription registration**
+
+Open `src/pluggable_protocol_tree/plugin.py`. Find the existing `_assemble_columns` and the imports above it. Make the following changes:
+
+Add this import alongside the other `from pluggable_protocol_tree.builtins...` imports:
+
+```python
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+```
+
+Replace the existing `_assemble_columns` body so the order is `type, id, name, repetitions, duration_s + contributed`:
+
+```python
+    def _assemble_columns(self):
+        builtins = [
+            make_type_column(),
+            make_id_column(),
+            make_name_column(),
+            make_repetitions_column(),
+            make_duration_column(),
+        ]
+        return builtins + list(self.contributed_columns)
+```
+
+Now add the `start()` method that registers the executor listener's subscriptions. Insert it inside the `PluggableProtocolTreePlugin` class (under `_assemble_columns` is fine):
+
+```python
+    def start(self):
+        """Register the executor listener's subscriptions with the
+        message router. Called by Envisage at plugin start, after
+        extension points have resolved (so contributed_columns is
+        populated)."""
+        super().start()
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterData
+        except ImportError:
+            # Headless test environments may not have a broker. Plugin
+            # construction must not require Redis; a missing broker is
+            # only a problem at the moment a protocol actually runs.
+            return
+        topics = sorted({
+            t for c in self._assemble_columns()
+            for t in (c.handler.wait_for_topics or [])
+        })
+        if not topics:
+            return
+        router_data = MessageRouterData()
+        for topic in topics:
+            router_data.add_subscriber_to_topic(
+                topic=topic,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+```
+
+- [ ] **Step 4: Run plugin + builtins tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_plugin.py pluggable_protocol_tree/tests/test_builtins.py -v"
+```
+
+Expected: existing 2 + new 2 + the 18 builtins all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/plugin.py pluggable_protocol_tree/tests/test_plugin.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Plugin: assemble repetitions + register executor subscriptions
+
+_assemble_columns now ships repetitions in canonical position
+(between name and duration_s), so every default protocol has a Reps
+column without needing PPT-3+ to land first.
+
+start() aggregates wait_for_topics from all contributed handlers and
+registers them with the message router under the executor listener's
+actor name. Done dynamically (not via the static ACTOR_TOPIC_DICT)
+because the topic set depends on which columns get contributed, which
+is only knowable after extension-point resolution.
+
+Wrapped in try/except for ImportError so headless test environments
+without a broker can still construct the plugin — Redis is only
+required at protocol-run time, not at plugin construction.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Demo MessageColumn
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/demos/message_column.py`
+
+This task has no unit tests — the column is exercised by the demo end-to-end and by the Redis integration test in Task 16.
+
+- [ ] **Step 1: Implement the demo column**
+
+Create `src/pluggable_protocol_tree/demos/message_column.py`:
+
+```python
+"""Toy demo column — publishes a log line on every on_step.
+
+Lives in demos/, not builtins/, because it has no production purpose.
+The Redis integration test in tests_with_redis_server_need/ uses this
+column to prove the round-trip publish → listener → mailbox → wait_for
+path works against a real broker.
+"""
+
+from traits.api import Str
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.views.columns.string_edit import (
+    StringEditColumnView,
+)
+
+
+DEMO_MESSAGE_TOPIC = "microdrop/protocol_tree/demo_message"
+
+
+class MessageColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Str("hello", desc="Message published when this step runs")
+
+
+class MessageColumnHandler(BaseColumnHandler):
+    priority = 50
+    wait_for_topics = []        # demo doesn't wait
+
+    def on_step(self, row, ctx):
+        msg = self.model.get_value(row)
+        publish_message(
+            topic=DEMO_MESSAGE_TOPIC,
+            message={
+                "row_uuid": row.uuid,
+                "name": row.name,
+                "msg": msg,
+            },
+        )
+
+
+def make_message_column():
+    return Column(
+        model=MessageColumnModel(
+            col_id="demo_message", col_name="Message", default_value="hello",
+        ),
+        view=StringEditColumnView(),
+        handler=MessageColumnHandler(),
+    )
+```
+
+- [ ] **Step 2: Smoke-test import**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c 'from pluggable_protocol_tree.demos.message_column import make_message_column; c = make_message_column(); print(c.model.col_id, c.handler.priority)'"
+```
+
+Expected: `demo_message 50`
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/demos/message_column.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Demo MessageColumn
+
+Toy column that publishes "microdrop/protocol_tree/demo_message" on
+every on_step. Lives in demos/ because it has no production purpose;
+exercised end-to-end by the demo widget and by the Redis integration
+test (Task 16).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Demo run_widget — Run/Pause/Stop toolbar + signal wiring
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/run_widget.py`
+
+This is purely UI wiring — no unit tests. Verified by the manual demo check at Task 17.
+
+- [ ] **Step 1: Replace the existing run_widget.py with the enhanced version**
+
+Open `src/pluggable_protocol_tree/demos/run_widget.py` and replace the entire file with:
+
+```python
+"""Standalone demo — open ProtocolTreeWidget in a QMainWindow with
+Run / Pause / Stop toolbar buttons and active-row highlighting.
+
+No envisage, no dramatiq broker required for the in-process demo (the
+MessageColumn publishes to Dramatiq but the publish call no-ops if no
+broker is configured — the demo still exercises the executor's full
+control flow). For the round-trip with real subscribers, run the
+integration test or the full app.
+
+Run: pixi run python -m pluggable_protocol_tree.demos.run_widget
+"""
+
+import json
+import sys
+import threading
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtWidgets import (
+    QApplication, QFileDialog, QMainWindow, QMessageBox, QToolBar,
+)
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.message_column import make_message_column
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+def _columns():
+    return [
+        make_type_column(),
+        make_id_column(),
+        make_name_column(),
+        make_repetitions_column(),
+        make_duration_column(),
+        make_message_column(),
+    ]
+
+
+class DemoWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Pluggable Protocol Tree — Demo (PPT-2)")
+        self.resize(1000, 600)
+
+        self.manager = RowManager(columns=_columns())
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        self.setCentralWidget(self.widget)
+
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        self._wire_signals()
+        self._build_toolbar()
+
+    def _wire_signals(self):
+        # Active-row highlighting
+        self.executor.qsignals.step_started.connect(
+            self.widget.model.set_active_node
+        )
+        self.executor.qsignals.step_finished.connect(
+            lambda _row: self.widget.model.set_active_node(None)
+        )
+        # Clean up highlight on terminal lifecycle signals
+        for sig in (
+            self.executor.qsignals.protocol_finished,
+            self.executor.qsignals.protocol_aborted,
+        ):
+            sig.connect(lambda: self.widget.model.set_active_node(None))
+        self.executor.qsignals.protocol_error.connect(self._on_error)
+
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.manager.add_step())
+        tb.addAction("Add Group", lambda: self.manager.add_group())
+        tb.addSeparator()
+        tb.addAction("Save…", self._save)
+        tb.addAction("Load…", self._load)
+        tb.addSeparator()
+        tb.addAction("Run",   self.executor.start)
+        self._pause_action = tb.addAction("Pause", self._toggle_pause)
+        tb.addAction("Stop",  self.executor.stop)
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+            self._pause_action.setText("Pause")
+        else:
+            self.executor.pause()
+            self._pause_action.setText("Resume")
+
+    def _on_error(self, msg):
+        self.widget.model.set_active_node(None)
+        QMessageBox.critical(self, "Protocol error", msg)
+
+    def _save(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.manager.to_json(), f, indent=2)
+
+    def _load(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        try:
+            self.manager = RowManager.from_json(data, columns=_columns())
+        except Exception as e:
+            QMessageBox.critical(self, "Load error", str(e))
+            return
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        self.setCentralWidget(self.widget)
+        # Re-wire executor against the new manager
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+        self._wire_signals()
+
+
+def main():
+    app = QApplication.instance() or QApplication(sys.argv)
+    w = DemoWindow()
+    w.show()
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Smoke-test import**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c 'from pluggable_protocol_tree.demos.run_widget import DemoWindow; print(DemoWindow)'"
+```
+
+Expected: prints the class.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/demos/run_widget.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Demo widget — Run/Pause/Stop toolbar + active-row highlighting
+
+DemoWindow constructs a ProtocolExecutor and wires:
+- step_started/step_finished → MvcTreeModel.set_active_node (the green
+  highlight already plumbed in PPT-1)
+- protocol_finished / _aborted → clear highlight
+- protocol_error → clear highlight + critical dialog
+
+Toolbar gains Run / Pause / Stop. Pause toggles its own label between
+"Pause" and "Resume" so the user can tell what clicking it will do.
+
+The MessageColumn is preloaded so a Run on a 3-step protocol produces
+visible activity (the highlight walks down the tree as Dramatiq
+publishes go out). With Repetitions=3 on a step, the highlight bounces
+back to that row 3× — visual confirmation iter_execution_steps still
+works through PPT-2's executor.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Redis-backed integration test
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/tests/tests_with_redis_server_need/__init__.py`
+- Create: `src/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py`
+
+- [ ] **Step 1: Create the directory + empty package init**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  mkdir -p pluggable_protocol_tree/tests/tests_with_redis_server_need
+```
+
+Create `src/pluggable_protocol_tree/tests/tests_with_redis_server_need/__init__.py` as **empty**.
+
+- [ ] **Step 2: Write the integration test**
+
+Create `src/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py`:
+
+```python
+"""End-to-end test for the executor's Dramatiq round-trip.
+
+Skips automatically if Redis isn't reachable. Run via:
+
+    redis-server &              # in another shell
+    cd microdrop-py && pixi run bash -c \\
+      "cd src && pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/ -v"
+"""
+
+import threading
+import time
+
+import pytest
+
+
+def _redis_available() -> bool:
+    try:
+        import dramatiq
+        broker = dramatiq.get_broker()
+        broker.client.ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_available(),
+    reason="Redis broker not reachable",
+)
+
+
+def test_publish_then_wait_for_round_trips_via_real_dramatiq():
+    """A handler publishes a request and then waits for an ack on the
+    same topic the message router routes back to the executor's
+    listener. Proves: publish → broker → executor_listener actor →
+    route_to_active_step → mailbox → wait_for → handler returns the
+    payload."""
+    from microdrop_utils.dramatiq_pub_sub_helpers import (
+        MessageRouterData, publish_message,
+    )
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.execution.events import PauseEvent
+    from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+    from pluggable_protocol_tree.execution.signals import ExecutorSignals
+    from pluggable_protocol_tree.models.column import (
+        BaseColumnHandler, BaseColumnModel, Column,
+    )
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    from pluggable_protocol_tree.views.columns.readonly_label import (
+        ReadOnlyLabelColumnView,
+    )
+
+    ACK_TOPIC = "pluggable_protocol_tree/test/ack"
+    received = []
+
+    class _AckHandler(BaseColumnHandler):
+        wait_for_topics = [ACK_TOPIC]
+
+        def on_step(self, row, ctx):
+            # Publish the ack ourselves (in a real handler this would
+            # publish a request and a different actor would publish the
+            # ack). The point is to prove the mailbox round-trips.
+            publish_message(
+                topic=ACK_TOPIC, message={"step_uuid": row.uuid, "ok": True},
+            )
+            payload = ctx.wait_for(ACK_TOPIC, timeout=5.0)
+            received.append(payload)
+
+    ack_col = Column(
+        model=BaseColumnModel(col_id="ack", col_name="Ack", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_AckHandler(),
+    )
+
+    # Register the executor listener's subscription for ACK_TOPIC. (The
+    # plugin's start() does this in production; we do it inline here.)
+    router_data = MessageRouterData()
+    router_data.add_subscriber_to_topic(
+        topic=ACK_TOPIC,
+        subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+    )
+    try:
+        cols = [make_type_column(), make_id_column(), make_name_column(),
+                make_repetitions_column(), make_duration_column(), ack_col]
+        rm = RowManager(columns=cols)
+        rm.add_step(values={"name": "S"})
+        ex = ProtocolExecutor(
+            row_manager=rm,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        # Run on a worker thread so dramatiq has time to deliver while
+        # the main thread monitors. (Unit tests call ex.run() directly;
+        # here we exercise the same code path but with the broker live.)
+        runner = threading.Thread(target=ex.run, daemon=True)
+        runner.start()
+        runner.join(timeout=10.0)
+
+        assert not runner.is_alive(), "executor.run did not return in 10s"
+        assert len(received) == 1
+        assert received[0]["ok"] is True
+        assert received[0]["step_uuid"] == rm.root.children[0].uuid
+
+    finally:
+        router_data.remove_subscriber_from_topic(
+            topic=ACK_TOPIC,
+            subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+        )
+```
+
+- [ ] **Step 3: Run the test (assumes Redis is up)**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py -v"
+```
+
+Expected with Redis up: 1 passed.
+Expected without Redis: 1 skipped.
+
+If the test fails because Redis isn't running, start it (`redis-server &` or `python examples/start_redis_server.py`) and rerun. If it fails for any other reason, debug — this test is the load-bearing assurance that the listener actually wires up to the broker.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && \
+  git add pluggable_protocol_tree/tests/tests_with_redis_server_need/__init__.py pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py && \
+  git commit -m "$(cat <<'EOF'
+[PPT-2] Redis integration test for the executor round-trip
+
+One end-to-end test that proves the publish → broker →
+executor_listener actor → route_to_active_step → mailbox → wait_for →
+handler return chain works against a real Dramatiq broker. Skips
+automatically if Redis isn't reachable, matching the existing
+tests_with_redis_server_need convention.
+
+Catches the integration glue bugs (subscription registration, payload
+envelope, MQTT-style topic match for the listener actor) that the
+stub-listener unit tests can't see.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Final verification + push + PR
+
+**Files:** none (git/gh + manual verification only)
+
+- [ ] **Step 1: Run the full PPT test suite (no Redis)**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/ -v --ignore=pluggable_protocol_tree/tests/tests_with_redis_server_need"
+```
+
+Expected: every test green. New tests added by PPT-2: ~30 in `test_step_context.py`, ~22 in `test_executor.py`, ~5 in `test_builtins.py` (repetitions), ~2 in `test_plugin.py` (assemble), all on top of the PPT-1 baseline (~111).
+
+- [ ] **Step 2: Run the integration test (with Redis up)**
+
+```bash
+# In another shell:
+redis-server &
+# Then:
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/ -v"
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 3: Manual demo verification**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run python -m pluggable_protocol_tree.demos.run_widget
+```
+
+Manual checks:
+- Right-click → Add Step three times. Set the Reps column on the middle one to 3. Set the Message column to a custom string on each.
+- Click Run. The active-row highlight should walk down: row 1 → row 2 (3×) → row 3.
+- Click Pause during execution. Active row stays highlighted; nothing else moves. Click Resume — execution continues.
+- Click Stop during execution. Highlight clears, no error dialog, demo stays open.
+- Right-click → Add Group; expand; Add Step inside. Run again — the group's children execute in order.
+
+- [ ] **Step 4: Verify clean tree + branch state**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && git status --short && git log --oneline feat/ppt-2-executor --not main
+```
+
+Expected: only ` M protocol_grid/preferences.py` in status. The `git log` output is the full chain of `[Spec]` + `[PPT-2]` commits — should be ~17 lines.
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && git push -u origin feat/ppt-2-executor
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && gh pr create \
+  --repo Blue-Ocean-Technologies-Inc/Microdrop \
+  --title "[PPT-2] Executor + StepContext.wait_for + pause/stop" \
+  --body "$(cat <<'EOF'
+Closes #364
+
+## Summary
+
+Ships the protocol-execution layer for the new pluggable protocol tree:
+
+- **`execution/`** subpackage: `AbortError`, `PauseEvent`, `ExecutorSignals` (QObject), `Mailbox` + `wait_first` helper, `ProtocolContext` + `StepContext` with `ctx.wait_for(topic, timeout, predicate)`, single Dramatiq listener actor + active-step pointer, and `ProtocolExecutor` (HasTraits, QThread-hosted).
+- **Pre-registered mailboxes** at step start cover the union of every contributed handler's `wait_for_topics` — fixes the publish-then-register race so fast hardware acks don't get lost.
+- **Priority-bucket fan-out**: lower priority first; equal priorities run in parallel via per-bucket `ThreadPoolExecutor`. First exception in a bucket sets `stop_event` so sibling waits abort promptly, the pool drains, and the original exception propagates.
+- **Three terminal signals** (`finished` / `aborted` / `error`) decided in `_emit_terminal_signal` so call sites stay simple. `stop()` also clears `pause_event` so a Stop-while-paused doesn't deadlock.
+- **Same-topic conflict assertion**: two columns in the same priority bucket both declaring the same `wait_for_topic` raises a clear error (multiple-waiter broadcast is out of scope until someone needs it).
+- **Repetitions** built-in column shipped as the 5th always-on default.
+- **Demo MessageColumn** + enhanced `demos/run_widget.py` with Run/Pause/Stop toolbar and active-row highlighting wired to the `MvcTreeModel.set_active_node` hook PPT-1 already plumbed.
+- **Plugin** registers the executor listener's subscriptions dynamically via `MessageRouterData.add_subscriber_to_topic` (the static `ACTOR_TOPIC_DICT` pattern doesn't fit because the topic set depends on which columns get contributed, only known after extension-point resolution).
+
+## Test plan
+
+- [x] `pytest pluggable_protocol_tree/tests/ -v --ignore=...tests_with_redis_server_need` — all green
+- [x] `pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/` — 1 passed with `redis-server` running
+- [ ] Manual demo verification: Run on a 3-step protocol with Repetitions=3 on the middle step; active row highlight walks correctly. Pause/Resume work between steps. Stop exits cleanly.
+
+## Not in scope (see follow-ups)
+
+- Electrode + Routes columns + device-viewer binding → PPT-3
+- Voltage/Frequency columns → PPT-4
+- Production dock-pane Run/Pause/Stop buttons (deferred to PPT-3 when there's hardware to gate)
+- Long-running CPU hooks with cooperative abort (best-practice doc'd; will be exercised by PPT-3's RoutesHandler)
+
+Design doc: `src/docs/superpowers/specs/2026-04-22-ppt-2-executor-design.md`
+Plan: `src/docs/superpowers/plans/2026-04-22-ppt-2-executor.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Confirm PR opens cleanly**
+
+Copy the PR URL the command prints. Visit in browser; verify:
+- Description renders
+- `Closes #364` link is detected by GitHub
+- All commits show up in the timeline
+
+The umbrella issue's checklist should tick automatically on merge.
+
+---
+
+## Done
+
+PPT-2 ships the executor. PPT-3 picks up: electrode column, routes column, device-viewer binding, phase math lift from `path_execution_service.py`. The hooks contract this PR establishes is exactly what PPT-3's `RoutesHandler` will plug into — no further executor work needed.

--- a/docs/superpowers/specs/2026-04-22-ppt-2-executor-design.md
+++ b/docs/superpowers/specs/2026-04-22-ppt-2-executor-design.md
@@ -1,0 +1,488 @@
+# PPT-2 Design — Executor + StepContext.wait_for + pause/stop
+
+Companion to `2026-04-21-pluggable-protocol-tree-design.md` (sections 9–10).
+Refines and locks down the choices that the parent spec deferred to PPT-2.
+
+## 0. Scope
+
+Ship the protocol-execution layer for the new pluggable protocol tree:
+
+1. `ProtocolExecutor` — long-lived, one-per-`RowManager`, runs on its own `QThread`.
+2. `StepContext` and `ProtocolContext` — passed to each hook, carry per-scope scratch and `wait_for(topic, timeout, predicate)`.
+3. Per-step pre-registered mailboxes + a single Dramatiq listener actor that fans incoming messages into the active step's mailboxes.
+4. Pause / Resume / Stop with the boundary semantics established in the parent spec.
+5. A `repetitions` built-in column (always-on, default 1) so `iter_execution_steps`'s rep-expansion has a real column to drive it.
+6. Demo `MessageColumn` (toy) and an enhanced `demos/run_widget.py` that adds Run / Pause / Stop toolbar buttons and wires `MvcTreeModel.set_active_node` to the executor's `step_started` / `step_finished` signals.
+
+Out of scope: hardware columns, route phase math, voltage/frequency, production dock-pane toolbar (deferred to PPT-3+).
+
+## 1. Decisions locked in during brainstorming
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Threading model | **QThread** — `executor.start()` constructs a `QThread`, `moveToThread`s the executor, connects `started → run`. Headless tests can call `executor.run()` directly without ever calling `start()`. |
+| 2 | UI scope | **Programmatic API + active-row highlighting + demo toolbar.** Production dock pane stays passive until PPT-3. |
+| 3 | Repetitions column | **Always-on built-in** (5th default column). `IntSpinBoxColumnView` default 1, range 1–1000. Visible by default. |
+| 4 | Test strategy | **Stub-listener unit tests + one real-Redis integration test** in `tests_with_redis_server_need/`. |
+| 5 | `wait_for` buffering | **Per-step pre-registered mailboxes.** At step start the executor opens one empty mailbox per topic in any contributed handler's `wait_for_topics`. Listener routes incoming messages into mailboxes. `wait_for` drains. Predicate-rejected messages are discarded. |
+
+## 2. Package layout
+
+```
+pluggable_protocol_tree/
+├── execution/
+│   ├── __init__.py
+│   ├── exceptions.py        # AbortError
+│   ├── events.py            # PauseEvent (threading.Event + wait_cleared())
+│   ├── signals.py           # ExecutorSignals (QObject)
+│   ├── step_context.py      # ProtocolContext, StepContext, Mailbox, wait_first
+│   ├── listener.py          # Dramatiq actor + active-step pointer
+│   └── executor.py          # ProtocolExecutor (HasTraits, QThread-hosted)
+├── builtins/
+│   └── repetitions_column.py    # NEW 5th built-in
+├── demos/
+│   ├── run_widget.py            # extended: Run/Pause/Stop toolbar + signal wiring
+│   └── message_column.py        # NEW toy column for the demo
+├── tests/
+│   ├── test_step_context.py             # mailbox semantics, predicate, timeout, abort
+│   ├── test_executor.py                 # bucket fan-out, pause/stop, error propagation
+│   ├── test_repetitions_column.py       # 5th built-in
+│   └── tests_with_redis_server_need/
+│       └── test_executor_redis_integration.py    # one end-to-end test
+```
+
+`execution/` is a single cohesive subpackage. Every file in it serves the same responsibility (running protocols). Keeping it separate from `services/` (which only holds `persistence.py` today) makes the boundary obvious.
+
+## 3. Core types
+
+```python
+# execution/exceptions.py
+class AbortError(Exception):
+    """Raised inside ctx.wait_for() when the executor's stop_event fires.
+    Hooks should let it propagate; the executor catches it at the bucket boundary."""
+
+
+# execution/events.py
+class PauseEvent:
+    """threading.Event with a wait_cleared() helper so the executor's main loop
+    can block at a step boundary until the user resumes."""
+    def __init__(self):
+        self._set = threading.Event()
+        self._cleared = threading.Event()
+        self._cleared.set()
+    def set(self):       self._set.set();    self._cleared.clear()
+    def clear(self):     self._set.clear();  self._cleared.set()
+    def is_set(self):    return self._set.is_set()
+    def wait_cleared(self, timeout=None):
+        self._cleared.wait(timeout)
+
+
+# execution/signals.py
+class ExecutorSignals(QObject):
+    protocol_started   = Signal()
+    step_started       = Signal(object)        # row
+    step_finished      = Signal(object)
+    protocol_paused    = Signal()
+    protocol_resumed   = Signal()
+    protocol_finished  = Signal()              # ran to completion
+    protocol_aborted   = Signal()              # user pressed Stop
+    protocol_error     = Signal(str)           # exception raised in a hook
+
+
+# execution/step_context.py
+class ProtocolContext(HasTraits):
+    """Spans the whole protocol run."""
+    columns    = List(Instance(IColumn))
+    scratch    = Dict(Str, Any, desc="protocol-scoped scratch (cleared on each run)")
+    stop_event = Instance(threading.Event)
+
+
+class StepContext(HasTraits):
+    """Spans one step. Hooks call wait_for() on this."""
+    row        = Instance(BaseRow)
+    protocol   = Instance(ProtocolContext)
+    scratch    = Dict(Str, Any, desc="step-scoped scratch (cleared per step)")
+    _mailboxes = Dict(Str, Instance(Mailbox))   # topic → Mailbox; pre-opened at step start
+
+    def wait_for(self, topic: str, timeout: float = 5.0,
+                 predicate: Optional[Callable[[Any], bool]] = None) -> Any:
+        """Block until a buffered or arriving message on `topic` satisfies
+        `predicate`. Returns the payload. Raises TimeoutError on timeout.
+        Raises AbortError if the protocol's stop_event fires."""
+```
+
+Note: hook signature is `(self, row, ctx)` for per-step hooks (matches PPT-1's `IColumnHandler` interface as written), `(self, ctx)` for protocol-level (`on_protocol_start`, `on_protocol_end`). The executor passes arguments in this order.
+
+## 4. Mailbox + listener
+
+### Per-step mailbox lifecycle
+
+```python
+# execution/step_context.py
+class Mailbox:
+    """SimpleQueue-backed buffer with a wake event. One per (step, topic)."""
+    def __init__(self):
+        self.q    = queue.SimpleQueue()
+        self.wake = threading.Event()
+    def deposit(self, payload):
+        self.q.put(payload)
+        self.wake.set()
+    def drain_one(self, predicate, timeout, stop_event):
+        deadline = time.monotonic() + timeout
+        while True:
+            # 1. Pull a satisfying item out of the queue, if any.
+            while not self.q.empty():
+                item = self.q.get_nowait()
+                if predicate is None or predicate(item):
+                    return item
+                # else discard and continue draining
+            self.wake.clear()
+            # 2. Block until the listener wakes us, stop fires, or timeout.
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(...)
+            triggered = wait_first([self.wake, stop_event], timeout=remaining)
+            if triggered is stop_event:
+                raise AbortError(...)
+
+
+def wait_first(events: list[threading.Event], timeout: float) -> Optional[threading.Event]:
+    """Block until any of `events` fires, or timeout. Returns the event that fired,
+    or None on timeout. Implemented via a shared 'waker' event the executor + listener
+    both signal when they want to interrupt a wait."""
+```
+
+### Listener — single Dramatiq actor, fans into the active step
+
+```python
+# execution/listener.py
+_active_step_ctx: Optional[StepContext] = None
+_active_lock    = threading.Lock()
+
+def set_active_step(step_ctx):  # called by executor before each step
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = step_ctx
+
+def clear_active_step():        # called by executor after each step
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = None
+
+
+@dramatiq.actor(actor_name="pluggable_protocol_tree_executor_listener", queue_name="default")
+def executor_listener(message: dict):
+    """Receives every message on any topic in the aggregated wait_for_topics
+    set. Routes payload into the active step's mailbox for that topic."""
+    topic   = message["topic"]
+    payload = message["payload"]
+    with _active_lock:
+        ctx = _active_step_ctx
+    if ctx is None:
+        return                  # no protocol running; drop silently
+    box = ctx._mailboxes.get(topic)
+    if box is not None:
+        box.deposit(payload)
+```
+
+**Rationale.** The listener is module-level / singleton-ish; the active-step pointer is what gates message routing. Late messages from the previous step on a topic the next step also watches are *not* delivered — `clear_active_step` is called inside `finally`, so by the time the next step's `set_active_step` runs there's a deliberate gap. (If we wanted at-most-once cross-step buffering we'd carry a per-protocol mailbox; PPT-2 doesn't need it.)
+
+### Subscription set — registered once at plugin start
+
+The message router exposes `add_subscriber_to_topic(topic, actor_name)` (in `microdrop_utils/dramatiq_pub_sub_helpers.py`) for dynamic subscriptions. At plugin start the PPT plugin aggregates `wait_for_topics` from every contributed handler and registers each one for the executor's listener actor:
+
+```python
+# pluggable_protocol_tree/plugin.py — additions
+class PluggableProtocolTreePlugin(Plugin):
+    ...
+    def start(self):
+        super().start()
+        all_columns = self._assemble_columns()
+        topics = sorted({t for c in all_columns for t in c.handler.wait_for_topics})
+        router_data = MessageRouterData()    # connects via shared Redis hash
+        for topic in topics:
+            router_data.add_subscriber_to_topic(
+                topic=topic,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+```
+
+(The static `ACTOR_TOPIC_DICT = {}` declared in `consts.py` stays empty — the executor's subscription is registered dynamically because the topic set depends on which columns are contributed, which is only knowable after extension-point resolution.)
+
+The aggregated subscription list is computed once at plugin start. Adding a column with a new `wait_for_topic` after start would require a restart — acceptable for PPT-2; revisit if dynamic plugin loading becomes a thing.
+
+### Executor's per-step setup
+
+For each step in `iter_execution_steps`:
+1. Build `step_ctx` with one empty `Mailbox` per topic in any contributed handler's `wait_for_topics`.
+2. Call `set_active_step(step_ctx)`.
+3. Run `on_pre_step`, `on_step`, `on_post_step` (each phase fans out across priority buckets).
+4. Call `clear_active_step()` in a `finally`.
+
+### Same-topic conflict guard
+
+If two columns in the *same priority bucket* both declare the same topic in `wait_for_topics`, the executor raises a clear error at step start. Multiple concurrent waiters on the same topic is a fan-out pattern we don't have a use case for yet — supporting it changes `Mailbox` from a queue to a per-waiter copy-on-deposit broadcast. Two columns in *different* priority buckets is fine (sequential).
+
+## 5. Executor mainloop
+
+```python
+# execution/executor.py
+class ProtocolExecutor(HasTraits):
+    """Long-lived; one per RowManager. Reused across runs."""
+
+    row_manager = Instance(RowManager)
+    qsignals    = Instance(ExecutorSignals)
+
+    pause_event = Instance(PauseEvent)
+    stop_event  = Instance(threading.Event)
+
+    _thread = Instance(QThread)
+    _error  = Instance(Exception)
+
+    bucket_pool_factory = Callable    # injectable for tests; default ThreadPoolExecutor
+
+    # --- public API (called from the GUI thread) ---
+
+    def start(self):
+        if self._thread and self._thread.isRunning():
+            return                    # idempotent; ignore double-start
+        self.pause_event.clear()
+        self.stop_event.clear()
+        self._error = None
+        self._thread = QThread()
+        self.moveToThread(self._thread)
+        self._thread.started.connect(self.run)
+        self._thread.start()
+
+    def pause(self):
+        self.pause_event.set()
+        self.qsignals.protocol_paused.emit()
+
+    def resume(self):
+        self.pause_event.clear()
+        self.qsignals.protocol_resumed.emit()
+
+    def stop(self):
+        self.stop_event.set()
+        self.pause_event.clear()      # unblock wait_cleared() so loop can notice
+
+    # --- main loop (runs on _thread) ---
+
+    def run(self):
+        cols = list(self.row_manager.columns)
+        proto_ctx = ProtocolContext(columns=cols, stop_event=self.stop_event)
+        try:
+            self._run_hooks("on_protocol_start", cols, proto_ctx, row=None)
+            self.qsignals.protocol_started.emit()
+
+            for row in self.row_manager.iter_execution_steps():
+                if self.stop_event.is_set():
+                    break
+                if self.pause_event.is_set():
+                    self.pause_event.wait_cleared()
+                    if self.stop_event.is_set():
+                        break
+
+                step_ctx = self._build_step_ctx(row, cols, proto_ctx)
+                set_active_step(step_ctx)
+                try:
+                    self.qsignals.step_started.emit(row)
+                    self._run_hooks("on_pre_step",  cols, step_ctx, row)
+                    self._run_hooks("on_step",      cols, step_ctx, row)
+                    self._run_hooks("on_post_step", cols, step_ctx, row)
+                    self.qsignals.step_finished.emit(row)
+                finally:
+                    clear_active_step()
+
+            # on_protocol_end runs even on stop, as best-effort cleanup
+            self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+
+        except Exception as e:
+            self._error = e
+            logger.exception("Protocol error")
+            try:
+                self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+            except Exception:
+                logger.exception("on_protocol_end raised during error cleanup")
+
+        finally:
+            self._emit_terminal_signal()
+            self._thread.quit()
+
+    def _emit_terminal_signal(self):
+        if self._error is not None:
+            self.qsignals.protocol_error.emit(str(self._error))
+        elif self.stop_event.is_set():
+            self.qsignals.protocol_aborted.emit()
+        else:
+            self.qsignals.protocol_finished.emit()
+
+    def _run_hooks(self, hook_name, cols, ctx, row):
+        """Priority-bucket fan-out. Sequential buckets, parallel within."""
+        buckets = group_by_priority(cols)
+        for priority in sorted(buckets):
+            bucket_cols = buckets[priority]
+            self._assert_no_topic_conflicts(bucket_cols)
+            with self.bucket_pool_factory(max_workers=max(1, len(bucket_cols))) as pool:
+                futures = {
+                    pool.submit(self._invoke_hook, col, hook_name, ctx, row): col
+                    for col in bucket_cols
+                }
+                first_exc = None
+                for f in as_completed(futures):
+                    if f.exception() and first_exc is None:
+                        first_exc = f.exception()
+                        # Set stop so any sibling wait_for() returns promptly,
+                        # then let the pool drain naturally.
+                        self.stop_event.set()
+                if first_exc is not None:
+                    raise first_exc
+```
+
+### Three pinned-down behaviors
+
+1. **Three terminal signal cases — single source of truth.** `_emit_terminal_signal` reads `self._error` and `self.stop_event` to decide which of `protocol_finished` / `protocol_aborted` / `protocol_error` fires. No path in `run()` emits these directly.
+
+2. **`stop` unblocks `pause`.** A naive `pause_event.set(); wait_cleared()` would deadlock if Stop happens during pause — Stop only sets `stop_event`, not `pause_event`. So `stop()` also clears `pause_event`, and the main loop re-checks `stop_event` after `wait_cleared()` returns.
+
+3. **Bucket parallel error → cooperative abort.** First exception in a bucket sets `stop_event`, lets siblings drain (their `wait_for` calls raise `AbortError` immediately), then raises the original exception out of `_run_hooks` to the outer try/except. We don't try to cancel futures — Python threads aren't cancellable.
+
+### Acknowledged limitation
+
+Hooks doing pure CPU work (no `wait_for`) **can't be aborted mid-call**. If a hook spins for 30 seconds doing math, Stop won't take effect until it returns. Doc'd best-practice: long-running hooks check `ctx.protocol.stop_event.is_set()` periodically. PPT-2's toy `MessageColumn` doesn't have this problem; PPT-3's `RoutesHandler` will need to mind it.
+
+## 6. The repetitions built-in column
+
+Always-on, fifth default column.
+
+```python
+# builtins/repetitions_column.py
+class RepetitionsColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Int(1, desc="Number of times this row executes (groups expand subtree N×)")
+
+
+def make_repetitions_column():
+    return Column(
+        model=RepetitionsColumnModel(
+            col_id="repetitions", col_name="Reps", default_value=1,
+        ),
+        view=IntSpinBoxColumnView(low=1, high=1000),
+    )
+```
+
+Plugin's `_assemble_columns` becomes `[type, id, name, repetitions, duration_s] + contributed`. Default visible. PPT-1 ships `iter_execution_steps` already reading `getattr(row, "repetitions", 1)`; the column populates the trait so the `getattr` fallback becomes vestigial (kept as-is for safety against orphan persisted protocols).
+
+## 7. Toy MessageColumn (demo only)
+
+```python
+# demos/message_column.py
+class MessageColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Str("hello", desc="Message published when this step runs")
+
+
+class MessageColumnHandler(BaseColumnHandler):
+    priority        = 50
+    wait_for_topics = []
+
+    def on_step(self, row, ctx):
+        msg = self.model.get_value(row)
+        publish_message(topic="microdrop/protocol_tree/demo_message",
+                        message={"row_uuid": row.uuid, "name": row.name, "msg": msg})
+
+
+def make_message_column():
+    return Column(
+        model=MessageColumnModel(
+            col_id="demo_message", col_name="Message", default_value="hello",
+        ),
+        view=StringEditColumnView(),
+        handler=MessageColumnHandler(),
+    )
+```
+
+Lives in `demos/`, not `builtins/`, because it's only useful in the demo. Tests instantiate it directly.
+
+## 8. Demo enhancement
+
+`demos/run_widget.py` gains a Run / Pause / Stop toolbar group; each button is wired to the executor. The demo wires:
+
+```python
+# in DemoWindow.__init__
+self.executor = ProtocolExecutor(
+    row_manager=self.manager,
+    qsignals=ExecutorSignals(),
+    pause_event=PauseEvent(),
+    stop_event=threading.Event(),
+)
+
+# Active-row highlighting
+self.executor.qsignals.step_started.connect(self.widget.model.set_active_node)
+self.executor.qsignals.step_finished.connect(lambda row: self.widget.model.set_active_node(None))
+self.executor.qsignals.protocol_finished.connect(lambda: self.widget.model.set_active_node(None))
+self.executor.qsignals.protocol_aborted.connect(lambda: self.widget.model.set_active_node(None))
+self.executor.qsignals.protocol_error.connect(lambda msg: QMessageBox.critical(self, "Protocol error", msg))
+
+# Toolbar
+tb.addAction("Run",   self.executor.start)
+tb.addAction("Pause", self._toggle_pause)   # toggles between pause()/resume()
+tb.addAction("Stop",  self.executor.stop)
+```
+
+The MessageColumn is added to the demo's column list so a fresh demo shows it as a column. Default reps=1 means a 3-step protocol runs 3 times through `on_step`; if the user changes a row's reps to 3, the active-row highlight visibly bounces back to that row 3 times.
+
+## 9. Testing
+
+### `tests/test_step_context.py` — pure unit, no Qt, no Dramatiq
+- `Mailbox.deposit` + `drain_one` round-trip
+- `drain_one` with predicate: matching message returns; non-matching is discarded; subsequent matching wakes
+- `drain_one` timeout raises `TimeoutError`
+- `drain_one` with `stop_event` pre-set raises `AbortError` immediately
+- `drain_one` with `stop_event` fired mid-wait raises `AbortError` (not waiting out timeout)
+- `wait_first` helper picks up the first event of N to fire
+- Pre-deposited messages return without blocking (the race-fix that justifies the buffering model)
+
+### `tests/test_executor.py` — executor logic, no Qt event loop, no Dramatiq
+Uses an injected synchronous `bucket_pool_factory` for deterministic test order. Signals are spied via direct-connect lambdas appending to a list (no `QApplication` needed).
+- All five hooks fire in the right order across one step (`on_protocol_start`, then per step `on_pre_step` / `on_step` / `on_post_step`, then `on_protocol_end`)
+- Bucket fan-out ordering: priority 10 column runs entirely before priority 30 starts
+- Same-priority bucket: two parallel columns both enter `on_step` before either returns (use a `threading.Barrier`)
+- Same-topic conflict assertion: two columns in the same priority bucket both declaring `wait_for_topics=["foo"]` raises a clear error at step start
+- `pause` between steps actually blocks: a column whose `on_step` calls `executor.pause()`; assert next step doesn't start until `executor.resume()`
+- `stop` mid-protocol exits cleanly + emits `protocol_aborted` (not `_finished`)
+- `stop` while paused unblocks (the deadlock-avoidance code in `executor.stop`)
+- Hook raises → `protocol_error(str)` emitted, NOT `protocol_finished` or `protocol_aborted`; `on_protocol_end` still called as cleanup
+- `on_protocol_end` raising during error cleanup is swallowed (logged, not re-raised) — original error wins
+- Repetitions column with value 3 → `on_step` fires 3× for the row
+
+### `tests/test_repetitions_column.py` — the new built-in
+- Default value is 1
+- IntSpinBox view low=1 high=1000
+- `iter_execution_steps` expands a step with `repetitions=3` to 3 yields (regression-locks the existing PPT-1 contract through a real column rather than `setattr`)
+
+### `tests_with_redis_server_need/test_executor_redis_integration.py` — one end-to-end test
+- Spin up a real `executor_listener` Dramatiq actor with a fixture
+- Build a column whose `on_step` does `publish_message("test/ack", {"ok": True})` then `ctx.wait_for("test/ack", timeout=2)`
+- Run the executor with one step
+- Assert the published message round-trips through Redis → listener → mailbox → `wait_for` → handler returns the payload
+- Skip via the existing `tests_with_redis_server_need/` convention if Redis isn't reachable
+
+### Acceptance bar for PPT-2 merge
+- All `pluggable_protocol_tree/tests/` pass without Redis (the integration test is gated)
+- The integration test passes with `redis-server` running
+- `demos/run_widget.py` opens, you can click Run on a 3-step protocol with the MessageColumn enabled, the active row highlight walks down the tree, Pause/Resume work between steps, Stop exits cleanly
+
+## 10. What's deferred
+
+- **Multiple concurrent waiters on the same topic.** Out of scope. The conflict assertion documents the contract.
+- **Dynamic column registration after plugin start.** The `wait_for_topics` aggregation runs once. New columns require a restart.
+- **Long-running CPU hooks with cooperative abort.** Best-practice doc'd; no enforcement until PPT-3's `RoutesHandler` needs it.
+- **Listener queue backpressure / persistence.** Default Dramatiq behavior; we don't tune it.
+- **Production dock-pane Run/Pause/Stop buttons.** Wait for PPT-3 when there's hardware to gate.
+
+## 11. Issue tracking
+
+- Sub-issue: `#364 [PPT-2] Executor + StepContext.wait_for + pause/stop` (already exists)
+- PR will close it via `Closes #364`
+- Each bite-sized implementation task in the PPT-2 plan gets its own commit; the PR aggregates them.

--- a/pluggable_protocol_tree/builtins/duration_column.py
+++ b/pluggable_protocol_tree/builtins/duration_column.py
@@ -1,17 +1,54 @@
 """Step duration in seconds.
 
 Stored as a Float trait on each row. Not meaningful on groups; the
-double-spinbox view already marks group cells non-editable."""
+double-spinbox view already marks group cells non-editable.
+
+The DurationColumnHandler sleeps for row.duration_s during on_step at
+priority 90 — late enough that other on_step hooks (route actuation,
+voltage application, etc.) have already published their commands and
+this handler provides the dwell time during which the action takes
+effect.
+"""
+
+import time
 
 from traits.api import Float
 
-from pluggable_protocol_tree.models.column import BaseColumnModel, Column
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
 from pluggable_protocol_tree.views.columns.spinbox import DoubleSpinBoxColumnView
 
 
 class DurationColumnModel(BaseColumnModel):
     def trait_for_row(self):
-        return Float(1.0, desc="Dwell time for this step in seconds")
+        # Honor the model's declared default_value rather than
+        # hard-coding a literal — lets callers (e.g. fast unit-test
+        # fixtures) configure the dwell-time default per protocol.
+        return Float(float(self.default_value or 0.0),
+                     desc="Dwell time for this step in seconds")
+
+
+class DurationColumnHandler(BaseColumnHandler):
+    """Sleeps for row.duration_s seconds in on_step.
+
+    Sleep is cooperative: a 50ms slice loop checks ctx.protocol.stop_event
+    every tick so a user Stop press lands within ~50ms even if the
+    duration is long. Without this, a 30-second duration would block
+    the worker thread for the full 30s past the Stop press.
+    """
+    priority = 90
+
+    _SLICE_S = 0.05
+
+    def on_step(self, row, ctx):
+        remaining = float(getattr(row, "duration_s", 0.0) or 0.0)
+        while remaining > 0:
+            if ctx.protocol.stop_event.is_set():
+                return
+            sleep_for = min(self._SLICE_S, remaining)
+            time.sleep(sleep_for)
+            remaining -= sleep_for
 
 
 def make_duration_column():
@@ -22,4 +59,5 @@ def make_duration_column():
         view=DoubleSpinBoxColumnView(
             low=0.0, high=3600.0, decimals=2, single_step=0.1,
         ),
+        handler=DurationColumnHandler(),
     )

--- a/pluggable_protocol_tree/builtins/repetitions_column.py
+++ b/pluggable_protocol_tree/builtins/repetitions_column.py
@@ -1,0 +1,31 @@
+"""Repetitions column — number of times each row executes.
+
+Steps repeat their on_step N times. Groups expand their child subtree
+N times. Default 1.
+
+iter_execution_steps in RowManager already reads ``getattr(row,
+"repetitions", 1)`` (PPT-1 left the contract in place); this column
+populates the trait so that getattr fallback becomes vestigial for
+new protocols. The fallback is kept for safety against persisted
+protocols that pre-date the column.
+"""
+
+from traits.api import Int
+
+from pluggable_protocol_tree.models.column import BaseColumnModel, Column
+from pluggable_protocol_tree.views.columns.spinbox import IntSpinBoxColumnView
+
+
+class RepetitionsColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Int(1, desc="Number of times this row executes (groups "
+                            "expand subtree N×)")
+
+
+def make_repetitions_column():
+    return Column(
+        model=RepetitionsColumnModel(
+            col_id="repetitions", col_name="Reps", default_value=1,
+        ),
+        view=IntSpinBoxColumnView(low=1, high=1000),
+    )

--- a/pluggable_protocol_tree/builtins/repetitions_column.py
+++ b/pluggable_protocol_tree/builtins/repetitions_column.py
@@ -10,6 +10,7 @@ new protocols. The fallback is kept for safety against persisted
 protocols that pre-date the column.
 """
 
+from pyface.qt.QtCore import Qt
 from traits.api import Int
 
 from pluggable_protocol_tree.models.column import BaseColumnModel, Column
@@ -22,10 +23,23 @@ class RepetitionsColumnModel(BaseColumnModel):
                             "expand subtree N×)")
 
 
+class RepsSpinBoxColumnView(IntSpinBoxColumnView):
+    """IntSpinBoxColumnView variant that stays editable on group rows.
+
+    The base IntSpinBoxColumnView strips ItemIsEditable on GroupRow
+    cells (numbers don't apply to most group columns). Repetitions IS
+    meaningful on groups — it multiplies the child subtree — so groups
+    must be editable here too.
+    """
+
+    def get_flags(self, row):
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+
+
 def make_repetitions_column():
     return Column(
         model=RepetitionsColumnModel(
             col_id="repetitions", col_name="Reps", default_value=1,
         ),
-        view=IntSpinBoxColumnView(low=1, high=1000),
+        view=RepsSpinBoxColumnView(low=1, high=1000),
     )

--- a/pluggable_protocol_tree/demos/ack_roundtrip_column.py
+++ b/pluggable_protocol_tree/demos/ack_roundtrip_column.py
@@ -1,0 +1,75 @@
+"""Demo column with publish → wait_for round-trip via Dramatiq.
+
+Mimics what production hardware columns (PPT-3+ Voltage / Routes /
+Electrodes) will do: publish a state-set request to a topic, block
+on ctx.wait_for() until the ack arrives on a different topic, then
+return so the next priority bucket (DurationColumnHandler at 90) can
+run its dwell sleep.
+
+The responder is an in-process Dramatiq actor that sleeps for a
+simulated settle time and publishes confirmation. Requires Redis +
+a worker; the demo's run_widget starts both. If Redis isn't reachable
+the wait_for will raise TimeoutError → protocol_error dialog.
+"""
+
+import logging
+import time
+
+import dramatiq
+from traits.api import Str
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.views.columns.string_edit import StringEditColumnView
+
+
+logger = logging.getLogger(__name__)
+
+DEMO_REQUEST_TOPIC = "microdrop/protocol_tree/demo_state_request"
+DEMO_APPLIED_TOPIC = "microdrop/protocol_tree/demo_state_applied"
+RESPONDER_ACTOR_NAME = "ppt_demo_state_responder"
+DEMO_ACK_DELAY_S = 0.3
+
+
+@dramatiq.actor(actor_name=RESPONDER_ACTOR_NAME, queue_name="default")
+def _demo_state_responder(message: str, topic: str, timestamp: float = None):
+    """Hardware-controller stand-in. Sleeps DEMO_ACK_DELAY_S (simulating
+    settle time) then publishes confirmation back through the router."""
+    logger.info("[demo responder] received %r on %s, applying...",
+                message, topic)
+    time.sleep(DEMO_ACK_DELAY_S)
+    publish_message(message=f"applied: {message}", topic=DEMO_APPLIED_TOPIC)
+    logger.info("[demo responder] published applied")
+
+
+class AckRoundtripModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Str(str(self.default_value or "HV=on"))
+
+
+class AckRoundtripHandler(BaseColumnHandler):
+    """Publishes the row's State value and waits for the ack before
+    returning. Priority 30 keeps this in an earlier bucket than
+    DurationColumnHandler (90) — sequential, not parallel — so the
+    duration timer only starts ticking once the ack arrives."""
+    priority = 30
+    wait_for_topics = [DEMO_APPLIED_TOPIC]
+
+    def on_step(self, row, ctx):
+        msg = self.model.get_value(row)
+        logger.info("[apply state] requesting %r", msg)
+        publish_message(message=str(msg), topic=DEMO_REQUEST_TOPIC)
+        payload = ctx.wait_for(DEMO_APPLIED_TOPIC, timeout=5.0)
+        logger.info("[apply state] ack received %r", payload)
+
+
+def make_ack_roundtrip_column():
+    return Column(
+        model=AckRoundtripModel(
+            col_id="state", col_name="State", default_value="HV=on",
+        ),
+        view=StringEditColumnView(),
+        handler=AckRoundtripHandler(),
+    )

--- a/pluggable_protocol_tree/demos/message_column.py
+++ b/pluggable_protocol_tree/demos/message_column.py
@@ -1,0 +1,51 @@
+"""Toy demo column — publishes a log line on every on_step.
+
+Lives in demos/, not builtins/, because it has no production purpose.
+The Redis integration test in tests_with_redis_server_need/ uses this
+column to prove the round-trip publish → listener → mailbox → wait_for
+path works against a real broker.
+"""
+
+from traits.api import Str
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.views.columns.string_edit import (
+    StringEditColumnView,
+)
+
+
+DEMO_MESSAGE_TOPIC = "microdrop/protocol_tree/demo_message"
+
+
+class MessageColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Str("hello", desc="Message published when this step runs")
+
+
+class MessageColumnHandler(BaseColumnHandler):
+    priority = 50
+    wait_for_topics = []        # demo doesn't wait
+
+    def on_step(self, row, ctx):
+        msg = self.model.get_value(row)
+        publish_message(
+            topic=DEMO_MESSAGE_TOPIC,
+            message={
+                "row_uuid": row.uuid,
+                "name": row.name,
+                "msg": msg,
+            },
+        )
+
+
+def make_message_column():
+    return Column(
+        model=MessageColumnModel(
+            col_id="demo_message", col_name="Message", default_value="hello",
+        ),
+        view=StringEditColumnView(),
+        handler=MessageColumnHandler(),
+    )

--- a/pluggable_protocol_tree/demos/run_headless.py
+++ b/pluggable_protocol_tree/demos/run_headless.py
@@ -16,17 +16,46 @@ The executor itself is Qt-aware (ExecutorSignals subclasses QObject) but
 no QApplication / event loop is required — Qt direct-connected slots
 fire synchronously on the worker thread. So this script runs anywhere
 PySide6 can be imported, headless servers included.
+
+Redis behaviour
+---------------
+If a Redis broker is reachable, the protocol includes the demo
+ack-roundtrip column (publishes a "set state" request to one topic and
+blocks via ctx.wait_for() for the ack on a different topic; the
+duration timer only starts ticking once the ack arrives). The script
+spins up an in-process Dramatiq Worker so the responder + listener
+actors actually fire, then stops it on exit.
+
+If Redis isn't reachable, the script logs a warning and runs the
+protocol without that column — still demonstrates the executor's
+scripting API end-to-end.
 """
 
 import logging
 import sys
+import threading
 import time
+
+import dramatiq
+
+# Strip the Prometheus middleware before any actor publishes — the
+# default install in this env raises 'Prometheus object has no attribute
+# message_durations' inside its after_process_message hook, which
+# corrupts the dispatch chain and turns every subsequent publish into
+# a silent drop. (The GUI demo applies the same workaround.)
+for _m in list(dramatiq.get_broker().middleware):
+    if _m.__module__ == "dramatiq.middleware.prometheus":
+        dramatiq.get_broker().middleware.remove(_m)
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
 from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
 from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.ack_roundtrip_column import (
+    DEMO_APPLIED_TOPIC, DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME,
+    make_ack_roundtrip_column,
+)
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.models.row_manager import RowManager
 
@@ -34,8 +63,75 @@ from pluggable_protocol_tree.models.row_manager import RowManager
 logger = logging.getLogger(__name__)
 
 
-def _build_protocol() -> RowManager:
-    """A small protocol exercising flat steps + a repeating group."""
+_SUBSCRIPTIONS = (
+    (DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME),
+    (DEMO_APPLIED_TOPIC, "pluggable_protocol_tree_executor_listener"),
+)
+
+
+def _setup_dramatiq_routing():
+    """Best-effort Dramatiq + Redis setup.
+
+    Returns ``(worker, router, ok)``: ``worker`` is a started
+    ``Dramatiq.Worker`` or None; ``router`` is the
+    ``MessageRouterActor`` instance for cleanup; ``ok`` is True iff the
+    routing was registered (i.e. the ack-roundtrip column will succeed).
+
+    Subscriptions are removed-then-re-added so a previous broken run
+    (e.g. one that crashed before its finally block could clean up)
+    doesn't leave stale subscribers in the Redis hash that double-fire
+    or absorb messages we expect.
+    """
+    try:
+        import dramatiq
+        from dramatiq import Worker
+        from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterActor
+
+        router = MessageRouterActor()
+        for topic, actor_name in _SUBSCRIPTIONS:
+            try:
+                router.message_router_data.remove_subscriber_from_topic(
+                    topic=topic, subscribing_actor_name=actor_name,
+                )
+            except Exception:
+                pass     # not subscribed → nothing to remove
+            router.message_router_data.add_subscriber_to_topic(
+                topic=topic, subscribing_actor_name=actor_name,
+            )
+        worker = Worker(dramatiq.get_broker(), worker_timeout=100)
+        worker.start()
+        logger.info("Dramatiq worker started; ack-roundtrip column enabled")
+        return worker, router, True
+    except Exception as e:
+        logger.warning(
+            "Dramatiq routing setup failed (Redis not running?): %s — "
+            "ack-roundtrip column will be omitted from the protocol", e,
+        )
+        return None, None, False
+
+
+def _teardown_dramatiq_routing(worker, router):
+    """Stop the worker and remove our subscriptions from the Redis hash.
+    Called from main()'s finally so subsequent demo runs start clean."""
+    if router is not None:
+        for topic, actor_name in _SUBSCRIPTIONS:
+            try:
+                router.message_router_data.remove_subscriber_from_topic(
+                    topic=topic, subscribing_actor_name=actor_name,
+                )
+            except Exception:
+                logger.exception("Error removing subscription %s/%s",
+                                 topic, actor_name)
+    if worker is not None:
+        try:
+            worker.stop()
+        except Exception:
+            logger.exception("Error stopping demo Dramatiq worker")
+
+
+def _build_protocol(include_ack_column: bool) -> RowManager:
+    """A small protocol exercising flat steps + a repeating group +
+    optionally the publish/wait_for round-trip column."""
     cols = [
         make_type_column(),
         make_id_column(),
@@ -43,11 +139,14 @@ def _build_protocol() -> RowManager:
         make_repetitions_column(),
         make_duration_column(),
     ]
+    if include_ack_column:
+        cols.append(make_ack_roundtrip_column())
     rm = RowManager(columns=cols)
 
     rm.add_step(values={"name": "Warmup", "duration_s": 0.5})
 
-    # A group that repeats twice
+    # A group that repeats twice — each child runs through the
+    # publish/wait_for cycle (if enabled) before its dwell timer.
     g = rm.add_group(name="LoopBody")
     rm.get_row(g).repetitions = 2
     rm.add_step(parent_path=g, values={"name": "InnerA", "duration_s": 0.3})
@@ -58,6 +157,17 @@ def _build_protocol() -> RowManager:
     rm.get_row(s).repetitions = 3
 
     rm.add_step(values={"name": "Cooldown", "duration_s": 0.5})
+
+    if include_ack_column:
+        # Override the State value on a few rows so the per-step log
+        # lines show different request payloads (the responder echoes
+        # them back in its "applied: ..." reply). Top-level positions:
+        # 0=Warmup, 1=LoopBody (group), 2=ThreeTimes, 3=Cooldown.
+        rm.get_row((0,)).state = "HV=on"
+        rm.get_row((1, 0)).state = "HV=ramp"   # InnerA inside LoopBody
+        rm.get_row((2,)).state = "HV=peak"
+        rm.get_row((3,)).state = "HV=off"
+
     return rm
 
 
@@ -68,23 +178,29 @@ def main() -> int:
         datefmt="%H:%M:%S",
     )
 
-    rm = _build_protocol()
-    n_steps = sum(1 for _ in rm.iter_execution_steps())
-    logger.info("Built protocol with %d total steps after rep expansion",
-                n_steps)
-
-    # Start non-blocking so we can still field Ctrl+C while the
-    # protocol runs on the worker thread.
-    ex = ProtocolExecutor.execute(rm, blocking=False)
-    print("Protocol running headlessly. Press Ctrl+C to stop.")
+    worker, router, redis_ok = _setup_dramatiq_routing()
     try:
-        ex.wait()
-    except KeyboardInterrupt:
-        print("\nKeyboardInterrupt — requesting stop")
-        ex.stop()
-        ex.wait(timeout=5.0)
-        return 130   # standard SIGINT exit code
-    return 0
+        rm = _build_protocol(include_ack_column=redis_ok)
+        n_steps = sum(1 for _ in rm.iter_execution_steps())
+        logger.info(
+            "Built protocol: %d total steps after rep expansion (ack-column %s)",
+            n_steps, "ENABLED" if redis_ok else "DISABLED — no Redis",
+        )
+
+        # Start non-blocking so we can still field Ctrl+C while the
+        # protocol runs on the worker thread.
+        ex = ProtocolExecutor.execute(rm, blocking=False)
+        print("Protocol running headlessly. Press Ctrl+C to stop.")
+        try:
+            ex.wait()
+        except KeyboardInterrupt:
+            print("\nKeyboardInterrupt — requesting stop")
+            ex.stop()
+            ex.wait(timeout=5.0)
+            return 130   # standard SIGINT exit code
+        return 0
+    finally:
+        _teardown_dramatiq_routing(worker, router)
 
 
 if __name__ == "__main__":

--- a/pluggable_protocol_tree/demos/run_headless.py
+++ b/pluggable_protocol_tree/demos/run_headless.py
@@ -1,0 +1,91 @@
+"""Headless protocol-execution demo — no Qt window, just log messages.
+
+Demonstrates the executor's scripting API:
+
+    ex = ProtocolExecutor.execute(row_manager, blocking=False)
+    ex.pause();  time.sleep(2);  ex.resume()
+    ex.stop()
+    ex.wait()
+
+Run:
+    pixi run python -m pluggable_protocol_tree.demos.run_headless
+
+Press Ctrl+C to stop the running protocol.
+
+The executor itself is Qt-aware (ExecutorSignals subclasses QObject) but
+no QApplication / event loop is required — Qt direct-connected slots
+fire synchronously on the worker thread. So this script runs anywhere
+PySide6 can be imported, headless servers included.
+"""
+
+import logging
+import sys
+import time
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.models.row_manager import RowManager
+
+
+logger = logging.getLogger(__name__)
+
+
+def _build_protocol() -> RowManager:
+    """A small protocol exercising flat steps + a repeating group."""
+    cols = [
+        make_type_column(),
+        make_id_column(),
+        make_name_column(),
+        make_repetitions_column(),
+        make_duration_column(),
+    ]
+    rm = RowManager(columns=cols)
+
+    rm.add_step(values={"name": "Warmup", "duration_s": 0.5})
+
+    # A group that repeats twice
+    g = rm.add_group(name="LoopBody")
+    rm.get_row(g).repetitions = 2
+    rm.add_step(parent_path=g, values={"name": "InnerA", "duration_s": 0.3})
+    rm.add_step(parent_path=g, values={"name": "InnerB", "duration_s": 0.3})
+
+    # A step that repeats by itself
+    s = rm.add_step(values={"name": "ThreeTimes", "duration_s": 0.2})
+    rm.get_row(s).repetitions = 3
+
+    rm.add_step(values={"name": "Cooldown", "duration_s": 0.5})
+    return rm
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    rm = _build_protocol()
+    n_steps = sum(1 for _ in rm.iter_execution_steps())
+    logger.info("Built protocol with %d total steps after rep expansion",
+                n_steps)
+
+    # Start non-blocking so we can still field Ctrl+C while the
+    # protocol runs on the worker thread.
+    ex = ProtocolExecutor.execute(rm, blocking=False)
+    print("Protocol running headlessly. Press Ctrl+C to stop.")
+    try:
+        ex.wait()
+    except KeyboardInterrupt:
+        print("\nKeyboardInterrupt — requesting stop")
+        ex.stop()
+        ex.wait(timeout=5.0)
+        return 130   # standard SIGINT exit code
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -11,12 +11,15 @@ Run: pixi run python -m pluggable_protocol_tree.demos.run_widget
 """
 
 import json
+import logging
 import sys
 import threading
+import time
 
-from pyface.qt.QtCore import Qt
+from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QMainWindow, QMessageBox, QToolBar,
+    QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox, QStatusBar,
+    QToolBar,
 )
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
@@ -60,11 +63,23 @@ class DemoWindow(QMainWindow):
             stop_event=threading.Event(),
         )
 
+        # Per-step timing state (mutated from GUI thread only).
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._step_total_duration = None
+        self._current_row = None
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(100)   # 10 Hz elapsed-time display
+        self._tick_timer.timeout.connect(self._refresh_status)
+
+        self._build_status_bar()
         self._wire_signals()
         self._build_toolbar()
+        self._reset_status()
 
     def _wire_signals(self):
-        # Active-row highlighting. Only step_started + terminal signals
+        # Active-row highlight. Only step_started + terminal signals
         # touch the highlight — step_finished does NOT clear it, so the
         # highlight stays on the just-finished row through the gap until
         # the next step_started replaces it. (Clearing on step_finished
@@ -72,6 +87,9 @@ class DemoWindow(QMainWindow):
         self.executor.qsignals.step_started.connect(
             self.widget.highlight_active_row
         )
+        # Status bar updates
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.step_finished.connect(self._on_step_finished)
         # Button state machine
         self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
         self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
@@ -116,24 +134,106 @@ class DemoWindow(QMainWindow):
         else:
             self.executor.pause()
 
+    # --- status bar (step counter + elapsed time + step name/path) ---
+
+    def _build_status_bar(self):
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        self._status_step_label = QLabel("Idle")
+        self._status_time_label = QLabel("")
+        self._status_row_label = QLabel("")
+        # First two stretch=0 (fixed width to text); row label takes the rest.
+        sb.addWidget(self._status_step_label)
+        sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_time_label)
+
+    def _reset_status(self):
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._step_total_duration = None
+        self._current_row = None
+        self._status_step_label.setText("Idle")
+        self._status_row_label.setText("")
+        self._status_time_label.setText("")
+
+    def _refresh_status(self):
+        if self._step_started_at is None or self._current_row is None:
+            return
+        elapsed = time.monotonic() - self._step_started_at
+        if self._step_total_duration is not None:
+            self._status_time_label.setText(
+                f"{elapsed:5.2f}s / {self._step_total_duration:.2f}s"
+            )
+        else:
+            self._status_time_label.setText(f"{elapsed:5.2f}s")
+
     # --- protocol-state slot handlers ---
 
     def _on_protocol_started(self):
         self._set_running_button_state()
+        # Pre-count total steps after rep expansion. This forces a one-
+        # time walk of iter_execution_steps; for huge protocols the cost
+        # is O(N) but acceptable here. Re-counted because reps may have
+        # changed since last run.
+        try:
+            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            self._step_total = 0
+        self._step_index = 0
+        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        self._step_started_at = time.monotonic()
+        try:
+            self._step_total_duration = float(getattr(row, "duration_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            self._step_total_duration = None
+        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
+        path_str = f" (path {path})" if path else ""
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self._status_row_label.setText(f"{row.name}{path_str}")
+        self._refresh_status()
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+
+    def _on_step_finished(self, _row):
+        # Freeze the time label at the step's actual elapsed; keep the
+        # step labels visible until the next step_started replaces them.
+        if self._step_started_at is not None:
+            elapsed = time.monotonic() - self._step_started_at
+            if self._step_total_duration is not None:
+                self._status_time_label.setText(
+                    f"{elapsed:5.2f}s / {self._step_total_duration:.2f}s"
+                )
+            else:
+                self._status_time_label.setText(f"{elapsed:5.2f}s")
 
     def _on_protocol_paused(self):
         self._pause_action.setText("Resume")
+        # Stop the elapsed-time tick during pause; resume restarts it.
+        self._tick_timer.stop()
 
     def _on_protocol_resumed(self):
         self._pause_action.setText("Pause")
+        if self._step_started_at is not None:
+            self._tick_timer.start()
 
     def _on_protocol_terminated(self):
         self.widget.highlight_active_row(None)
         self._set_idle_button_state()
+        self._tick_timer.stop()
+        self._reset_status()
 
     def _on_error(self, msg):
         self.widget.highlight_active_row(None)
         self._set_idle_button_state()
+        self._tick_timer.stop()
+        self._reset_status()
         QMessageBox.critical(self, "Protocol error", msg)
 
     def _save(self):
@@ -171,6 +271,13 @@ class DemoWindow(QMainWindow):
 
 
 def main():
+    # Surface the executor's INFO-level step transition logs so the
+    # demo user sees them in the terminal as the protocol runs.
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
     app = QApplication.instance() or QApplication(sys.argv)
     w = DemoWindow()
     w.show()

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -88,6 +88,7 @@ class DemoWindow(QMainWindow):
             self.widget.highlight_active_row
         )
         # Status bar updates
+        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
         self.executor.qsignals.step_started.connect(self._on_step_started)
         self.executor.qsignals.step_finished.connect(self._on_step_finished)
         # Button state machine
@@ -140,11 +141,13 @@ class DemoWindow(QMainWindow):
         sb = QStatusBar()
         self.setStatusBar(sb)
         self._status_step_label = QLabel("Idle")
-        self._status_time_label = QLabel("")
         self._status_row_label = QLabel("")
-        # First two stretch=0 (fixed width to text); row label takes the rest.
+        self._status_reps_label = QLabel("")
+        self._status_time_label = QLabel("")
+        # Row label takes any remaining width via stretch=1.
         sb.addWidget(self._status_step_label)
         sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_reps_label)
         sb.addPermanentWidget(self._status_time_label)
 
     def _reset_status(self):
@@ -155,6 +158,7 @@ class DemoWindow(QMainWindow):
         self._current_row = None
         self._status_step_label.setText("Idle")
         self._status_row_label.setText("")
+        self._status_reps_label.setText("")
         self._status_time_label.setText("")
 
     def _refresh_status(self):
@@ -182,6 +186,16 @@ class DemoWindow(QMainWindow):
             self._step_total = 0
         self._step_index = 0
         self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_repetition(self, rep_chain):
+        """Render the active rep context — e.g. "rep 2/3 of 'Wash'" —
+        into the status bar. Empty chain (no repeating ancestor) clears."""
+        if not rep_chain:
+            self._status_reps_label.setText("")
+            return
+        parts = [f"rep {idx}/{total} of '{name}'"
+                 for name, idx, total in rep_chain]
+        self._status_reps_label.setText(" · ".join(parts))
 
     def _on_step_started(self, row):
         self._step_index += 1

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -27,12 +27,19 @@ from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
 from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.ack_roundtrip_column import (
+    DEMO_APPLIED_TOPIC, DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME,
+    make_ack_roundtrip_column,
+)
 from pluggable_protocol_tree.demos.message_column import make_message_column
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+logger = logging.getLogger(__name__)
 
 
 def _columns():
@@ -43,6 +50,7 @@ def _columns():
         make_repetitions_column(),
         make_duration_column(),
         make_message_column(),
+        make_ack_roundtrip_column(),
     ]
 
 
@@ -73,10 +81,62 @@ class DemoWindow(QMainWindow):
         self._tick_timer.setInterval(100)   # 10 Hz elapsed-time display
         self._tick_timer.timeout.connect(self._refresh_status)
 
+        # Set up Dramatiq routing + a worker so the ack-roundtrip
+        # column's publish → wait_for actually completes. Best-effort:
+        # if Redis isn't running, the column will time out at runtime
+        # and surface as protocol_error in the dialog.
+        self._dramatiq_worker = None
+        self._setup_dramatiq_routing()
+
         self._build_status_bar()
         self._wire_signals()
         self._build_toolbar()
         self._reset_status()
+
+    def _setup_dramatiq_routing(self):
+        """Best-effort: register subscriptions for the ack-roundtrip
+        column's request/applied topics, and spin up an in-process
+        Dramatiq worker so the responder + executor_listener actors
+        actually receive messages."""
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterActor
+            from dramatiq import Worker
+            import dramatiq
+
+            router = MessageRouterActor()
+            router.message_router_data.add_subscriber_to_topic(
+                topic=DEMO_REQUEST_TOPIC,
+                subscribing_actor_name=RESPONDER_ACTOR_NAME,
+            )
+            router.message_router_data.add_subscriber_to_topic(
+                topic=DEMO_APPLIED_TOPIC,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+            self._router = router
+
+            self._dramatiq_worker = Worker(
+                dramatiq.get_broker(), worker_timeout=100,
+            )
+            self._dramatiq_worker.start()
+            logger.info("Dramatiq worker started for demo")
+        except ValueError as e:
+            # MessageRouterActor() raises if message_router_actor is
+            # already registered (e.g. demo loaded a second time in
+            # the same process via Load…). Reuse — don't double-register.
+            if "already registered" not in str(e):
+                logger.warning("Demo Dramatiq routing setup failed: %s", e)
+        except Exception as e:
+            logger.warning(
+                "Demo Dramatiq routing setup failed (Redis not running?): %s", e,
+            )
+
+    def closeEvent(self, event):
+        if self._dramatiq_worker is not None:
+            try:
+                self._dramatiq_worker.stop()
+            except Exception:
+                logger.exception("Error stopping demo dramatiq worker")
+        super().closeEvent(event)
 
     def _wire_signals(self):
         # Active-row highlight. Only step_started + terminal signals

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -16,6 +16,7 @@ import sys
 import threading
 import time
 
+import dramatiq
 from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
     QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox, QStatusBar,
@@ -38,7 +39,10 @@ from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
-
+# remove prometheus metrics for now
+for el in dramatiq.get_broker().middleware:
+    if el.__module__ == "dramatiq.middleware.prometheus":
+        dramatiq.get_broker().middleware.remove(el)
 logger = logging.getLogger(__name__)
 
 

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -64,19 +64,23 @@ class DemoWindow(QMainWindow):
         self._build_toolbar()
 
     def _wire_signals(self):
-        # Active-row highlighting
+        # Active-row highlighting. Only step_started + terminal signals
+        # touch the highlight — step_finished does NOT clear it, so the
+        # highlight stays on the just-finished row through the gap until
+        # the next step_started replaces it. (Clearing on step_finished
+        # makes the highlight flash off between steps and is invisible.)
         self.executor.qsignals.step_started.connect(
-            self.widget.model.set_active_node
+            self.widget.highlight_active_row
         )
-        self.executor.qsignals.step_finished.connect(
-            lambda _row: self.widget.model.set_active_node(None)
-        )
-        # Clean up highlight on terminal lifecycle signals
+        # Button state machine
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
+        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
         for sig in (
             self.executor.qsignals.protocol_finished,
             self.executor.qsignals.protocol_aborted,
         ):
-            sig.connect(lambda: self.widget.model.set_active_node(None))
+            sig.connect(self._on_protocol_terminated)
         self.executor.qsignals.protocol_error.connect(self._on_error)
 
     def _build_toolbar(self):
@@ -88,20 +92,48 @@ class DemoWindow(QMainWindow):
         tb.addAction("Save…", self._save)
         tb.addAction("Load…", self._load)
         tb.addSeparator()
-        tb.addAction("Run",   self.executor.start)
+        self._run_action = tb.addAction("Run", self.executor.start)
         self._pause_action = tb.addAction("Pause", self._toggle_pause)
-        tb.addAction("Stop",  self.executor.stop)
+        self._stop_action = tb.addAction("Stop", self.executor.stop)
+        # Initial state: only Run is enabled.
+        self._set_idle_button_state()
+
+    def _set_idle_button_state(self):
+        self._run_action.setEnabled(True)
+        self._pause_action.setEnabled(False)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(False)
+
+    def _set_running_button_state(self):
+        self._run_action.setEnabled(False)
+        self._pause_action.setEnabled(True)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(True)
 
     def _toggle_pause(self):
         if self.executor.pause_event.is_set():
             self.executor.resume()
-            self._pause_action.setText("Pause")
         else:
             self.executor.pause()
-            self._pause_action.setText("Resume")
+
+    # --- protocol-state slot handlers ---
+
+    def _on_protocol_started(self):
+        self._set_running_button_state()
+
+    def _on_protocol_paused(self):
+        self._pause_action.setText("Resume")
+
+    def _on_protocol_resumed(self):
+        self._pause_action.setText("Pause")
+
+    def _on_protocol_terminated(self):
+        self.widget.highlight_active_row(None)
+        self._set_idle_button_state()
 
     def _on_error(self, msg):
-        self.widget.model.set_active_node(None)
+        self.widget.highlight_active_row(None)
+        self._set_idle_button_state()
         QMessageBox.critical(self, "Protocol error", msg)
 
     def _save(self):

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -1,14 +1,18 @@
-"""Standalone demo — open ProtocolTreeWidget in a QMainWindow.
+"""Standalone demo — open ProtocolTreeWidget in a QMainWindow with
+Run / Pause / Stop toolbar buttons and active-row highlighting.
 
-No envisage, no dramatiq, no hardware. Smoke-tests the whole data
-path: add/remove/move rows, edit cells, select, copy/cut/paste,
-save/load (save uses a file dialog).
+No envisage, no dramatiq broker required for the in-process demo (the
+MessageColumn publishes to Dramatiq but the publish call no-ops if no
+broker is configured — the demo still exercises the executor's full
+control flow). For the round-trip with real subscribers, run the
+integration test or the full app.
 
 Run: pixi run python -m pluggable_protocol_tree.demos.run_widget
 """
 
 import json
 import sys
+import threading
 
 from pyface.qt.QtCore import Qt
 from pyface.qt.QtWidgets import (
@@ -18,7 +22,12 @@ from pyface.qt.QtWidgets import (
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
 from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.message_column import make_message_column
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
@@ -28,27 +37,72 @@ def _columns():
         make_type_column(),
         make_id_column(),
         make_name_column(),
+        make_repetitions_column(),
         make_duration_column(),
+        make_message_column(),
     ]
 
 
 class DemoWindow(QMainWindow):
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("Pluggable Protocol Tree — Demo")
-        self.resize(900, 600)
+        self.setWindowTitle("Pluggable Protocol Tree — Demo (PPT-2)")
+        self.resize(1000, 600)
 
         self.manager = RowManager(columns=_columns())
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
         self.setCentralWidget(self.widget)
 
-        tb = QToolBar("File")
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        self._wire_signals()
+        self._build_toolbar()
+
+    def _wire_signals(self):
+        # Active-row highlighting
+        self.executor.qsignals.step_started.connect(
+            self.widget.model.set_active_node
+        )
+        self.executor.qsignals.step_finished.connect(
+            lambda _row: self.widget.model.set_active_node(None)
+        )
+        # Clean up highlight on terminal lifecycle signals
+        for sig in (
+            self.executor.qsignals.protocol_finished,
+            self.executor.qsignals.protocol_aborted,
+        ):
+            sig.connect(lambda: self.widget.model.set_active_node(None))
+        self.executor.qsignals.protocol_error.connect(self._on_error)
+
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
         self.addToolBar(tb)
         tb.addAction("Add Step", lambda: self.manager.add_step())
         tb.addAction("Add Group", lambda: self.manager.add_group())
         tb.addSeparator()
         tb.addAction("Save…", self._save)
         tb.addAction("Load…", self._load)
+        tb.addSeparator()
+        tb.addAction("Run",   self.executor.start)
+        self._pause_action = tb.addAction("Pause", self._toggle_pause)
+        tb.addAction("Stop",  self.executor.stop)
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+            self._pause_action.setText("Pause")
+        else:
+            self.executor.pause()
+            self._pause_action.setText("Resume")
+
+    def _on_error(self, msg):
+        self.widget.model.set_active_node(None)
+        QMessageBox.critical(self, "Protocol error", msg)
 
     def _save(self):
         path, _ = QFileDialog.getSaveFileName(
@@ -74,6 +128,14 @@ class DemoWindow(QMainWindow):
             return
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
         self.setCentralWidget(self.widget)
+        # Re-wire executor against the new manager
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+        self._wire_signals()
 
 
 def main():

--- a/pluggable_protocol_tree/execution/events.py
+++ b/pluggable_protocol_tree/execution/events.py
@@ -1,0 +1,41 @@
+"""Synchronization primitives used by the executor."""
+
+import threading
+
+
+class PauseEvent:
+    """A pause/resume primitive built on two ``threading.Event``s.
+
+    ``threading.Event`` itself doesn't have a ``wait_cleared()`` method,
+    but the executor's main loop needs to block at a step boundary until
+    the user resumes — a single Event would only let it block until
+    *something* is set, not until the existing 'set' state goes away.
+    Implementing it as two events (one fires on set, the other on clear)
+    keeps each side a simple Event.wait() under the hood.
+    """
+
+    def __init__(self):
+        self._set = threading.Event()
+        self._cleared = threading.Event()
+        self._cleared.set()       # initial state: not paused
+
+    def set(self):
+        """Mark paused. wait_cleared() will block until clear() is called."""
+        self._set.set()
+        self._cleared.clear()
+
+    def clear(self):
+        """Mark unpaused. Wakes any thread blocked in wait_cleared()."""
+        self._set.clear()
+        self._cleared.set()
+
+    def is_set(self) -> bool:
+        return self._set.is_set()
+
+    def wait_cleared(self, timeout: float = None) -> bool:
+        """Block until the event is cleared (i.e., not paused).
+
+        Returns True if the event was cleared, False on timeout.
+        Returns immediately if already clear.
+        """
+        return self._cleared.wait(timeout)

--- a/pluggable_protocol_tree/execution/exceptions.py
+++ b/pluggable_protocol_tree/execution/exceptions.py
@@ -1,0 +1,11 @@
+"""Execution-layer exceptions."""
+
+
+class AbortError(Exception):
+    """Raised inside ctx.wait_for() when the executor's stop_event fires.
+
+    Hooks should let it propagate; the executor catches it at the bucket
+    boundary, sets stop_event (idempotent), drains other in-flight hooks,
+    and routes to the protocol_aborted or protocol_error terminal signal
+    via _emit_terminal_signal().
+    """

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -24,7 +24,13 @@ from pyface.qt.QtCore import QThread
 from traits.api import Any, Callable as CallableTrait, HasTraits, Instance
 
 from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.listener import (
+    set_active_step, clear_active_step,
+)
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.execution.step_context import (
+    ProtocolContext, StepContext,
+)
 from pluggable_protocol_tree.models.row_manager import RowManager
 
 
@@ -81,8 +87,95 @@ class ProtocolExecutor(HasTraits):
         self.stop_event.set()
         self.pause_event.clear()
 
-    # ------- main loop (overridden in Task 9) -------
+    # ------- main loop -------
 
     def run(self) -> None:
-        """Stub — fully implemented in Task 9."""
-        raise NotImplementedError("run() lands in Task 9")
+        """Main loop. Runs synchronously when called directly (tests),
+        or on its QThread when entered via start()."""
+        cols = list(self.row_manager.columns)
+        proto_ctx = ProtocolContext(
+            columns=cols, stop_event=self.stop_event,
+        )
+        try:
+            self._run_hooks("on_protocol_start", cols, proto_ctx, row=None)
+            self.qsignals.protocol_started.emit()
+
+            for row in self.row_manager.iter_execution_steps():
+                if self.stop_event.is_set():
+                    break
+                if self.pause_event.is_set():
+                    self.pause_event.wait_cleared()
+                    if self.stop_event.is_set():
+                        break
+
+                step_ctx = self._build_step_ctx(row, cols, proto_ctx)
+                set_active_step(step_ctx)
+                try:
+                    self.qsignals.step_started.emit(row)
+                    self._run_hooks("on_pre_step",  cols, step_ctx, row)
+                    self._run_hooks("on_step",      cols, step_ctx, row)
+                    self._run_hooks("on_post_step", cols, step_ctx, row)
+                    self.qsignals.step_finished.emit(row)
+                finally:
+                    clear_active_step()
+
+            # on_protocol_end runs even on stop, as best-effort cleanup.
+            self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+
+        except Exception as e:
+            self._error = e
+            logger.exception("Protocol error")
+            try:
+                self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
+            except Exception:
+                logger.exception("on_protocol_end raised during error cleanup")
+
+        finally:
+            self._emit_terminal_signal()
+            if self._thread is not None:
+                self._thread.quit()
+
+    # ------- helpers -------
+
+    def _emit_terminal_signal(self) -> None:
+        """Single source of truth for which lifecycle-end signal fires.
+
+        Order matters: an in-loop exception (recorded as self._error)
+        wins over user Stop, which wins over normal completion.
+        """
+        if self._error is not None:
+            self.qsignals.protocol_error.emit(str(self._error))
+        elif self.stop_event.is_set():
+            self.qsignals.protocol_aborted.emit()
+        else:
+            self.qsignals.protocol_finished.emit()
+
+    def _build_step_ctx(self, row, cols, proto_ctx) -> StepContext:
+        """Construct a fresh StepContext and pre-open one mailbox per
+        topic in the union of all handlers' wait_for_topics."""
+        step_ctx = StepContext(row=row, protocol=proto_ctx)
+        for col in cols:
+            for topic in (col.handler.wait_for_topics or []):
+                step_ctx.open_mailbox(topic)
+        return step_ctx
+
+    def _run_hooks(self, hook_name, cols, ctx, row) -> None:
+        """Stub — full priority-bucket implementation lands in Task 10.
+        Until then, run hooks sequentially in given order so the run-loop
+        tests can pass without depending on the bucket fan-out yet."""
+        for col in cols:
+            self._invoke_hook(col, hook_name, ctx, row)
+
+    def _invoke_hook(self, col, hook_name, ctx, row) -> None:
+        """Dispatch to the handler's named hook with the right signature.
+
+        Per-step hooks take (row, ctx); protocol-level take (ctx).
+        Default handlers from BaseColumnHandler are no-ops, so calling
+        them on every column is safe (and cheaper than introspecting
+        which columns override).
+        """
+        fn = getattr(col.handler, hook_name)
+        if hook_name in ("on_protocol_start", "on_protocol_end"):
+            fn(ctx)
+        else:
+            fn(row, ctx)

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -40,6 +40,11 @@ from pluggable_protocol_tree.models.row_manager import RowManager
 logger = logging.getLogger(__name__)
 
 
+def _dotted_path(path: tuple) -> str:
+    """1-indexed dotted display ('1.2.3') for a 0-indexed path tuple."""
+    return ".".join(str(i + 1) for i in path) if path else ""
+
+
 class ProtocolExecutor(HasTraits):
     """One executor per RowManager. Reused across runs."""
 
@@ -96,22 +101,37 @@ class ProtocolExecutor(HasTraits):
 
     def run(self) -> None:
         """Main loop. Runs synchronously when called directly (tests),
-        or on its QThread when entered via start()."""
+        or on its worker thread when entered via start()."""
+        import time as _time
         cols = list(self.row_manager.columns)
         proto_ctx = ProtocolContext(
             columns=cols, stop_event=self.stop_event,
         )
+        proto_started_at = _time.monotonic()
         try:
             self._run_hooks("on_protocol_start", cols, proto_ctx, row=None)
             self.qsignals.protocol_started.emit()
+            logger.info("Protocol started")
 
+            step_index = 0
             for row in self.row_manager.iter_execution_steps():
                 if self.stop_event.is_set():
                     break
                 if self.pause_event.is_set():
+                    logger.info("Protocol paused at step %d", step_index + 1)
                     self.pause_event.wait_cleared()
                     if self.stop_event.is_set():
                         break
+                    logger.info("Protocol resumed")
+
+                step_index += 1
+                step_started_at = _time.monotonic()
+                logger.info(
+                    "Step %d started: %r (path %s, duration_s=%s)",
+                    step_index, row.name,
+                    _dotted_path(row.path),
+                    getattr(row, "duration_s", None),
+                )
 
                 step_ctx = self._build_step_ctx(row, cols, proto_ctx)
                 set_active_step(step_ctx)
@@ -123,6 +143,11 @@ class ProtocolExecutor(HasTraits):
                     self.qsignals.step_finished.emit(row)
                 finally:
                     clear_active_step()
+
+                logger.info(
+                    "Step %d finished: %r in %.2fs",
+                    step_index, row.name, _time.monotonic() - step_started_at,
+                )
 
             # on_protocol_end runs even on stop, as best-effort cleanup.
             self._run_hooks("on_protocol_end", cols, proto_ctx, row=None)
@@ -137,6 +162,15 @@ class ProtocolExecutor(HasTraits):
 
         finally:
             self._emit_terminal_signal()
+            outcome = (
+                "errored" if self._error is not None
+                else "aborted" if self.stop_event.is_set()
+                else "finished"
+            )
+            logger.info(
+                "Protocol %s in %.2fs",
+                outcome, _time.monotonic() - proto_started_at,
+            )
             # threading.Thread terminates naturally when run() returns;
             # nothing to quit() here. start() checks is_alive() to make
             # sure a previous run has completed before starting a new one.

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -153,10 +153,29 @@ class ProtocolExecutor(HasTraits):
 
     def _build_step_ctx(self, row, cols, proto_ctx) -> StepContext:
         """Construct a fresh StepContext and pre-open one mailbox per
-        topic in the union of all handlers' wait_for_topics."""
+        topic in the union of all handlers' wait_for_topics.
+
+        Raises ValueError if two columns *in the same priority bucket*
+        declare the same topic — they'd race for the mailbox under
+        parallel fan-out, and we don't yet have a use case for
+        broadcast-to-multiple-waiters semantics. Same topic in
+        different buckets is fine (sequential).
+        """
         step_ctx = StepContext(row=row, protocol=proto_ctx)
+        # Detect within-bucket topic collisions before opening any boxes.
+        per_priority_topics: dict[int, dict[str, str]] = {}  # priority → topic → col_id
         for col in cols:
-            for topic in (col.handler.wait_for_topics or []):
+            topics = col.handler.wait_for_topics or []
+            bucket = per_priority_topics.setdefault(col.handler.priority, {})
+            for topic in topics:
+                if topic in bucket:
+                    raise ValueError(
+                        f"Topic conflict: columns {bucket[topic]!r} and "
+                        f"{col.model.col_id!r} both declare wait_for_topics={topic!r} "
+                        f"at the same priority bucket ({col.handler.priority}); "
+                        f"they would race for the mailbox."
+                    )
+                bucket[topic] = col.model.col_id
                 step_ctx.open_mailbox(topic)
         return step_ctx
 

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -17,7 +17,8 @@ hook fan-out, and conflict assertion land in subsequent tasks.
 
 import logging
 import threading
-from concurrent.futures import ThreadPoolExecutor
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Optional
 
 from pyface.qt.QtCore import QThread
@@ -160,11 +161,41 @@ class ProtocolExecutor(HasTraits):
         return step_ctx
 
     def _run_hooks(self, hook_name, cols, ctx, row) -> None:
-        """Stub — full priority-bucket implementation lands in Task 10.
-        Until then, run hooks sequentially in given order so the run-loop
-        tests can pass without depending on the bucket fan-out yet."""
+        """Priority-bucket fan-out.
+
+        Lower priority runs first. Equal priorities run in parallel
+        (one ThreadPoolExecutor per bucket; the executor returns
+        only when every future in the bucket has resolved).
+
+        The first exception in any bucket wins: stop_event is set so
+        sibling hooks waiting on ctx.wait_for() return promptly via
+        AbortError, the pool drains, and the original exception is
+        re-raised out of this method.
+        """
+        buckets = defaultdict(list)
         for col in cols:
-            self._invoke_hook(col, hook_name, ctx, row)
+            buckets[col.handler.priority].append(col)
+
+        for priority in sorted(buckets):
+            bucket_cols = buckets[priority]
+            with self.bucket_pool_factory(
+                max_workers=max(1, len(bucket_cols)),
+            ) as pool:
+                futures = {
+                    pool.submit(self._invoke_hook, col, hook_name, ctx, row): col
+                    for col in bucket_cols
+                }
+                first_exc = None
+                for f in as_completed(futures):
+                    exc = f.exception()
+                    if exc is not None and first_exc is None:
+                        first_exc = exc
+                        # Set stop so sibling wait_for() calls return
+                        # promptly — pool.__exit__ will then wait for
+                        # those threads to drain naturally.
+                        self.stop_event.set()
+                if first_exc is not None:
+                    raise first_exc
 
     def _invoke_hook(self, col, hook_name, ctx, row) -> None:
         """Dispatch to the handler's named hook with the right signature.

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -1,0 +1,88 @@
+"""Protocol executor — runs a RowManager's rows on a QThread.
+
+Responsibilities:
+  * Walk row_manager.iter_execution_steps() in order.
+  * For each row, fan the five hooks across priority buckets (sequential
+    between buckets, parallel within).
+  * Distinguish protocol_finished / protocol_aborted / protocol_error in
+    one place (_emit_terminal_signal).
+  * Cooperate with stop/pause/error: stop_event short-circuits the loop
+    and propagates into ctx.wait_for; pause_event blocks at step
+    boundaries only; first hook exception aborts the step and routes to
+    protocol_error.
+
+This task ships only the scaffolding + public control API. The run loop,
+hook fan-out, and conflict assertion land in subsequent tasks.
+"""
+
+import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable, Optional
+
+from pyface.qt.QtCore import QThread
+from traits.api import Any, Callable as CallableTrait, HasTraits, Instance
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProtocolExecutor(HasTraits):
+    """One executor per RowManager. Reused across runs."""
+
+    row_manager = Instance(RowManager)
+    qsignals    = Instance(ExecutorSignals)
+
+    pause_event = Instance(PauseEvent)
+    stop_event  = Instance(threading.Event)
+
+    # Internal — set by start() / cleared by run()'s finally.
+    _thread = Any
+    _error  = Any
+
+    # Injectable for tests (e.g. a synchronous executor for determinism).
+    bucket_pool_factory = CallableTrait
+
+    def _bucket_pool_factory_default(self):
+        return ThreadPoolExecutor
+
+    # ------- public control API (called from the GUI thread) -------
+
+    def start(self) -> None:
+        """Spawn a QThread and call run() on it. Idempotent — a second
+        call while already running is ignored."""
+        if self._thread is not None and self._thread.isRunning():
+            return
+        self.pause_event.clear()
+        self.stop_event.clear()
+        self._error = None
+        self._thread = QThread()
+        self.moveToThread(self._thread)
+        self._thread.started.connect(self.run)
+        self._thread.start()
+
+    def pause(self) -> None:
+        """Set pause_event. Effective at the next step boundary."""
+        self.pause_event.set()
+        self.qsignals.protocol_paused.emit()
+
+    def resume(self) -> None:
+        """Clear pause_event so the main loop unblocks."""
+        self.pause_event.clear()
+        self.qsignals.protocol_resumed.emit()
+
+    def stop(self) -> None:
+        """Set stop_event AND clear pause_event so a Stop-while-paused
+        doesn't deadlock the main loop in pause_event.wait_cleared()."""
+        self.stop_event.set()
+        self.pause_event.clear()
+
+    # ------- main loop (overridden in Task 9) -------
+
+    def run(self) -> None:
+        """Stub — fully implemented in Task 9."""
+        raise NotImplementedError("run() lands in Task 9")

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -61,8 +61,41 @@ class ProtocolExecutor(HasTraits):
     # Injectable for tests (e.g. a synchronous executor for determinism).
     bucket_pool_factory = CallableTrait
 
+    # ------- defaults so headless callers can ProtocolExecutor(row_manager=rm) -------
+
+    def _qsignals_default(self):
+        return ExecutorSignals()
+
+    def _pause_event_default(self):
+        return PauseEvent()
+
+    def _stop_event_default(self):
+        return threading.Event()
+
     def _bucket_pool_factory_default(self):
         return ThreadPoolExecutor
+
+    # ------- one-shot convenience for headless / scripting callers -------
+
+    @classmethod
+    def execute(cls, row_manager, blocking: bool = True,
+                timeout: float = None) -> "ProtocolExecutor":
+        """Construct an executor with sensible defaults, start it, and
+        optionally block until done. Returns the executor so the caller
+        can pause/resume/stop or inspect signals afterwards.
+
+        Headless usage:
+            ex = ProtocolExecutor.execute(rm, blocking=False)
+            ex.pause()
+            time.sleep(2)
+            ex.resume()
+            ex.wait()
+        """
+        ex = cls(row_manager=row_manager)
+        ex.start()
+        if blocking:
+            ex.wait(timeout=timeout)
+        return ex
 
     # ------- public control API (called from the GUI thread) -------
 
@@ -80,6 +113,16 @@ class ProtocolExecutor(HasTraits):
             daemon=True,
         )
         self._thread.start()
+
+    def wait(self, timeout: float = None) -> bool:
+        """Block until the executor's worker thread finishes (or the
+        timeout elapses). Returns True if the thread is no longer
+        running, False if it's still going (timeout case). Returns True
+        immediately if start() was never called."""
+        if self._thread is None:
+            return True
+        self._thread.join(timeout=timeout)
+        return not self._thread.is_alive()
 
     def pause(self) -> None:
         """Set pause_event. Effective at the next step boundary."""

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -117,7 +117,7 @@ class ProtocolExecutor(HasTraits):
             logger.info("Protocol started")
 
             step_index = 0
-            for row in self.row_manager.iter_execution_steps():
+            for row, rep_chain in self.row_manager.iter_execution_frames():
                 if self.stop_event.is_set():
                     break
                 if self.pause_event.is_set():
@@ -129,16 +129,25 @@ class ProtocolExecutor(HasTraits):
 
                 step_index += 1
                 step_started_at = _time.monotonic()
+                rep_str = (
+                    " | " + ", ".join(f"rep {i}/{n} of {name!r}"
+                                      for name, i, n in rep_chain)
+                    if rep_chain else ""
+                )
                 logger.info(
-                    "Step %d started: %r (path %s, duration_s=%s)",
+                    "Step %d started: %r (path %s, duration_s=%s)%s",
                     step_index, row.name,
                     _dotted_path(row.path),
                     getattr(row, "duration_s", None),
+                    rep_str,
                 )
 
                 step_ctx = self._build_step_ctx(row, cols, proto_ctx)
                 set_active_step(step_ctx)
                 try:
+                    # Rep info first so UI labels are populated before the
+                    # row-highlight fires from step_started.
+                    self.qsignals.step_repetition.emit(rep_chain)
                     self.qsignals.step_started.emit(row)
                     self._run_hooks("on_pre_step",  cols, step_ctx, row)
                     self._run_hooks("on_step",      cols, step_ctx, row)

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -28,7 +28,7 @@ from traits.api import Any, Callable as CallableTrait, HasTraits, Instance
 
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.listener import (
-    set_active_step, clear_active_step,
+    set_active_step, clear_active_step, warm_broker_connection,
 )
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.execution.step_context import (
@@ -109,6 +109,9 @@ class ProtocolExecutor(HasTraits):
         )
         proto_started_at = _time.monotonic()
         try:
+            # Hide first-publish latency (Redis connect ~2s) from step 1's
+            # observed duration by warming the broker connection upfront.
+            warm_broker_connection()
             self._run_hooks("on_protocol_start", cols, proto_ctx, row=None)
             self.qsignals.protocol_started.emit()
             logger.info("Protocol started")

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -1,4 +1,4 @@
-"""Protocol executor — runs a RowManager's rows on a QThread.
+"""Protocol executor — runs a RowManager's rows on a worker thread.
 
 Responsibilities:
   * Walk row_manager.iter_execution_steps() in order.
@@ -11,8 +11,11 @@ Responsibilities:
     boundaries only; first hook exception aborts the step and routes to
     protocol_error.
 
-This task ships only the scaffolding + public control API. The run loop,
-hook fan-out, and conflict assertion land in subsequent tasks.
+The worker thread is a plain ``threading.Thread``, not ``QThread``. The
+executor itself is a HasTraits, not a QObject — moveToThread only works
+on QObjects. Qt signal marshalling to GUI-thread slots still works
+because ExecutorSignals is its own QObject; emissions from any thread
+queue correctly to slots living on the GUI thread.
 """
 
 import logging
@@ -21,7 +24,6 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Callable, Optional
 
-from pyface.qt.QtCore import QThread
 from traits.api import Any, Callable as CallableTrait, HasTraits, Instance
 
 from pluggable_protocol_tree.execution.events import PauseEvent
@@ -60,16 +62,18 @@ class ProtocolExecutor(HasTraits):
     # ------- public control API (called from the GUI thread) -------
 
     def start(self) -> None:
-        """Spawn a QThread and call run() on it. Idempotent — a second
-        call while already running is ignored."""
-        if self._thread is not None and self._thread.isRunning():
+        """Spawn a worker thread and call run() on it. Idempotent —
+        a second call while already running is ignored."""
+        if self._thread is not None and self._thread.is_alive():
             return
         self.pause_event.clear()
         self.stop_event.clear()
         self._error = None
-        self._thread = QThread()
-        self.moveToThread(self._thread)
-        self._thread.started.connect(self.run)
+        self._thread = threading.Thread(
+            target=self.run,
+            name="pluggable_protocol_tree_executor",
+            daemon=True,
+        )
         self._thread.start()
 
     def pause(self) -> None:
@@ -133,8 +137,9 @@ class ProtocolExecutor(HasTraits):
 
         finally:
             self._emit_terminal_signal()
-            if self._thread is not None:
-                self._thread.quit()
+            # threading.Thread terminates naturally when run() returns;
+            # nothing to quit() here. start() checks is_alive() to make
+            # sure a previous run has completed before starting a new one.
 
     # ------- helpers -------
 

--- a/pluggable_protocol_tree/execution/listener.py
+++ b/pluggable_protocol_tree/execution/listener.py
@@ -62,13 +62,16 @@ def route_to_active_step(topic: str, payload) -> None:
 
 @dramatiq.actor(actor_name="pluggable_protocol_tree_executor_listener",
                 queue_name="default")
-def executor_listener(message: dict) -> None:
-    """Receives every message on any topic in the aggregated
-    wait_for_topics set. Conforms to the project's message-router
-    payload shape: ``{"topic": ..., "message": ...}`` (the message
-    router's publish_message wraps user payloads in this envelope)."""
-    topic = message.get("topic")
-    payload = message.get("message")
-    if topic is None:
-        return
-    route_to_active_step(topic, payload)
+def executor_listener(message: str, topic: str, timestamp: float = None) -> None:
+    """Receives every message routed by message_router_actor on any
+    topic the plugin aggregated from contributed handlers'
+    wait_for_topics. Signature mirrors the project's message-router
+    contract: ``(message, topic, timestamp)`` — see
+    DramatiqControllerBase._listener_actor_default for reference.
+
+    The payload is whatever ``publish_message(message=..., topic=...)``
+    sent, after str()-conversion via TimestampedMessage. Handlers that
+    publish JSON-encoded dicts json.loads() the result on the
+    receiving side.
+    """
+    route_to_active_step(topic, message)

--- a/pluggable_protocol_tree/execution/listener.py
+++ b/pluggable_protocol_tree/execution/listener.py
@@ -1,0 +1,74 @@
+"""Dramatiq listener actor + active-step pointer.
+
+The actor itself receives every message published on any topic the
+plugin's start() method aggregated from contributed handlers'
+wait_for_topics. It routes payloads into the active step's mailbox via
+``route_to_active_step`` — the same function tests can call directly to
+bypass Dramatiq.
+
+Only one protocol runs at a time, so a single module-level pointer is
+enough. set/clear are guarded by a lock so the listener thread and the
+executor's main loop don't see a torn read on the pointer transition
+between steps.
+"""
+
+import threading
+from typing import Optional
+
+import dramatiq
+
+from pluggable_protocol_tree.execution.step_context import StepContext
+
+
+_active_step_ctx: Optional[StepContext] = None
+_active_lock = threading.Lock()
+
+
+def set_active_step(step_ctx: StepContext) -> None:
+    """Called by the executor at the start of each step (before any
+    hook runs)."""
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = step_ctx
+
+
+def clear_active_step() -> None:
+    """Called by the executor at the end of each step. Subsequent
+    incoming messages on what *was* the step's topics are dropped
+    silently until the next set_active_step()."""
+    global _active_step_ctx
+    with _active_lock:
+        _active_step_ctx = None
+
+
+def get_active_step() -> Optional[StepContext]:
+    """For tests + the dramatiq actor."""
+    with _active_lock:
+        return _active_step_ctx
+
+
+def route_to_active_step(topic: str, payload) -> None:
+    """Deposit a payload into the active step's mailbox for ``topic``.
+    Drops silently if no protocol is running, or if the active step
+    didn't pre-open a mailbox for ``topic``.
+
+    Direct entry point for both the dramatiq actor and unit tests.
+    """
+    ctx = get_active_step()
+    if ctx is None:
+        return
+    ctx.deposit(topic, payload)
+
+
+@dramatiq.actor(actor_name="pluggable_protocol_tree_executor_listener",
+                queue_name="default")
+def executor_listener(message: dict) -> None:
+    """Receives every message on any topic in the aggregated
+    wait_for_topics set. Conforms to the project's message-router
+    payload shape: ``{"topic": ..., "message": ...}`` (the message
+    router's publish_message wraps user payloads in this envelope)."""
+    topic = message.get("topic")
+    payload = message.get("message")
+    if topic is None:
+        return
+    route_to_active_step(topic, payload)

--- a/pluggable_protocol_tree/execution/listener.py
+++ b/pluggable_protocol_tree/execution/listener.py
@@ -47,6 +47,30 @@ def get_active_step() -> Optional[StepContext]:
         return _active_step_ctx
 
 
+def warm_broker_connection() -> None:
+    """Touch the Dramatiq broker so the first publish_message during a
+    step doesn't pay first-connection latency.
+
+    The first call to ``broker.enqueue(...)`` against a RedisBroker
+    establishes the underlying TCP connection and pulls in middleware —
+    we've measured ~2 seconds on the first call after process start.
+    Subsequent calls reuse the connection (microseconds). Doing a cheap
+    ``client.ping()`` here at protocol start hides that from the first
+    step's measured duration.
+
+    Best-effort — silently skips if no broker is configured, the broker
+    doesn't expose a client (e.g. StubBroker), or the ping itself
+    fails. The first real publish will pay the cost in those cases.
+    """
+    try:
+        broker = dramatiq.get_broker()
+        client = getattr(broker, "client", None)
+        if client is not None and hasattr(client, "ping"):
+            client.ping()
+    except Exception:
+        pass
+
+
 def route_to_active_step(topic: str, payload) -> None:
     """Deposit a payload into the active step's mailbox for ``topic``.
     Drops silently if no protocol is running, or if the active step

--- a/pluggable_protocol_tree/execution/signals.py
+++ b/pluggable_protocol_tree/execution/signals.py
@@ -23,3 +23,8 @@ class ExecutorSignals(QObject):
     # Per-step
     step_started       = Signal(object)     # row
     step_finished      = Signal(object)     # row
+    # Tuple of (group_name, rep_idx_1based, rep_total) entries describing
+    # the active rep context for the current step (outermost-first).
+    # Empty tuple means "no repeating ancestor". Emitted just before
+    # each step_started so UI labels can update in lockstep.
+    step_repetition    = Signal(object)

--- a/pluggable_protocol_tree/execution/signals.py
+++ b/pluggable_protocol_tree/execution/signals.py
@@ -1,0 +1,25 @@
+"""QObject carrying the executor's UI-facing signals.
+
+Lives on a QObject (not the Traits-based ProtocolExecutor) so Qt's
+queued-connection machinery can marshal emissions from the executor's
+worker thread to slots living on the GUI thread automatically.
+
+UI consumers connect directly:
+    executor.qsignals.step_started.connect(tree_model.set_active_node)
+"""
+
+from pyface.qt.QtCore import QObject, Signal
+
+
+class ExecutorSignals(QObject):
+    # Lifecycle
+    protocol_started   = Signal()
+    protocol_paused    = Signal()
+    protocol_resumed   = Signal()
+    protocol_finished  = Signal()           # ran to completion
+    protocol_aborted   = Signal()           # user pressed Stop
+    protocol_error     = Signal(str)        # exception raised in a hook
+
+    # Per-step
+    step_started       = Signal(object)     # row
+    step_finished      = Signal(object)     # row

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -98,3 +98,80 @@ class Mailbox:
             if triggered is stop_event:
                 raise AbortError("stop_event fired while waiting")
             # else self._wake fired; loop back and try to drain.
+
+
+# --- contexts ---
+
+from traits.api import Any, Dict, HasTraits, Instance, Str, List
+
+from pluggable_protocol_tree.interfaces.i_column import IColumn
+from pluggable_protocol_tree.models.row import BaseRow
+
+
+class ProtocolContext(HasTraits):
+    """Spans one protocol run.
+
+    Hooks reach this from a StepContext via ``ctx.protocol``. Use
+    ``scratch`` for cross-step state (e.g. cumulative stats). The
+    ``stop_event`` lets long-running CPU hooks check for Stop without
+    going through ctx.wait_for; e.g.
+    ``while not ctx.protocol.stop_event.is_set(): ...``.
+    """
+    columns    = List(Instance(IColumn))
+    scratch    = Dict(Str, Any,
+                      desc="protocol-scoped scratch (cleared on each run)")
+    stop_event = Instance(threading.Event)
+
+
+class StepContext(HasTraits):
+    """Spans one row's execution.
+
+    Hooks call ``wait_for(topic, ...)`` on this. Mailboxes are opened by
+    the executor before any hook runs (so a hook can publish a request
+    and immediately wait for the ack without losing fast replies).
+    """
+    row       = Instance(BaseRow)
+    protocol  = Instance(ProtocolContext)
+    scratch   = Dict(Str, Any,
+                     desc="step-scoped scratch (cleared per step)")
+    _mailboxes = Dict(Str, Instance(Mailbox))
+
+    def open_mailbox(self, topic: str) -> None:
+        """Pre-register a mailbox for ``topic``. Called by the executor
+        at step start for every topic in the union of all handlers'
+        wait_for_topics. Idempotent."""
+        if topic not in self._mailboxes:
+            self._mailboxes[topic] = Mailbox()
+
+    def deposit(self, topic: str, payload) -> None:
+        """Called by the dramatiq listener for any message on a topic
+        the active step has a mailbox for. Drops messages for topics
+        without an open mailbox (handler didn't declare wait_for)."""
+        box = self._mailboxes.get(topic)
+        if box is not None:
+            box.deposit(payload)
+
+    def wait_for(self, topic: str, timeout: float = 5.0,
+                 predicate: Optional[Callable] = None):
+        """Block until a message on ``topic`` satisfying ``predicate``
+        arrives, or the timeout/stop fires.
+
+        Returns the payload. Raises:
+          * ``KeyError`` if ``topic`` was not declared in any handler's
+            ``wait_for_topics`` (the executor would not have opened a
+            mailbox; waiting would block forever).
+          * ``TimeoutError`` after ``timeout`` seconds.
+          * ``AbortError`` if the protocol's stop_event fires.
+        """
+        try:
+            box = self._mailboxes[topic]
+        except KeyError:
+            raise KeyError(
+                f"wait_for({topic!r}) called but topic not in any handler's "
+                f"wait_for_topics; declare it on the IColumnHandler."
+            )
+        return box.drain_one(
+            predicate=predicate,
+            timeout=timeout,
+            stop_event=self.protocol.stop_event,
+        )

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -1,0 +1,100 @@
+"""Per-protocol and per-step contexts plus the mailbox machinery that
+backs ctx.wait_for().
+
+This file groups Mailbox, wait_first, ProtocolContext, and StepContext
+together because they form one cohesive unit — a Mailbox's lifetime is
+bound to a StepContext's lifetime, and wait_for is the public method
+that ties them together. Splitting them across files would scatter
+their tight coupling for no payoff.
+
+ProtocolContext / StepContext land in Task 6 — this task ships only the
+two primitives Mailbox depends on.
+"""
+
+import queue
+import threading
+import time
+from typing import Callable, Optional
+
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def wait_first(events: list, timeout: float) -> Optional[threading.Event]:
+    """Block until any of `events` fires, or the timeout elapses.
+
+    Returns the Event that fired, or None on timeout. Implemented by
+    polling each event with a short slice — Python's stdlib does not
+    expose a kqueue/epoll-style multi-event wait, and rolling a
+    waker-channel implementation is more code than the executor needs.
+
+    The poll interval is small enough that responsiveness is dominated
+    by the OS scheduler, not by the polling cadence.
+    """
+    deadline = time.monotonic() + timeout
+    poll_interval = 0.01      # 10ms
+    while True:
+        for e in events:
+            if e.is_set():
+                return e
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return None
+        time.sleep(min(poll_interval, remaining))
+
+
+class Mailbox:
+    """A SimpleQueue-backed buffer with a wake event.
+
+    One Mailbox per (active step, topic) pair. The dramatiq listener
+    deposits payloads; ``drain_one`` blocks until a satisfying item is
+    available, the stop_event fires, or the timeout expires.
+    """
+
+    def __init__(self):
+        self._queue = queue.SimpleQueue()
+        self._wake = threading.Event()
+
+    def deposit(self, payload):
+        """Push a payload onto the queue and wake any blocked waiter."""
+        self._queue.put(payload)
+        self._wake.set()
+
+    def drain_one(self, predicate: Optional[Callable], timeout: float,
+                  stop_event: threading.Event):
+        """Return the first queued item satisfying ``predicate``.
+
+        Discards predicate-rejected items (they are not requeued).
+        Raises ``TimeoutError`` if the deadline elapses with no match.
+        Raises ``AbortError`` if ``stop_event`` is set, either before
+        the call or while the call is blocked.
+        """
+        if stop_event.is_set():
+            raise AbortError("stop_event set before wait_for")
+        deadline = time.monotonic() + timeout
+        while True:
+            # 1) Drain any currently-queued items.
+            while True:
+                try:
+                    item = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                if predicate is None or predicate(item):
+                    return item
+                # else discard and continue
+            # 2) Block for more.
+            self._wake.clear()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"wait_for timed out after {timeout}s"
+                )
+            triggered = wait_first(
+                [self._wake, stop_event], timeout=remaining
+            )
+            if triggered is None:
+                raise TimeoutError(
+                    f"wait_for timed out after {timeout}s"
+                )
+            if triggered is stop_event:
+                raise AbortError("stop_event fired while waiting")
+            # else self._wake fired; loop back and try to drain.

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -346,28 +346,49 @@ class RowManager(HasTraits):
 
     def iter_execution_steps(self) -> Iterator[BaseRow]:
         """Yield rows in execution order, flattening groups and expanding
-        repetitions.
-
-        Repetitions contract: any row may have an integer attribute named
-        ``repetitions``. When present, that row's yield is multiplied. If
-        the row is a step, it's yielded `n` times. If a group, its entire
-        child-subtree is expanded n times. Missing attribute defaults to
-        1 rep. (The repetitions column is a core built-in that lands
-        alongside PPT-3's trail-config columns; PPT-1 establishes the
-        contract so the executor in PPT-2 can rely on it.)
+        repetitions. Backward-compat shim — delegates to the richer
+        ``iter_execution_frames``.
         """
-        yield from self._expand(self.root)
+        for row, _rep_chain in self.iter_execution_frames():
+            yield row
+
+    def iter_execution_frames(self) -> Iterator[tuple]:
+        """Yield ``(row, rep_chain)`` tuples in execution order.
+
+        ``rep_chain`` is a tuple of ``(name, rep_idx_1based, rep_total)``
+        triples, ordered outermost-first, covering ancestors with
+        ``repetitions > 1`` plus the row itself if its own reps > 1.
+        Singleton-rep rows contribute nothing to the chain. The root
+        group is always excluded from the chain (it represents "the
+        protocol", not a meaningful group).
+
+        Demos and the executor format ``rep_chain`` for human display
+        (e.g. "rep 2/3 of 'Wash'"). The empty tuple means "no repeating
+        ancestors" — a plain step in a non-repeating context.
+
+        Repetitions contract: any row may have an integer attribute
+        named ``repetitions``. Missing attribute defaults to 1.
+        """
+        yield from self._expand_frames(self.root, prefix=(), is_root=True)
 
     @classmethod
-    def _expand(cls, node) -> Iterator[BaseRow]:
+    def _expand_frames(cls, node, prefix, is_root=False) -> Iterator[tuple]:
         reps = max(1, int(getattr(node, "repetitions", 1) or 1))
         if isinstance(node, GroupRow):
-            for _ in range(reps):
+            for r in range(reps):
+                # Don't surface the root in the rep chain; it's "the
+                # protocol", not a group the user reasons about.
+                child_prefix = prefix
+                if not is_root and reps > 1:
+                    child_prefix = prefix + ((node.name, r + 1, reps),)
                 for child in node.children:
-                    yield from cls._expand(child)
+                    yield from cls._expand_frames(child, child_prefix)
         else:
-            for _ in range(reps):
-                yield node
+            for r in range(reps):
+                row_prefix = prefix
+                if reps > 1:
+                    row_prefix = prefix + ((node.name, r + 1, reps),)
+                yield (node, row_prefix)
 
     # --- slicing (pandas facade) ---
 

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -13,6 +13,7 @@ from microdrop_application.consts import PKG as microdrop_application_PKG
 from message_router.consts import ACTOR_TOPIC_ROUTES
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
 from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
@@ -56,6 +57,38 @@ class PluggableProtocolTreePlugin(Plugin):
             make_type_column(),
             make_id_column(),
             make_name_column(),
+            make_repetitions_column(),
             make_duration_column(),
         ]
-        return builtins + list(self.contributed_columns)
+        try:
+            contributed = list(self.contributed_columns)
+        except ValueError:
+            # No extension registry attached (e.g. headless unit tests).
+            contributed = []
+        return builtins + contributed
+
+    def start(self):
+        """Register the executor listener's subscriptions with the
+        message router. Called by Envisage at plugin start, after
+        extension points have resolved (so contributed_columns is
+        populated)."""
+        super().start()
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterData
+        except ImportError:
+            # Headless test environments may not have a broker. Plugin
+            # construction must not require Redis; a missing broker is
+            # only a problem at the moment a protocol actually runs.
+            return
+        topics = sorted({
+            t for c in self._assemble_columns()
+            for t in (c.handler.wait_for_topics or [])
+        })
+        if not topics:
+            return
+        router_data = MessageRouterData()
+        for topic in topics:
+            router_data.add_subscriber_to_topic(
+                topic=topic,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )

--- a/pluggable_protocol_tree/tests/test_builtins.py
+++ b/pluggable_protocol_tree/tests/test_builtins.py
@@ -153,3 +153,13 @@ def test_repetitions_column_metadata():
     col = make_repetitions_column()
     assert col.model.col_id == "repetitions"
     assert col.model.col_name == "Reps"
+
+
+def test_repetitions_column_editable_on_groups():
+    """Reps must be editable on group rows — that's the whole point of
+    group repetitions. The base IntSpinBoxColumnView strips
+    ItemIsEditable on groups; the reps column overrides that."""
+    from pyface.qt.QtCore import Qt
+    col = make_repetitions_column()
+    flags = col.view.get_flags(GroupRow())
+    assert flags & Qt.ItemIsEditable

--- a/pluggable_protocol_tree/tests/test_builtins.py
+++ b/pluggable_protocol_tree/tests/test_builtins.py
@@ -111,3 +111,45 @@ def test_id_column_nested_display():
 def test_id_column_orphan_row_empty():
     col = make_id_column()
     assert col.view.format_display(None, BaseRow()) == ""
+
+
+# --- repetitions column ---
+
+from pluggable_protocol_tree.builtins.repetitions_column import (
+    make_repetitions_column,
+)
+
+
+def test_repetitions_column_default_one():
+    col = make_repetitions_column()
+    assert col.model.default_value == 1
+
+
+def test_repetitions_column_trait_is_int_with_default_one():
+    col = make_repetitions_column()
+    RowType = build_row_type([col], base=BaseRow)
+    r = RowType()
+    assert r.repetitions == 1
+
+
+def test_repetitions_column_view_uses_intspinbox_range():
+    col = make_repetitions_column()
+    assert col.view.low == 1
+    assert col.view.high == 1000
+
+
+def test_repetitions_column_drives_iter_execution_steps_expansion():
+    """Locks in the PPT-1 contract through a real column (not setattr)."""
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    cols = [make_type_column(), make_id_column(), make_name_column(),
+            make_repetitions_column(), make_duration_column()]
+    rm = RowManager(columns=cols)
+    rm.add_step(values={"name": "A", "repetitions": 3})
+    names = [r.name for r in rm.iter_execution_steps()]
+    assert names == ["A", "A", "A"]
+
+
+def test_repetitions_column_metadata():
+    col = make_repetitions_column()
+    assert col.model.col_id == "repetitions"
+    assert col.model.col_name == "Reps"

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -108,3 +108,95 @@ def test_executor_stop_sets_stop_event_and_clears_pause():
     ex.stop()
     assert ex.stop_event.is_set() is True
     assert ex.pause_event.is_set() is False
+
+
+# --- ProtocolExecutor.run() — main loop ---
+
+import time
+
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+
+
+class _SignalSpy:
+    """Collects signal emissions into a list for assertion."""
+    def __init__(self, sigs: ExecutorSignals):
+        self.events = []
+        sigs.protocol_started.connect(lambda: self.events.append(("protocol_started",)))
+        sigs.step_started.connect(lambda r: self.events.append(("step_started", r.name)))
+        sigs.step_finished.connect(lambda r: self.events.append(("step_finished", r.name)))
+        sigs.protocol_finished.connect(lambda: self.events.append(("protocol_finished",)))
+        sigs.protocol_aborted.connect(lambda: self.events.append(("protocol_aborted",)))
+        sigs.protocol_error.connect(lambda m: self.events.append(("protocol_error", m)))
+
+
+def test_run_empty_protocol_emits_started_then_finished():
+    ex = _make_executor()
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()       # synchronous; bypasses start()/QThread
+    assert spy.events[0] == ("protocol_started",)
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_run_three_steps_emits_step_signals_in_order():
+    ex = _make_executor()
+    a = ex.row_manager.add_step(values={"name": "A"})
+    b = ex.row_manager.add_step(values={"name": "B"})
+    c = ex.row_manager.add_step(values={"name": "C"})
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    step_events = [e for e in spy.events if e[0] in ("step_started", "step_finished")]
+    assert step_events == [
+        ("step_started", "A"), ("step_finished", "A"),
+        ("step_started", "B"), ("step_finished", "B"),
+        ("step_started", "C"), ("step_finished", "C"),
+    ]
+
+
+def test_run_stop_pre_set_aborts_immediately():
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.row_manager.add_step(values={"name": "B"})
+    ex.stop_event.set()
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    # No step events; terminal is aborted, not finished.
+    assert ("step_started", "A") not in spy.events
+    assert spy.events[-1] == ("protocol_aborted",)
+
+
+def test_run_pause_then_resume_blocks_then_continues():
+    """Set pause_event before calling run() so iter_execution_steps's
+    first iteration hits wait_cleared(). Then clear it from another
+    thread to release."""
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.pause_event.set()
+    spy = _SignalSpy(ex.qsignals)
+
+    def resumer():
+        time.sleep(0.05)
+        ex.pause_event.clear()
+
+    threading.Thread(target=resumer, daemon=True).start()
+    start = time.monotonic()
+    ex.run()
+    elapsed = time.monotonic() - start
+    # We waited ~50ms before resume; protocol then completed quickly.
+    assert elapsed >= 0.05
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_run_stop_while_paused_breaks_out():
+    """Regression for the deadlock-avoidance code in stop()."""
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.pause_event.set()
+    spy = _SignalSpy(ex.qsignals)
+
+    def stopper():
+        time.sleep(0.05)
+        ex.stop()
+
+    threading.Thread(target=stopper, daemon=True).start()
+    ex.run()
+    assert spy.events[-1] == ("protocol_aborted",)

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -99,6 +99,69 @@ def test_executor_resume_emits_protocol_resumed():
     assert received == ["resumed"]
 
 
+def test_executor_start_runs_protocol_on_worker_thread_and_finishes():
+    """Regression test: start() spawns a worker thread that calls run().
+
+    Originally written using QThread + moveToThread, which raised
+    AttributeError because ProtocolExecutor is a HasTraits, not a
+    QObject. Switched to threading.Thread.
+    """
+    from pyface.qt.QtCore import Qt
+    ex = _make_executor()
+    ex.row_manager.add_step(values={"name": "A"})
+    finished = threading.Event()
+    # DirectConnection so the slot fires synchronously on the worker
+    # thread without needing a Qt event loop on the receiver side.
+    ex.qsignals.protocol_finished.connect(finished.set, type=Qt.DirectConnection)
+    ex.start()
+    # start() returns immediately; wait for the worker to finish.
+    assert finished.wait(timeout=5.0), "protocol_finished did not fire within 5s"
+    # The worker thread should have terminated by the time finished fires.
+    ex._thread.join(timeout=1.0)
+    assert not ex._thread.is_alive()
+
+
+def test_executor_start_is_idempotent_while_running():
+    """A second start() while already running should be a no-op (not
+    a TypeError or a duplicate thread)."""
+    import time
+    from pyface.qt.QtCore import Qt
+    ex = _make_executor()
+    started_count = []
+    # Make the protocol take a moment so the second start() races with it.
+    pause_in_step = threading.Event()
+
+    class _SlowHandler(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            pause_in_step.wait(timeout=2.0)
+
+    slow_col = Column(
+        model=BaseColumnModel(col_id="slow", col_name="slow", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_SlowHandler(),
+    )
+    ex.row_manager.columns = list(ex.row_manager.columns) + [slow_col]
+    ex.row_manager.add_step(values={"name": "A"})
+    ex.qsignals.protocol_started.connect(
+        lambda: started_count.append(1), type=Qt.DirectConnection,
+    )
+
+    ex.start()
+    # Give the first start a head start before issuing the second one.
+    time.sleep(0.05)
+    first_thread = ex._thread
+    ex.start()              # should be a no-op
+    assert ex._thread is first_thread, "start() must not replace the live thread"
+
+    # Let the protocol finish.
+    pause_in_step.set()
+    finished = threading.Event()
+    ex.qsignals.protocol_finished.connect(finished.set, type=Qt.DirectConnection)
+    assert finished.wait(timeout=5.0)
+    ex._thread.join(timeout=1.0)
+    assert sum(started_count) == 1, "protocol_started fired more than once"
+
+
 def test_executor_stop_sets_stop_event_and_clears_pause():
     """stop() must also clear pause_event so a Stop-while-paused doesn't
     deadlock the main loop in wait_cleared()."""

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -56,13 +56,32 @@ from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.builtins.type_column import make_type_column
 from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
-from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.duration_column import (
+    DurationColumnHandler, DurationColumnModel, make_duration_column,
+)
+from pluggable_protocol_tree.models.column import Column
+from pluggable_protocol_tree.views.columns.spinbox import DoubleSpinBoxColumnView
+
+
+def _fast_duration_column():
+    """Like make_duration_column() but defaults to 0s so unit tests
+    don't actually sleep. Production duration column is used in the
+    demo and integration tests."""
+    return Column(
+        model=DurationColumnModel(
+            col_id="duration_s", col_name="Duration (s)", default_value=0.0,
+        ),
+        view=DoubleSpinBoxColumnView(
+            low=0.0, high=3600.0, decimals=2, single_step=0.1,
+        ),
+        handler=DurationColumnHandler(),
+    )
 
 
 def _make_executor():
     """Bare-bones executor with the four PPT-1 built-in columns."""
     cols = [make_type_column(), make_id_column(),
-            make_name_column(), make_duration_column()]
+            make_name_column(), _fast_duration_column()]
     rm = RowManager(columns=cols)
     return ProtocolExecutor(
         row_manager=rm,
@@ -313,7 +332,7 @@ def _executor_with(cols):
     from pluggable_protocol_tree.builtins.name_column import make_name_column
     from pluggable_protocol_tree.builtins.duration_column import make_duration_column
     builtins = [make_type_column(), make_id_column(),
-                make_name_column(), make_duration_column()]
+                make_name_column(), _fast_duration_column()]
     rm = RowManager(columns=builtins + list(cols))
     rm.add_step(values={"name": "A"})
     return ProtocolExecutor(

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -118,6 +118,70 @@ def test_executor_resume_emits_protocol_resumed():
     assert received == ["resumed"]
 
 
+def test_executor_constructible_with_only_row_manager():
+    """Headless / scripting use: pass just the row_manager and let
+    qsignals / pause_event / stop_event default."""
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), _fast_duration_column()]
+    rm = RowManager(columns=cols)
+    ex = ProtocolExecutor(row_manager=rm)
+    assert ex.qsignals is not None
+    assert ex.pause_event is not None
+    assert ex.stop_event is not None
+
+
+def test_executor_wait_returns_true_when_never_started():
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), _fast_duration_column()]
+    rm = RowManager(columns=cols)
+    ex = ProtocolExecutor(row_manager=rm)
+    # Never called start(); wait should return True immediately.
+    assert ex.wait(timeout=0.01) is True
+
+
+def test_executor_wait_blocks_until_run_finishes():
+    from pyface.qt.QtCore import Qt
+    cols = [make_type_column(), make_id_command if False else make_id_column(),
+            make_name_column(), _fast_duration_column()]
+    rm = RowManager(columns=cols)
+    rm.add_step(values={"name": "A"})
+    ex = ProtocolExecutor(row_manager=rm)
+    finished = []
+    ex.qsignals.protocol_finished.connect(
+        lambda: finished.append(True), type=Qt.DirectConnection,
+    )
+    ex.start()
+    assert ex.wait(timeout=5.0) is True
+    assert finished == [True]
+
+
+def test_executor_execute_classmethod_blocks_by_default():
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), _fast_duration_column()]
+    rm = RowManager(columns=cols)
+    rm.add_step(values={"name": "A"})
+    ex = ProtocolExecutor.execute(rm)   # blocking=True by default
+    # By the time execute returns, the worker thread is done.
+    assert not ex._thread.is_alive()
+
+
+def test_executor_execute_classmethod_non_blocking_returns_immediately():
+    import time as _time
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), make_duration_column()]   # full 1s default
+    rm = RowManager(columns=cols)
+    rm.add_step(values={"name": "A"})
+    t0 = _time.monotonic()
+    ex = ProtocolExecutor.execute(rm, blocking=False)
+    elapsed = _time.monotonic() - t0
+    # Returned without waiting for the 1s dwell.
+    assert elapsed < 0.5, f"execute(blocking=False) took {elapsed:.3f}s"
+    assert ex._thread is not None
+    # Stop and wait so the thread isn't left running for the next test.
+    ex.stop()
+    ex.wait(timeout=5.0)
+
+
 def test_executor_start_runs_protocol_on_worker_thread_and_finishes():
     """Regression test: start() spawns a worker thread that calls run().
 

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -313,3 +313,118 @@ def test_run_hooks_all_five_phases_fire_in_order_for_one_step():
         "on_pre_step", "on_step", "on_post_step",
         "on_protocol_end",
     ]
+
+
+# --- same-topic conflict + error propagation ---
+
+def _handler_with_topic(name, priority, topic, log):
+    class _H(BaseColumnHandler):
+        wait_for_topics = [topic]
+        def on_step(self, row, ctx):
+            log.append((name, "on_step"))
+    h = _H()
+    h.priority = priority
+    return h
+
+
+def _column_with_topic_handler(col_id, priority, topic, log):
+    return Column(
+        model=BaseColumnModel(col_id=col_id, col_name=col_id, default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_handler_with_topic(col_id, priority, topic, log),
+    )
+
+
+def test_same_topic_in_same_priority_bucket_raises():
+    """Two columns both declaring the same wait_for_topic at the same
+    priority would race for the mailbox. Detected at step start."""
+    log = []
+    a = _column_with_topic_handler("a", 20, "shared/topic", log)
+    b = _column_with_topic_handler("b", 20, "shared/topic", log)
+    ex = _executor_with([a, b])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    # Surfaces as a protocol_error (the _build_step_ctx assertion raises).
+    assert spy.events[-1][0] == "protocol_error"
+    assert "shared/topic" in spy.events[-1][1]
+
+
+def test_same_topic_different_priority_buckets_is_fine():
+    """Sequential — no race. Should not raise."""
+    log = []
+    a = _column_with_topic_handler("a", 10, "shared/topic", log)
+    b = _column_with_topic_handler("b", 30, "shared/topic", log)
+    ex = _executor_with([a, b])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    assert spy.events[-1] == ("protocol_finished",)
+
+
+def test_hook_exception_emits_protocol_error_not_finished():
+    log = []
+
+    class _Boom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("kaboom")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_Boom(),
+    )
+    ex = _executor_with([col])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    err_events = [e for e in spy.events if e[0] == "protocol_error"]
+    assert len(err_events) == 1
+    assert "kaboom" in err_events[0][1]
+    # Did NOT emit finished or aborted.
+    assert ("protocol_finished",) not in spy.events
+    assert ("protocol_aborted",) not in spy.events
+
+
+def test_on_protocol_end_runs_even_on_error():
+    """Best-effort cleanup: if on_step raises, on_protocol_end still
+    fires (in the except branch's fallback)."""
+    log = []
+
+    class _Boom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("kaboom")
+        def on_protocol_end(self, ctx):
+            log.append("end_ran")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_Boom(),
+    )
+    ex = _executor_with([col])
+    ex.run()
+    assert "end_ran" in log
+
+
+def test_on_protocol_end_raising_during_error_cleanup_is_swallowed():
+    """If both on_step AND on_protocol_end raise, the original error
+    wins (it's what surfaces as protocol_error) and the on_protocol_end
+    exception is logged but not re-raised."""
+    log = []
+
+    class _DoubleBoom(BaseColumnHandler):
+        def on_step(self, row, ctx):
+            raise RuntimeError("first")
+        def on_protocol_end(self, ctx):
+            raise RuntimeError("second")
+
+    col = Column(
+        model=BaseColumnModel(col_id="boom", col_name="boom", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_DoubleBoom(),
+    )
+    ex = _executor_with([col])
+    spy = _SignalSpy(ex.qsignals)
+    ex.run()
+    err_events = [e for e in spy.events if e[0] == "protocol_error"]
+    assert len(err_events) == 1
+    assert "first" in err_events[0][1]
+    assert "second" not in err_events[0][1]

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -200,3 +200,116 @@ def test_run_stop_while_paused_breaks_out():
     threading.Thread(target=stopper, daemon=True).start()
     ex.run()
     assert spy.events[-1] == ("protocol_aborted",)
+
+
+# --- priority bucket fan-out ---
+
+from traits.api import HasTraits, Int, List, provides, Str
+
+from pluggable_protocol_tree.interfaces.i_column import IColumnHandler
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.views.columns.readonly_label import (
+    ReadOnlyLabelColumnView,
+)
+
+
+def _recording_handler(name, priority, log: list, barrier=None):
+    """Build a handler that appends (name, hook_name) to `log` on each
+    fire. Optional `barrier` makes the handler block on a threading
+    barrier inside on_step (used to prove parallel execution)."""
+    class _H(BaseColumnHandler):
+        def on_protocol_start(self, ctx):  log.append((name, "on_protocol_start"))
+        def on_pre_step(self, row, ctx):   log.append((name, "on_pre_step"))
+        def on_step(self, row, ctx):
+            log.append((name, "on_step"))
+            if barrier is not None:
+                barrier.wait(timeout=2.0)
+        def on_post_step(self, row, ctx):  log.append((name, "on_post_step"))
+        def on_protocol_end(self, ctx):    log.append((name, "on_protocol_end"))
+    h = _H()
+    h.priority = priority
+    return h
+
+
+def _make_recording_column(col_id, priority, log, barrier=None):
+    return Column(
+        model=BaseColumnModel(col_id=col_id, col_name=col_id, default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_recording_handler(col_id, priority, log, barrier),
+    )
+
+
+def _executor_with(cols):
+    """Build an executor on a fresh RowManager containing one step,
+    with the given extra columns layered on top of the four PPT-1
+    builtins (so iter_execution_steps yields one row)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    builtins = [make_type_column(), make_id_column(),
+                make_name_column(), make_duration_column()]
+    rm = RowManager(columns=builtins + list(cols))
+    rm.add_step(values={"name": "A"})
+    return ProtocolExecutor(
+        row_manager=rm,
+        qsignals=ExecutorSignals(),
+        pause_event=PauseEvent(),
+        stop_event=threading.Event(),
+    )
+
+
+def test_run_hooks_orders_buckets_by_priority():
+    log = []
+    low = _make_recording_column("low", priority=10, log=log)
+    high = _make_recording_column("high", priority=30, log=log)
+    ex = _executor_with([high, low])   # deliberately shuffled
+    ex.run()
+    on_step_calls = [name for (name, hook) in log if hook == "on_step"]
+    # All low (priority 10) before any high (priority 30)
+    assert on_step_calls.index("low") < on_step_calls.index("high")
+
+
+def test_run_hooks_fans_same_priority_in_parallel():
+    log = []
+    barrier = threading.Barrier(2)
+    a = _make_recording_column("a", priority=20, log=log, barrier=barrier)
+    b = _make_recording_column("b", priority=20, log=log, barrier=barrier)
+    ex = _executor_with([a, b])
+    # If they don't run in parallel the barrier never trips and the
+    # executor blocks until barrier timeout (2s) — test would take >2s.
+    start = time.monotonic()
+    ex.run()
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.5, "same-priority hooks did not fan out in parallel"
+    on_step_names = [name for (name, hook) in log if hook == "on_step"]
+    assert sorted(on_step_names) == ["a", "b"]
+
+
+def test_run_hooks_uses_default_priority_50_for_unset():
+    """BaseColumnHandler defaults priority to 50 — no explicit set
+    needed for a column that doesn't care about ordering."""
+    log = []
+    no_pri = _make_recording_column("default", priority=50, log=log)
+    early = _make_recording_column("early", priority=10, log=log)
+    ex = _executor_with([no_pri, early])
+    ex.run()
+    on_step_calls = [name for (name, hook) in log if hook == "on_step"]
+    assert on_step_calls.index("early") < on_step_calls.index("default")
+
+
+def test_run_hooks_all_five_phases_fire_in_order_for_one_step():
+    log = []
+    col = _make_recording_column("c", priority=50, log=log)
+    ex = _executor_with([col])
+    ex.run()
+    # Filter to the recording column only (built-ins also fire but with
+    # no logging side effect — their handlers are BaseColumnHandler).
+    c_calls = [hook for (name, hook) in log if name == "c"]
+    assert c_calls == [
+        "on_protocol_start",
+        "on_pre_step", "on_step", "on_post_step",
+        "on_protocol_end",
+    ]

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -42,3 +42,69 @@ def test_executor_signals_protocol_error_carries_message():
     s.protocol_error.connect(lambda msg: received.append(msg))
     s.protocol_error.emit("oops")
     assert received == ["oops"]
+
+
+# --- ProtocolExecutor public API ---
+
+import threading
+
+import pytest
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+
+
+def _make_executor():
+    """Bare-bones executor with the four PPT-1 built-in columns."""
+    cols = [make_type_column(), make_id_column(),
+            make_name_column(), make_duration_column()]
+    rm = RowManager(columns=cols)
+    return ProtocolExecutor(
+        row_manager=rm,
+        qsignals=ExecutorSignals(),
+        pause_event=PauseEvent(),
+        stop_event=threading.Event(),
+    )
+
+
+def test_executor_constructible_with_required_traits():
+    ex = _make_executor()
+    assert ex.row_manager is not None
+    assert ex.qsignals is not None
+    assert ex.pause_event is not None
+    assert ex.stop_event is not None
+
+
+def test_executor_pause_emits_protocol_paused():
+    ex = _make_executor()
+    received = []
+    ex.qsignals.protocol_paused.connect(lambda: received.append("paused"))
+    ex.pause()
+    assert ex.pause_event.is_set() is True
+    assert received == ["paused"]
+
+
+def test_executor_resume_emits_protocol_resumed():
+    ex = _make_executor()
+    received = []
+    ex.qsignals.protocol_resumed.connect(lambda: received.append("resumed"))
+    ex.pause()
+    ex.resume()
+    assert ex.pause_event.is_set() is False
+    assert received == ["resumed"]
+
+
+def test_executor_stop_sets_stop_event_and_clears_pause():
+    """stop() must also clear pause_event so a Stop-while-paused doesn't
+    deadlock the main loop in wait_cleared()."""
+    ex = _make_executor()
+    ex.pause()
+    assert ex.pause_event.is_set() is True
+    ex.stop()
+    assert ex.stop_event.is_set() is True
+    assert ex.pause_event.is_set() is False

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -1,0 +1,44 @@
+"""Tests for execution.executor and .signals.
+
+Most tests do NOT require a QApplication — Qt direct-connect signals work
+without an event loop when sender and receiver share a thread. Tests that
+need cross-thread signal delivery construct a QApplication via fixture.
+"""
+
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+
+
+def test_executor_signals_constructible_without_qapplication():
+    s = ExecutorSignals()
+    # All eight expected signals are present as attributes.
+    for name in (
+        "protocol_started", "step_started", "step_finished",
+        "protocol_paused", "protocol_resumed",
+        "protocol_finished", "protocol_aborted", "protocol_error",
+    ):
+        assert hasattr(s, name), f"missing signal: {name}"
+
+
+def test_executor_signals_direct_connect_invokes_slot():
+    s = ExecutorSignals()
+    received = []
+    s.protocol_finished.connect(lambda: received.append("finished"))
+    s.protocol_finished.emit()
+    assert received == ["finished"]
+
+
+def test_executor_signals_step_started_carries_row():
+    s = ExecutorSignals()
+    received = []
+    s.step_started.connect(lambda row: received.append(row))
+    sentinel = object()
+    s.step_started.emit(sentinel)
+    assert received == [sentinel]
+
+
+def test_executor_signals_protocol_error_carries_message():
+    s = ExecutorSignals()
+    received = []
+    s.protocol_error.connect(lambda msg: received.append(msg))
+    s.protocol_error.emit("oops")
+    assert received == ["oops"]

--- a/pluggable_protocol_tree/tests/test_plugin.py
+++ b/pluggable_protocol_tree/tests/test_plugin.py
@@ -13,3 +13,22 @@ def test_plugin_declares_extension_point():
     p = PluggableProtocolTreePlugin()
     point_ids = [ep.id for ep in p.get_extension_points()]
     assert PROTOCOL_COLUMNS in point_ids
+
+
+# --- PPT-2 additions ---
+
+def test_assemble_columns_includes_repetitions():
+    p = PluggableProtocolTreePlugin()
+    cols = p._assemble_columns()
+    ids = [c.model.col_id for c in cols]
+    assert "repetitions" in ids
+
+
+def test_assemble_columns_canonical_order():
+    """Built-ins land in: type, id, name, repetitions, duration_s order."""
+    p = PluggableProtocolTreePlugin()
+    cols = p._assemble_columns()
+    builtin_ids = [c.model.col_id for c in cols
+                   if c.model.col_id in ("type", "id", "name",
+                                         "repetitions", "duration_s")]
+    assert builtin_ids == ["type", "id", "name", "repetitions", "duration_s"]

--- a/pluggable_protocol_tree/tests/test_row_manager.py
+++ b/pluggable_protocol_tree/tests/test_row_manager.py
@@ -336,3 +336,75 @@ def test_apply_runs_callable_per_row(manager):
     manager.apply([a, b], lambda r: setattr(r, "duration_s", r.duration_s * 10))
     assert manager.get_row(a).duration_s == 10.0
     assert manager.get_row(b).duration_s == 20.0
+
+
+# --- iter_execution_frames (rep context surface) ---
+
+def test_frames_step_no_reps_yields_empty_chain(manager):
+    manager.add_step(values={"name": "A"})
+    frames = list(manager.iter_execution_frames())
+    assert len(frames) == 1
+    row, chain = frames[0]
+    assert row.name == "A"
+    assert chain == ()
+
+
+def test_frames_step_with_reps_carries_self_in_chain(manager):
+    s = manager.add_step(values={"name": "A"})
+    setattr(manager.get_row(s), "repetitions", 3)
+    frames = list(manager.iter_execution_frames())
+    assert [c for _r, c in frames] == [
+        (("A", 1, 3),), (("A", 2, 3),), (("A", 3, 3),),
+    ]
+
+
+def test_frames_group_reps_propagate_to_child_chain(manager):
+    g = manager.add_group(name="Wash")
+    manager.add_step(parent_path=g, values={"name": "A"})
+    manager.add_step(parent_path=g, values={"name": "B"})
+    setattr(manager.get_row(g), "repetitions", 2)
+    frames = list(manager.iter_execution_frames())
+    names = [r.name for r, _c in frames]
+    chains = [c for _r, c in frames]
+    assert names == ["A", "B", "A", "B"]
+    # Each child carries the group's rep context (outermost-first).
+    assert chains == [
+        (("Wash", 1, 2),), (("Wash", 1, 2),),
+        (("Wash", 2, 2),), (("Wash", 2, 2),),
+    ]
+
+
+def test_frames_nested_group_reps_compose(manager):
+    outer = manager.add_group(name="Outer")
+    inner = manager.add_group(parent_path=outer, name="Inner")
+    manager.add_step(parent_path=inner, values={"name": "S"})
+    setattr(manager.get_row(outer), "repetitions", 2)
+    setattr(manager.get_row(inner), "repetitions", 3)
+    chains = [c for _r, c in manager.iter_execution_frames()]
+    # 2 outer × 3 inner = 6 yields. Outer first, inner second.
+    assert chains == [
+        (("Outer", 1, 2), ("Inner", 1, 3)),
+        (("Outer", 1, 2), ("Inner", 2, 3)),
+        (("Outer", 1, 2), ("Inner", 3, 3)),
+        (("Outer", 2, 2), ("Inner", 1, 3)),
+        (("Outer", 2, 2), ("Inner", 2, 3)),
+        (("Outer", 2, 2), ("Inner", 3, 3)),
+    ]
+
+
+def test_frames_singleton_group_reps_excluded_from_chain(manager):
+    """Groups with reps==1 don't appear in the chain — chain represents
+    *active repetition context*, not group nesting."""
+    g = manager.add_group(name="Plain")
+    manager.add_step(parent_path=g, values={"name": "A"})
+    chains = [c for _r, c in manager.iter_execution_frames()]
+    assert chains == [()]
+
+
+def test_iter_execution_steps_still_works_via_delegation(manager):
+    """Backward compat: iter_execution_steps must still yield plain rows."""
+    g = manager.add_group(name="G")
+    manager.add_step(parent_path=g, values={"name": "A"})
+    setattr(manager.get_row(g), "repetitions", 2)
+    names = [r.name for r in manager.iter_execution_steps()]
+    assert names == ["A", "A"]

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -168,3 +168,89 @@ def test_mailbox_predicate_rejects_all_pre_deposited_then_blocks():
         stop_event=stop,
     )
     assert item == {"ready": True}
+
+
+# --- ProtocolContext + StepContext + wait_for ---
+
+from pluggable_protocol_tree.execution.step_context import (
+    ProtocolContext, StepContext,
+)
+from pluggable_protocol_tree.models.row import BaseRow
+
+
+def _make_step_ctx(topics: list) -> StepContext:
+    """Helper: build a StepContext with mailboxes pre-opened for `topics`."""
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    for t in topics:
+        step.open_mailbox(t)
+    return step
+
+
+def test_wait_for_returns_payload_after_deposit():
+    step = _make_step_ctx(["t/foo"])
+    threading.Timer(
+        0.05, lambda: step.deposit("t/foo", {"v": 1})
+    ).start()
+    payload = step.wait_for("t/foo", timeout=1.0)
+    assert payload == {"v": 1}
+
+
+def test_wait_for_returns_pre_deposited_immediately():
+    """The race-fix that justifies the per-step pre-registration model."""
+    step = _make_step_ctx(["t/ack"])
+    step.deposit("t/ack", {"ok": True})
+    start = time.monotonic()
+    payload = step.wait_for("t/ack", timeout=1.0)
+    assert payload == {"ok": True}
+    assert time.monotonic() - start < 0.1
+
+
+def test_wait_for_unknown_topic_raises_keyerror():
+    """Unopened topics indicate a missing wait_for_topics declaration."""
+    step = _make_step_ctx(["t/known"])
+    import pytest
+    with pytest.raises(KeyError):
+        step.wait_for("t/unknown", timeout=0.1)
+
+
+def test_wait_for_timeout():
+    step = _make_step_ctx(["t/never"])
+    import pytest
+    with pytest.raises(TimeoutError):
+        step.wait_for("t/never", timeout=0.05)
+
+
+def test_wait_for_abort_when_stop_event_fires():
+    step = _make_step_ctx(["t/never"])
+    threading.Timer(0.05, step.protocol.stop_event.set).start()
+    import pytest
+    with pytest.raises(AbortError):
+        step.wait_for("t/never", timeout=2.0)
+
+
+def test_wait_for_predicate_filters_payloads():
+    step = _make_step_ctx(["t/status"])
+    step.deposit("t/status", {"ready": False})
+    step.deposit("t/status", {"ready": True})
+    payload = step.wait_for(
+        "t/status", timeout=1.0,
+        predicate=lambda p: p.get("ready") is True,
+    )
+    assert payload == {"ready": True}
+
+
+def test_protocol_context_scratch_is_per_protocol():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    proto.scratch["k"] = "v"
+    assert proto.scratch["k"] == "v"
+
+
+def test_step_context_scratch_is_per_step_and_independent():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    a = StepContext(row=BaseRow(name="a"), protocol=proto)
+    b = StepContext(row=BaseRow(name="b"), protocol=proto)
+    a.scratch["k"] = "av"
+    b.scratch["k"] = "bv"
+    assert a.scratch["k"] == "av"
+    assert b.scratch["k"] == "bv"

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -254,3 +254,63 @@ def test_step_context_scratch_is_per_step_and_independent():
     b.scratch["k"] = "bv"
     assert a.scratch["k"] == "av"
     assert b.scratch["k"] == "bv"
+
+
+# --- listener active-step pointer ---
+
+from pluggable_protocol_tree.execution import listener as _listener
+
+
+def test_listener_active_step_initially_none():
+    _listener.clear_active_step()
+    assert _listener.get_active_step() is None
+
+
+def test_listener_set_then_get_returns_step():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    _listener.set_active_step(step)
+    try:
+        assert _listener.get_active_step() is step
+    finally:
+        _listener.clear_active_step()
+
+
+def test_listener_clear_resets_to_none():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    _listener.set_active_step(step)
+    _listener.clear_active_step()
+    assert _listener.get_active_step() is None
+
+
+def test_listener_route_to_active_step_deposits_into_mailbox():
+    """Direct route() helper bypasses Dramatiq for unit testing."""
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    step.open_mailbox("t/foo")
+    _listener.set_active_step(step)
+    try:
+        _listener.route_to_active_step("t/foo", {"v": 42})
+        item = step.wait_for("t/foo", timeout=0.1)
+        assert item == {"v": 42}
+    finally:
+        _listener.clear_active_step()
+
+
+def test_listener_route_with_no_active_step_drops_silently():
+    _listener.clear_active_step()
+    # No exception, no observable side effect.
+    _listener.route_to_active_step("t/foo", {"v": 1})
+
+
+def test_listener_route_for_unopened_topic_drops_silently():
+    proto = ProtocolContext(columns=[], stop_event=threading.Event())
+    step = StepContext(row=BaseRow(name="x"), protocol=proto)
+    step.open_mailbox("t/known")
+    _listener.set_active_step(step)
+    try:
+        # No exception — the listener simply has nowhere to put it.
+        _listener.route_to_active_step("t/unknown", {"v": 1})
+    finally:
+        _listener.clear_active_step()

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -1,0 +1,17 @@
+"""Tests for execution.exceptions, .events, .step_context.
+
+Pure-Python unit tests — no Qt application, no Dramatiq broker.
+Behavioral tests for Mailbox / ProtocolContext / StepContext / wait_for
+get appended in later tasks; this file starts with the smallest
+foundational types."""
+
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def test_abort_error_is_exception():
+    assert issubclass(AbortError, Exception)
+
+
+def test_abort_error_carries_message():
+    e = AbortError("stop pressed")
+    assert str(e) == "stop pressed"

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -62,3 +62,109 @@ def test_pause_event_wait_cleared_blocks_until_clear():
     p.clear()
     assert woken.wait(timeout=1.0) is True
     t.join(timeout=1.0)
+
+
+# --- wait_first ---
+
+from pluggable_protocol_tree.execution.step_context import wait_first
+
+
+def test_wait_first_returns_event_that_fires_first():
+    a = threading.Event()
+    b = threading.Event()
+    threading.Timer(0.05, b.set).start()
+    fired = wait_first([a, b], timeout=1.0)
+    assert fired is b
+
+
+def test_wait_first_returns_none_on_timeout():
+    a = threading.Event()
+    b = threading.Event()
+    fired = wait_first([a, b], timeout=0.05)
+    assert fired is None
+
+
+def test_wait_first_returns_immediately_when_event_already_set():
+    a = threading.Event()
+    a.set()
+    start = time.monotonic()
+    fired = wait_first([a], timeout=1.0)
+    assert fired is a
+    assert time.monotonic() - start < 0.1
+
+
+# --- Mailbox ---
+
+from pluggable_protocol_tree.execution.step_context import Mailbox
+from pluggable_protocol_tree.execution.exceptions import AbortError
+
+
+def test_mailbox_drain_one_returns_pre_deposited_immediately():
+    mb = Mailbox()
+    mb.deposit({"v": 1})
+    stop = threading.Event()
+    start = time.monotonic()
+    item = mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+    assert item == {"v": 1}
+    assert time.monotonic() - start < 0.1
+
+
+def test_mailbox_drain_one_blocks_then_wakes_on_deposit():
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, lambda: mb.deposit("hello")).start()
+    item = mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+    assert item == "hello"
+
+
+def test_mailbox_drain_one_raises_timeout_when_nothing_arrives():
+    mb = Mailbox()
+    stop = threading.Event()
+    with __import__("pytest").raises(TimeoutError):
+        mb.drain_one(predicate=None, timeout=0.05, stop_event=stop)
+
+
+def test_mailbox_drain_one_raises_abort_when_stop_pre_set():
+    mb = Mailbox()
+    stop = threading.Event()
+    stop.set()
+    with __import__("pytest").raises(AbortError):
+        mb.drain_one(predicate=None, timeout=1.0, stop_event=stop)
+
+
+def test_mailbox_drain_one_raises_abort_when_stop_fires_mid_wait():
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, stop.set).start()
+    start = time.monotonic()
+    with __import__("pytest").raises(AbortError):
+        mb.drain_one(predicate=None, timeout=2.0, stop_event=stop)
+    # Must abort promptly, not wait out the 2s timeout.
+    assert time.monotonic() - start < 0.5
+
+
+def test_mailbox_predicate_rejects_then_accepts():
+    mb = Mailbox()
+    stop = threading.Event()
+    mb.deposit({"ready": False})
+    mb.deposit({"ready": True})
+    item = mb.drain_one(
+        predicate=lambda p: p.get("ready"),
+        timeout=1.0,
+        stop_event=stop,
+    )
+    assert item == {"ready": True}
+
+
+def test_mailbox_predicate_rejects_all_pre_deposited_then_blocks():
+    mb = Mailbox()
+    stop = threading.Event()
+    mb.deposit({"ready": False})
+    mb.deposit({"ready": False})
+    threading.Timer(0.05, lambda: mb.deposit({"ready": True})).start()
+    item = mb.drain_one(
+        predicate=lambda p: p.get("ready"),
+        timeout=1.0,
+        stop_event=stop,
+    )
+    assert item == {"ready": True}

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -15,3 +15,50 @@ def test_abort_error_is_exception():
 def test_abort_error_carries_message():
     e = AbortError("stop pressed")
     assert str(e) == "stop pressed"
+
+
+# --- PauseEvent ---
+
+import threading
+import time
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+
+
+def test_pause_event_starts_unset_and_cleared():
+    p = PauseEvent()
+    assert p.is_set() is False
+
+
+def test_pause_event_set_and_clear_round_trip():
+    p = PauseEvent()
+    p.set()
+    assert p.is_set() is True
+    p.clear()
+    assert p.is_set() is False
+
+
+def test_pause_event_wait_cleared_returns_immediately_when_unset():
+    p = PauseEvent()
+    # Already cleared; should not block.
+    start = time.monotonic()
+    p.wait_cleared(timeout=0.5)
+    assert time.monotonic() - start < 0.1
+
+
+def test_pause_event_wait_cleared_blocks_until_clear():
+    p = PauseEvent()
+    p.set()
+    woken = threading.Event()
+
+    def waiter():
+        p.wait_cleared(timeout=2.0)
+        woken.set()
+
+    t = threading.Thread(target=waiter, daemon=True)
+    t.start()
+    # waiter should still be blocked
+    assert woken.wait(timeout=0.1) is False
+    p.clear()
+    assert woken.wait(timeout=1.0) is True
+    t.join(timeout=1.0)

--- a/pluggable_protocol_tree/tests/tests_with_redis_server_need/conftest.py
+++ b/pluggable_protocol_tree/tests/tests_with_redis_server_need/conftest.py
@@ -30,3 +30,17 @@ def pytest_collection_modifyitems(config, items):
     skip_marker = pytest.mark.skip(reason="Redis broker not reachable")
     for item in items:
         item.add_marker(skip_marker)
+
+
+@pytest.fixture(scope="session")
+def router_actor():
+    """One MessageRouterActor for the whole pytest session.
+
+    DramatiqControllerBase.traits_init registers the underlying actor
+    on construction, and Dramatiq raises ValueError on duplicate actor
+    names — so each test that calls MessageRouterActor() works in
+    isolation but two tests in the same session conflict. Construct
+    once, reuse everywhere.
+    """
+    from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterActor
+    return MessageRouterActor()

--- a/pluggable_protocol_tree/tests/tests_with_redis_server_need/conftest.py
+++ b/pluggable_protocol_tree/tests/tests_with_redis_server_need/conftest.py
@@ -1,0 +1,32 @@
+"""Conftest for executor Redis-integration tests.
+
+The broker MUST be configured at module load time, before any test
+modules import code that registers @dramatiq.actor decorators —
+otherwise those actors register against the default StubBroker and
+the RedisBroker we'd swap in via fixture wouldn't see them, producing
+an ActorNotFound when the worker tries to dispatch.
+
+Skips the entire module if Redis isn't reachable.
+"""
+
+import pytest
+
+from microdrop_utils.broker_server_helpers import (
+    configure_dramatiq_broker, is_redis_running,
+)
+
+
+# Configure the broker at module import (before test collection imports
+# any actor-registering code). Done unconditionally — if Redis isn't
+# reachable the test module will be skipped below anyway, and Dramatiq
+# is happy to register actors against an unreachable broker (failures
+# only surface on broker.enqueue / worker.start).
+configure_dramatiq_broker()
+
+
+def pytest_collection_modifyitems(config, items):
+    if is_redis_running():
+        return
+    skip_marker = pytest.mark.skip(reason="Redis broker not reachable")
+    for item in items:
+        item.add_marker(skip_marker)

--- a/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
+++ b/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
@@ -1,60 +1,50 @@
 """End-to-end test for the executor's Dramatiq round-trip.
 
-Skips automatically if Redis isn't reachable. Run via:
+Skips automatically if Redis isn't reachable (see conftest.py).
 
-    redis-server &              # in another shell
-    cd microdrop-py && pixi run bash -c \\
-      "cd src && pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/ -v"
+Proves: publish_message → message_router_actor → executor_listener actor
+→ route_to_active_step → mailbox → ctx.wait_for → handler returns the
+payload (as a JSON string — that's the wire format, handlers JSON-decode
+on the receiving side).
 """
 
+import json
 import threading
-import time
 
-import pytest
+import dramatiq
+from dramatiq import Worker
 
-
-def _redis_available() -> bool:
-    try:
-        import dramatiq
-        broker = dramatiq.get_broker()
-        broker.client.ping()
-        return True
-    except Exception:
-        return False
-
-
-pytestmark = pytest.mark.skipif(
-    not _redis_available(),
-    reason="Redis broker not reachable",
+from microdrop_utils.dramatiq_pub_sub_helpers import (
+    MessageRouterActor, MessageRouterData, publish_message,
 )
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+# Importing the listener module registers the Dramatiq actor.
+from pluggable_protocol_tree.execution import listener  # noqa: F401
+from pluggable_protocol_tree.models.column import (
+    BaseColumnHandler, BaseColumnModel, Column,
+)
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.columns.readonly_label import (
+    ReadOnlyLabelColumnView,
+)
+
+
+ACK_TOPIC = "pluggable_protocol_tree/test/ack"
 
 
 def test_publish_then_wait_for_round_trips_via_real_dramatiq():
     """A handler publishes a request and then waits for an ack on the
     same topic the message router routes back to the executor's
-    listener. Proves: publish → broker → executor_listener actor →
-    route_to_active_step → mailbox → wait_for → handler returns the
-    payload."""
-    from microdrop_utils.dramatiq_pub_sub_helpers import (
-        MessageRouterData, publish_message,
-    )
-    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
-    from pluggable_protocol_tree.builtins.id_column import make_id_column
-    from pluggable_protocol_tree.builtins.name_column import make_name_column
-    from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.execution.events import PauseEvent
-    from pluggable_protocol_tree.execution.executor import ProtocolExecutor
-    from pluggable_protocol_tree.execution.signals import ExecutorSignals
-    from pluggable_protocol_tree.models.column import (
-        BaseColumnHandler, BaseColumnModel, Column,
-    )
-    from pluggable_protocol_tree.models.row_manager import RowManager
-    from pluggable_protocol_tree.views.columns.readonly_label import (
-        ReadOnlyLabelColumnView,
-    )
-
-    ACK_TOPIC = "pluggable_protocol_tree/test/ack"
+    listener. Worker context manager runs the message_router_actor and
+    executor_listener actors in the background while the executor's
+    on_step blocks on ctx.wait_for."""
     received = []
 
     class _AckHandler(BaseColumnHandler):
@@ -63,12 +53,12 @@ def test_publish_then_wait_for_round_trips_via_real_dramatiq():
         def on_step(self, row, ctx):
             # Publish the ack ourselves (in a real handler this would
             # publish a request and a different actor would publish the
-            # ack). The point is to prove the mailbox round-trips.
-            publish_message(
-                topic=ACK_TOPIC, message={"step_uuid": row.uuid, "ok": True},
-            )
-            payload = ctx.wait_for(ACK_TOPIC, timeout=5.0)
-            received.append(payload)
+            # ack — here we drive both halves to keep the test self-
+            # contained while still exercising the round-trip).
+            payload_out = json.dumps({"step_uuid": row.uuid, "ok": True})
+            publish_message(message=payload_out, topic=ACK_TOPIC)
+            payload_in = ctx.wait_for(ACK_TOPIC, timeout=5.0)
+            received.append(payload_in)
 
     ack_col = Column(
         model=BaseColumnModel(col_id="ack", col_name="Ack", default_value=None),
@@ -76,13 +66,17 @@ def test_publish_then_wait_for_round_trips_via_real_dramatiq():
         handler=_AckHandler(),
     )
 
-    # Register the executor listener's subscription for ACK_TOPIC. (The
-    # plugin's start() does this in production; we do it inline here.)
-    router_data = MessageRouterData()
-    router_data.add_subscriber_to_topic(
+    # Instantiate the message router actor (registers its Dramatiq
+    # actor) and add the subscription for ACK_TOPIC. The plugin's
+    # start() does this in production.
+    router_actor = MessageRouterActor()
+    router_actor.message_router_data.add_subscriber_to_topic(
         topic=ACK_TOPIC,
         subscribing_actor_name="pluggable_protocol_tree_executor_listener",
     )
+
+    broker = dramatiq.get_broker()
+    broker.flush_all()
     try:
         cols = [make_type_column(), make_id_column(), make_name_column(),
                 make_repetitions_column(), make_duration_column(), ack_col]
@@ -95,20 +89,27 @@ def test_publish_then_wait_for_round_trips_via_real_dramatiq():
             stop_event=threading.Event(),
         )
 
-        # Run on a worker thread so dramatiq has time to deliver while
-        # the main thread monitors. (Unit tests call ex.run() directly;
-        # here we exercise the same code path but with the broker live.)
-        runner = threading.Thread(target=ex.run, daemon=True)
-        runner.start()
-        runner.join(timeout=10.0)
+        # Start a Dramatiq worker so message_router_actor and
+        # executor_listener actually fire. Without this, publishes go
+        # into Redis but never get consumed, so wait_for would time out.
+        worker = Worker(broker, worker_timeout=100)
+        worker.start()
+        try:
+            runner = threading.Thread(target=ex.run, daemon=True)
+            runner.start()
+            runner.join(timeout=10.0)
+            assert not runner.is_alive(), "executor.run did not return in 10s"
+        finally:
+            worker.stop()
 
-        assert not runner.is_alive(), "executor.run did not return in 10s"
-        assert len(received) == 1
-        assert received[0]["ok"] is True
-        assert received[0]["step_uuid"] == rm.root.children[0].uuid
+        assert len(received) == 1, f"expected 1 received message, got {len(received)}"
+        # Listener delivers the raw string from message_router; decode here.
+        payload = json.loads(received[0])
+        assert payload["ok"] is True
+        assert payload["step_uuid"] == rm.root.children[0].uuid
 
     finally:
-        router_data.remove_subscriber_from_topic(
+        router_actor.message_router_data.remove_subscriber_from_topic(
             topic=ACK_TOPIC,
             subscribing_actor_name="pluggable_protocol_tree_executor_listener",
         )

--- a/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
+++ b/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
@@ -10,6 +10,7 @@ on the receiving side).
 
 import json
 import threading
+import time
 
 import dramatiq
 from dramatiq import Worker
@@ -39,7 +40,7 @@ from pluggable_protocol_tree.views.columns.readonly_label import (
 ACK_TOPIC = "pluggable_protocol_tree/test/ack"
 
 
-def test_publish_then_wait_for_round_trips_via_real_dramatiq():
+def test_publish_then_wait_for_round_trips_via_real_dramatiq(router_actor):
     """A handler publishes a request and then waits for an ack on the
     same topic the message router routes back to the executor's
     listener. Worker context manager runs the message_router_actor and
@@ -66,10 +67,8 @@ def test_publish_then_wait_for_round_trips_via_real_dramatiq():
         handler=_AckHandler(),
     )
 
-    # Instantiate the message router actor (registers its Dramatiq
-    # actor) and add the subscription for ACK_TOPIC. The plugin's
-    # start() does this in production.
-    router_actor = MessageRouterActor()
+    # Add the subscription for ACK_TOPIC against the session-shared
+    # router_actor (the plugin's start() does this in production).
     router_actor.message_router_data.add_subscriber_to_topic(
         topic=ACK_TOPIC,
         subscribing_actor_name="pluggable_protocol_tree_executor_listener",
@@ -111,5 +110,180 @@ def test_publish_then_wait_for_round_trips_via_real_dramatiq():
     finally:
         router_actor.message_router_data.remove_subscriber_from_topic(
             topic=ACK_TOPIC,
+            subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+        )
+
+
+# --- realistic two-actor protocol flow test ----------------------------
+
+REQUEST_TOPIC = "pluggable_protocol_tree/test/state_request"
+APPLIED_TOPIC = "pluggable_protocol_tree/test/state_applied"
+
+# Module-level so registration happens once when the test module is
+# imported (the conftest configures the broker before this runs).
+# Mutable state lives on a fresh list per test (cleared in setup).
+_responder_log: list = []
+ACK_DELAY_S = 0.30
+
+
+@dramatiq.actor(
+    actor_name="ppt_test_state_responder",
+    queue_name="default",
+)
+def _state_responder(message: str, topic: str, timestamp: float = None):
+    """Simulates a hardware controller that takes ACK_DELAY_S to apply
+    state and then publishes a confirmation."""
+    import time as _t
+    _responder_log.append(("received", _t.monotonic()))
+    _t.sleep(ACK_DELAY_S)
+    publish_message(message="ok", topic=APPLIED_TOPIC)
+    _responder_log.append(("published_ack", _t.monotonic()))
+
+
+def test_step_blocks_on_state_apply_before_duration_starts(router_actor):
+    """End-to-end protocol-flow test:
+
+    A column's on_step publishes a 'set state' request and waits for an
+    asynchronous 'state applied' confirmation from another actor. Only
+    once the confirmation arrives may the next priority bucket
+    (DurationColumnHandler at priority 90) start its dwell sleep.
+
+    Proves:
+      * publish_message → message_router → subscriber actor → router →
+        executor_listener → mailbox → ctx.wait_for round-trip works
+        end-to-end against a real broker.
+      * Priority buckets serialize correctly: state-apply (priority 30)
+        finishes BEFORE the duration sleep (priority 90) starts —
+        observable as step duration ≈ ack_delay + duration_s, not
+        max(ack_delay, duration_s).
+      * The protocol stays on the active step the entire time (no
+        premature step_finished while wait_for is blocked).
+    """
+    from pyface.qt.QtCore import Qt
+    DURATION_S = 0.40
+
+    _responder_log.clear()
+    handler_events: list = []
+
+    class _ApplyStateHandler(BaseColumnHandler):
+        # Priority 30 puts this in a strictly earlier bucket than
+        # DurationColumnHandler's 90 — so they MUST run sequentially,
+        # not in parallel.
+        priority = 30
+        wait_for_topics = [APPLIED_TOPIC]
+
+        def on_step(self, row, ctx):
+            handler_events.append(("publish_request", time.monotonic()))
+            publish_message(message="set_state", topic=REQUEST_TOPIC)
+            payload = ctx.wait_for(APPLIED_TOPIC, timeout=5.0)
+            handler_events.append(("got_ack", time.monotonic(), payload))
+
+    apply_col = Column(
+        model=BaseColumnModel(
+            col_id="apply", col_name="Apply", default_value=None,
+        ),
+        view=ReadOnlyLabelColumnView(),
+        handler=_ApplyStateHandler(),
+    )
+
+    router_actor.message_router_data.add_subscriber_to_topic(
+        topic=REQUEST_TOPIC,
+        subscribing_actor_name="ppt_test_state_responder",
+    )
+    router_actor.message_router_data.add_subscriber_to_topic(
+        topic=APPLIED_TOPIC,
+        subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+    )
+
+    broker = dramatiq.get_broker()
+    broker.flush_all()
+    try:
+        cols = [
+            make_type_column(), make_id_column(), make_name_column(),
+            make_repetitions_column(), make_duration_column(), apply_col,
+        ]
+        rm = RowManager(columns=cols)
+        rm.add_step(values={"name": "S", "duration_s": DURATION_S})
+        ex = ProtocolExecutor(
+            row_manager=rm,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        # Capture step boundaries via Qt signals. DirectConnection so
+        # the slot fires synchronously on the worker thread without
+        # needing a QApplication event loop.
+        timing: dict = {}
+        ex.qsignals.step_started.connect(
+            lambda r: timing.update(step_started=time.monotonic()),
+            type=Qt.DirectConnection,
+        )
+        ex.qsignals.step_finished.connect(
+            lambda r: timing.update(step_finished=time.monotonic()),
+            type=Qt.DirectConnection,
+        )
+
+        worker = Worker(broker, worker_timeout=100)
+        worker.start()
+        try:
+            runner = threading.Thread(target=ex.run, daemon=True)
+            runner.start()
+            runner.join(timeout=15.0)
+            assert not runner.is_alive(), "executor.run did not return"
+        finally:
+            worker.stop()
+
+        # --- assertions ----------------------------------------------
+
+        assert "step_started" in timing, "step_started signal didn't fire"
+        assert "step_finished" in timing, "step_finished signal didn't fire"
+        step_elapsed = timing["step_finished"] - timing["step_started"]
+
+        # The handler ran in the right order: publish, then ack.
+        publish_t = next(t for e, t in
+                         ((e[0], e[1]) for e in handler_events)
+                         if e == "publish_request")
+        ack_t = next(t for e, t in
+                     ((e[0], e[1]) for e in handler_events)
+                     if e == "got_ack")
+        ack_elapsed = ack_t - publish_t
+
+        # The responder also ran end-to-end.
+        assert ("received", ) == tuple(e[0] for e in _responder_log[:1]), \
+            f"responder didn't receive request; log={_responder_log!r}"
+        assert "published_ack" in [e[0] for e in _responder_log], \
+            f"responder didn't publish ack; log={_responder_log!r}"
+
+        # Ack arrived AT LEAST ACK_DELAY_S after the request — the
+        # responder slept that long. Allow 10% slack.
+        assert ack_elapsed >= ACK_DELAY_S * 0.9, (
+            f"ack arrived too fast: {ack_elapsed:.3f}s "
+            f"< expected ~{ACK_DELAY_S}s"
+        )
+
+        # The whole step took ack_delay + duration_s — NOT max() of
+        # them. If the duration sleep had started in parallel with
+        # the wait_for, step would have taken ~max(ACK_DELAY,
+        # DURATION) ~= 0.4s. Sequential is ~0.7s.
+        expected_min = ACK_DELAY_S + DURATION_S
+        assert step_elapsed >= expected_min * 0.9, (
+            f"step took {step_elapsed:.3f}s; expected >= "
+            f"{expected_min:.3f}s (ack {ACK_DELAY_S}s + dwell {DURATION_S}s). "
+            f"Did the duration sleep start in parallel with wait_for?"
+        )
+        # Sanity: not wildly longer than expected (allow 0.5s overhead).
+        assert step_elapsed < expected_min + 0.5, (
+            f"step took {step_elapsed:.3f}s; expected ~{expected_min:.3f}s "
+            f"(too much overhead — broker / worker contention?)"
+        )
+
+    finally:
+        router_actor.message_router_data.remove_subscriber_from_topic(
+            topic=REQUEST_TOPIC,
+            subscribing_actor_name="ppt_test_state_responder",
+        )
+        router_actor.message_router_data.remove_subscriber_from_topic(
+            topic=APPLIED_TOPIC,
             subscribing_actor_name="pluggable_protocol_tree_executor_listener",
         )

--- a/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
+++ b/pluggable_protocol_tree/tests/tests_with_redis_server_need/test_executor_redis_integration.py
@@ -1,0 +1,114 @@
+"""End-to-end test for the executor's Dramatiq round-trip.
+
+Skips automatically if Redis isn't reachable. Run via:
+
+    redis-server &              # in another shell
+    cd microdrop-py && pixi run bash -c \\
+      "cd src && pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/ -v"
+"""
+
+import threading
+import time
+
+import pytest
+
+
+def _redis_available() -> bool:
+    try:
+        import dramatiq
+        broker = dramatiq.get_broker()
+        broker.client.ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_available(),
+    reason="Redis broker not reachable",
+)
+
+
+def test_publish_then_wait_for_round_trips_via_real_dramatiq():
+    """A handler publishes a request and then waits for an ack on the
+    same topic the message router routes back to the executor's
+    listener. Proves: publish → broker → executor_listener actor →
+    route_to_active_step → mailbox → wait_for → handler returns the
+    payload."""
+    from microdrop_utils.dramatiq_pub_sub_helpers import (
+        MessageRouterData, publish_message,
+    )
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.execution.events import PauseEvent
+    from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+    from pluggable_protocol_tree.execution.signals import ExecutorSignals
+    from pluggable_protocol_tree.models.column import (
+        BaseColumnHandler, BaseColumnModel, Column,
+    )
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    from pluggable_protocol_tree.views.columns.readonly_label import (
+        ReadOnlyLabelColumnView,
+    )
+
+    ACK_TOPIC = "pluggable_protocol_tree/test/ack"
+    received = []
+
+    class _AckHandler(BaseColumnHandler):
+        wait_for_topics = [ACK_TOPIC]
+
+        def on_step(self, row, ctx):
+            # Publish the ack ourselves (in a real handler this would
+            # publish a request and a different actor would publish the
+            # ack). The point is to prove the mailbox round-trips.
+            publish_message(
+                topic=ACK_TOPIC, message={"step_uuid": row.uuid, "ok": True},
+            )
+            payload = ctx.wait_for(ACK_TOPIC, timeout=5.0)
+            received.append(payload)
+
+    ack_col = Column(
+        model=BaseColumnModel(col_id="ack", col_name="Ack", default_value=None),
+        view=ReadOnlyLabelColumnView(),
+        handler=_AckHandler(),
+    )
+
+    # Register the executor listener's subscription for ACK_TOPIC. (The
+    # plugin's start() does this in production; we do it inline here.)
+    router_data = MessageRouterData()
+    router_data.add_subscriber_to_topic(
+        topic=ACK_TOPIC,
+        subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+    )
+    try:
+        cols = [make_type_column(), make_id_column(), make_name_column(),
+                make_repetitions_column(), make_duration_column(), ack_col]
+        rm = RowManager(columns=cols)
+        rm.add_step(values={"name": "S"})
+        ex = ProtocolExecutor(
+            row_manager=rm,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        # Run on a worker thread so dramatiq has time to deliver while
+        # the main thread monitors. (Unit tests call ex.run() directly;
+        # here we exercise the same code path but with the broker live.)
+        runner = threading.Thread(target=ex.run, daemon=True)
+        runner.start()
+        runner.join(timeout=10.0)
+
+        assert not runner.is_alive(), "executor.run did not return in 10s"
+        assert len(received) == 1
+        assert received[0]["ok"] is True
+        assert received[0]["step_uuid"] == rm.root.children[0].uuid
+
+    finally:
+        router_data.remove_subscriber_from_topic(
+            topic=ACK_TOPIC,
+            subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+        )

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -15,14 +15,16 @@ from pluggable_protocol_tree.models.row import GroupRow
 class MvcTreeModel(QAbstractItemModel):
     """Qt tree model over a RowManager.
 
-    An 'active' row (set via set_active_node) gets a light-green
-    background via BackgroundRole — used in PPT-2 by the executor to
-    highlight the running step. In PPT-1 this stays None.
+    An 'active' row (set via set_active_node) gets a blue background
+    with white foreground — used by the executor to highlight the
+    currently-running step (matching the legacy protocol_grid look).
+    In a non-running protocol this stays None.
     """
 
     structure_changed = Signal()   # high-level "redraw" nudge
 
-    _ACTIVE_BG = QBrush(QColor(200, 255, 200))
+    _ACTIVE_BG = QBrush(QColor(0, 90, 200))   # solid blue
+    _ACTIVE_FG = QBrush(QColor(255, 255, 255))
 
     def __init__(self, row_manager, parent=None):
         super().__init__(parent)
@@ -69,8 +71,11 @@ class MvcTreeModel(QAbstractItemModel):
         node = index.internalPointer()
         col = self._manager.columns[index.column()]
 
-        if role == Qt.BackgroundRole and node is self._active_node:
-            return self._ACTIVE_BG
+        if node is self._active_node:
+            if role == Qt.BackgroundRole:
+                return self._ACTIVE_BG
+            if role == Qt.ForegroundRole:
+                return self._ACTIVE_FG
 
         value = col.model.get_value(node)
 

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -30,6 +30,13 @@ class MvcTreeModel(QAbstractItemModel):
         super().__init__(parent)
         self._manager = row_manager
         self._active_node = None
+        # Strong refs to every row this model has handed to Qt via
+        # createIndex(). Qt stores the third arg as a raw void*; if
+        # Python GCs the row before Qt drops the QModelIndex, the
+        # next access (selection sync, parent walk, etc.) dereferences
+        # freed memory and segfaults the QApplication. Keeping refs
+        # here costs O(rows-ever-shown) memory but is bulletproof.
+        self._owned_rows = set()
 
         # Rebroadcast manager changes as layoutChanged
         row_manager.observe(self._on_rows_changed, "rows_changed")
@@ -49,7 +56,12 @@ class MvcTreeModel(QAbstractItemModel):
         node = parent.internalPointer() if parent.isValid() else self._manager.root
         if row >= len(node.children):
             return QModelIndex()
-        return self.createIndex(row, column, node.children[row])
+        child = node.children[row]
+        # Pin the row so Qt's createIndex pointer stays valid even
+        # after the user removes the row from the manager (Qt's stale
+        # QModelIndex would otherwise dereference freed memory).
+        self._owned_rows.add(child)
+        return self.createIndex(row, column, child)
 
     def parent(self, index):
         if not index.isValid():

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -4,7 +4,7 @@ remove / copy / cut / paste / group."""
 import logging
 from enum import Enum
 
-from pyface.qt.QtCore import Qt, QPersistentModelIndex
+from pyface.qt.QtCore import Qt, QPersistentModelIndex, Signal
 from pyface.qt.QtGui import QKeySequence, QShortcut
 from pyface.qt.QtWidgets import QWidget, QVBoxLayout, QTreeView, QMenu, QAbstractItemView
 
@@ -16,6 +16,26 @@ from pluggable_protocol_tree.views.qt_tree_model import MvcTreeModel
 logger = logging.getLogger(__name__)
 
 
+class _ProtocolTreeView(QTreeView):
+    """QTreeView subclass that emits a Qt signal on Delete keypress.
+
+    Using a keyPressEvent override (rather than QShortcut) is the most
+    reliable path: the event is captured directly on the focused widget,
+    no overload-resolution surprises, no shortcut-context confusion, and
+    we explicitly accept() the event so Qt's default key handling
+    doesn't get a second chance to interpret it.
+    """
+
+    delete_pressed = Signal()
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Delete:
+            self.delete_pressed.emit()
+            event.accept()
+            return
+        super().keyPressEvent(event)
+
+
 class ProtocolTreeWidget(QWidget):
     def __init__(self, row_manager: RowManager, parent=None):
         super().__init__(parent)
@@ -24,10 +44,11 @@ class ProtocolTreeWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        self.tree = QTreeView()
+        self.tree = _ProtocolTreeView()
         self.tree.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.tree.setEditTriggers(QAbstractItemView.DoubleClicked
                                   | QAbstractItemView.EditKeyPressed)
+        self.tree.delete_pressed.connect(self._delete_selection)
         layout.addWidget(self.tree)
 
         self.model = MvcTreeModel(row_manager, parent=self.tree)
@@ -39,20 +60,17 @@ class ProtocolTreeWidget(QWidget):
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
         self.tree.customContextMenuRequested.connect(self._on_context_menu)
 
-        # Keyboard shortcuts. Bind via .activated.connect() rather than
-        # the (seq, parent, callable) constructor — the latter can fail
-        # to wire silently in PySide6 (the third arg is documented as a
-        # const char* slot name in Qt; passing a Python callable lands
-        # in an overload that may discard it). Bind to the tree, with
-        # WidgetWithChildrenShortcut context so they only fire when the
-        # tree or its delegates have focus — pressing Delete in the
-        # toolbar or anywhere else in the window must not delete rows.
+        # Copy / Cut / Paste keyboard shortcuts. Bind via
+        # .activated.connect() rather than the (seq, parent, callable)
+        # constructor — the latter can fail to wire silently in PySide6.
+        # WidgetWithChildrenShortcut so they only fire when the tree
+        # has focus. Delete is handled by _ProtocolTreeView.keyPressEvent
+        # rather than a QShortcut for maximum reliability.
         self._shortcuts = []     # keep refs alive (Qt doesn't, in PySide6)
         for seq, slot in (
-            (QKeySequence.Copy,   self._copy),
-            (QKeySequence.Cut,    self._cut),
-            (QKeySequence.Paste,  self._paste),
-            (QKeySequence.Delete, self._delete_selection),
+            (QKeySequence.Copy,  self._copy),
+            (QKeySequence.Cut,   self._cut),
+            (QKeySequence.Paste, self._paste),
         ):
             sc = QShortcut(seq, self.tree)
             sc.setContext(Qt.WidgetWithChildrenShortcut)

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -1,14 +1,19 @@
 """Qt widget: QTreeView over a RowManager, with context menu for add /
 remove / copy / cut / paste / group."""
 
+import logging
 from enum import Enum
 
 from pyface.qt.QtCore import Qt, QPersistentModelIndex
+from pyface.qt.QtGui import QKeySequence, QShortcut
 from pyface.qt.QtWidgets import QWidget, QVBoxLayout, QTreeView, QMenu, QAbstractItemView
 
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.delegate import ProtocolItemDelegate
 from pluggable_protocol_tree.views.qt_tree_model import MvcTreeModel
+
+
+logger = logging.getLogger(__name__)
 
 
 class ProtocolTreeWidget(QWidget):
@@ -34,12 +39,25 @@ class ProtocolTreeWidget(QWidget):
         self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
         self.tree.customContextMenuRequested.connect(self._on_context_menu)
 
-        # Keyboard shortcuts for copy/cut/paste
-        from pyface.qt.QtGui import QShortcut, QKeySequence
-        QShortcut(QKeySequence.Copy, self, self._copy)
-        QShortcut(QKeySequence.Cut, self, self._cut)
-        QShortcut(QKeySequence.Paste, self, self._paste)
-        QShortcut(QKeySequence.Delete, self, self._delete_selection)
+        # Keyboard shortcuts. Bind via .activated.connect() rather than
+        # the (seq, parent, callable) constructor — the latter can fail
+        # to wire silently in PySide6 (the third arg is documented as a
+        # const char* slot name in Qt; passing a Python callable lands
+        # in an overload that may discard it). Bind to the tree, with
+        # WidgetWithChildrenShortcut context so they only fire when the
+        # tree or its delegates have focus — pressing Delete in the
+        # toolbar or anywhere else in the window must not delete rows.
+        self._shortcuts = []     # keep refs alive (Qt doesn't, in PySide6)
+        for seq, slot in (
+            (QKeySequence.Copy,   self._copy),
+            (QKeySequence.Cut,    self._cut),
+            (QKeySequence.Paste,  self._paste),
+            (QKeySequence.Delete, self._delete_selection),
+        ):
+            sc = QShortcut(seq, self.tree)
+            sc.setContext(Qt.WidgetWithChildrenShortcut)
+            sc.activated.connect(slot)
+            self._shortcuts.append(sc)
 
         # Mirror Qt selection → RowManager selection
         self.tree.selectionModel().selectionChanged.connect(self._sync_selection)
@@ -128,16 +146,40 @@ class ProtocolTreeWidget(QWidget):
         return path[:-1]
 
     def _copy(self):
-        self._manager.copy()
+        try:
+            self._manager.copy()
+        except Exception:
+            logger.exception("Copy failed")
 
     def _cut(self):
-        self._manager.cut()
+        try:
+            self._manager.cut()
+        except Exception:
+            logger.exception("Cut failed")
 
     def _paste(self):
-        # Use current anchor as target
-        idxs = self.tree.selectionModel().selectedRows(0)
-        target = self._index_to_path(idxs[-1]) if idxs else None
-        self._manager.paste(target_path=target)
+        try:
+            idxs = self.tree.selectionModel().selectedRows(0)
+            target = self._index_to_path(idxs[-1]) if idxs else None
+            self._manager.paste(target_path=target)
+        except Exception:
+            logger.exception("Paste failed")
 
     def _delete_selection(self):
-        self._manager.remove(list(self._manager.selection))
+        """Remove the currently-selected rows. Defensive: stale paths
+        (rows already removed by a previous action) are silently
+        skipped rather than propagating IndexError, which under
+        PySide6 6.x terminates the QApplication."""
+        try:
+            paths = [tuple(p) for p in self._manager.selection]
+            valid = []
+            for p in paths:
+                try:
+                    self._manager.get_row(p)
+                except (IndexError, KeyError):
+                    continue
+                valid.append(p)
+            if valid:
+                self._manager.remove(valid)
+        except Exception:
+            logger.exception("Delete failed")

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -44,6 +44,35 @@ class ProtocolTreeWidget(QWidget):
         # Mirror Qt selection → RowManager selection
         self.tree.selectionModel().selectionChanged.connect(self._sync_selection)
 
+    # --- active-row highlight + scroll (called by the executor wiring) ---
+
+    def highlight_active_row(self, node):
+        """Mark `node` as the currently-active step and scroll to it.
+
+        Pass `None` to clear the highlight (typical at protocol end).
+        """
+        self.model.set_active_node(node)
+        if node is None:
+            return
+        idx = self._node_to_index(node)
+        if idx.isValid():
+            self.tree.scrollTo(idx, QTreeView.PositionAtCenter)
+            # Expand any collapsed ancestor groups so the row is visible.
+            parent = idx.parent()
+            while parent.isValid():
+                self.tree.expand(parent)
+                parent = parent.parent()
+
+    def _node_to_index(self, node):
+        """Walk the row's path to a QModelIndex on the first column."""
+        path = node.path
+        idx = self.model.index(path[0], 0) if path else self.model.index(-1, -1)
+        for r in path[1:]:
+            if not idx.isValid():
+                return idx
+            idx = self.model.index(r, 0, idx)
+        return idx
+
     # --- selection sync ---
 
     def _sync_selection(self, *_):


### PR DESCRIPTION
Closes #364

## Summary

Ships the protocol-execution layer for the new pluggable protocol tree:

- **`execution/`** subpackage: \`AbortError\`, \`PauseEvent\`, \`ExecutorSignals\` (QObject), \`Mailbox\` + \`wait_first\` helper, \`ProtocolContext\` + \`StepContext\` with \`ctx.wait_for(topic, timeout, predicate)\`, single Dramatiq listener actor + active-step pointer, and \`ProtocolExecutor\` (HasTraits, QThread-hosted).
- **Pre-registered mailboxes** at step start cover the union of every contributed handler's \`wait_for_topics\` — fixes the publish-then-register race so fast hardware acks don't get lost.
- **Priority-bucket fan-out**: lower priority first; equal priorities run in parallel via per-bucket \`ThreadPoolExecutor\`. First exception in a bucket sets \`stop_event\` so sibling waits abort promptly via \`AbortError\`, the pool drains, and the original exception propagates.
- **Three terminal signals** (\`finished\` / \`aborted\` / \`error\`) decided in \`_emit_terminal_signal\` so call sites stay simple. \`stop()\` also clears \`pause_event\` so a Stop-while-paused doesn't deadlock.
- **Same-topic conflict assertion**: two columns in the same priority bucket both declaring the same \`wait_for_topic\` raises a clear error (multiple-waiter broadcast is out of scope until someone needs it).
- **Repetitions** built-in column shipped as the 5th always-on default.
- **Demo MessageColumn** + enhanced \`demos/run_widget.py\` with Run/Pause/Stop toolbar and active-row highlighting wired to the \`MvcTreeModel.set_active_node\` hook PPT-1 already plumbed.
- **Plugin** registers the executor listener's subscriptions dynamically via \`MessageRouterData.add_subscriber_to_topic\` (the static \`ACTOR_TOPIC_DICT\` pattern doesn't fit because the topic set depends on which columns get contributed, only known after extension-point resolution).

## Test plan

- [x] \`pytest pluggable_protocol_tree/tests/ -v --ignore=...tests_with_redis_server_need\` — **170 tests passing**
- [x] \`pytest pluggable_protocol_tree/tests/tests_with_redis_server_need/\` — **1 test passing** with \`redis-server\` running (proves real Dramatiq round-trip)
- [x] Manual demo verification: Run on a 3-step protocol with Repetitions=3 on the middle step; active row highlight walks correctly. Pause/Resume work between steps. Stop exits cleanly.

## Implementation notes

Two non-obvious bits the integration test surfaced:

1. The executor_listener actor signature is \`(message, topic, timestamp=None)\` to match the message-router's \`publish_message(message_str, topic, actor_name, ...)\` calling convention. Payload arrives as a string (handlers JSON-decode if they want a dict).
2. The Redis test conftest configures the broker at module-import time, not in a fixture, so any \`@dramatiq.actor\` decorators in the test imports register against the RedisBroker rather than the default StubBroker.

## Not in scope (see follow-ups)

- Electrode + Routes columns + device-viewer binding → PPT-3
- Voltage/Frequency columns → PPT-4
- Production dock-pane Run/Pause/Stop buttons (deferred to PPT-3 when there's hardware to gate)
- Long-running CPU hooks with cooperative abort (best-practice doc'd; will be exercised by PPT-3's RoutesHandler)

Design doc: \`src/docs/superpowers/specs/2026-04-22-ppt-2-executor-design.md\`
Plan: \`src/docs/superpowers/plans/2026-04-22-ppt-2-executor.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)