### PR TITLE
[PPT-12] Extract BasePluggableProtocolDemoWindow + refactor 4 demos + add integration demo

### DIFF
--- a/docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md
+++ b/docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md
@@ -1,0 +1,2538 @@
+# PPT-12 Demo Base Window + Integration Demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a composition-based `BasePluggableProtocolDemoWindow` for shared demo UX (active-row highlight, status bar with timers, button state machine, Save/Load, etc.), refactor the 4 existing demos to use it, and add a new full-stack integration demo that exercises every column type at once.
+
+**Architecture:** New `BasePluggableProtocolDemoWindow(QMainWindow)` takes a `DemoConfig` dataclass — no subclassing required. `DemoConfig` declares columns, sample steps, demo-specific routing, ack-driven status readouts, and an optional side panel factory. The base owns the tree widget, executor, status bar, button state machine, Dramatiq routing scaffolding, and lifecycle. Each refactored demo collapses to ~50-100 LOC of just-its-stuff.
+
+**Tech Stack:** Python 3.x, PySide6/Qt (QMainWindow + Qt signals), Dramatiq + Redis pub/sub, pytest, dataclasses.
+
+**Spec:** `src/docs/superpowers/specs/2026-04-28-ppt-12-demo-base-design.md`
+
+**Branch:** `feat/ppt-12-demo-base` (already created from main with PPT-5 merged in).
+
+**Test runner:** `pixi run pytest …` from outer repo root `C:\Users\Info\PycharmProjects\pixi-microdrop\microdrop-py`.
+
+---
+
+## Task 1: `DemoConfig` + `StatusReadout` dataclasses + slug helper
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/demos/base_demo_window.py` (initial — dataclasses + helper only; window class added in Task 2)
+- Create: `src/pluggable_protocol_tree/tests/test_base_demo_window.py`
+
+**Why:** Pure-Python data scaffolding. No Qt yet. Lays the contract demos will build against. The `slug()` helper turns a status-readout label into a Dramatiq actor name suffix.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# src/pluggable_protocol_tree/tests/test_base_demo_window.py
+"""Tests for the demo base window + DemoConfig + StatusReadout."""
+
+import pytest
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.demos.base_demo_window import (
+    DemoConfig, StatusReadout, _slug,
+)
+
+
+def test_status_readout_required_fields():
+    r = StatusReadout(label="Voltage", topic="dropbot/signals/voltage_applied",
+                      fmt=lambda m: f"{int(m)} V")
+    assert r.label == "Voltage"
+    assert r.topic == "dropbot/signals/voltage_applied"
+    assert r.fmt("100") == "100 V"
+    assert r.initial == "--"   # default
+
+
+def test_status_readout_initial_overridable():
+    r = StatusReadout(label="Magnet", topic="x/applied",
+                      fmt=lambda m: m, initial="idle")
+    assert r.initial == "idle"
+
+
+def test_demo_config_minimum_required_fields():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    assert cfg.title == "Pluggable Protocol Tree Demo"
+    assert cfg.window_size == (1100, 650)
+    assert cfg.phase_ack_topic == ELECTRODES_STATE_APPLIED   # default
+    assert cfg.status_readouts == []
+    assert cfg.side_panel_factory is None
+
+
+def test_demo_config_pre_populate_default_is_no_op():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    # Default pre_populate is a no-op lambda accepting one arg.
+    cfg.pre_populate(None)   # must not raise
+
+
+def test_demo_config_routing_setup_default_is_no_op():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    cfg.routing_setup(None)
+
+
+def test_demo_config_phase_ack_can_be_none():
+    cfg = DemoConfig(columns_factory=lambda: [], phase_ack_topic=None)
+    assert cfg.phase_ack_topic is None
+
+
+def test_slug_lowercases_and_strips_punctuation():
+    """slug('Voltage')='voltage'; slug('Magnet Height (mm)')='magnet_height_mm'."""
+    assert _slug("Voltage") == "voltage"
+    assert _slug("Magnet Height (mm)") == "magnet_height_mm"
+    assert _slug("Step Time") == "step_time"
+
+
+def test_slug_handles_empty_string():
+    assert _slug("") == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: FAIL with `ModuleNotFoundError: No module named 'pluggable_protocol_tree.demos.base_demo_window'`.
+
+- [ ] **Step 3: Implement the dataclasses + slug helper**
+
+Create `src/pluggable_protocol_tree/demos/base_demo_window.py`:
+
+```python
+"""Composition-based base window for pluggable protocol tree demos.
+
+Demos build a DemoConfig (declarative dataclass) and call
+BasePluggableProtocolDemoWindow.run(config). The base owns the standard
+UX scaffolding: protocol tree widget, executor, active-row highlight,
+status bar, button state machine, Dramatiq routing, Save/Load.
+
+Each demo declares only its specific bits: columns, sample steps,
+demo-specific responder subscriptions, ack-driven status readouts,
+and an optional side panel.
+
+See PPT-12 spec for design rationale (composition vs inheritance).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+
+
+@dataclass
+class StatusReadout:
+    """One ack-driven readout label in the status bar.
+
+    The base creates one Dramatiq actor per StatusReadout (auto-named
+    ppt12_demo_<label_slug>_listener) that subscribes to ``topic``,
+    emits a Qt signal, and updates a QLabel in the status bar with
+    ``f"{label}: {fmt(message)}"``. Until the first ack, the label
+    shows ``f"{label}: {initial}"``.
+    """
+    label: str
+    topic: str
+    fmt: Callable[[str], str]
+    initial: str = "--"
+
+
+@dataclass
+class DemoConfig:
+    """Declarative demo configuration. Only ``columns_factory`` is required;
+    all other fields have sensible defaults."""
+
+    # Required.
+    columns_factory: Callable[[], list]
+
+    # Cosmetic.
+    title: str = "Pluggable Protocol Tree Demo"
+    window_size: tuple[int, int] = (1100, 650)
+
+    # Optional sample steps populated after RowManager construction.
+    pre_populate: Callable[[Any], None] = field(
+        default_factory=lambda: (lambda rm: None)
+    )
+
+    # Subscribe demo responders / additional listeners on the router.
+    # Called AFTER the base wires the standard PPT-3 electrode chain
+    # + the phase-ack listener (if phase_ack_topic is set) +
+    # the StatusReadout listeners.
+    routing_setup: Callable[[Any], None] = field(
+        default_factory=lambda: (lambda router: None)
+    )
+
+    # Single ack topic that drives the per-phase timer.
+    # If None: only step-elapsed timer shown, no per-phase timer.
+    phase_ack_topic: str | None = ELECTRODES_STATE_APPLIED
+
+    # Right-side status bar readouts.
+    status_readouts: list[StatusReadout] = field(default_factory=list)
+
+    # Side panel (e.g. SimpleDeviceViewer for PPT-3 / integration demo).
+    # Returns a QWidget or None. Called once during window setup.
+    side_panel_factory: Callable[[Any], Any] | None = None
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(label: str) -> str:
+    """Slugify a status-readout label for use as a Dramatiq actor name suffix.
+
+    'Voltage' -> 'voltage'
+    'Magnet Height (mm)' -> 'magnet_height_mm'
+    """
+    return _SLUG_RE.sub("_", label.lower()).strip("_")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 8 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Add DemoConfig + StatusReadout dataclasses + slug helper"
+```
+
+---
+
+## Task 2: `BasePluggableProtocolDemoWindow` minimum constructor
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (add window class)
+- Create: `src/pluggable_protocol_tree/tests/conftest.py` (qapp fixture)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add window construction tests)
+
+**Why:** Stand up the bare minimum window — `RowManager` + `ProtocolTreeWidget` + `ProtocolExecutor` constructed from the config's `columns_factory`. Title and window size applied. No status bar yet, no toolbar yet. Subsequent tasks add features incrementally.
+
+- [ ] **Step 1: Write the qapp fixture (shared for all Qt-needing tests)**
+
+Create `src/pluggable_protocol_tree/tests/conftest.py`:
+
+```python
+"""Shared fixtures for pluggable_protocol_tree tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Session-scoped QApplication so Qt widget tests can construct
+    QMainWindow + child widgets without crashing."""
+    from pyface.qt.QtWidgets import QApplication
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # Don't quit — pytest-qt doesn't either; lets subsequent test
+    # modules reuse the same QApplication.
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_base_demo_window.py`:
+
+```python
+def test_window_constructs_with_minimum_config(qapp):
+    """Window builds successfully with just a columns_factory."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.windowTitle() == "Pluggable Protocol Tree Demo"
+    # Has the manager + executor + tree widget wired
+    assert w.manager is not None
+    assert w.executor is not None
+    assert w.widget is not None
+    # Window size matches default
+    assert (w.width(), w.height()) == (1100, 650)
+
+
+def test_window_applies_custom_title_and_size(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        title="My Demo",
+        window_size=(800, 500),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.windowTitle() == "My Demo"
+    assert (w.width(), w.height()) == (800, 500)
+
+
+def test_window_columns_match_factory_output(qapp):
+    """RowManager has the columns returned by columns_factory."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [
+        make_type_column(), make_id_column(), make_name_column(),
+    ])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    ids = [c.model.col_id for c in w.manager.columns]
+    assert ids == ["type", "id", "name"]
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 8 dataclass tests pass; 3 new window tests FAIL with `ImportError: cannot import name 'BasePluggableProtocolDemoWindow'`.
+
+- [ ] **Step 4: Implement the window class (minimum)**
+
+Append to `src/pluggable_protocol_tree/demos/base_demo_window.py`:
+
+```python
+import threading
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtWidgets import (
+    QApplication, QMainWindow, QSplitter,
+)
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+class BasePluggableProtocolDemoWindow(QMainWindow):
+    """Hosts a ProtocolTreeWidget + ProtocolExecutor with the standard
+    UX scaffolding. See PPT-12 spec for the full feature list.
+
+    Construct with a DemoConfig; call .show() and .exec() OR use the
+    .run(config) classmethod for one-shot main() convenience."""
+
+    def __init__(self, config: DemoConfig):
+        super().__init__()
+        self.config = config
+        self.setWindowTitle(config.title)
+        self.resize(*config.window_size)
+
+        self.manager = RowManager(columns=config.columns_factory())
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        self.setCentralWidget(self.widget)
+
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 11 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/conftest.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Add BasePluggableProtocolDemoWindow minimum constructor"
+```
+
+---
+
+## Task 3: `pre_populate` hook + standard PPT-3 electrode chain auto-wired
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (call pre_populate after manager construction; setup_dramatiq_routing skeleton with electrode chain + routing_setup callback)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 3 tests)
+
+**Why:** Two things demos always need: a place to add sample steps (pre_populate), and the standard PPT-3 electrode-actuation chain wired automatically (so demos don't all reimplement the same `add_subscriber_to_topic` calls). Demos that need extra responders use `routing_setup`.
+
+- [ ] **Step 1: Append the failing tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_base_demo_window.py`:
+
+```python
+def test_pre_populate_runs_after_manager_construction(qapp):
+    """The pre_populate callback receives the live RowManager and
+    rows added there are present after window construction."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    def populate(rm):
+        rm.add_step(values={"name": "S1", "duration_s": 0.1})
+        rm.add_step(values={"name": "S2", "duration_s": 0.2})
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+            make_duration_column(),
+        ],
+        pre_populate=populate,
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert len(w.manager.root.children) == 2
+    assert w.manager.root.children[0].name == "S1"
+    assert w.manager.root.children[1].name == "S2"
+
+
+def test_routing_setup_called_after_standard_chain(qapp, monkeypatch):
+    """The routing_setup callback receives the router AFTER the base
+    wires the PPT-3 electrode chain. Verify by recording the order."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    call_log = []
+
+    def fake_router_setup_inner(self):
+        # Replace the real broker setup with a recording fake.
+        call_log.append("base_routing_setup")
+        # Need to set self._router so routing_setup can be called with it.
+        self._router = "fake-router"
+
+    monkeypatch.setattr(
+        BasePluggableProtocolDemoWindow,
+        "_setup_dramatiq_routing_internal",
+        fake_router_setup_inner,
+    )
+
+    def my_routing(router):
+        call_log.append(("routing_setup", router))
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        routing_setup=my_routing,
+    )
+    BasePluggableProtocolDemoWindow(cfg)
+    assert call_log == ["base_routing_setup", ("routing_setup", "fake-router")]
+
+
+def test_window_has_router_attribute_after_construction(qapp):
+    """self._router exists (may be None if Redis unavailable, that's fine)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert hasattr(w, "_router")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 11 prior tests pass; 3 new tests FAIL — `pre_populate` not called yet, no `_router` attribute.
+
+- [ ] **Step 3: Implement pre_populate + routing setup skeleton**
+
+Add imports near the top of `src/pluggable_protocol_tree/demos/base_demo_window.py`:
+
+```python
+import logging
+
+import dramatiq
+
+from microdrop_utils.broker_server_helpers import (
+    remove_middleware_from_dramatiq_broker,
+)
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.demos.electrode_responder import (
+    DEMO_RESPONDER_ACTOR_NAME,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Strip Prometheus middleware once at module import time — every
+# downstream demo needs this and the stripping is idempotent.
+remove_middleware_from_dramatiq_broker(
+    middleware_name="dramatiq.middleware.prometheus",
+    broker=dramatiq.get_broker(),
+)
+```
+
+Update `BasePluggableProtocolDemoWindow.__init__` to call `pre_populate` and the routing setup:
+
+```python
+    def __init__(self, config: DemoConfig):
+        super().__init__()
+        self.config = config
+        self.setWindowTitle(config.title)
+        self.resize(*config.window_size)
+
+        self.manager = RowManager(columns=config.columns_factory())
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        self.setCentralWidget(self.widget)
+
+        # Pre-populate sample steps BEFORE the executor is built.
+        config.pre_populate(self.manager)
+
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+        self._router = None
+        self._dramatiq_worker = None
+        self._setup_dramatiq_routing_internal()
+        if self._router is not None:
+            # Demo-specific responders / listeners — called AFTER the
+            # standard chain so the demo can rely on it being in place.
+            config.routing_setup(self._router)
+
+    def _setup_dramatiq_routing_internal(self):
+        """Wires the standard PPT-3 electrode actuation chain
+        (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED).
+
+        Best-effort: if Redis isn't reachable, sets self._router = None
+        and logs a warning. Runtime calls to ctx.wait_for() will then
+        time out at protocol-run time and surface as protocol_error.
+        """
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import (
+                MessageRouterActor,
+            )
+            from dramatiq import Worker
+
+            broker = dramatiq.get_broker()
+            broker.flush_all()
+            router = MessageRouterActor()
+
+            # Standard PPT-3 electrode chain.
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_CHANGE,
+                subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
+            )
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_APPLIED,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+
+            self._router = router
+            self._dramatiq_worker = Worker(broker, worker_timeout=100)
+            self._dramatiq_worker.start()
+        except ValueError as e:
+            if "already registered" not in str(e):
+                logger.warning("Demo Dramatiq routing setup failed: %s", e)
+        except Exception as e:
+            logger.warning(
+                "Demo Dramatiq routing setup failed (Redis not running?): %s",
+                e,
+            )
+
+    def closeEvent(self, event):
+        if self._dramatiq_worker is not None:
+            try:
+                self._dramatiq_worker.stop()
+            except Exception:
+                logger.exception("Error stopping demo dramatiq worker")
+        super().closeEvent(event)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 14 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Add pre_populate hook + standard electrode chain + routing_setup callback"
+```
+
+---
+
+## Task 4: Status bar (step counter + row name + step elapsed timer + tick) + active-row highlight
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (status bar, tick timer, executor signal wiring for highlight + step transitions)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 4 tests)
+
+**Why:** Visual scaffolding always present — step counter / row name / step elapsed timer + the active-row highlight (executor's `step_started` signal connected to the tree widget's `highlight_active_row`). Tick timer at 10 Hz refreshes the elapsed-time label.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_window_has_status_bar_with_step_label(qapp):
+    """Status bar exists with the step counter label."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    sb = w.statusBar()
+    assert sb is not None
+    # Step label and row label should be there.
+    assert w._status_step_label.text() == "Idle"
+    assert w._status_row_label.text() == ""
+
+
+def test_window_status_step_elapsed_label_exists(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_step_time_label is not None
+
+
+def test_window_executor_step_started_connected_to_tree_highlight(qapp):
+    """The executor's step_started signal must connect to the tree
+    widget's highlight_active_row slot — verifies the active-row
+    highlight wiring is in place."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Indirect check: emit step_started with a fake row, watch tree's
+    # highlight_active_row receive it.
+    received = []
+    orig = w.widget.highlight_active_row
+    w.widget.highlight_active_row = lambda r: received.append(r)
+    try:
+        w.executor.qsignals.step_started.emit("fake-row")
+        assert received == ["fake-row"]
+    finally:
+        w.widget.highlight_active_row = orig
+
+
+def test_window_tick_timer_runs_at_10_hz(qapp):
+    """Tick timer interval should be 100 ms (10 Hz)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._tick_timer.interval() == 100
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 14 prior pass; 4 new FAIL.
+
+- [ ] **Step 3: Implement status bar + highlight + tick timer**
+
+Add imports:
+
+```python
+import time
+
+from pyface.qt.QtCore import QTimer
+from pyface.qt.QtWidgets import QLabel, QStatusBar
+```
+
+Update `BasePluggableProtocolDemoWindow.__init__` — add the calls at the end (after the routing setup):
+
+```python
+        # Per-step / per-phase timing state. Mutated from GUI thread only.
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at: float | None = None
+        self._phase_started_at: float | None = None
+        self._phase_target: float | None = None
+        self._current_row = None
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(100)   # 10 Hz
+        self._tick_timer.timeout.connect(self._refresh_status)
+
+        self._build_status_bar()
+        self._wire_executor_signals()
+```
+
+Add the methods:
+
+```python
+    def _build_status_bar(self):
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        self._status_step_label = QLabel("Idle")
+        self._status_row_label = QLabel("")
+        self._status_step_time_label = QLabel("")
+        sb.addWidget(self._status_step_label)
+        sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_step_time_label)
+
+    def _wire_executor_signals(self):
+        # Active-row highlight on each step start.
+        self.executor.qsignals.step_started.connect(
+            self.widget.highlight_active_row
+        )
+        # Status bar updates.
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+
+    def _on_protocol_started(self):
+        try:
+            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            self._step_total = 0
+        self._step_index = 0
+        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        self._step_started_at = time.monotonic()
+        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
+        path_str = f" (path {path})" if path else ""
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self._status_row_label.setText(f"{row.name}{path_str}")
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+
+    def _refresh_status(self):
+        if self._step_started_at is None:
+            return
+        elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {elapsed:5.2f}s")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 18 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Status bar + active-row highlight + 10Hz tick timer"
+```
+
+---
+
+## Task 5: Phase ack listener + phase-elapsed timer (when phase_ack_topic set)
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (phase ack listener actor + phase timer label)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 3 tests)
+
+**Why:** When `phase_ack_topic` is set, the base wires a Dramatiq listener that emits a Qt signal restarting the per-phase timer from the actual ack moment (matches PPT-3/4's semantic). When `phase_ack_topic=None`, no phase timer label.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_phase_ack_topic_none_hides_phase_timer(qapp):
+    """When phase_ack_topic=None, no phase elapsed label in status bar."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic=None)
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_phase_time_label is None
+
+
+def test_phase_ack_topic_set_creates_phase_label(qapp):
+    """When phase_ack_topic set, phase elapsed label is in status bar."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic="x/applied")
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_phase_time_label is not None
+
+
+def test_phase_acked_signal_resets_phase_timer(qapp):
+    """Emitting the phase_acked signal sets _phase_started_at = monotonic()."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic="x/applied")
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Set the current row so phase ack handler doesn't early-return.
+    w._current_row = object()
+    w._step_started_at = None
+    before = w._phase_started_at
+    w.phase_acked.emit()
+    assert w._phase_started_at is not None
+    assert w._phase_started_at != before
+    # First ack also sets step_started_at if it was None.
+    assert w._step_started_at is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 18 prior pass; 3 new FAIL.
+
+- [ ] **Step 3: Implement phase ack listener + phase label**
+
+Add a Qt signal + slot to the class. Add the import:
+
+```python
+from pyface.qt.QtCore import Signal
+```
+
+Add the signal as a class-level Signal:
+
+```python
+class BasePluggableProtocolDemoWindow(QMainWindow):
+    """..."""
+
+    # Cross-thread signal — Dramatiq actor emits via the module-level
+    # listener (registered when phase_ack_topic is set); auto-connection
+    # delivers _on_phase_ack on the GUI thread.
+    phase_acked = Signal()
+```
+
+In `__init__`, initialize `_status_phase_time_label = None` BEFORE `_build_status_bar`:
+
+```python
+        self._status_phase_time_label = None
+        ...
+        self._build_status_bar()
+```
+
+Update `_build_status_bar` to conditionally add the phase label:
+
+```python
+    def _build_status_bar(self):
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        self._status_step_label = QLabel("Idle")
+        self._status_row_label = QLabel("")
+        self._status_step_time_label = QLabel("")
+        sb.addWidget(self._status_step_label)
+        sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_step_time_label)
+        if self.config.phase_ack_topic is not None:
+            self._status_phase_time_label = QLabel("")
+            sb.addPermanentWidget(self._status_phase_time_label)
+```
+
+Update `_wire_executor_signals` to also connect the phase_acked signal:
+
+```python
+    def _wire_executor_signals(self):
+        self.executor.qsignals.step_started.connect(
+            self.widget.highlight_active_row
+        )
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        if self.config.phase_ack_topic is not None:
+            self.phase_acked.connect(self._on_phase_ack)
+```
+
+Add the slot:
+
+```python
+    def _on_phase_ack(self):
+        """Each ack restarts the per-phase timer. The first ack of a step
+        also starts the per-step timer (overrides the time.monotonic()
+        set in _on_step_started so timers run from the actual ack moment)."""
+        if self._current_row is None:
+            return
+        now = time.monotonic()
+        if self._step_started_at is None:
+            self._step_started_at = now
+        self._phase_started_at = now
+```
+
+Update `_refresh_status` to also paint phase elapsed:
+
+```python
+    def _refresh_status(self):
+        if self._step_started_at is None:
+            return
+        step_elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
+        if self._status_phase_time_label is not None:
+            phase_elapsed = (
+                0.0 if self._phase_started_at is None
+                else time.monotonic() - self._phase_started_at
+            )
+            target = self._phase_target if self._phase_target is not None else 0.0
+            self._status_phase_time_label.setText(
+                f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
+            )
+```
+
+Update `_on_step_started` to capture `_phase_target` from row.duration_s:
+
+```python
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        # Reset phase timestamps; the phase ack handler restarts them.
+        self._step_started_at = time.monotonic()
+        self._phase_started_at = None
+        try:
+            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            self._phase_target = None
+        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
+        path_str = f" (path {path})" if path else ""
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self._status_row_label.setText(f"{row.name}{path_str}")
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+```
+
+Now — register a module-level Dramatiq actor for the phase ack. Add at module level (near `_slug`):
+
+```python
+# Module-level target for the phase-ack listener actor. The actor runs
+# on a Dramatiq worker thread; it emits a Qt signal that auto-connection
+# delivers on the GUI thread.
+_phase_ack_target = {"window": None}
+
+
+@dramatiq.actor(actor_name="ppt12_demo_phase_ack_listener", queue_name="default")
+def _phase_ack_listener(message: str, topic: str, timestamp: float = None):
+    window = _phase_ack_target.get("window")
+    if window is None:
+        return
+    window.phase_acked.emit()
+```
+
+In `_setup_dramatiq_routing_internal`, after the standard chain block, add (only if `phase_ack_topic` set):
+
+```python
+            if self.config.phase_ack_topic is not None:
+                _phase_ack_target["window"] = self
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=self.config.phase_ack_topic,
+                    subscribing_actor_name="ppt12_demo_phase_ack_listener",
+                )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 21 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Phase ack listener + per-phase elapsed timer"
+```
+
+---
+
+## Task 6: `StatusReadout` listeners — auto-named actors + Qt signals + labels
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (per-readout actor + signal + label)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 3 tests)
+
+**Why:** Every demo with ack-driven readouts (V/F for PPT-4, magnet for PPT-5, all three for the integration demo) declares them as `StatusReadout` entries. Base creates one Dramatiq actor + one Qt signal + one QLabel per entry, named `ppt12_demo_<slug>_listener`.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_status_readout_creates_label_with_initial_text(qapp):
+    """Each StatusReadout adds a QLabel with `<label>: <initial>` text."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+            StatusReadout("Frequency", "f/applied", lambda m: f"{int(m)} Hz"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    labels = list(w._readout_labels.values())
+    assert len(labels) == 2
+    assert labels[0].text() == "Voltage: --"
+    assert labels[1].text() == "Frequency: --"
+
+
+def test_status_readout_label_updates_on_signal(qapp):
+    """Emitting the per-readout Qt signal updates the label text."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w._readout_signals["voltage"].emit("100")
+    assert w._readout_labels["voltage"].text() == "Voltage: 100 V"
+
+
+def test_status_readout_actor_names_are_slug_prefixed(qapp):
+    """Each readout's auto-registered Dramatiq actor uses the slug-based
+    naming convention. Verify by inspecting the broker's registered actors."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Magnet Height (mm)", "m/applied",
+                          lambda m: f"{m} mm"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Actor name = ppt12_demo_<slug>_listener
+    expected_name = "ppt12_demo_magnet_height_mm_listener"
+    broker = dramatiq.get_broker()
+    # Should not raise
+    broker.get_actor(expected_name)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 21 prior pass; 3 new FAIL.
+
+- [ ] **Step 3: Implement readout listeners**
+
+In `BasePluggableProtocolDemoWindow.__init__`, add BEFORE `_build_status_bar`:
+
+```python
+        # Per-readout state — populated below in _build_status_bar.
+        self._readout_labels: dict[str, QLabel] = {}
+        self._readout_signals: dict[str, Signal] = {}
+```
+
+Update `_build_status_bar` to add readout labels at the end:
+
+```python
+    def _build_status_bar(self):
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        self._status_step_label = QLabel("Idle")
+        self._status_row_label = QLabel("")
+        self._status_step_time_label = QLabel("")
+        sb.addWidget(self._status_step_label)
+        sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_step_time_label)
+        if self.config.phase_ack_topic is not None:
+            self._status_phase_time_label = QLabel("")
+            sb.addPermanentWidget(self._status_phase_time_label)
+        # StatusReadout labels.
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = QLabel(f"{readout.label}: {readout.initial}")
+            sb.addPermanentWidget(label)
+            self._readout_labels[slug] = label
+```
+
+Add a method to emit-on-ack via per-instance signals. Since Qt signals are class-level, we instead hold a dispatcher: a single `readout_acked = Signal(str, str)` (slug, message) signal that the listener actors emit, and a slot that updates the right label:
+
+Add to the class declaration (alongside `phase_acked`):
+
+```python
+    # Cross-thread signal for status-readout updates: (slug, message)
+    readout_acked = Signal(str, str)
+```
+
+In `__init__`, after `_build_status_bar`:
+
+```python
+        # Wire readout updates: one signal-emit handler per slug → label update.
+        self._readout_fmts = {
+            _slug(r.label): (r.label, r.fmt) for r in self.config.status_readouts
+        }
+        # Convenience: per-slug Signal accessors that just emit on the
+        # shared readout_acked. Tests can do w._readout_signals[slug].emit(msg).
+        # We wrap the shared signal so per-slug emission is ergonomic.
+        self._readout_signals = {
+            slug: _PerSlugEmitter(self.readout_acked, slug)
+            for slug in self._readout_fmts
+        }
+        self.readout_acked.connect(self._on_readout_ack)
+```
+
+Add the `_PerSlugEmitter` helper at module level (just below `_slug`):
+
+```python
+class _PerSlugEmitter:
+    """Tiny shim that exposes .emit(message) and forwards to the
+    window's per-instance readout_acked signal with a fixed slug."""
+    __slots__ = ("_signal", "_slug")
+    def __init__(self, signal, slug):
+        self._signal = signal
+        self._slug = slug
+    def emit(self, message):
+        self._signal.emit(self._slug, message)
+```
+
+Add the slot:
+
+```python
+    def _on_readout_ack(self, slug: str, message: str):
+        spec = self._readout_fmts.get(slug)
+        if spec is None:
+            return
+        label_prefix, fmt = spec
+        label_widget = self._readout_labels.get(slug)
+        if label_widget is None:
+            return
+        try:
+            text = fmt(message)
+        except Exception as e:
+            text = f"<error: {e}>"
+        label_widget.setText(f"{label_prefix}: {text}")
+```
+
+Now the per-readout Dramatiq actors. Add at module level (after `_phase_ack_listener`):
+
+```python
+# Module-level target for status-readout listeners. Each actor reads
+# its own message and forwards (slug, message) to the bound window.
+_readout_target = {"window": None}
+
+
+def _make_readout_actor(slug: str):
+    """Register a Dramatiq actor named ppt12_demo_<slug>_listener that
+    emits the window's readout_acked signal on every message received."""
+    actor_name = f"ppt12_demo_{slug}_listener"
+
+    @dramatiq.actor(actor_name=actor_name, queue_name="default")
+    def _listener(message: str, topic: str, timestamp: float = None):
+        window = _readout_target.get("window")
+        if window is None:
+            return
+        window.readout_acked.emit(slug, message)
+
+    return actor_name
+```
+
+In `_setup_dramatiq_routing_internal`, after the phase-ack subscription, add:
+
+```python
+            # StatusReadout listeners — auto-named actor per readout.
+            _readout_target["window"] = self
+            for readout in self.config.status_readouts:
+                slug = _slug(readout.label)
+                actor_name = _make_readout_actor(slug)
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=readout.topic,
+                    subscribing_actor_name=actor_name,
+                )
+```
+
+Note: `_make_readout_actor` is idempotent on the actor name — Dramatiq's `@dramatiq.actor` decorator raises on duplicate registration. To handle multiple windows being constructed in tests, wrap in try/except:
+
+```python
+def _make_readout_actor(slug: str):
+    actor_name = f"ppt12_demo_{slug}_listener"
+    broker = dramatiq.get_broker()
+    try:
+        broker.get_actor(actor_name)
+        return actor_name   # already registered
+    except Exception:
+        pass
+
+    @dramatiq.actor(actor_name=actor_name, queue_name="default")
+    def _listener(message: str, topic: str, timestamp: float = None):
+        window = _readout_target.get("window")
+        if window is None:
+            return
+        window.readout_acked.emit(slug, message)
+
+    return actor_name
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 24 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] StatusReadout listeners — auto-named actors + per-slug labels"
+```
+
+---
+
+## Task 7: Toolbar with Run/Pause/Resume/Stop button state machine + Add Step/Group
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (toolbar + button state machine + protocol-state slots)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 4 tests)
+
+**Why:** Standard executor controls. Run is initially the only enabled action; once protocol_started fires, Pause + Stop become enabled and Run is disabled. Pause toggles to Resume. Stop returns to idle.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_toolbar_has_standard_actions(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    actions = [a.text() for a in w.findChildren(__import__("pyface.qt.QtWidgets", fromlist=["QToolBar"]).QToolBar)[0].actions()]
+    assert "Add Step" in actions
+    assert "Add Group" in actions
+    assert "Run" in actions
+    assert "Pause" in actions
+    assert "Stop" in actions
+
+
+def test_idle_button_state(qapp):
+    """Initially: Run enabled; Pause + Stop disabled."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._run_action.isEnabled()
+    assert not w._pause_action.isEnabled()
+    assert not w._stop_action.isEnabled()
+
+
+def test_protocol_started_swaps_buttons(qapp):
+    """When protocol_started fires: Run disabled; Pause + Stop enabled."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.executor.qsignals.protocol_started.emit()
+    assert not w._run_action.isEnabled()
+    assert w._pause_action.isEnabled()
+    assert w._stop_action.isEnabled()
+
+
+def test_protocol_terminated_returns_to_idle(qapp):
+    """When protocol_finished fires: back to idle button state."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.executor.qsignals.protocol_started.emit()
+    w.executor.qsignals.protocol_finished.emit()
+    assert w._run_action.isEnabled()
+    assert not w._pause_action.isEnabled()
+    assert not w._stop_action.isEnabled()
+    assert w._pause_action.text() == "Pause"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 24 prior pass; 4 new FAIL.
+
+- [ ] **Step 3: Implement toolbar + button state machine**
+
+Add import:
+
+```python
+from pyface.qt.QtWidgets import QToolBar
+```
+
+Add to `__init__`, after `_wire_executor_signals()`:
+
+```python
+        self._build_toolbar()
+        self._wire_button_state_machine()
+        self._set_idle_button_state()
+```
+
+Add methods:
+
+```python
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.manager.add_step())
+        tb.addAction("Add Group", lambda: self.manager.add_group())
+        tb.addSeparator()
+        # Save/Load added in Task 8.
+        self._run_action = tb.addAction("Run", self.executor.start)
+        self._pause_action = tb.addAction("Pause", self._toggle_pause)
+        self._stop_action = tb.addAction("Stop", self.executor.stop)
+
+    def _wire_button_state_machine(self):
+        self.executor.qsignals.protocol_started.connect(self._set_running_button_state)
+        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
+        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
+        for sig in (
+            self.executor.qsignals.protocol_finished,
+            self.executor.qsignals.protocol_aborted,
+        ):
+            sig.connect(self._on_protocol_terminated)
+
+    def _set_idle_button_state(self):
+        self._run_action.setEnabled(True)
+        self._pause_action.setEnabled(False)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(False)
+
+    def _set_running_button_state(self):
+        self._run_action.setEnabled(False)
+        self._pause_action.setEnabled(True)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(True)
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+        else:
+            self.executor.pause()
+
+    def _on_protocol_paused(self):
+        self._pause_action.setText("Resume")
+        self._tick_timer.stop()
+
+    def _on_protocol_resumed(self):
+        self._pause_action.setText("Pause")
+        if self._current_row is not None:
+            self._tick_timer.start()
+
+    def _on_protocol_terminated(self):
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 28 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Toolbar + Run/Pause/Resume/Stop button state machine"
+```
+
+---
+
+## Task 8: Save/Load toolbar actions + JSON file dialog
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (Save/Load toolbar buttons)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 2 tests)
+
+**Why:** JSON save/load round-trip via the file dialog. Common to all demos.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
+    """Save button writes manager.to_json() to the chosen file."""
+    from pyface.qt.QtWidgets import QFileDialog
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+            make_duration_column(),
+        ],
+        pre_populate=lambda rm: rm.add_step(values={"name": "S1", "duration_s": 0.1}),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    save_path = tmp_path / "out.json"
+    monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    w._save()
+    import json
+    payload = json.loads(save_path.read_text())
+    assert payload["columns"][0]["id"] == "type"
+    assert any(r[3] == "S1" for r in payload["rows"])
+
+
+def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
+    """Load button reads JSON and applies via manager.set_state_from_json."""
+    from pyface.qt.QtWidgets import QFileDialog
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    import json
+
+    cfg = DemoConfig(columns_factory=lambda: [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+
+    # Build a window once, save its empty state, then load it back.
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.manager.add_step(values={"name": "Saved Step", "duration_s": 0.5})
+    save_path = tmp_path / "in.json"
+    save_path.write_text(json.dumps(w.manager.to_json()))
+
+    # Fresh window with empty state.
+    w2 = BasePluggableProtocolDemoWindow(cfg)
+    assert len(w2.manager.root.children) == 0
+    monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    w2._load()
+    assert len(w2.manager.root.children) == 1
+    assert w2.manager.root.children[0].name == "Saved Step"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 28 prior pass; 2 new FAIL.
+
+- [ ] **Step 3: Implement Save/Load**
+
+Add imports:
+
+```python
+import json
+from pyface.qt.QtWidgets import QFileDialog, QMessageBox
+```
+
+Update `_build_toolbar` — insert Save/Load between the separator and Run:
+
+```python
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.manager.add_step())
+        tb.addAction("Add Group", lambda: self.manager.add_group())
+        tb.addSeparator()
+        tb.addAction("Save…", self._save)
+        tb.addAction("Load…", self._load)
+        tb.addSeparator()
+        self._run_action = tb.addAction("Run", self.executor.start)
+        self._pause_action = tb.addAction("Pause", self._toggle_pause)
+        self._stop_action = tb.addAction("Stop", self.executor.stop)
+```
+
+Add methods:
+
+```python
+    def _save(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.manager.to_json(), f, indent=2)
+
+    def _load(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        try:
+            self.manager.set_state_from_json(
+                data, columns=self.config.columns_factory(),
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Load error", str(e))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 30 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Save/Load toolbar actions via JSON file dialog"
+```
+
+---
+
+## Task 9: Side panel via splitter (when `side_panel_factory` provided)
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (use QSplitter when side_panel_factory yields a widget)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 2 tests)
+
+**Why:** PPT-3 + integration demo need a side panel (`SimpleDeviceViewer`). PPT-4/5/11 don't. The base supports either via the optional `side_panel_factory` callback.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_window_no_side_panel_uses_tree_as_central(qapp):
+    """When side_panel_factory is None, the central widget IS the tree."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.centralWidget() is w.widget
+
+
+def test_window_side_panel_uses_splitter(qapp):
+    """When side_panel_factory returns a widget, central is a splitter
+    holding tree + side panel."""
+    from pyface.qt.QtWidgets import QLabel, QSplitter
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        side_panel_factory=lambda rm: QLabel("side"),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    central = w.centralWidget()
+    assert isinstance(central, QSplitter)
+    assert central.count() == 2   # tree + side panel
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 30 prior pass; 2 new FAIL.
+
+- [ ] **Step 3: Implement side panel**
+
+Replace the existing `setCentralWidget(self.widget)` line in `__init__` with:
+
+```python
+        # Central layout: just the tree, OR a splitter with tree + side panel.
+        if self.config.side_panel_factory is not None:
+            side = self.config.side_panel_factory(self.manager)
+            if side is not None:
+                splitter = QSplitter(Qt.Horizontal)
+                splitter.addWidget(self.widget)
+                splitter.addWidget(side)
+                splitter.setSizes([
+                    int(self.config.window_size[0] * 0.65),
+                    int(self.config.window_size[0] * 0.35),
+                ])
+                self.setCentralWidget(splitter)
+            else:
+                self.setCentralWidget(self.widget)
+        else:
+            self.setCentralWidget(self.widget)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 32 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Side panel via splitter when side_panel_factory provided"
+```
+
+---
+
+## Task 10: Stale-subscriber purge + `_clear_all_highlights` + `.run()` classmethod
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py` (purge logic + clear highlights on terminate + .run() classmethod)
+- Modify: `src/pluggable_protocol_tree/tests/test_base_demo_window.py` (add 3 tests)
+
+**Why:** Three small lifecycle features: (1) purge stale demo subscribers from prior runs (matches PPT-4's pattern); (2) clear all highlights/labels on protocol end so the next run starts clean; (3) `.run(config)` classmethod for one-line `if __name__ == "__main__"` use.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_clear_all_highlights_resets_status(qapp):
+    """After protocol terminates, status labels reset and step counters cleared."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Simulate state mid-run.
+    w._step_index = 2
+    w._step_total = 3
+    w._step_started_at = 100.0
+    w._readout_labels["voltage"].setText("Voltage: 99 V")
+    w._status_step_label.setText("Step 2 / 3")
+    # Terminate.
+    w._on_protocol_terminated()
+    assert w._status_step_label.text() == "Idle"
+    assert w._step_started_at is None
+    assert w._readout_labels["voltage"].text() == "Voltage: --"
+
+
+def test_purge_stale_subscribers_only_touches_demo_prefixes(qapp):
+    """The purger should ONLY consider actor names with demo prefixes
+    (ppt_demo_, ppt4_demo_, ppt5_demo_, ppt11_demo_, ppt12_demo_,
+    ppt_vf_demo_). Real listeners are NEVER touched."""
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        _is_purgable_demo_actor_name,
+    )
+    assert _is_purgable_demo_actor_name("ppt_demo_electrode_responder")
+    assert _is_purgable_demo_actor_name("ppt4_demo_voltage_applied_listener")
+    assert _is_purgable_demo_actor_name("ppt5_demo_magnet_responder")
+    assert _is_purgable_demo_actor_name("ppt12_demo_voltage_listener")
+    assert _is_purgable_demo_actor_name("ppt_vf_demo_spy")
+    # Real listeners — must NOT be purgable.
+    assert not _is_purgable_demo_actor_name("dropbot_controller_listener")
+    assert not _is_purgable_demo_actor_name(
+        "dropbot_status_and_controls_listener",
+    )
+    assert not _is_purgable_demo_actor_name(
+        "pluggable_protocol_tree_executor_listener",
+    )
+
+
+def test_run_classmethod_returns_int(qapp, monkeypatch):
+    """The .run(config) classmethod calls app.exec() and returns its int result."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    from pyface.qt.QtWidgets import QApplication
+
+    # Patch QApplication.exec to return 0 immediately.
+    monkeypatch.setattr(QApplication, "exec", lambda self: 0)
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    rc = BasePluggableProtocolDemoWindow.run(cfg)
+    assert rc == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 32 prior pass; 3 new FAIL.
+
+- [ ] **Step 3: Implement purge + clear highlights + .run()**
+
+Add module-level constant + helper:
+
+```python
+_DEMO_PREFIXES = (
+    "ppt_demo_", "ppt4_demo_", "ppt5_demo_", "ppt11_demo_",
+    "ppt12_demo_", "ppt_vf_demo_",
+)
+
+
+def _is_purgable_demo_actor_name(name: str) -> bool:
+    """True if an actor name matches a known demo-prefix convention.
+    Used by the stale-subscriber purger to leave real listeners alone."""
+    return name.startswith(_DEMO_PREFIXES)
+```
+
+In `_setup_dramatiq_routing_internal`, after `router = MessageRouterActor()`, add the purge:
+
+```python
+            # Purge stale demo subscribers — actor names recorded in
+            # Redis by prior demo processes whose actors aren't
+            # registered in this process. Without this, a previous
+            # demo's spy/listener leaves behind a subscription that
+            # fires ActorNotFound on every publish to its topic.
+            #
+            # Only touch demo-prefixed names — leave real listeners
+            # belonging to other processes alone.
+            broker_topics_to_check = (
+                ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED,
+            )
+            extra_topics = []
+            if self.config.phase_ack_topic is not None:
+                extra_topics.append(self.config.phase_ack_topic)
+            for r in self.config.status_readouts:
+                extra_topics.append(r.topic)
+            for topic in (*broker_topics_to_check, *extra_topics):
+                try:
+                    subs = router.message_router_data.get_subscribers_for_topic(topic)
+                except Exception:
+                    continue
+                for entry in subs:
+                    actor_name = entry[0] if isinstance(entry, tuple) else entry
+                    if not _is_purgable_demo_actor_name(actor_name):
+                        continue
+                    try:
+                        broker.get_actor(actor_name)
+                    except Exception:
+                        try:
+                            router.message_router_data.remove_subscriber_from_topic(
+                                topic=topic,
+                                subscribing_actor_name=actor_name,
+                            )
+                            logger.info("purged stale demo subscriber %s on %s",
+                                        actor_name, topic)
+                        except Exception:
+                            logger.warning(
+                                "failed to purge %s on %s (likely wrong "
+                                "listener_queue from another router)",
+                                actor_name, topic,
+                            )
+```
+
+Update `_on_protocol_terminated` to call clear-all:
+
+```python
+    def _on_protocol_terminated(self):
+        self._clear_all_highlights()
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+```
+
+Add `_clear_all_highlights`:
+
+```python
+    def _clear_all_highlights(self):
+        """Restore an idle visual state at protocol end."""
+        from pyface.qt.QtCore import QModelIndex
+
+        self.widget.highlight_active_row(None)
+        self.widget.tree.clearSelection()
+        self.widget.tree.setCurrentIndex(QModelIndex())
+
+        # Reset step / row / timer state.
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._phase_started_at = None
+        self._phase_target = None
+        self._current_row = None
+        self._status_step_label.setText("Idle")
+        self._status_row_label.setText("")
+        self._status_step_time_label.setText("")
+        if self._status_phase_time_label is not None:
+            self._status_phase_time_label.setText("")
+
+        # Reset readout labels to initial text.
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = self._readout_labels.get(slug)
+            if label is not None:
+                label.setText(f"{readout.label}: {readout.initial}")
+```
+
+Add the `.run()` classmethod (at the end of the class):
+
+```python
+    @classmethod
+    def run(cls, config: DemoConfig) -> int:
+        """One-shot main(): build the window, show it, run app.exec().
+        Reuses an existing QApplication if one is already running."""
+        app = QApplication.instance() or QApplication([])
+        w = cls(config)
+        w.show()
+        return app.exec()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/test_base_demo_window.py -v
+```
+Expected: 35 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git -C src commit -m "[PPT-12] Stale-subscriber purge + clear-all-highlights + .run() classmethod"
+```
+
+---
+
+## Task 11: Refactor `pluggable_protocol_tree/demos/run_widget.py` (PPT-3)
+
+**Files:**
+- Replace: `src/pluggable_protocol_tree/demos/run_widget.py` (currently 531 LOC → ~80 LOC)
+
+**Why:** First demo refactor. Verifies the base class actually delivers what PPT-3 needed.
+
+- [ ] **Step 1: Replace the file with the refactored shape**
+
+Replace `src/pluggable_protocol_tree/demos/run_widget.py` with:
+
+```python
+"""PPT-3 demo — protocol tree + electrodes/routes + device viewer +
+PPT-2 ack-roundtrip column.
+
+Run: pixi run python -m pluggable_protocol_tree.demos.run_widget
+"""
+
+import logging
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.linear_repeats_column import (
+    make_linear_repeats_column,
+)
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repeat_duration_column import (
+    make_repeat_duration_column,
+)
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.routes_column import make_routes_column
+from pluggable_protocol_tree.builtins.soft_end_column import make_soft_end_column
+from pluggable_protocol_tree.builtins.soft_start_column import make_soft_start_column
+from pluggable_protocol_tree.builtins.trail_length_column import make_trail_length_column
+from pluggable_protocol_tree.builtins.trail_overlay_column import (
+    make_trail_overlay_column,
+)
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.demos.ack_roundtrip_column import (
+    DEMO_APPLIED_TOPIC, DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME,
+    make_ack_roundtrip_column,
+)
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig,
+)
+from pluggable_protocol_tree.demos.message_column import make_message_column
+from pluggable_protocol_tree.demos.simple_device_viewer import (
+    GRID_H, GRID_W, SimpleDeviceViewer,
+)
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        make_message_column(), make_ack_roundtrip_column(),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+
+
+def _routing_setup(router):
+    """PPT-2 ack-roundtrip column responder (specific to run_widget)."""
+    router.message_router_data.add_subscriber_to_topic(
+        topic=DEMO_REQUEST_TOPIC,
+        subscribing_actor_name=RESPONDER_ACTOR_NAME,
+    )
+    router.message_router_data.add_subscriber_to_topic(
+        topic=DEMO_APPLIED_TOPIC,
+        subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+    )
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Pluggable Protocol Tree — PPT-3 Demo",
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()
+```
+
+- [ ] **Step 2: Verify import + smoke run**
+
+```bash
+pixi run python -c "import pluggable_protocol_tree.demos.run_widget; print('OK')"
+```
+Expected: `OK`.
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/ -v --ignore=src/pluggable_protocol_tree/tests/tests_with_redis_server_need
+```
+Expected: All non-Redis tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/run_widget.py
+git -C src commit -m "[PPT-12] Refactor PPT-3 run_widget to use BasePluggableProtocolDemoWindow"
+```
+
+---
+
+## Task 12: Refactor `pluggable_protocol_tree/demos/run_widget_compound_demo.py` (PPT-11)
+
+**Files:**
+- Replace: `src/pluggable_protocol_tree/demos/run_widget_compound_demo.py` (currently 131 LOC → ~50 LOC)
+
+- [ ] **Step 1: Replace the file**
+
+Replace `src/pluggable_protocol_tree/demos/run_widget_compound_demo.py` with:
+
+```python
+"""PPT-11 demo — synthetic enabled+count compound column.
+
+Now uses the BasePluggableProtocolDemoWindow + gains Run/Pause/Stop +
+status bar / step elapsed timer for free.
+
+Run: pixi run python -m pluggable_protocol_tree.demos.run_widget_compound_demo
+"""
+
+import logging
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig,
+)
+from pluggable_protocol_tree.demos.enabled_count_compound import (
+    make_enabled_count_compound,
+)
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+        *_expand_compound(make_enabled_count_compound()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.add_step(values={
+        "name": "Step 1: enabled, count=5",
+        "duration_s": 0.2,
+        "ec_enabled": True, "ec_count": 5,
+    })
+    rm.add_step(values={
+        "name": "Step 2: disabled (count read-only)",
+        "duration_s": 0.2,
+        "ec_enabled": False, "ec_count": 0,
+    })
+    rm.add_step(values={
+        "name": "Step 3: enabled, count=99",
+        "duration_s": 0.2,
+        "ec_enabled": True, "ec_count": 99,
+    })
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-11 Demo — Compound Column Framework",
+    pre_populate=_pre_populate,
+    phase_ack_topic=None,    # synthetic compound has no ack-emitting handlers
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()
+```
+
+- [ ] **Step 2: Verify import + tests**
+
+```bash
+pixi run python -c "import pluggable_protocol_tree.demos.run_widget_compound_demo; print('OK')"
+pixi run pytest src/pluggable_protocol_tree/tests/ -v --ignore=src/pluggable_protocol_tree/tests/tests_with_redis_server_need
+```
+Expected: `OK` + all non-Redis tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C src add pluggable_protocol_tree/demos/run_widget_compound_demo.py
+git -C src commit -m "[PPT-12] Refactor PPT-11 compound demo to use BasePluggableProtocolDemoWindow"
+```
+
+---
+
+## Task 13: Refactor `dropbot_protocol_controls/demos/run_widget_with_vf.py` (PPT-4)
+
+**Files:**
+- Replace: `src/dropbot_protocol_controls/demos/run_widget_with_vf.py` (currently 658 LOC → ~80 LOC)
+
+- [ ] **Step 1: Replace the file**
+
+Replace `src/dropbot_protocol_controls/demos/run_widget_with_vf.py` with:
+
+```python
+"""PPT-4 demo — protocol tree with voltage + frequency columns.
+
+Run: pixi run python -m dropbot_protocol_controls.demos.run_widget_with_vf
+"""
+
+import logging
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.linear_repeats_column import (
+    make_linear_repeats_column,
+)
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repeat_duration_column import (
+    make_repeat_duration_column,
+)
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.routes_column import make_routes_column
+from pluggable_protocol_tree.builtins.soft_end_column import make_soft_end_column
+from pluggable_protocol_tree.builtins.soft_start_column import make_soft_start_column
+from pluggable_protocol_tree.builtins.trail_length_column import make_trail_length_column
+from pluggable_protocol_tree.builtins.trail_overlay_column import (
+    make_trail_overlay_column,
+)
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.demos.simple_device_viewer import (
+    GRID_H, GRID_W, SimpleDeviceViewer,
+)
+
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder,
+)
+from dropbot_protocol_controls.protocol_columns.frequency_column import (
+    make_frequency_column,
+)
+from dropbot_protocol_controls.protocol_columns.voltage_column import (
+    make_voltage_column,
+)
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        make_voltage_column(), make_frequency_column(),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+    rm.add_step(values={
+        "name": "Step 1: 100V/10kHz on e00,e01",
+        "duration_s": 0.3,
+        "electrodes": ["e00", "e01"],
+        "voltage": 100, "frequency": 10000,
+    })
+    rm.add_step(values={
+        "name": "Step 2: 120V/5kHz on e02,e03",
+        "duration_s": 0.3,
+        "electrodes": ["e02", "e03"],
+        "voltage": 120, "frequency": 5000,
+    })
+    rm.add_step(values={
+        "name": "Step 3: 75V/1kHz cooldown",
+        "duration_s": 0.3,
+        "voltage": 75, "frequency": 1000,
+    })
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-4 Demo — Voltage + Frequency",
+    pre_populate=_pre_populate,
+    routing_setup=lambda router: subscribe_demo_responder(router),
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()
+```
+
+- [ ] **Step 2: Verify import + tests**
+
+```bash
+pixi run python -c "import dropbot_protocol_controls.demos.run_widget_with_vf; print('OK')"
+pixi run pytest src/dropbot_protocol_controls/tests/ -v --ignore=src/dropbot_protocol_controls/tests/tests_with_redis_server_need
+```
+Expected: `OK` + 30 PPT-4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C src add dropbot_protocol_controls/demos/run_widget_with_vf.py
+git -C src commit -m "[PPT-12] Refactor PPT-4 V/F demo to use BasePluggableProtocolDemoWindow"
+```
+
+---
+
+## Task 14: Refactor `peripheral_protocol_controls/demos/run_widget_magnet_demo.py` (PPT-5)
+
+**Files:**
+- Replace: `src/peripheral_protocol_controls/demos/run_widget_magnet_demo.py` (currently 213 LOC → ~50 LOC). **This task is what enables you to manually test the PPT-5 magnet demo with all the UX features the user wanted.**
+
+- [ ] **Step 1: Replace the file**
+
+Replace `src/peripheral_protocol_controls/demos/run_widget_magnet_demo.py` with:
+
+```python
+"""PPT-5 demo — protocol tree with the magnet compound column.
+
+Run: pixi run python -m peripheral_protocol_controls.demos.run_widget_magnet_demo
+"""
+
+import logging
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
+
+from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_protocol_controls.demos.magnet_responder import (
+    subscribe_demo_responder,
+)
+from peripheral_protocol_controls.protocol_columns.magnet_column import (
+    make_magnet_column,
+)
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+        *_expand_compound(make_magnet_column()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.add_step(values={
+        "name": "Step 1: engage at Default (sentinel; uses live pref)",
+        "duration_s": 0.2,
+        "magnet_on": True, "magnet_height_mm": 0.0,
+    })
+    rm.add_step(values={
+        "name": "Step 2: engage at 12.0 mm explicit",
+        "duration_s": 0.2,
+        "magnet_on": True, "magnet_height_mm": 12.0,
+    })
+    rm.add_step(values={
+        "name": "Step 3: retract",
+        "duration_s": 0.2,
+        "magnet_on": False, "magnet_height_mm": 0.0,
+    })
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-5 Demo — Magnet",
+    pre_populate=_pre_populate,
+    routing_setup=lambda router: subscribe_demo_responder(router),
+    phase_ack_topic=MAGNET_APPLIED,
+    status_readouts=[
+        StatusReadout("Magnet", MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()
+```
+
+- [ ] **Step 2: Verify import + tests**
+
+```bash
+pixi run python -c "import peripheral_protocol_controls.demos.run_widget_magnet_demo; print('OK')"
+pixi run pytest src/peripheral_protocol_controls/tests/ -v --ignore=src/peripheral_protocol_controls/tests/tests_with_redis_server_need
+```
+Expected: `OK` + 17 PPT-5 unit tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C src add peripheral_protocol_controls/demos/run_widget_magnet_demo.py
+git -C src commit -m "[PPT-12] Refactor PPT-5 magnet demo to use BasePluggableProtocolDemoWindow"
+```
+
+---
+
+## Task 15: Create `examples/demos/run_full_integration_demo.py`
+
+**Files:**
+- Create: `src/examples/demos/run_full_integration_demo.py`
+
+**Why:** The integration demo. Exercises every column type at once. Verifies priority bucketing in practice (V/F/magnet at priority 20 complete before electrode actuation at priority 30).
+
+- [ ] **Step 1: Create the file**
+
+Create `src/examples/demos/run_full_integration_demo.py`:
+
+```python
+"""Full-stack integration demo: PPT-3 electrodes/routes + PPT-4 voltage/
+frequency + PPT-5 magnet, all in one window. Verifies priority bucketing
+in practice (priority 20 V/F/magnet bucket completes before priority 30
+RoutesHandler publishes electrodes).
+
+Run: pixi run python -m examples.demos.run_full_integration_demo
+"""
+
+import logging
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.linear_repeats_column import (
+    make_linear_repeats_column,
+)
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repeat_duration_column import (
+    make_repeat_duration_column,
+)
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.routes_column import make_routes_column
+from pluggable_protocol_tree.builtins.soft_end_column import make_soft_end_column
+from pluggable_protocol_tree.builtins.soft_start_column import make_soft_start_column
+from pluggable_protocol_tree.builtins.trail_length_column import make_trail_length_column
+from pluggable_protocol_tree.builtins.trail_overlay_column import (
+    make_trail_overlay_column,
+)
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.demos.simple_device_viewer import (
+    GRID_H, GRID_W, SimpleDeviceViewer,
+)
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
+
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder as subscribe_vf_responder,
+)
+from dropbot_protocol_controls.protocol_columns.frequency_column import (
+    make_frequency_column,
+)
+from dropbot_protocol_controls.protocol_columns.voltage_column import (
+    make_voltage_column,
+)
+
+from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_protocol_controls.demos.magnet_responder import (
+    subscribe_demo_responder as subscribe_magnet_responder,
+)
+from peripheral_protocol_controls.protocol_columns.magnet_column import (
+    make_magnet_column,
+)
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        # PPT-4
+        make_voltage_column(), make_frequency_column(),
+        # PPT-5 (compound, expanded)
+        *_expand_compound(make_magnet_column()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+    rm.add_step(values={
+        "name": "Step 1: 100V/10kHz, magnet=Default, route top row",
+        "duration_s": 0.3,
+        "voltage": 100, "frequency": 10000,
+        "magnet_on": True, "magnet_height_mm": 0.0,   # sentinel = Default
+        "routes": [["e00", "e01", "e02", "e03", "e04"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 2: 120V/5kHz, magnet=12mm, diagonal",
+        "duration_s": 0.3,
+        "voltage": 120, "frequency": 5000,
+        "magnet_on": True, "magnet_height_mm": 12.0,
+        "routes": [["e00", "e06", "e12", "e18", "e24"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 3: 75V/1kHz cooldown, retract magnet",
+        "duration_s": 0.3,
+        "voltage": 75, "frequency": 1000,
+        "magnet_on": False, "magnet_height_mm": 0.0,
+    })
+
+
+def _routing_setup(router):
+    """All three demo responders. The PPT-3 electrode chain is wired
+    by the base automatically."""
+    subscribe_vf_responder(router)
+    subscribe_magnet_responder(router)
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Full Integration Demo — PPT-3 routes + PPT-4 V/F + PPT-5 magnet",
+    window_size=(1300, 700),
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+        StatusReadout("Magnet",    MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()
+```
+
+- [ ] **Step 2: Verify import**
+
+```bash
+pixi run python -c "import examples.demos.run_full_integration_demo; print('OK')"
+```
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C src add examples/demos/run_full_integration_demo.py
+git -C src commit -m "[PPT-12] Add examples/demos/run_full_integration_demo.py"
+```
+
+---
+
+## Task 16: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: All PPT-12 + regression suites**
+
+```bash
+pixi run pytest src/pluggable_protocol_tree/tests/ -v
+pixi run pytest src/dropbot_protocol_controls/tests/ -v --ignore=src/dropbot_protocol_controls/tests/tests_with_redis_server_need
+pixi run pytest src/peripheral_protocol_controls/tests/ -v --ignore=src/peripheral_protocol_controls/tests/tests_with_redis_server_need
+pixi run pytest src/dropbot_controller/tests/ -v
+pixi run pytest src/peripheral_controller/tests/ -v
+```
+Expected: all suites pass (with the one pre-existing peripheral_controller failure noted in PPT-5).
+
+- [ ] **Step 2: Demo scripts import cleanly**
+
+```bash
+pixi run python -c "import pluggable_protocol_tree.demos.run_widget; print('PPT-3 OK')"
+pixi run python -c "import pluggable_protocol_tree.demos.run_widget_compound_demo; print('PPT-11 OK')"
+pixi run python -c "import dropbot_protocol_controls.demos.run_widget_with_vf; print('PPT-4 OK')"
+pixi run python -c "import peripheral_protocol_controls.demos.run_widget_magnet_demo; print('PPT-5 OK')"
+pixi run python -c "import examples.demos.run_full_integration_demo; print('Integration OK')"
+```
+Expected: 5 `OK` lines.
+
+- [ ] **Step 3: git status clean**
+
+```bash
+git -C src status
+```
+Expected: clean working tree (besides any pre-existing untracked files unrelated to PPT-12).
+
+- [ ] **Step 4: Show the PPT-12 commit history**
+
+```bash
+git -C src log --oneline main..HEAD
+```
+Expected: ~16 commits all prefixed `[PPT-12]`.
+
+---
+
+## Implementation Notes
+
+**Branch hygiene:** branch is `feat/ppt-12-demo-base`, branched from main (PPT-3, PPT-4, PPT-5, PPT-11 already merged). When PR opens, target main.
+
+**Layering:** all framework changes live inside `pluggable_protocol_tree/demos/`. Each demo refactor touches exactly one file. The integration demo is the only file outside the existing tree (`examples/demos/run_full_integration_demo.py`).
+
+**The composition shape** is the load-bearing decision: demos become small declarative scripts; the base is a polished, well-tested Qt class. If a future PR finds the composition limits expressiveness, the alternative is inheritance — but four real consumers built fine on composition, so don't switch without strong evidence.
+
+**Phase-ack listener pattern** is per-demo Dramatiq actor + Qt signal. This is the same pattern used by PPT-3/4. Issue #386 tracks replacing it with an executor-emitted `step_phase_started` signal — depends on PPT-12 merging first.
+
+**If a test fails unexpectedly during execution:** use `superpowers:systematic-debugging`. Most likely failure modes: (1) Qt widget tests need a `qapp` fixture — make sure `conftest.py` exports it; (2) Dramatiq actor name conflicts when running multiple `BasePluggableProtocolDemoWindow` instances in tests — `_make_readout_actor` should idempotently return existing actors.

--- a/docs/superpowers/specs/2026-04-21-pluggable-protocol-tree-design.md
+++ b/docs/superpowers/specs/2026-04-21-pluggable-protocol-tree-design.md
@@ -629,3 +629,17 @@ Incremental, one PR per sub-issue:
 - Exact pandas dtype handling for object-typed columns (list-of-lists). Likely `object` dtype with per-column accessors; to validate during PPT-1 testing.
 - Whether the `executor` should run on its own `QThread` or re-use existing worker thread infrastructure from `protocol_grid`. Decided during PPT-2 when concrete constraints surface.
 - UI treatment of hidden columns (header right-click menu vs. preferences pane vs. view submenu). Decided during PPT-1.
+
+## 20. Demo lifecycle gotchas
+
+These bit us during PPT-12 (base demo window extraction) and are easy to repeat. Capture here so future demo work avoids them.
+
+### Don't instantiate `dramatiq.Worker(...)` inside demo windows
+
+Demo `__main__` blocks already wrap `main()` with `with dramatiq_workers_context():`. That context manager owns the worker lifecycle (start, stop, signal handling). If demo / window code separately constructs `dramatiq.Worker(broker, ...).start()` — as the original `run_widget_with_vf.py` did, and as `BasePluggableProtocolDemoWindow._setup_dramatiq_routing_internal` did until cleaned up — Dramatiq registers two worker instances against the same broker and emits a "workers added twice" warning. Shutdown also gets messy because the in-window worker isn't part of the context manager's cleanup.
+
+**Rule:** in any code that runs under `with dramatiq_workers_context():`, the only Dramatiq setup the demo window should do is router / topic state (`MessageRouterActor()`, `add_subscriber_to_topic(...)`). Worker lifetime stays with the context manager.
+
+### Use `microdrop_application.dialogs.pyface_wrapper`, never raw `QMessageBox`
+
+The application has a styled `BaseMessageDialog` system. `pyface_wrapper` exposes `error`, `warning`, `information`, `confirm`, `success`, `disclaimer`, `file_dialog` with a Pyface-compatible signature. Raw `QMessageBox` and direct `pyface.api` calls bypass the styling and produce visually inconsistent dialogs. The base demo window's `_save` / `_load` / `_on_error` all use `pyface_wrapper.error`; downstream demos should follow suit.

--- a/docs/superpowers/specs/2026-04-28-ppt-12-demo-base-design.md
+++ b/docs/superpowers/specs/2026-04-28-ppt-12-demo-base-design.md
@@ -1,0 +1,467 @@
+# PPT-12 — Demo base window + full integration demo (composition)
+
+**Status:** READY FOR REVIEW — all three sections confirmed by the user during brainstorming. Pending self-review pass + final approval, then transition to writing-plans.
+
+**Issue:** [#385](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/385) (standalone — not under #361)
+
+**Follow-up issue:** [#386](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/386) — replace per-demo Dramatiq ack listeners with an executor-emitted `step_phase_started` Qt signal. Out of scope for PPT-12; will land after #385 merges.
+
+**Brainstorming session:** 2026-04-28, in conversation with the user.
+
+---
+
+## Why this exists
+
+Each existing demo (`pluggable_protocol_tree.demos.run_widget` PPT-3, `dropbot_protocol_controls.demos.run_widget_with_vf` PPT-4, `pluggable_protocol_tree.demos.run_widget_compound_demo` PPT-11, `peripheral_protocol_controls.demos.run_widget_magnet_demo` PPT-5) reimplements the same UX scaffolding: active-row highlight, status bar with step counter + row name + step/phase timers, button state machine, Save/Load, stale-subscriber purge, phase-ack listener. Each new column-migration sub-issue copies the boilerplate again.
+
+Today PPT-5's demo is missing some of these features (no active-row highlight, no per-step/per-phase timers) — caught by the user during manual testing. Rather than patch PPT-5's demo inline, this issue extracts the common UX into a single base class so:
+
+1. Every demo gets the standard UX **for free**.
+2. Future column-migration sub-issues (PPT-6/7/8/10) cost ~50 LOC of demo glue instead of ~500 LOC of full demo file.
+3. A single integration demo can exercise EVERY column at once — exposes priority-bucketing behaviour and integration concerns no individual demo can show.
+
+---
+
+## Section 1 — Architecture: composition shape ✅ CONFIRMED
+
+The base is a Qt window class that takes a `DemoConfig` dataclass. Demos are tiny scripts that build the config and call `BasePluggableProtocolDemoWindow.run(config)`. **No subclassing**.
+
+### `pluggable_protocol_tree/demos/base_demo_window.py`
+
+```python
+@dataclass
+class StatusReadout:
+    """One ack-driven readout label in the status bar.
+
+    The base creates one Dramatiq actor per StatusReadout (auto-named
+    ppt12_demo_<label_slug>_listener) that subscribes to `topic`,
+    emits a Qt signal, and updates a QLabel in the status bar with
+    `f"{label}: {fmt(message)}"`. Until the first ack, the label
+    shows `f"{label}: {initial}"`.
+    """
+    label: str           # display prefix, e.g. "Voltage"
+    topic: str           # ack topic to subscribe to
+    fmt: Callable[[str], str]   # message → displayed text after the prefix
+    initial: str = "--"  # initial text shown before any ack lands
+
+
+@dataclass
+class DemoConfig:
+    """Everything a demo needs to declare. All fields except
+    columns_factory have sensible defaults."""
+
+    # Required: returns the column list.
+    columns_factory: Callable[[], list[Column]]
+
+    # Cosmetic.
+    title: str = "Pluggable Protocol Tree Demo"
+    window_size: tuple[int, int] = (1100, 650)
+
+    # Optional sample steps populated after RowManager construction.
+    pre_populate: Callable[[RowManager], None] = lambda rm: None
+
+    # Subscribe demo responders / additional listeners on the router.
+    # Called AFTER the base wires the standard PPT-3 electrode chain
+    # + the phase-ack listener (if phase_ack_topic is set) +
+    # the StatusReadout listeners.
+    routing_setup: Callable[[Any], None] = lambda router: None
+
+    # Single ack topic that drives the per-phase timer.
+    # If None: only step-elapsed timer shown, no per-phase timer.
+    # Default ELECTRODES_STATE_APPLIED matches PPT-3 / integration-demo
+    # semantics (the priority-30 ack is the real phase boundary).
+    phase_ack_topic: str | None = ELECTRODES_STATE_APPLIED
+
+    # Right-side status bar readouts.
+    status_readouts: list[StatusReadout] = field(default_factory=list)
+
+    # Side panel (e.g., SimpleDeviceViewer for PPT-3 / integration demo).
+    # Returns a QWidget or None. Called once during window setup.
+    side_panel_factory: Callable[[RowManager], QWidget | None] | None = None
+
+
+class BasePluggableProtocolDemoWindow(QMainWindow):
+    """Hosts a ProtocolTreeWidget + ProtocolExecutor with the standard
+    UX scaffolding."""
+
+    def __init__(self, config: DemoConfig): ...
+
+    @classmethod
+    def run(cls, config: DemoConfig) -> int:
+        """Convenience: creates QApplication if none exists, builds
+        the window, shows it, runs app.exec(). Returns exit code."""
+```
+
+### What the base owns
+
+- `RowManager`, `ProtocolTreeWidget`, `ProtocolExecutor` construction
+- Active-row highlight wired from `executor.qsignals.step_started`
+- Status bar with: step counter / row label + path / reps / step elapsed timer / phase elapsed timer (if `phase_ack_topic` set) / one QLabel per `StatusReadout`
+- 10 Hz tick timer for elapsed-time refresh
+- Phase-ack listener — auto-named Dramatiq actor subscribed to `phase_ack_topic` if set; emits Qt signal that restarts per-phase timer from the actual ack moment
+- StatusReadout listeners — one Dramatiq actor per readout
+- Pause/Resume/Stop button state machine (Run, Pause→Resume toggle, Stop)
+- Save/Load toolbar buttons (open file dialog, JSON serialize/deserialize via `RowManager.to_json` / `set_state_from_json`)
+- Add Step / Add Group toolbar buttons
+- Stale-subscriber purge — drops actor names recorded in Redis whose actors aren't registered in the current process; only touches `ppt_demo_*`, `ppt4_demo_*`, `ppt5_demo_*`, `ppt11_demo_*`, `ppt12_demo_*`, `ppt_vf_demo_*` prefixed names (leaves real listeners belonging to other processes alone)
+- `_clear_all_highlights` on protocol end / abort / error — restores idle visual state including resetting StatusReadout labels to their `initial` text
+- In-process Dramatiq Worker started in `__init__`, stopped in `closeEvent`
+- Splitter layout — protocol tree + side panel (if `side_panel_factory` returns one)
+- Standard middleware strip via `microdrop_utils.broker_server_helpers.remove_middleware_from_dramatiq_broker`
+- PPT-3 electrode actuation chain wired automatically (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED) — every demo gets electrode end-to-end for free
+
+### What the demo declares
+
+- Columns (the only required field)
+- Title / window size (cosmetic)
+- Sample steps + protocol metadata (`pre_populate`)
+- Demo-specific responder subscriptions (`routing_setup`) — called AFTER the base wires the standard machinery
+- Which ack drives the phase timer (`phase_ack_topic`)
+- Extra status bar readouts (`status_readouts`)
+- Side panel (`side_panel_factory`)
+
+### Why composition (not inheritance)
+
+User's call. Composition advantages: the base "demo window" is a polished, well-tested Qt class with no per-demo subclass requirement; demos become tiny declarative scripts; easier to test the base in isolation; easier for the integration demo (just a much bigger config). Composition disadvantages: extra-status-widget wiring needed an explicit API (the `StatusReadout` dataclass solves this).
+
+---
+
+## Section 2 — Refactor mapping for the 4 existing demos ✅ CONFIRMED
+
+Each demo collapses to ~50-100 lines: just its specific columns + responders + readouts.
+
+### `pluggable_protocol_tree/demos/run_widget.py` (PPT-3, currently 531 LOC → ~80 LOC)
+
+```python
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        make_message_column(), make_ack_roundtrip_column(),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+
+
+def _routing_setup(router):
+    # PPT-2 ack-roundtrip column responder (specific to run_widget)
+    router.add_subscriber_to_topic(DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME)
+    router.add_subscriber_to_topic(
+        DEMO_APPLIED_TOPIC, "pluggable_protocol_tree_executor_listener",
+    )
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Pluggable Protocol Tree — PPT-3 Demo",
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            BasePluggableProtocolDemoWindow.run(config)
+```
+
+### `dropbot_protocol_controls/demos/run_widget_with_vf.py` (PPT-4, currently 658 → ~80 LOC)
+
+```python
+def _columns():
+    return [...PPT-3 builtins..., make_voltage_column(), make_frequency_column()]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {f"e{i:02d}": i for i in range(25)}
+    rm.add_step(values={"name": "Step 1: 100V/10kHz on e00,e01",
+                        "duration_s": 0.3, "electrodes": ["e00", "e01"],
+                        "voltage": 100, "frequency": 10000})
+    rm.add_step(values={"name": "Step 2: 120V/5kHz on e02,e03", ...})
+    rm.add_step(values={"name": "Step 3: 75V/1kHz cooldown", ...})
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-4 Demo — Voltage + Frequency",
+    pre_populate=_pre_populate,
+    routing_setup=lambda r: subscribe_demo_responder(r),  # PPT-4 V/F responder
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+```
+
+### `peripheral_protocol_controls/demos/run_widget_magnet_demo.py` (PPT-5, currently 213 → ~50 LOC)
+
+```python
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+        *_expand_compound(make_magnet_column()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.add_step(values={"name": "Step 1: engage at Default",
+                        "duration_s": 0.2, "magnet_on": True, "magnet_height_mm": 0.0})
+    rm.add_step(values={"name": "Step 2: engage at 12.0 mm",
+                        "duration_s": 0.2, "magnet_on": True, "magnet_height_mm": 12.0})
+    rm.add_step(values={"name": "Step 3: retract",
+                        "duration_s": 0.2, "magnet_on": False, "magnet_height_mm": 0.0})
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-5 Demo — Magnet",
+    pre_populate=_pre_populate,
+    routing_setup=lambda r: subscribe_demo_responder(r),
+    phase_ack_topic=MAGNET_APPLIED,
+    status_readouts=[
+        StatusReadout("Magnet", MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+)
+```
+
+### `pluggable_protocol_tree/demos/run_widget_compound_demo.py` (PPT-11, currently 131 → ~50 LOC)
+
+```python
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+        *_expand_compound(make_enabled_count_compound()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.add_step(values={"name": "Step 1: enabled, count=5",
+                        "duration_s": 0.2, "ec_enabled": True, "ec_count": 5})
+    rm.add_step(values={"name": "Step 2: disabled (count read-only)",
+                        "duration_s": 0.2, "ec_enabled": False, "ec_count": 0})
+    rm.add_step(values={"name": "Step 3: enabled, count=99",
+                        "duration_s": 0.2, "ec_enabled": True, "ec_count": 99})
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-11 Demo — Compound Column Framework",
+    pre_populate=_pre_populate,
+    phase_ack_topic=None,    # no ack-emitting handlers
+)
+```
+
+The PPT-11 demo gains Run/Pause/Stop + step elapsed timer for free (synthetic compound has no `wait_for`, so each step completes instantly + the duration_s sleep) — useful regression test that the framework actually runs without errors.
+
+### Net lines deleted
+
+~1330 → ~260 across the four demos. Base class is ~250 LOC. Net ~820 LOC removed; future demos cost ~50 LOC each.
+
+---
+
+## Section 3 — Integration demo ✅ CONFIRMED
+
+`src/examples/demos/run_full_integration_demo.py` — single runnable that exercises every column type at once. Lives in `examples/demos/` (not a sibling-plugin demo) because it's the cross-plugin integration smoke runner.
+
+### Sample protocol (3 steps)
+
+| Step | Voltage | Frequency | Magnet | Routes |
+|---|---|---|---|---|
+| 1 | 100 V | 10000 Hz | engage at Default | top row e00→e04 |
+| 2 | 120 V | 5000 Hz | engage at 12.0 mm | diagonal e00→e24 |
+| 3 | 75 V | 1000 Hz | retract | none (cooldown) |
+
+### Code
+
+```python
+"""Full-stack integration demo: PPT-3 electrodes/routes + PPT-4 voltage/
+frequency + PPT-5 magnet, all in one window. Verifies the priority
+bucketing in practice (priority 20 V/F/magnet bucket completes before
+priority 30 RoutesHandler publishes electrodes).
+
+Run: pixi run python -m examples.demos.run_full_integration_demo
+"""
+
+# ...all PPT-3 builtin column factories...
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.demos.simple_device_viewer import (
+    GRID_H, GRID_W, SimpleDeviceViewer,
+)
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
+
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
+from dropbot_protocol_controls.protocol_columns.voltage_column import make_voltage_column
+from dropbot_protocol_controls.protocol_columns.frequency_column import make_frequency_column
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder as subscribe_vf_responder,
+)
+
+from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_protocol_controls.protocol_columns.magnet_column import make_magnet_column
+from peripheral_protocol_controls.demos.magnet_responder import (
+    subscribe_demo_responder as subscribe_magnet_responder,
+)
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        # PPT-4
+        make_voltage_column(), make_frequency_column(),
+        # PPT-5 (compound, expanded)
+        *_expand_compound(make_magnet_column()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+    rm.add_step(values={
+        "name": "Step 1: 100V/10kHz, magnet=Default, route top row",
+        "duration_s": 0.3,
+        "voltage": 100, "frequency": 10000,
+        "magnet_on": True, "magnet_height_mm": 0.0,
+        "routes": [["e00", "e01", "e02", "e03", "e04"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 2: 120V/5kHz, magnet=12mm, diagonal",
+        "duration_s": 0.3,
+        "voltage": 120, "frequency": 5000,
+        "magnet_on": True, "magnet_height_mm": 12.0,
+        "routes": [["e00", "e06", "e12", "e18", "e24"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 3: 75V/1kHz cooldown, retract magnet",
+        "duration_s": 0.3,
+        "voltage": 75, "frequency": 1000,
+        "magnet_on": False, "magnet_height_mm": 0.0,
+    })
+
+
+def _routing_setup(router):
+    """Wire all three demo responders. Each turnkey helper subscribes
+    its responder + the executor listener for its ack topic. The PPT-3
+    electrode chain is wired by the base automatically."""
+    subscribe_vf_responder(router)
+    subscribe_magnet_responder(router)
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Full Integration Demo — PPT-3 routes + PPT-4 V/F + PPT-5 magnet",
+    window_size=(1300, 700),
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,   # priority-30 ack = real phase boundary
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+        StatusReadout("Magnet",    MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            BasePluggableProtocolDemoWindow.run(config)
+```
+
+### What the user can verify by running it
+
+1. Status bar shows all three readouts updating per step (`Voltage: 100 V → 120 V → 75 V`, `Frequency: 10000 Hz → 5000 Hz → 1000 Hz`, `Magnet: engaged → engaged → retracted`).
+2. Active row highlight tracks step progression.
+3. Step + Phase timers refresh at 10 Hz.
+4. Device viewer's electrode overlay paints each phase's electrodes during the route.
+5. **Priority bucketing in practice:** all three priority-20 readouts (V, F, Magnet) update BEFORE the device viewer's electrode overlay starts changing for that step — proves V/F/magnet bucket completes before RoutesHandler at priority 30.
+6. Save → quit → reload → run again — full round-trip persistence with mixed simple + compound columns.
+7. Pause mid-route, resume, stop — full executor control.
+
+---
+
+## Tests
+
+### Unit tests (`pluggable_protocol_tree/tests/test_base_demo_window.py`)
+
+| Test | Verifies |
+|---|---|
+| `test_demo_config_minimum_required_fields` | `DemoConfig(columns_factory=...)` constructs with all defaults |
+| `test_status_readout_dataclass_shape` | `StatusReadout(label, topic, fmt)` constructs; `initial` defaults to `"--"` |
+| `test_window_constructs_with_minimal_config` | Window builds with just a columns_factory; title/size defaults applied |
+| `test_window_pre_populate_runs_after_manager_construction` | The `pre_populate` callback receives the live `RowManager` and added rows are present |
+| `test_window_routing_setup_called_after_base_subscriptions` | `routing_setup` callback receives the router with PPT-3 electrode chain already wired |
+| `test_status_readout_creates_actor_per_entry` | One Dramatiq actor registered per StatusReadout, named `ppt12_demo_<slug>_listener` |
+| `test_status_readout_label_initial_text` | Each readout's QLabel shows `"<label>: <initial>"` until first ack |
+| `test_phase_ack_topic_none_hides_phase_timer` | When `phase_ack_topic=None`, no phase-elapsed label in status bar |
+| `test_run_classmethod_returns_exit_code` | `run(config)` returns int from `app.exec()` (mocked) |
+| `test_clear_highlights_resets_status_readouts_to_initial` | After protocol terminates, each readout label is back to `f"{label}: {initial}"` |
+| `test_stale_subscriber_purge_only_touches_demo_prefixes` | Real-listener subscribers (e.g., `dropbot_controller_listener`) are NOT removed |
+
+### Integration test (Redis required) — `tests_with_redis_server_need/test_base_demo_window_redis.py`
+
+| Test | Verifies |
+|---|---|
+| `test_status_readout_updates_on_ack` | Run a fake ack on a registered readout's topic; assert the QLabel text becomes `f"{label}: {fmt(message)}"` |
+| `test_phase_timer_restarts_on_each_phase_ack` | Run a 3-phase fake protocol with phase acks; assert the phase elapsed timer reset between acks |
+
+### Demo regression smoke
+
+After refactor, each of the four refactored demos imports cleanly + window builds without crash + 3 sample steps appear in the protocol tree. (Headed verification = manual.)
+
+---
+
+## Out of scope
+
+- The framework itself (`models/`, `interfaces/`, `executor/`, `services/`) — no changes
+- New column types
+- Headless integration tests (already covered by per-PPT Redis-backed tests)
+- Replacing per-demo Dramatiq listeners with executor signals — tracked in #386, depends on PPT-12 merging first
+
+## Resolved during brainstorming
+
+| Question | Resolution |
+|---|---|
+| Inheritance vs composition? | **Composition.** Demos are tiny declarative scripts; base class needs no subclassing. |
+| Phase ack: single topic, multi-topic, or executor-emitted signal? | **Single topic** (`phase_ack_topic: str \| None`) — covers all 4 demos. Executor-emitted signal is the future cleaner path, tracked in #386. |
+| Extra status widgets API? | **Declarative `list[StatusReadout]`** — base auto-creates one Dramatiq actor + Qt signal + QLabel per entry. |
+| File location for the integration demo? | `examples/demos/run_full_integration_demo.py` — the existing home for cross-plugin one-off scripts. |
+| PPT-11 demo gains Run/Pause/Stop? | **Yes** — useful regression test that the synthetic compound runs end-to-end. |
+
+## Remaining TODO
+
+1. **User reviews written spec** — gate before invoking writing-plans.
+2. **Invoke `superpowers:writing-plans`** — once approved, generate `docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md`.

--- a/dropbot_protocol_controls/demos/run_widget_with_vf.py
+++ b/dropbot_protocol_controls/demos/run_widget_with_vf.py
@@ -118,8 +118,7 @@ def _post_build(window):
     """Wire the side-panel: device viewer follows the tree's current
     selection AND the executor's currently-running step. Bind the
     module-level overlay target to this window's device viewer."""
-    central = window.centralWidget()
-    device_view = central.widget(1)
+    device_view = window._side_panel
     _overlay_target["viewer"] = device_view
 
     sel_model = window.widget.tree.selectionModel()

--- a/dropbot_protocol_controls/demos/run_widget_with_vf.py
+++ b/dropbot_protocol_controls/demos/run_widget_with_vf.py
@@ -1,34 +1,14 @@
-"""Standalone demo — PPT-4 voltage/frequency column integration.
-
-Opens a QMainWindow with:
-- Protocol tree on the left (PPT-3 builtins + Voltage + Frequency columns)
-- SimpleDeviceViewer on the right
-- Run / Pause / Stop toolbar
-- Active-row highlight
-- Status bar with step counter, step name/path, elapsed timers, AND
-  real-time voltage/frequency readouts that update as the protocol runs
-
-Three sample steps are pre-populated so you can click Run immediately
-and see the V/F status labels update (100V/10kHz → 120V/5kHz → 75V/1kHz).
-
-No envisage required. Redis + Dramatiq workers are started in-process
-when run as __main__.
+"""PPT-4 demo — protocol tree with voltage + frequency columns,
+electrode overlay, and side-panel device viewer.
 
 Run: pixi run python -m dropbot_protocol_controls.demos.run_widget_with_vf
 """
 
 import json
 import logging
-import sys
-import threading
-import time
 
 import dramatiq
-from pyface.qt.QtCore import Qt, QTimer, Signal
-from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox, QStatusBar,
-    QToolBar, QSplitter,
-)
+from pyface.qt.QtCore import Qt
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
 from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
@@ -52,57 +32,33 @@ from pluggable_protocol_tree.builtins.type_column import make_type_column
 from pluggable_protocol_tree.consts import (
     ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
 )
-from pluggable_protocol_tree.demos.electrode_responder import (
-    DEMO_RESPONDER_ACTOR_NAME,
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
 )
 from pluggable_protocol_tree.demos.simple_device_viewer import (
     GRID_H, GRID_W, SimpleDeviceViewer,
 )
-from pluggable_protocol_tree.execution.events import PauseEvent
-from pluggable_protocol_tree.execution.executor import ProtocolExecutor
-from pluggable_protocol_tree.execution.signals import ExecutorSignals
-from pluggable_protocol_tree.models.row_manager import RowManager
-from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
-from dropbot_controller.consts import (
-    PROTOCOL_SET_VOLTAGE, PROTOCOL_SET_FREQUENCY,
-    VOLTAGE_APPLIED, FREQUENCY_APPLIED,
-)
-from dropbot_protocol_controls.protocol_columns.voltage_column import (
-    make_voltage_column,
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder,
 )
 from dropbot_protocol_controls.protocol_columns.frequency_column import (
     make_frequency_column,
 )
-from dropbot_protocol_controls.demos.voltage_frequency_responder import (
-    subscribe_demo_responder,
+from dropbot_protocol_controls.protocol_columns.voltage_column import (
+    make_voltage_column,
 )
 
-# Strip Prometheus middleware — raises on every actor publish otherwise.
-from microdrop_utils.broker_server_helpers import remove_middleware_from_dramatiq_broker
-remove_middleware_from_dramatiq_broker(middleware_name="dramatiq.middleware.prometheus", broker=dramatiq.get_broker())
 
-logger = logging.getLogger(__name__)
+# Module-level overlay listener — captures the device viewer via a
+# global hook set by the post_build_setup callback.
+_overlay_target = {"viewer": None}
 
-# ---------------------------------------------------------------------------
-# Module-level targets for cross-thread actor → Qt signal bridging.
-# Each actor runs on a Dramatiq worker thread; it emits a Qt Signal that
-# auto-connection delivers on the GUI thread.
-# ---------------------------------------------------------------------------
-
-_overlay_target = {"viewer": None}  # SimpleDeviceViewer (electrode overlay)
-_ack_target = {"window": None}       # DemoWindow (phase-ack timer trigger)
-_vf_target = {"window": None}        # DemoWindow (voltage/frequency readouts)
-
-
-# ---------------------------------------------------------------------------
-# Module-level Dramatiq actors
-# ---------------------------------------------------------------------------
 
 @dramatiq.actor(actor_name="ppt4_demo_actuation_overlay_listener",
                 queue_name="default")
 def _overlay_listener(message: str, topic: str, timestamp: float = None):
-    """Paints the live electrode overlay in the device viewer."""
     viewer = _overlay_target["viewer"]
     if viewer is None:
         return
@@ -114,527 +70,81 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     viewer.actuation_changed.emit(list(electrodes))
 
 
-@dramatiq.actor(actor_name="ppt4_demo_phase_ack_listener",
-                queue_name="default")
-def _phase_ack_listener(message: str, topic: str, timestamp: float = None):
-    """Fires on each ELECTRODES_STATE_APPLIED ack so the status bar can
-    start the per-phase / per-step timers from the moment hardware actually
-    confirmed the actuation, not from the upstream publish_message call."""
-    window = _ack_target["window"]
-    if window is None:
-        return
-    window.phase_acked.emit()
-
-
-@dramatiq.actor(actor_name="ppt4_demo_voltage_applied_listener",
-                queue_name="default")
-def _voltage_applied_listener(message: str, topic: str,
-                               timestamp: float = None):
-    """Updates the status-bar voltage readout when a VOLTAGE_APPLIED ack lands."""
-    window = _vf_target.get("window")
-    if window is None:
-        return
-    try:
-        window.voltage_acked.emit(int(message))
-    except (TypeError, ValueError):
-        pass
-
-
-@dramatiq.actor(actor_name="ppt4_demo_frequency_applied_listener",
-                queue_name="default")
-def _frequency_applied_listener(message: str, topic: str,
-                                  timestamp: float = None):
-    """Updates the status-bar frequency readout when a FREQUENCY_APPLIED ack lands."""
-    window = _vf_target.get("window")
-    if window is None:
-        return
-    try:
-        window.frequency_acked.emit(int(message))
-    except (TypeError, ValueError):
-        pass
-
-
-# ---------------------------------------------------------------------------
-# Column list
-# ---------------------------------------------------------------------------
-
 def _columns():
-    """PPT-3 builtins + voltage + frequency columns."""
     return [
-        make_type_column(),
-        make_id_column(),
-        make_name_column(),
-        make_repetitions_column(),
-        make_duration_column(),
-        make_electrodes_column(),
-        make_routes_column(),
-        make_trail_length_column(),
-        make_trail_overlay_column(),
-        make_soft_start_column(),
-        make_soft_end_column(),
-        make_repeat_duration_column(),
-        make_linear_repeats_column(),
-        make_voltage_column(),
-        make_frequency_column(),
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        make_voltage_column(), make_frequency_column(),
     ]
 
 
-# ---------------------------------------------------------------------------
-# Main demo window
-# ---------------------------------------------------------------------------
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+    rm.add_step(values={
+        "name": "Step 1: 100V/10kHz on e00,e01",
+        "duration_s": 0.3,
+        "electrodes": ["e00", "e01"],
+        "voltage": 100, "frequency": 10000,
+    })
+    rm.add_step(values={
+        "name": "Step 2: 120V/5kHz on e02,e03",
+        "duration_s": 0.3,
+        "electrodes": ["e02", "e03"],
+        "voltage": 120, "frequency": 5000,
+    })
+    rm.add_step(values={
+        "name": "Step 3: 75V/1kHz cooldown",
+        "duration_s": 0.3,
+        "voltage": 75, "frequency": 1000,
+    })
 
-class DemoWindow(QMainWindow):
 
-    # Cross-thread signals — Dramatiq worker threads emit; auto-connection
-    # delivers all slots on the GUI thread.
-    phase_acked = Signal()
-    voltage_acked = Signal(int)
-    frequency_acked = Signal(int)
+def _routing_setup(router):
+    """V/F demo responder + actuation overlay subscription."""
+    subscribe_demo_responder(router)
+    router.message_router_data.add_subscriber_to_topic(
+        topic=ELECTRODES_STATE_CHANGE,
+        subscribing_actor_name="ppt4_demo_actuation_overlay_listener",
+    )
 
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle("PPT-4 Demo — Voltage + Frequency Columns")
-        self.resize(1100, 650)
 
-        self.manager = RowManager(columns=_columns())
-        self.widget = ProtocolTreeWidget(self.manager, parent=self)
-        self.device_view = SimpleDeviceViewer(self.manager, parent=self)
+def _post_build(window):
+    """Wire the side-panel: device viewer follows the tree's current
+    selection AND the executor's currently-running step. Bind the
+    module-level overlay target to this window's device viewer."""
+    central = window.centralWidget()
+    device_view = central.widget(1)
+    _overlay_target["viewer"] = device_view
 
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(self.widget)
-        splitter.addWidget(self.device_view)
-        splitter.setSizes([750, 400])
-        self.setCentralWidget(splitter)
-
-        # Seed the electrode→channel mapping. e00..e24 → channels 0..24.
-        self.manager.protocol_metadata["electrode_to_channel"] = {
-            f"e{i:02d}": i for i in range(GRID_W * GRID_H)
-        }
-
-        # Wire the module-level actor targets to this window.
-        _overlay_target["viewer"] = self.device_view
-        _ack_target["window"] = self
-        _vf_target["window"] = self
-
-        self.phase_acked.connect(self._on_phase_ack)
-        self.voltage_acked.connect(self._on_voltage_ack)
-        self.frequency_acked.connect(self._on_frequency_ack)
-
-        # Pre-populate sample steps so the user can hit Run immediately
-        # and see V/F change. Must happen BEFORE the executor is built.
-        self.manager.add_step(values={
-            "name": "Step 1: 100V / 10kHz on e00,e01",
-            "duration_s": 0.3,
-            "electrodes": ["e00", "e01"],
-            "voltage": 100,
-            "frequency": 10000,
-        })
-        self.manager.add_step(values={
-            "name": "Step 2: 120V / 5kHz on e02,e03",
-            "duration_s": 0.3,
-            "electrodes": ["e02", "e03"],
-            "voltage": 120,
-            "frequency": 5000,
-        })
-        self.manager.add_step(values={
-            "name": "Step 3: 75V / 1kHz cooldown",
-            "duration_s": 0.3,
-            "voltage": 75,
-            "frequency": 1000,
-        })
-
-        self.executor = ProtocolExecutor(
-            row_manager=self.manager,
-            qsignals=ExecutorSignals(),
-            pause_event=PauseEvent(),
-            stop_event=threading.Event(),
+    sel_model = window.widget.tree.selectionModel()
+    sel_model.currentRowChanged.connect(
+        lambda cur, _prev: device_view.set_active_row(
+            cur.data(Qt.UserRole) if cur.isValid() else None
         )
-
-        # Per-step / per-phase timing state.  All timestamps are
-        # time.monotonic() from the moment the corresponding ack arrives.
-        # None means "not yet started; display 0.00s".
-        # Mutated from the GUI thread only (via Qt signals).
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None
-        self._phase_started_at = None
-        self._phase_target = None
-        self._current_row = None
-        self._tick_timer = QTimer(self)
-        self._tick_timer.setInterval(100)   # 10 Hz elapsed-time display
-        self._tick_timer.timeout.connect(self._refresh_status)
-
-        self._dramatiq_worker = None
-        self._setup_dramatiq_routing()
-
-        self._build_status_bar()
-        self._wire_signals()
-        self._build_toolbar()
-        self._reset_status()
-
-    # ------------------------------------------------------------------
-    # Dramatiq routing
-    # ------------------------------------------------------------------
-
-    def _setup_dramatiq_routing(self):
-        """Register subscriptions for all demo actors and start a worker.
-
-        Best-effort: if Redis isn't running, columns will time out at
-        runtime and surface as protocol_error in the dialog.
-        """
-        try:
-            from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterActor
-            from dramatiq import Worker
-
-            broker = dramatiq.get_broker()
-            # Drop any queued messages from prior demo runs.
-            broker.flush_all()
-
-            router = MessageRouterActor()
-
-            # Purge stale demo subscribers — actor names recorded in
-            # Redis by prior demo processes whose actors aren't
-            # registered in this process. Without this, a previous demo
-            # (e.g. run_voltage_frequency_demo's ppt_vf_demo_spy) leaves
-            # behind a subscription that fires ActorNotFound on every
-            # publish.
-            #
-            # Only touch demo-namespaced actor names — leave real
-            # listeners (e.g., dropbot_controller_listener subscribed
-            # from the full app running in another process) alone.
-            _demo_prefixes = ("ppt_demo_", "ppt4_demo_", "ppt_vf_demo_")
-            _demo_topics = (
-                ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED,
-                PROTOCOL_SET_VOLTAGE, PROTOCOL_SET_FREQUENCY,
-                VOLTAGE_APPLIED, FREQUENCY_APPLIED,
-            )
-            for topic in _demo_topics:
-                try:
-                    subs = router.message_router_data.get_subscribers_for_topic(topic)
-                except Exception:
-                    continue
-                for entry in subs:
-                    actor_name = entry[0] if isinstance(entry, tuple) else entry
-                    if not actor_name.startswith(_demo_prefixes):
-                        continue
-                    try:
-                        broker.get_actor(actor_name)
-                    except Exception:
-                        try:
-                            router.message_router_data.remove_subscriber_from_topic(
-                                topic=topic, subscribing_actor_name=actor_name,
-                            )
-                            logger.info("purged stale demo subscriber %s on %s",
-                                        actor_name, topic)
-                        except Exception:
-                            logger.warning("failed to purge %s on %s: %s",
-                                           actor_name, topic,
-                                           "wrong listener_queue (likely from another router)")
-
-            # PPT-3: electrode actuation chain
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_CHANGE,
-                subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
-            )
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_APPLIED,
-                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
-            )
-            # Live electrode overlay in the device viewer
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_CHANGE,
-                subscribing_actor_name="ppt4_demo_actuation_overlay_listener",
-            )
-            # Phase-ack listener — drives per-phase / per-step timers
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_APPLIED,
-                subscribing_actor_name="ppt4_demo_phase_ack_listener",
-            )
-
-            # PPT-4: voltage/frequency demo responder + executor listener
-            subscribe_demo_responder(router)
-
-            # PPT-4: status-bar V/F readout listeners
-            router.message_router_data.add_subscriber_to_topic(
-                topic=VOLTAGE_APPLIED,
-                subscribing_actor_name="ppt4_demo_voltage_applied_listener",
-            )
-            router.message_router_data.add_subscriber_to_topic(
-                topic=FREQUENCY_APPLIED,
-                subscribing_actor_name="ppt4_demo_frequency_applied_listener",
-            )
-
-            self._router = router
-        except ValueError as e:
-            # MessageRouterActor() raises if message_router_actor is
-            # already registered (e.g. demo loaded a second time in the
-            # same process). Reuse — don't double-register.
-            if "already registered" not in str(e):
-                logger.warning("Demo Dramatiq routing setup failed: %s", e)
-        except Exception as e:
-            logger.warning(
-                "Demo Dramatiq routing setup failed (Redis not running?): %s", e,
-            )
-
-    def closeEvent(self, event):
-        if self._dramatiq_worker is not None:
-            try:
-                self._dramatiq_worker.stop()
-            except Exception:
-                logger.exception("Error stopping demo dramatiq worker")
-        super().closeEvent(event)
-
-    # ------------------------------------------------------------------
-    # Qt wiring
-    # ------------------------------------------------------------------
-
-    def _wire_signals(self):
-        # Active-row highlight. step_started sets; terminal signals clear.
-        self.executor.qsignals.step_started.connect(
-            self.widget.highlight_active_row
-        )
-
-        # Device viewer follows tree selection AND the executor's running step.
-        sel_model = self.widget.tree.selectionModel()
-        sel_model.currentRowChanged.connect(
-            lambda cur, _prev: self.device_view.set_active_row(
-                cur.data(Qt.UserRole) if cur.isValid() else None
-            )
-        )
-        self.executor.qsignals.step_started.connect(
-            self.device_view.set_active_row
-        )
-
-        # Status bar updates
-        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
-        self.executor.qsignals.step_started.connect(self._on_step_started)
-        self.executor.qsignals.step_finished.connect(self._on_step_finished)
-
-        # Button state machine
-        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
-        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
-        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
-        for sig in (
-            self.executor.qsignals.protocol_finished,
-            self.executor.qsignals.protocol_aborted,
-        ):
-            sig.connect(self._on_protocol_terminated)
-        self.executor.qsignals.protocol_error.connect(self._on_error)
-
-    def _build_toolbar(self):
-        tb = QToolBar("Protocol")
-        self.addToolBar(tb)
-        tb.addAction("Add Step", lambda: self.manager.add_step())
-        tb.addAction("Add Group", lambda: self.manager.add_group())
-        tb.addSeparator()
-        tb.addAction("Save…", self._save)
-        tb.addAction("Load…", self._load)
-        tb.addSeparator()
-        self._run_action = tb.addAction("Run", self.executor.start)
-        self._pause_action = tb.addAction("Pause", self._toggle_pause)
-        self._stop_action = tb.addAction("Stop", self.executor.stop)
-        self._set_idle_button_state()
-
-    def _set_idle_button_state(self):
-        self._run_action.setEnabled(True)
-        self._pause_action.setEnabled(False)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(False)
-
-    def _set_running_button_state(self):
-        self._run_action.setEnabled(False)
-        self._pause_action.setEnabled(True)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(True)
-
-    def _toggle_pause(self):
-        if self.executor.pause_event.is_set():
-            self.executor.resume()
-        else:
-            self.executor.pause()
-
-    # ------------------------------------------------------------------
-    # Status bar
-    # ------------------------------------------------------------------
-
-    def _build_status_bar(self):
-        sb = QStatusBar()
-        self.setStatusBar(sb)
-        self._status_step_label = QLabel("Idle")
-        self._status_row_label = QLabel("")
-        self._status_reps_label = QLabel("")
-        self._status_step_time_label = QLabel("")
-        self._status_phase_time_label = QLabel("")
-        # PPT-4: voltage/frequency readouts
-        self._status_voltage_label = QLabel("Voltage: --")
-        self._status_frequency_label = QLabel("Frequency: --")
-
-        # Row label takes remaining width via stretch=1.
-        sb.addWidget(self._status_step_label)
-        sb.addWidget(self._status_row_label, stretch=1)
-        sb.addPermanentWidget(self._status_reps_label)
-        sb.addPermanentWidget(self._status_step_time_label)
-        sb.addPermanentWidget(self._status_phase_time_label)
-        sb.addPermanentWidget(self._status_voltage_label)
-        sb.addPermanentWidget(self._status_frequency_label)
-
-    def _reset_status(self):
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None
-        self._phase_started_at = None
-        self._phase_target = None
-        self._current_row = None
-        self._status_step_label.setText("Idle")
-        self._status_row_label.setText("")
-        self._status_reps_label.setText("")
-        self._status_step_time_label.setText("")
-        self._status_phase_time_label.setText("")
-
-    def _refresh_status(self):
-        """Recompute the two timer labels from the ack-driven timestamps.
-        Both show 0.00s until the corresponding ack lands."""
-        if self._current_row is None:
-            return
-        target = self._phase_target if self._phase_target is not None else 0.0
-        step_elapsed = (
-            0.0 if self._step_started_at is None
-            else time.monotonic() - self._step_started_at
-        )
-        phase_elapsed = (
-            0.0 if self._phase_started_at is None
-            else time.monotonic() - self._phase_started_at
-        )
-        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
-        self._status_phase_time_label.setText(
-            f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
-        )
-
-    # ------------------------------------------------------------------
-    # Protocol state slots
-    # ------------------------------------------------------------------
-
-    def _on_protocol_started(self):
-        self._set_running_button_state()
-        try:
-            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
-        except Exception:
-            self._step_total = 0
-        self._step_index = 0
-        self._status_step_label.setText(f"Step 0 / {self._step_total}")
-
-    def _on_step_repetition(self, rep_chain):
-        """Render the active rep context into the status bar."""
-        if not rep_chain:
-            self._status_reps_label.setText("")
-            return
-        parts = [f"rep {idx}/{total} of '{name}'"
-                 for name, idx, total in rep_chain]
-        self._status_reps_label.setText(" · ".join(parts))
-
-    def _on_step_started(self, row):
-        self._step_index += 1
-        self._current_row = row
-        self._step_started_at = None
-        self._phase_started_at = None
-        try:
-            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            self._phase_target = None
-        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
-        path_str = f" (path {path})" if path else ""
-        self._status_step_label.setText(
-            f"Step {self._step_index} / {self._step_total}"
-        )
-        self._status_row_label.setText(f"{row.name}{path_str}")
-        self._refresh_status()
-        if not self._tick_timer.isActive():
-            self._tick_timer.start()
-
-    def _on_phase_ack(self):
-        """Each ELECTRODES_STATE_APPLIED ack (re)starts the per-phase timer.
-        The first ack of a step also starts the per-step timer."""
-        if self._current_row is None:
-            return
-        now = time.monotonic()
-        if self._step_started_at is None:
-            self._step_started_at = now
-        self._phase_started_at = now
-
-    def _on_voltage_ack(self, voltage: int):
-        """Update the status-bar voltage label when a VOLTAGE_APPLIED ack lands."""
-        self._status_voltage_label.setText(f"Voltage: {voltage} V")
-
-    def _on_frequency_ack(self, frequency: int):
-        """Update the status-bar frequency label when a FREQUENCY_APPLIED ack lands."""
-        self._status_frequency_label.setText(f"Frequency: {frequency} Hz")
-
-    def _on_step_finished(self, _row):
-        self._refresh_status()
-
-    def _on_protocol_paused(self):
-        self._pause_action.setText("Resume")
-        self._tick_timer.stop()
-
-    def _on_protocol_resumed(self):
-        self._pause_action.setText("Pause")
-        if self._current_row is not None:
-            self._tick_timer.start()
-
-    def _on_protocol_terminated(self):
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        self._reset_status()
-
-    def _on_error(self, msg):
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        self._reset_status()
-        QMessageBox.critical(self, "Protocol error", msg)
-
-    def _clear_all_highlights(self):
-        """Restore an idle visual state at protocol end."""
-        from pyface.qt.QtCore import QModelIndex
-        self.widget.highlight_active_row(None)
-        self.device_view.set_active_row(None)
-        self.widget.tree.clearSelection()
-        self.widget.tree.setCurrentIndex(QModelIndex())
-        # Reset V/F readouts so the next run starts clean.
-        self._status_voltage_label.setText("Voltage: --")
-        self._status_frequency_label.setText("Frequency: --")
-
-    # ------------------------------------------------------------------
-    # Save / Load
-    # ------------------------------------------------------------------
-
-    def _save(self):
-        path, _ = QFileDialog.getSaveFileName(
-            self, "Save Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.manager.to_json(), f, indent=2)
-
-    def _load(self):
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Load Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        try:
-            self.manager.set_state_from_json(data, columns=_columns())
-        except Exception as e:
-            QMessageBox.critical(self, "Load error", str(e))
+    )
+    window.executor.qsignals.step_started.connect(device_view.set_active_row)
 
 
-# ---------------------------------------------------------------------------
-# Entry point
-# ---------------------------------------------------------------------------
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-4 Demo — Voltage + Frequency",
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+    post_build_setup=_post_build,
+)
+
 
 def main():
     logging.basicConfig(
@@ -642,17 +152,13 @@ def main():
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
     )
-    app = QApplication.instance() or QApplication(sys.argv)
-    w = DemoWindow()
-    w.show()
-    app.exec()
+    BasePluggableProtocolDemoWindow.run(config)
 
 
 if __name__ == "__main__":
     from microdrop_utils.broker_server_helpers import (
         redis_server_context, dramatiq_workers_context,
     )
-
     with redis_server_context():
         with dramatiq_workers_context():
             main()

--- a/examples/demos/run_full_integration_demo.py
+++ b/examples/demos/run_full_integration_demo.py
@@ -1,0 +1,188 @@
+"""Full-stack integration demo: PPT-3 electrodes/routes + PPT-4 voltage/
+frequency + PPT-5 magnet, all in one window. Verifies priority bucketing
+in practice (priority 20 V/F/magnet bucket completes before priority 30
+RoutesHandler publishes electrodes).
+
+Run: pixi run python -m examples.demos.run_full_integration_demo
+"""
+
+import json
+import logging
+
+import dramatiq
+from pyface.qt.QtCore import Qt
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.linear_repeats_column import (
+    make_linear_repeats_column,
+)
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.repeat_duration_column import (
+    make_repeat_duration_column,
+)
+from pluggable_protocol_tree.builtins.repetitions_column import make_repetitions_column
+from pluggable_protocol_tree.builtins.routes_column import make_routes_column
+from pluggable_protocol_tree.builtins.soft_end_column import make_soft_end_column
+from pluggable_protocol_tree.builtins.soft_start_column import make_soft_start_column
+from pluggable_protocol_tree.builtins.trail_length_column import make_trail_length_column
+from pluggable_protocol_tree.builtins.trail_overlay_column import (
+    make_trail_overlay_column,
+)
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.demos.simple_device_viewer import (
+    GRID_H, GRID_W, SimpleDeviceViewer,
+)
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
+
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder as subscribe_vf_responder,
+)
+from dropbot_protocol_controls.protocol_columns.frequency_column import (
+    make_frequency_column,
+)
+from dropbot_protocol_controls.protocol_columns.voltage_column import (
+    make_voltage_column,
+)
+
+from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_protocol_controls.demos.magnet_responder import (
+    subscribe_demo_responder as subscribe_magnet_responder,
+)
+from peripheral_protocol_controls.protocol_columns.magnet_column import (
+    make_magnet_column,
+)
+
+
+# Module-level overlay listener — captures the device viewer via a
+# global hook set by the post_build_setup callback. The actor name uses
+# the integration demo's own slot in _DEMO_PREFIXES (ppt12_demo_*) so the
+# stale-subscriber purger handles it correctly.
+_overlay_target = {"viewer": None}
+
+
+@dramatiq.actor(actor_name="ppt12_demo_integration_overlay_listener",
+                queue_name="default")
+def _overlay_listener(message: str, topic: str, timestamp: float = None):
+    viewer = _overlay_target["viewer"]
+    if viewer is None:
+        return
+    try:
+        payload = json.loads(message)
+    except (TypeError, ValueError):
+        return
+    electrodes = payload.get("electrodes", []) or []
+    viewer.actuation_changed.emit(list(electrodes))
+
+
+def _columns():
+    return [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        # PPT-4
+        make_voltage_column(), make_frequency_column(),
+        # PPT-5 (compound, expanded)
+        *_expand_compound(make_magnet_column()),
+    ]
+
+
+def _pre_populate(rm):
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
+    rm.add_step(values={
+        "name": "Step 1: 100V/10kHz, magnet=Default, route top row",
+        "duration_s": 0.3,
+        "voltage": 100, "frequency": 10000,
+        "magnet_on": True, "magnet_height_mm": 0.0,   # sentinel = Default
+        "routes": [["e00", "e01", "e02", "e03", "e04"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 2: 120V/5kHz, magnet=12mm, diagonal",
+        "duration_s": 0.3,
+        "voltage": 120, "frequency": 5000,
+        "magnet_on": True, "magnet_height_mm": 12.0,
+        "routes": [["e00", "e06", "e12", "e18", "e24"]],
+        "trail_length": 1,
+    })
+    rm.add_step(values={
+        "name": "Step 3: 75V/1kHz cooldown, retract magnet",
+        "duration_s": 0.3,
+        "voltage": 75, "frequency": 1000,
+        "magnet_on": False, "magnet_height_mm": 0.0,
+    })
+
+
+def _routing_setup(router):
+    """All three demo responders + the integration overlay listener."""
+    subscribe_vf_responder(router)
+    subscribe_magnet_responder(router)
+    router.message_router_data.add_subscriber_to_topic(
+        topic=ELECTRODES_STATE_CHANGE,
+        subscribing_actor_name="ppt12_demo_integration_overlay_listener",
+    )
+
+
+def _post_build(window):
+    """Wire the side-panel: device viewer follows the tree's current
+    selection AND the executor's currently-running step."""
+    central = window.centralWidget()
+    device_view = central.widget(1)
+    _overlay_target["viewer"] = device_view
+
+    sel_model = window.widget.tree.selectionModel()
+    sel_model.currentRowChanged.connect(
+        lambda cur, _prev: device_view.set_active_row(
+            cur.data(Qt.UserRole) if cur.isValid() else None
+        )
+    )
+    window.executor.qsignals.step_started.connect(device_view.set_active_row)
+
+
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Full Integration Demo — PPT-3 routes + PPT-4 V/F + PPT-5 magnet",
+    window_size=(1300, 700),
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    status_readouts=[
+        StatusReadout("Voltage",   VOLTAGE_APPLIED,   lambda m: f"{int(m)} V"),
+        StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
+        StatusReadout("Magnet",    MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+    side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
+    post_build_setup=_post_build,
+)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    BasePluggableProtocolDemoWindow.run(config)
+
+
+if __name__ == "__main__":
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()

--- a/examples/demos/run_full_integration_demo.py
+++ b/examples/demos/run_full_integration_demo.py
@@ -64,12 +64,12 @@ from peripheral_protocol_controls.protocol_columns.magnet_column import (
 
 # Module-level overlay listener — captures the device viewer via a
 # global hook set by the post_build_setup callback. The actor name uses
-# the integration demo's own slot in _DEMO_PREFIXES (ppt12_demo_*) so the
-# stale-subscriber purger handles it correctly.
+# the dedicated `integration_demo_*` slot in `_DEMO_PREFIXES` so the
+# stale-subscriber purger handles leftover entries correctly.
 _overlay_target = {"viewer": None}
 
 
-@dramatiq.actor(actor_name="ppt12_demo_integration_overlay_listener",
+@dramatiq.actor(actor_name="integration_demo_overlay_listener",
                 queue_name="default")
 def _overlay_listener(message: str, topic: str, timestamp: float = None):
     viewer = _overlay_target["viewer"]
@@ -132,15 +132,14 @@ def _routing_setup(router):
     subscribe_magnet_responder(router)
     router.message_router_data.add_subscriber_to_topic(
         topic=ELECTRODES_STATE_CHANGE,
-        subscribing_actor_name="ppt12_demo_integration_overlay_listener",
+        subscribing_actor_name="integration_demo_overlay_listener",
     )
 
 
 def _post_build(window):
     """Wire the side-panel: device viewer follows the tree's current
     selection AND the executor's currently-running step."""
-    central = window.centralWidget()
-    device_view = central.widget(1)
+    device_view = window._side_panel
     _overlay_target["viewer"] = device_view
 
     sel_model = window.widget.tree.selectionModel()

--- a/examples/demos/run_full_integration_demo.py
+++ b/examples/demos/run_full_integration_demo.py
@@ -53,7 +53,10 @@ from dropbot_protocol_controls.protocol_columns.voltage_column import (
     make_voltage_column,
 )
 
-from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_controller.consts import MAGNET_APPLIED, PROTOCOL_SET_MAGNET
+from peripheral_protocol_controls.demos.run_widget_magnet_demo import (
+    _fmt_magnet_height,
+)
 from peripheral_protocol_controls.demos.magnet_responder import (
     subscribe_demo_responder as subscribe_magnet_responder,
 )
@@ -163,6 +166,7 @@ config = DemoConfig(
         StatusReadout("Frequency", FREQUENCY_APPLIED, lambda m: f"{int(m)} Hz"),
         StatusReadout("Magnet",    MAGNET_APPLIED,
                       lambda m: "engaged" if m == "1" else "retracted"),
+        StatusReadout("Magnet Height", PROTOCOL_SET_MAGNET, _fmt_magnet_height),
     ],
     side_panel_factory=lambda rm: SimpleDeviceViewer(rm),
     post_build_setup=_post_build,

--- a/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
+++ b/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
@@ -15,7 +15,10 @@ from pluggable_protocol_tree.demos.base_demo_window import (
 )
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 
-from peripheral_controller.consts import MAGNET_APPLIED, PROTOCOL_SET_MAGNET
+from peripheral_controller.consts import (
+    MAGNET_APPLIED, MIN_ZSTAGE_HEIGHT_MM, PROTOCOL_SET_MAGNET,
+)
+from peripheral_controller.preferences import PeripheralPreferences
 from peripheral_protocol_controls.demos.magnet_responder import (
     subscribe_demo_responder,
 )
@@ -25,19 +28,26 @@ from peripheral_protocol_controls.protocol_columns.magnet_column import (
 
 
 def _fmt_magnet_height(message: str) -> str:
-    """Parse the PROTOCOL_SET_MAGNET request payload and render the
-    requested height. The MAGNET_APPLIED ack itself is just '0'/'1'
-    (production wire format), so we read the height from the request
-    topic — under the demo responder the two arrive within ~50 ms."""
+    """Render the actual physical zstage height the production
+    zstage_state_setter_service would move to for this request:
+      - retract  → PeripheralPreferences().down_height_mm
+      - engage at sentinel (height < MIN_ZSTAGE_HEIGHT_MM)
+                 → PeripheralPreferences().up_height_mm  (live pref)
+      - engage at explicit height → that height
+
+    Reads height from the PROTOCOL_SET_MAGNET request payload — the
+    MAGNET_APPLIED ack itself is just '0'/'1' on the wire (production
+    wire format pinned by test_protocol_set_magnet)."""
     try:
         payload = json.loads(message)
     except (TypeError, ValueError):
         return "—"
+    prefs = PeripheralPreferences()
     if not payload.get("on"):
-        return "—"
+        return f"{prefs.down_height_mm:.1f} mm"
     height = payload.get("height_mm", 0.0)
-    if height == 0.0:
-        return "Default"   # sentinel meaning "use live pref"
+    if height < MIN_ZSTAGE_HEIGHT_MM:
+        return f"{prefs.up_height_mm:.1f} mm"
     return f"{height:.1f} mm"
 
 

--- a/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
+++ b/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
@@ -1,85 +1,26 @@
-"""Runnable headed demo for the magnet compound column.
-
-Builds a protocol with the existing PPT-3 builtins + the magnet
-compound column. Auto-populates 3 sample steps so the user can
-immediately verify:
-
-  1. Two columns render ('Magnet' checkbox + 'Magnet Height (mm)'
-     spinner) for the one compound contribution
-  2. The Height cell is read-only when Magnet is unchecked (greyed
-     out spinner)
-  3. The Height spinner displays 'Default' at the sentinel value;
-     spinning up shows numeric values
-  4. Toggling Magnet flips the Height cell's editability
-  5. Run the protocol -- the in-process magnet responder echoes the
-     setpoints + the status bar updates with the latest MAGNET_APPLIED
-     payload
+"""PPT-5 demo — protocol tree with the magnet compound column.
 
 Run: pixi run python -m peripheral_protocol_controls.demos.run_widget_magnet_demo
 """
 
-import json
 import logging
-import sys
-import threading
-import time
-from pathlib import Path
 
-import dramatiq
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig, StatusReadout,
+)
+from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 
-# Centralised middleware strip — see microdrop_utils.broker_server_helpers.
-from microdrop_utils.broker_server_helpers import (
-    remove_middleware_from_dramatiq_broker,
-)
-remove_middleware_from_dramatiq_broker(
-    middleware_name="dramatiq.middleware.prometheus",
-    broker=dramatiq.get_broker(),
-)
-
-from pyface.qt.QtCore import Qt, Signal
-from pyface.qt.QtWidgets import (
-    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar,
-)
-
-from peripheral_controller.consts import (
-    PROTOCOL_SET_MAGNET, MAGNET_APPLIED,
-)
+from peripheral_controller.consts import MAGNET_APPLIED
 from peripheral_protocol_controls.demos.magnet_responder import (
     subscribe_demo_responder,
 )
 from peripheral_protocol_controls.protocol_columns.magnet_column import (
     make_magnet_column,
 )
-from pluggable_protocol_tree.builtins.duration_column import (
-    make_duration_column,
-)
-from pluggable_protocol_tree.builtins.id_column import make_id_column
-from pluggable_protocol_tree.builtins.name_column import make_name_column
-from pluggable_protocol_tree.builtins.type_column import make_type_column
-from pluggable_protocol_tree.execution.events import PauseEvent
-from pluggable_protocol_tree.execution.executor import ProtocolExecutor
-from pluggable_protocol_tree.execution.signals import ExecutorSignals
-from pluggable_protocol_tree.models._compound_adapters import _expand_compound
-from pluggable_protocol_tree.models.row_manager import RowManager
-from pluggable_protocol_tree.session import ProtocolSession
-from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
-
-
-logger = logging.getLogger(__name__)
-
-
-# Module-level Qt-signal target for the magnet-applied listener. The
-# Dramatiq actor runs on a worker thread; it emits a Qt signal so
-# auto-connection delivers the slot on the GUI thread.
-_magnet_target = {"window": None}
-
-
-@dramatiq.actor(actor_name="ppt5_demo_magnet_applied_listener", queue_name="default")
-def _magnet_applied_listener(message: str, topic: str, timestamp: float = None):
-    window = _magnet_target.get("window")
-    if window is None:
-        return
-    window.magnet_acked.emit(message)
 
 
 def _columns():
@@ -90,106 +31,35 @@ def _columns():
     ]
 
 
-class DemoWindow(QMainWindow):
-    magnet_acked = Signal(str)
+def _pre_populate(rm):
+    rm.add_step(values={
+        "name": "Step 1: engage at Default (sentinel; uses live pref)",
+        "duration_s": 0.2,
+        "magnet_on": True, "magnet_height_mm": 0.0,
+    })
+    rm.add_step(values={
+        "name": "Step 2: engage at 12.0 mm explicit",
+        "duration_s": 0.2,
+        "magnet_on": True, "magnet_height_mm": 12.0,
+    })
+    rm.add_step(values={
+        "name": "Step 3: retract",
+        "duration_s": 0.2,
+        "magnet_on": False, "magnet_height_mm": 0.0,
+    })
 
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle("PPT-5 Demo — Magnet Compound Column")
-        self.resize(900, 500)
 
-        self.manager = RowManager(columns=_columns())
-        # Pre-populate the 3 magnet states.
-        self.manager.add_step(values={
-            "name": "Step 1: engage at Default (sentinel; uses live pref)",
-            "duration_s": 0.2,
-            "magnet_on": True,
-            # default value at row creation is the sentinel; explicit
-            # for clarity in the demo:
-            "magnet_height_mm": 0.0,
-        })
-        self.manager.add_step(values={
-            "name": "Step 2: engage at 12.0 mm explicit",
-            "duration_s": 0.2,
-            "magnet_on": True,
-            "magnet_height_mm": 12.0,
-        })
-        self.manager.add_step(values={
-            "name": "Step 3: retract",
-            "duration_s": 0.2,
-            "magnet_on": False,
-            "magnet_height_mm": 0.0,
-        })
-
-        self.widget = ProtocolTreeWidget(self.manager, parent=self)
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(self.widget)
-        self.setCentralWidget(splitter)
-
-        # Status bar with latest magnet state.
-        sb = QStatusBar()
-        self.setStatusBar(sb)
-        self._magnet_status = QLabel("Magnet: --")
-        sb.addPermanentWidget(self._magnet_status)
-
-        _magnet_target["window"] = self
-        self.magnet_acked.connect(self._on_magnet_acked)
-
-        self.executor = ProtocolExecutor(
-            row_manager=self.manager,
-            qsignals=ExecutorSignals(),
-            pause_event=PauseEvent(),
-            stop_event=threading.Event(),
-        )
-
-        self._dramatiq_worker = None
-        self._setup_dramatiq_routing()
-
-        tb = QToolBar("Demo")
-        self.addToolBar(tb)
-        self._run_action = tb.addAction("Run", self.executor.start)
-        self._stop_action = tb.addAction("Stop", self.executor.stop)
-
-    def _setup_dramatiq_routing(self):
-        try:
-            from microdrop_utils.dramatiq_pub_sub_helpers import (
-                MessageRouterActor,
-            )
-            from dramatiq import Worker
-
-            broker = dramatiq.get_broker()
-            broker.flush_all()
-
-            router = MessageRouterActor()
-
-            # Demo magnet responder + executor listener for MAGNET_APPLIED
-            subscribe_demo_responder(router)
-
-            # Listener for status-bar updates
-            router.message_router_data.add_subscriber_to_topic(
-                topic=MAGNET_APPLIED,
-                subscribing_actor_name="ppt5_demo_magnet_applied_listener",
-            )
-
-            self._router = router
-
-            self._dramatiq_worker = Worker(broker, worker_timeout=100)
-            self._dramatiq_worker.start()
-
-        except Exception as e:
-            logger.warning("Demo Dramatiq routing setup failed (Redis not running?): %s", e)
-
-    def _on_magnet_acked(self, payload: str):
-        state = "engaged" if payload == "1" else "retracted"
-        self._magnet_status.setText(f"Magnet: {state}")
-
-    def closeEvent(self, event):
-        if self._dramatiq_worker is not None:
-            try:
-                self._dramatiq_worker.stop()
-            except Exception:
-                logger.exception("Error stopping demo dramatiq worker")
-        super().closeEvent(event)
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-5 Demo — Magnet",
+    pre_populate=_pre_populate,
+    routing_setup=lambda router: subscribe_demo_responder(router),
+    phase_ack_topic=MAGNET_APPLIED,
+    status_readouts=[
+        StatusReadout("Magnet", MAGNET_APPLIED,
+                      lambda m: "engaged" if m == "1" else "retracted"),
+    ],
+)
 
 
 def main():
@@ -198,10 +68,7 @@ def main():
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
     )
-    app = QApplication.instance() or QApplication(sys.argv)
-    w = DemoWindow()
-    w.show()
-    app.exec()
+    BasePluggableProtocolDemoWindow.run(config)
 
 
 if __name__ == "__main__":

--- a/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
+++ b/peripheral_protocol_controls/demos/run_widget_magnet_demo.py
@@ -3,6 +3,7 @@
 Run: pixi run python -m peripheral_protocol_controls.demos.run_widget_magnet_demo
 """
 
+import json
 import logging
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
@@ -14,13 +15,30 @@ from pluggable_protocol_tree.demos.base_demo_window import (
 )
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 
-from peripheral_controller.consts import MAGNET_APPLIED
+from peripheral_controller.consts import MAGNET_APPLIED, PROTOCOL_SET_MAGNET
 from peripheral_protocol_controls.demos.magnet_responder import (
     subscribe_demo_responder,
 )
 from peripheral_protocol_controls.protocol_columns.magnet_column import (
     make_magnet_column,
 )
+
+
+def _fmt_magnet_height(message: str) -> str:
+    """Parse the PROTOCOL_SET_MAGNET request payload and render the
+    requested height. The MAGNET_APPLIED ack itself is just '0'/'1'
+    (production wire format), so we read the height from the request
+    topic — under the demo responder the two arrive within ~50 ms."""
+    try:
+        payload = json.loads(message)
+    except (TypeError, ValueError):
+        return "—"
+    if not payload.get("on"):
+        return "—"
+    height = payload.get("height_mm", 0.0)
+    if height == 0.0:
+        return "Default"   # sentinel meaning "use live pref"
+    return f"{height:.1f} mm"
 
 
 def _columns():
@@ -58,6 +76,7 @@ config = DemoConfig(
     status_readouts=[
         StatusReadout("Magnet", MAGNET_APPLIED,
                       lambda m: "engaged" if m == "1" else "retracted"),
+        StatusReadout("Magnet Height", PROTOCOL_SET_MAGNET, _fmt_magnet_height),
     ],
 )
 

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -456,8 +456,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         )
         if not path:
             return
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.manager.to_json(), f, indent=2)
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(self.manager.to_json(), f, indent=2)
+        except Exception as e:
+            QMessageBox.critical(self, "Save error", str(e))
 
     def _load(self):
         path, _ = QFileDialog.getOpenFileName(

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -14,6 +14,7 @@ See PPT-12 spec for design rationale (composition vs inheritance).
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -168,7 +169,8 @@ import time
 
 from pyface.qt.QtCore import Qt, QTimer, Signal
 from pyface.qt.QtWidgets import (
-    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar,
+    QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox,
+    QSplitter, QStatusBar, QToolBar,
 )
 
 from pluggable_protocol_tree.execution.events import PauseEvent
@@ -440,11 +442,37 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         tb.addAction("Add Step", lambda: self.manager.add_step())
         tb.addAction("Add Group", lambda: self.manager.add_group())
         tb.addSeparator()
-        # Save/Load added in Task 8.
+        tb.addAction("Save…", self._save)
+        tb.addAction("Load…", self._load)
+        tb.addSeparator()
         self._run_action = tb.addAction("Run", self.executor.start)
         self._pause_action = tb.addAction("Pause", self._toggle_pause)
         self._stop_action = tb.addAction("Stop", self.executor.stop)
         self._toolbar = tb
+
+    def _save(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(self.manager.to_json(), f, indent=2)
+
+    def _load(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        try:
+            self.manager.set_state_from_json(
+                data, columns=self.config.columns_factory(),
+            )
+        except Exception as e:
+            QMessageBox.critical(self, "Load error", str(e))
 
     def _wire_button_state_machine(self):
         self.executor.qsignals.protocol_started.connect(self._set_running_button_state)

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -108,6 +108,19 @@ def _slug(label: str) -> str:
     return _SLUG_RE.sub("_", label.lower()).strip("_")
 
 
+class _PerSlugEmitter:
+    """Tiny shim that exposes .emit(message) and forwards to the
+    window's per-instance readout_acked signal with a fixed slug."""
+    __slots__ = ("_signal", "_slug")
+
+    def __init__(self, signal, slug):
+        self._signal = signal
+        self._slug = slug
+
+    def emit(self, message):
+        self._signal.emit(self._slug, message)
+
+
 # Module-level target for the phase-ack listener actor. The actor runs
 # on a Dramatiq worker thread; it emits a Qt signal that auto-connection
 # delivers on the GUI thread.
@@ -120,6 +133,33 @@ def _phase_ack_listener(message: str, topic: str, timestamp: float = None):
     if window is None:
         return
     window.phase_acked.emit()
+
+
+# Module-level target for status-readout listeners. Each actor reads
+# its own message and forwards (slug, message) to the bound window.
+_readout_target = {"window": None}
+
+
+def _make_readout_actor(slug: str):
+    """Register a Dramatiq actor named ppt12_demo_<slug>_listener that
+    emits the window's readout_acked signal on every message received.
+    Idempotent — safe to call repeatedly with the same slug."""
+    actor_name = f"ppt12_demo_{slug}_listener"
+    broker = dramatiq.get_broker()
+    try:
+        broker.get_actor(actor_name)
+        return actor_name   # already registered
+    except Exception:
+        pass
+
+    @dramatiq.actor(actor_name=actor_name, queue_name="default")
+    def _listener(message: str, topic: str, timestamp: float = None):
+        window = _readout_target.get("window")
+        if window is None:
+            return
+        window.readout_acked.emit(slug, message)
+
+    return actor_name
 
 
 import threading
@@ -148,6 +188,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     # listener (registered when phase_ack_topic is set); auto-connection
     # delivers _on_phase_ack on the GUI thread.
     phase_acked = Signal()
+
+    # Cross-thread signal for status-readout updates: (slug, message)
+    readout_acked = Signal(str, str)
 
     def __init__(self, config: DemoConfig):
         super().__init__()
@@ -190,7 +233,30 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
         self._status_phase_time_label = None
 
+        # Per-readout state — populated below in _build_status_bar.
+        self._readout_labels: dict[str, "QLabel"] = {}
+        self._readout_signals: dict[str, _PerSlugEmitter] = {}
+
         self._build_status_bar()
+
+        # Wire readout updates: one signal-emit handler per slug → label update.
+        self._readout_fmts = {
+            _slug(r.label): (r.label, r.fmt) for r in self.config.status_readouts
+        }
+        # Per-slug Signal accessors that just emit on the shared readout_acked.
+        # Tests can do w._readout_signals[slug].emit(msg).
+        self._readout_signals = {
+            slug: _PerSlugEmitter(self.readout_acked, slug)
+            for slug in self._readout_fmts
+        }
+        self.readout_acked.connect(self._on_readout_ack)
+
+        # Register Dramatiq actors for each readout unconditionally — actor
+        # registration is in-memory and broker-agnostic (no Redis required).
+        _readout_target["window"] = self
+        for readout in self.config.status_readouts:
+            _make_readout_actor(_slug(readout.label))
+
         self._wire_executor_signals()
 
     def _setup_dramatiq_routing_internal(self):
@@ -228,6 +294,16 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                     subscribing_actor_name="ppt12_demo_phase_ack_listener",
                 )
 
+            # StatusReadout listeners — auto-named actor per readout.
+            _readout_target["window"] = self
+            for readout in self.config.status_readouts:
+                slug = _slug(readout.label)
+                actor_name = _make_readout_actor(slug)
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=readout.topic,
+                    subscribing_actor_name=actor_name,
+                )
+
             self._router = router
             self._dramatiq_worker = Worker(broker, worker_timeout=100)
             self._dramatiq_worker.start()
@@ -252,6 +328,12 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if self.config.phase_ack_topic is not None:
             self._status_phase_time_label = QLabel("")
             sb.addPermanentWidget(self._status_phase_time_label)
+        # StatusReadout labels.
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = QLabel(f"{readout.label}: {readout.initial}")
+            sb.addPermanentWidget(label)
+            self._readout_labels[slug] = label
 
     def _wire_executor_signals(self):
         # Active-row highlight on each step start.
@@ -301,6 +383,20 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if self._step_started_at is None:
             self._step_started_at = now
         self._phase_started_at = now
+
+    def _on_readout_ack(self, slug: str, message: str):
+        spec = self._readout_fmts.get(slug)
+        if spec is None:
+            return
+        label_prefix, fmt = spec
+        label_widget = self._readout_labels.get(slug)
+        if label_widget is None:
+            return
+        try:
+            text = fmt(message)
+        except Exception as e:
+            text = f"<error: {e}>"
+        label_widget.setText(f"{label_prefix}: {text}")
 
     def _refresh_status(self):
         if self._step_started_at is None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -110,6 +110,18 @@ def _slug(label: str) -> str:
     return _SLUG_RE.sub("_", label.lower()).strip("_")
 
 
+_DEMO_PREFIXES = (
+    "ppt_demo_", "ppt4_demo_", "ppt5_demo_", "ppt11_demo_",
+    "ppt12_demo_", "ppt_vf_demo_",
+)
+
+
+def _is_purgable_demo_actor_name(name: str) -> bool:
+    """True if an actor name matches a known demo-prefix convention.
+    Used by the stale-subscriber purger to leave real listeners alone."""
+    return name.startswith(_DEMO_PREFIXES)
+
+
 class _PerSlugEmitter:
     """Tiny shim that exposes .emit(message) and forwards to the
     window's per-instance readout_acked signal with a fixed slug."""
@@ -308,6 +320,48 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             broker = dramatiq.get_broker()
             broker.flush_all()
             router = MessageRouterActor()
+
+            # Purge stale demo subscribers — actor names recorded in
+            # Redis by prior demo processes whose actors aren't
+            # registered in this process. Without this, a previous
+            # demo's spy/listener leaves behind a subscription that
+            # fires ActorNotFound on every publish to its topic.
+            #
+            # Only touch demo-prefixed names — leave real listeners
+            # belonging to other processes alone.
+            broker_topics_to_check = (
+                ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED,
+            )
+            extra_topics = []
+            if self.config.phase_ack_topic is not None:
+                extra_topics.append(self.config.phase_ack_topic)
+            for r in self.config.status_readouts:
+                extra_topics.append(r.topic)
+            for topic in (*broker_topics_to_check, *extra_topics):
+                try:
+                    subs = router.message_router_data.get_subscribers_for_topic(topic)
+                except Exception:
+                    continue
+                for entry in subs:
+                    actor_name = entry[0] if isinstance(entry, tuple) else entry
+                    if not _is_purgable_demo_actor_name(actor_name):
+                        continue
+                    try:
+                        broker.get_actor(actor_name)
+                    except Exception:
+                        try:
+                            router.message_router_data.remove_subscriber_from_topic(
+                                topic=topic,
+                                subscribing_actor_name=actor_name,
+                            )
+                            logger.info("purged stale demo subscriber %s on %s",
+                                        actor_name, topic)
+                        except Exception:
+                            logger.warning(
+                                "failed to purge %s on %s (likely wrong "
+                                "listener_queue from another router)",
+                                actor_name, topic,
+                            )
 
             # Standard PPT-3 electrode chain.
             router.message_router_data.add_subscriber_to_topic(
@@ -531,8 +585,46 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self._tick_timer.start()
 
     def _on_protocol_terminated(self):
+        self._clear_all_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
+
+    def _clear_all_highlights(self):
+        """Restore an idle visual state at protocol end."""
+        from pyface.qt.QtCore import QModelIndex
+
+        self.widget.highlight_active_row(None)
+        self.widget.tree.clearSelection()
+        self.widget.tree.setCurrentIndex(QModelIndex())
+
+        # Reset step / row / timer state.
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._phase_started_at = None
+        self._phase_target = None
+        self._current_row = None
+        self._status_step_label.setText("Idle")
+        self._status_row_label.setText("")
+        self._status_step_time_label.setText("")
+        if self._status_phase_time_label is not None:
+            self._status_phase_time_label.setText("")
+
+        # Reset readout labels to initial text.
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = self._readout_labels.get(slug)
+            if label is not None:
+                label.setText(f"{readout.label}: {readout.initial}")
+
+    @classmethod
+    def run(cls, config: DemoConfig) -> int:
+        """One-shot main(): build the window, show it, run app.exec().
+        Reuses an existing QApplication if one is already running."""
+        app = QApplication.instance() or QApplication([])
+        w = cls(config)
+        w.show()
+        return app.exec()
 
     def closeEvent(self, event):
         if self._dramatiq_worker is not None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -1,0 +1,86 @@
+"""Composition-based base window for pluggable protocol tree demos.
+
+Demos build a DemoConfig (declarative dataclass) and call
+BasePluggableProtocolDemoWindow.run(config). The base owns the standard
+UX scaffolding: protocol tree widget, executor, active-row highlight,
+status bar, button state machine, Dramatiq routing, Save/Load.
+
+Each demo declares only its specific bits: columns, sample steps,
+demo-specific responder subscriptions, ack-driven status readouts,
+and an optional side panel.
+
+See PPT-12 spec for design rationale (composition vs inheritance).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+
+
+@dataclass
+class StatusReadout:
+    """One ack-driven readout label in the status bar.
+
+    The base creates one Dramatiq actor per StatusReadout (auto-named
+    ppt12_demo_<label_slug>_listener) that subscribes to ``topic``,
+    emits a Qt signal, and updates a QLabel in the status bar with
+    ``f"{label}: {fmt(message)}"``. Until the first ack, the label
+    shows ``f"{label}: {initial}"``.
+    """
+    label: str
+    topic: str
+    fmt: Callable[[str], str]
+    initial: str = "--"
+
+
+@dataclass
+class DemoConfig:
+    """Declarative demo configuration. Only ``columns_factory`` is required;
+    all other fields have sensible defaults."""
+
+    # Required.
+    columns_factory: Callable[[], list]
+
+    # Cosmetic.
+    title: str = "Pluggable Protocol Tree Demo"
+    window_size: tuple[int, int] = (1100, 650)
+
+    # Optional sample steps populated after RowManager construction.
+    pre_populate: Callable[[Any], None] = field(
+        default_factory=lambda: (lambda rm: None)
+    )
+
+    # Subscribe demo responders / additional listeners on the router.
+    # Called AFTER the base wires the standard PPT-3 electrode chain
+    # + the phase-ack listener (if phase_ack_topic is set) +
+    # the StatusReadout listeners.
+    routing_setup: Callable[[Any], None] = field(
+        default_factory=lambda: (lambda router: None)
+    )
+
+    # Single ack topic that drives the per-phase timer.
+    # If None: only step-elapsed timer shown, no per-phase timer.
+    phase_ack_topic: str | None = ELECTRODES_STATE_APPLIED
+
+    # Right-side status bar readouts.
+    status_readouts: list[StatusReadout] = field(default_factory=list)
+
+    # Side panel (e.g. SimpleDeviceViewer for PPT-3 / integration demo).
+    # Returns a QWidget or None. Called once during window setup.
+    side_panel_factory: Callable[[Any], Any] | None = None
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(label: str) -> str:
+    """Slugify a status-readout label for use as a Dramatiq actor name suffix.
+
+    'Voltage' -> 'voltage'
+    'Magnet Height (mm)' -> 'magnet_height_mm'
+    """
+    return _SLUG_RE.sub("_", label.lower()).strip("_")

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -266,7 +266,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         )
 
         self._router = None
-        self._dramatiq_worker = None
 
         # Per-step / per-phase timing state. Mutated from GUI thread only.
         self._step_index = 0
@@ -340,7 +339,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             from microdrop_utils.dramatiq_pub_sub_helpers import (
                 MessageRouterActor,
             )
-            from dramatiq import Worker
 
             broker = dramatiq.get_broker()
             broker.flush_all()
@@ -426,8 +424,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 )
 
             self._router = router
-            self._dramatiq_worker = Worker(broker, worker_timeout=100)
-            self._dramatiq_worker.start()
         except ValueError as e:
             if "already registered" not in str(e):
                 logger.warning("Demo Dramatiq routing setup failed: %s", e)
@@ -680,11 +676,3 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         w = cls(config)
         w.show()
         return app.exec()
-
-    def closeEvent(self, event):
-        if self._dramatiq_worker is not None:
-            try:
-                self._dramatiq_worker.stop()
-            except Exception:
-                logger.exception("Error stopping demo dramatiq worker")
-        super().closeEvent(event)

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -97,6 +97,15 @@ class DemoConfig:
     # Returns a QWidget or None. Called once during window setup.
     side_panel_factory: Callable[[Any], Any] | None = None
 
+    # Demo-specific wiring that needs the constructed window (e.g. wiring
+    # a side-panel widget's set_active_row to the executor's step_started,
+    # or installing a dramatiq actor that captures a window attribute).
+    # Called as the FINAL step of __init__ — all base scaffolding (executor,
+    # status bar, toolbar, routing) is already in place.
+    post_build_setup: Callable[[Any], None] = field(
+        default_factory=lambda: (lambda window: None)
+    )
+
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
@@ -186,9 +195,11 @@ import time
 
 from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox,
+    QApplication, QFileDialog, QLabel, QMainWindow,
     QSplitter, QStatusBar, QToolBar,
 )
+
+from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
 
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
@@ -308,6 +319,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._wire_button_state_machine()
         self._set_idle_button_state()
 
+        # Final: demo-specific wiring that needs the constructed window.
+        config.post_build_setup(self)
+
     def _setup_dramatiq_routing_internal(self):
         """Wires the standard PPT-3 electrode actuation chain
         (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED).
@@ -422,9 +436,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.setStatusBar(sb)
         self._status_step_label = QLabel("Idle")
         self._status_row_label = QLabel("")
+        self._status_reps_label = QLabel("")
         self._status_step_time_label = QLabel("")
         sb.addWidget(self._status_step_label)
         sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_reps_label)
         sb.addPermanentWidget(self._status_step_time_label)
         if self.config.phase_ack_topic is not None:
             self._status_phase_time_label = QLabel("")
@@ -443,7 +459,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         )
         # Status bar updates.
         self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.step_finished.connect(self._on_step_finished)
+        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
         self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        self.executor.qsignals.protocol_error.connect(self._on_error)
         if self.config.phase_ack_topic is not None:
             self.phase_acked.connect(self._on_phase_ack)
 
@@ -499,6 +518,29 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             text = f"<error: {e}>"
         label_widget.setText(f"{label_prefix}: {text}")
 
+    def _on_step_repetition(self, rep_chain):
+        """Render the active rep context (e.g. "rep 2/3 of 'Wash'") into
+        the status bar. Empty chain (no repeating ancestor) clears."""
+        if not rep_chain:
+            self._status_reps_label.setText("")
+            return
+        parts = [
+            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+        ]
+        self._status_reps_label.setText(" · ".join(parts))
+
+    def _on_step_finished(self, _row):
+        # Freeze the elapsed-time labels at the step's actual elapsed.
+        # They stay visible until the next step_started resets to 0.00s.
+        self._refresh_status()
+
+    def _on_error(self, msg):
+        """protocol_error → reset to idle and show a styled error dialog."""
+        self._clear_all_highlights()
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+        error_dialog(parent=self, title="Protocol error", message=str(msg))
+
     def _refresh_status(self):
         if self._step_started_at is None:
             return
@@ -538,7 +580,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(self.manager.to_json(), f, indent=2)
         except Exception as e:
-            QMessageBox.critical(self, "Save error", str(e))
+            error_dialog(parent=self, title="Save error", message=str(e))
 
     def _load(self):
         path, _ = QFileDialog.getOpenFileName(
@@ -553,7 +595,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 data, columns=self.config.columns_factory(),
             )
         except Exception as e:
-            QMessageBox.critical(self, "Load error", str(e))
+            error_dialog(parent=self, title="Load error", message=str(e))
 
     def _wire_button_state_machine(self):
         self.executor.qsignals.protocol_started.connect(self._set_running_button_state)
@@ -612,6 +654,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._current_row = None
         self._status_step_label.setText("Idle")
         self._status_row_label.setText("")
+        self._status_reps_label.setText("")
         self._status_step_time_label.setText("")
         if self._status_phase_time_label is not None:
             self._status_phase_time_label.setText("")

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -444,6 +444,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._run_action = tb.addAction("Run", self.executor.start)
         self._pause_action = tb.addAction("Pause", self._toggle_pause)
         self._stop_action = tb.addAction("Stop", self.executor.stop)
+        self._toolbar = tb
 
     def _wire_button_state_machine(self):
         self.executor.qsignals.protocol_started.connect(self._set_running_button_state)

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -168,7 +168,7 @@ import time
 
 from pyface.qt.QtCore import Qt, QTimer, Signal
 from pyface.qt.QtWidgets import (
-    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar,
+    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar,
 )
 
 from pluggable_protocol_tree.execution.events import PauseEvent
@@ -269,6 +269,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             config.routing_setup(self._router)
 
         self._wire_executor_signals()
+        self._build_toolbar()
+        self._wire_button_state_machine()
+        self._set_idle_button_state()
 
     def _setup_dramatiq_routing_internal(self):
         """Wires the standard PPT-3 electrode actuation chain
@@ -430,6 +433,58 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self._status_phase_time_label.setText(
                 f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
             )
+
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.manager.add_step())
+        tb.addAction("Add Group", lambda: self.manager.add_group())
+        tb.addSeparator()
+        # Save/Load added in Task 8.
+        self._run_action = tb.addAction("Run", self.executor.start)
+        self._pause_action = tb.addAction("Pause", self._toggle_pause)
+        self._stop_action = tb.addAction("Stop", self.executor.stop)
+
+    def _wire_button_state_machine(self):
+        self.executor.qsignals.protocol_started.connect(self._set_running_button_state)
+        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
+        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
+        for sig in (
+            self.executor.qsignals.protocol_finished,
+            self.executor.qsignals.protocol_aborted,
+        ):
+            sig.connect(self._on_protocol_terminated)
+
+    def _set_idle_button_state(self):
+        self._run_action.setEnabled(True)
+        self._pause_action.setEnabled(False)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(False)
+
+    def _set_running_button_state(self):
+        self._run_action.setEnabled(False)
+        self._pause_action.setEnabled(True)
+        self._pause_action.setText("Pause")
+        self._stop_action.setEnabled(True)
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+        else:
+            self.executor.pause()
+
+    def _on_protocol_paused(self):
+        self._pause_action.setText("Resume")
+        self._tick_timer.stop()
+
+    def _on_protocol_resumed(self):
+        self._pause_action.setText("Pause")
+        if self._current_row is not None:
+            self._tick_timer.start()
+
+    def _on_protocol_terminated(self):
+        self._set_idle_button_state()
+        self._tick_timer.stop()
 
     def closeEvent(self, event):
         if self._dramatiq_worker is not None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -14,7 +14,6 @@ See PPT-12 spec for design rationale (composition vs inheritance).
 
 from __future__ import annotations
 
-import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -32,7 +31,9 @@ from pluggable_protocol_tree.demos.electrode_responder import (
 )
 
 
-logger = logging.getLogger(__name__)
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
 
 
 # Strip Prometheus middleware once at module import time — every
@@ -149,7 +150,7 @@ def _make_readout_actor(slug: str):
     try:
         broker.get_actor(actor_name)
         return actor_name   # already registered
-    except Exception:
+    except dramatiq.errors.ActorNotFound:
         pass
 
     @dramatiq.actor(actor_name=actor_name, queue_name="default")
@@ -214,11 +215,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
         self._router = None
         self._dramatiq_worker = None
-        self._setup_dramatiq_routing_internal()
-        if self._router is not None:
-            # Demo-specific responders / listeners — called AFTER the
-            # standard chain so the demo can rely on it being in place.
-            config.routing_setup(self._router)
 
         # Per-step / per-phase timing state. Mutated from GUI thread only.
         self._step_index = 0
@@ -233,9 +229,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
         self._status_phase_time_label = None
 
-        # Per-readout state — populated below in _build_status_bar.
-        self._readout_labels: dict[str, "QLabel"] = {}
-        self._readout_signals: dict[str, _PerSlugEmitter] = {}
+        # Per-readout state — _readout_labels is populated by _build_status_bar;
+        # _readout_signals is populated afterwards from _readout_fmts.
+        self._readout_labels: dict[str, QLabel] = {}
 
         self._build_status_bar()
 
@@ -245,17 +241,32 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         }
         # Per-slug Signal accessors that just emit on the shared readout_acked.
         # Tests can do w._readout_signals[slug].emit(msg).
-        self._readout_signals = {
+        self._readout_signals: dict[str, _PerSlugEmitter] = {
             slug: _PerSlugEmitter(self.readout_acked, slug)
             for slug in self._readout_fmts
         }
         self.readout_acked.connect(self._on_readout_ack)
 
-        # Register Dramatiq actors for each readout unconditionally — actor
-        # registration is in-memory and broker-agnostic (no Redis required).
+        # Bind the module-level target so readout actor callbacks reach this window.
+        # Warn if a previous live window will be displaced (multi-window collision).
+        existing = _readout_target.get("window")
+        if existing is not None and existing is not self:
+            logger.warning(
+                "Multiple live BasePluggableProtocolDemoWindow instances detected. "
+                "Only the most recent window will receive readout messages."
+            )
         _readout_target["window"] = self
+
+        # Actor registration is broker-agnostic; topic subscription happens in
+        # _setup_dramatiq_routing_internal.
         for readout in self.config.status_readouts:
             _make_readout_actor(_slug(readout.label))
+
+        self._setup_dramatiq_routing_internal()
+        if self._router is not None:
+            # Demo-specific responders / listeners — called AFTER the
+            # standard chain so the demo can rely on it being in place.
+            config.routing_setup(self._router)
 
         self._wire_executor_signals()
 
@@ -288,17 +299,24 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             )
 
             if self.config.phase_ack_topic is not None:
+                existing_phase = _phase_ack_target.get("window")
+                if existing_phase is not None and existing_phase is not self:
+                    logger.warning(
+                        "Multiple live BasePluggableProtocolDemoWindow instances "
+                        "detected. Only the most recent window will receive "
+                        "phase-ack messages."
+                    )
                 _phase_ack_target["window"] = self
                 router.message_router_data.add_subscriber_to_topic(
                     topic=self.config.phase_ack_topic,
                     subscribing_actor_name="ppt12_demo_phase_ack_listener",
                 )
 
-            # StatusReadout listeners — auto-named actor per readout.
-            _readout_target["window"] = self
+            # StatusReadout listeners — actors already registered in __init__;
+            # here we only add the topic subscription.
             for readout in self.config.status_readouts:
                 slug = _slug(readout.label)
-                actor_name = _make_readout_actor(slug)
+                actor_name = f"ppt12_demo_{slug}_listener"
                 router.message_router_data.add_subscriber_to_topic(
                     topic=readout.topic,
                     subscribing_actor_name=actor_name,

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -14,11 +14,33 @@ See PPT-12 spec for design rationale (composition vs inheritance).
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+import dramatiq
+
+from microdrop_utils.broker_server_helpers import (
+    remove_middleware_from_dramatiq_broker,
+)
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.demos.electrode_responder import (
+    DEMO_RESPONDER_ACTOR_NAME,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Strip Prometheus middleware once at module import time — every
+# downstream demo needs this and the stripping is idempotent.
+remove_middleware_from_dramatiq_broker(
+    middleware_name="dramatiq.middleware.prometheus",
+    broker=dramatiq.get_broker(),
+)
 
 
 @dataclass
@@ -117,9 +139,68 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
         self.setCentralWidget(self.widget)
 
+        # Pre-populate sample steps BEFORE the executor is built.
+        config.pre_populate(self.manager)
+
         self.executor = ProtocolExecutor(
             row_manager=self.manager,
             qsignals=ExecutorSignals(),
             pause_event=PauseEvent(),
             stop_event=threading.Event(),
         )
+
+        self._router = None
+        self._dramatiq_worker = None
+        self._setup_dramatiq_routing_internal()
+        if self._router is not None:
+            # Demo-specific responders / listeners — called AFTER the
+            # standard chain so the demo can rely on it being in place.
+            config.routing_setup(self._router)
+
+    def _setup_dramatiq_routing_internal(self):
+        """Wires the standard PPT-3 electrode actuation chain
+        (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED).
+
+        Best-effort: if Redis isn't reachable, sets self._router = None
+        and logs a warning. Runtime calls to ctx.wait_for() will then
+        time out at protocol-run time and surface as protocol_error.
+        """
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import (
+                MessageRouterActor,
+            )
+            from dramatiq import Worker
+
+            broker = dramatiq.get_broker()
+            broker.flush_all()
+            router = MessageRouterActor()
+
+            # Standard PPT-3 electrode chain.
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_CHANGE,
+                subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
+            )
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_APPLIED,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+
+            self._router = router
+            self._dramatiq_worker = Worker(broker, worker_timeout=100)
+            self._dramatiq_worker.start()
+        except ValueError as e:
+            if "already registered" not in str(e):
+                logger.warning("Demo Dramatiq routing setup failed: %s", e)
+        except Exception as e:
+            logger.warning(
+                "Demo Dramatiq routing setup failed (Redis not running?): %s",
+                e,
+            )
+
+    def closeEvent(self, event):
+        if self._dramatiq_worker is not None:
+            try:
+                self._dramatiq_worker.stop()
+            except Exception:
+                logger.exception("Error stopping demo dramatiq worker")
+        super().closeEvent(event)

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -108,10 +108,24 @@ def _slug(label: str) -> str:
     return _SLUG_RE.sub("_", label.lower()).strip("_")
 
 
+# Module-level target for the phase-ack listener actor. The actor runs
+# on a Dramatiq worker thread; it emits a Qt signal that auto-connection
+# delivers on the GUI thread.
+_phase_ack_target = {"window": None}
+
+
+@dramatiq.actor(actor_name="ppt12_demo_phase_ack_listener", queue_name="default")
+def _phase_ack_listener(message: str, topic: str, timestamp: float = None):
+    window = _phase_ack_target.get("window")
+    if window is None:
+        return
+    window.phase_acked.emit()
+
+
 import threading
 import time
 
-from pyface.qt.QtCore import Qt, QTimer
+from pyface.qt.QtCore import Qt, QTimer, Signal
 from pyface.qt.QtWidgets import (
     QApplication, QLabel, QMainWindow, QSplitter, QStatusBar,
 )
@@ -129,6 +143,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     Construct with a DemoConfig; call .show() and .exec() OR use the
     .run(config) classmethod for one-shot main() convenience."""
+
+    # Cross-thread signal — Dramatiq actor emits via the module-level
+    # listener (registered when phase_ack_topic is set); auto-connection
+    # delivers _on_phase_ack on the GUI thread.
+    phase_acked = Signal()
 
     def __init__(self, config: DemoConfig):
         super().__init__()
@@ -169,6 +188,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._tick_timer.setInterval(100)   # 10 Hz
         self._tick_timer.timeout.connect(self._refresh_status)
 
+        self._status_phase_time_label = None
+
         self._build_status_bar()
         self._wire_executor_signals()
 
@@ -200,6 +221,13 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 subscribing_actor_name="pluggable_protocol_tree_executor_listener",
             )
 
+            if self.config.phase_ack_topic is not None:
+                _phase_ack_target["window"] = self
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=self.config.phase_ack_topic,
+                    subscribing_actor_name="ppt12_demo_phase_ack_listener",
+                )
+
             self._router = router
             self._dramatiq_worker = Worker(broker, worker_timeout=100)
             self._dramatiq_worker.start()
@@ -221,6 +249,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         sb.addWidget(self._status_step_label)
         sb.addWidget(self._status_row_label, stretch=1)
         sb.addPermanentWidget(self._status_step_time_label)
+        if self.config.phase_ack_topic is not None:
+            self._status_phase_time_label = QLabel("")
+            sb.addPermanentWidget(self._status_phase_time_label)
 
     def _wire_executor_signals(self):
         # Active-row highlight on each step start.
@@ -230,6 +261,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         # Status bar updates.
         self.executor.qsignals.step_started.connect(self._on_step_started)
         self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        if self.config.phase_ack_topic is not None:
+            self.phase_acked.connect(self._on_phase_ack)
 
     def _on_protocol_started(self):
         try:
@@ -242,7 +275,13 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     def _on_step_started(self, row):
         self._step_index += 1
         self._current_row = row
+        # Reset phase timestamps; the phase ack handler restarts them.
         self._step_started_at = time.monotonic()
+        self._phase_started_at = None
+        try:
+            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            self._phase_target = None
         path = ".".join(str(i + 1) for i in row.path) if row.path else ""
         path_str = f" (path {path})" if path else ""
         self._status_step_label.setText(
@@ -252,11 +291,31 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if not self._tick_timer.isActive():
             self._tick_timer.start()
 
+    def _on_phase_ack(self):
+        """Each ack restarts the per-phase timer. The first ack of a step
+        also starts the per-step timer (overrides the time.monotonic()
+        set in _on_step_started so timers run from the actual ack moment)."""
+        if self._current_row is None:
+            return
+        now = time.monotonic()
+        if self._step_started_at is None:
+            self._step_started_at = now
+        self._phase_started_at = now
+
     def _refresh_status(self):
         if self._step_started_at is None:
             return
-        elapsed = time.monotonic() - self._step_started_at
-        self._status_step_time_label.setText(f"Step {elapsed:5.2f}s")
+        step_elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
+        if self._status_phase_time_label is not None:
+            phase_elapsed = (
+                0.0 if self._phase_started_at is None
+                else time.monotonic() - self._phase_started_at
+            )
+            target = self._phase_target if self._phase_target is not None else 0.0
+            self._status_phase_time_label.setText(
+                f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
+            )
 
     def closeEvent(self, event):
         if self._dramatiq_worker is not None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -109,10 +109,11 @@ def _slug(label: str) -> str:
 
 
 import threading
+import time
 
-from pyface.qt.QtCore import Qt
+from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
-    QApplication, QMainWindow, QSplitter,
+    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar,
 )
 
 from pluggable_protocol_tree.execution.events import PauseEvent
@@ -157,6 +158,20 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             # standard chain so the demo can rely on it being in place.
             config.routing_setup(self._router)
 
+        # Per-step / per-phase timing state. Mutated from GUI thread only.
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at: float | None = None
+        self._phase_started_at: float | None = None
+        self._phase_target: float | None = None
+        self._current_row = None
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(100)   # 10 Hz
+        self._tick_timer.timeout.connect(self._refresh_status)
+
+        self._build_status_bar()
+        self._wire_executor_signals()
+
     def _setup_dramatiq_routing_internal(self):
         """Wires the standard PPT-3 electrode actuation chain
         (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED).
@@ -196,6 +211,52 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 "Demo Dramatiq routing setup failed (Redis not running?): %s",
                 e,
             )
+
+    def _build_status_bar(self):
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        self._status_step_label = QLabel("Idle")
+        self._status_row_label = QLabel("")
+        self._status_step_time_label = QLabel("")
+        sb.addWidget(self._status_step_label)
+        sb.addWidget(self._status_row_label, stretch=1)
+        sb.addPermanentWidget(self._status_step_time_label)
+
+    def _wire_executor_signals(self):
+        # Active-row highlight on each step start.
+        self.executor.qsignals.step_started.connect(
+            self.widget.highlight_active_row
+        )
+        # Status bar updates.
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+
+    def _on_protocol_started(self):
+        try:
+            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            self._step_total = 0
+        self._step_index = 0
+        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        self._step_started_at = time.monotonic()
+        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
+        path_str = f" (path {path})" if path else ""
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self._status_row_label.setText(f"{row.name}{path_str}")
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+
+    def _refresh_status(self):
+        if self._step_started_at is None:
+            return
+        elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {elapsed:5.2f}s")
 
     def closeEvent(self, event):
         if self._dramatiq_worker is not None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -110,6 +110,11 @@ def _slug(label: str) -> str:
     return _SLUG_RE.sub("_", label.lower()).strip("_")
 
 
+# Actor-name prefixes used by demo processes. The purge loop only touches
+# subscribers matching one of these — real listeners (other processes'
+# controllers, etc.) are never purged. New demos with their own actors
+# must add their prefix here. ``ppt11_demo_`` is forward-declared for the
+# planned PPT-11 demo refactor; no actors with that prefix exist yet.
 _DEMO_PREFIXES = (
     "ppt_demo_", "ppt4_demo_", "ppt5_demo_", "ppt11_demo_",
     "ppt12_demo_", "ppt_vf_demo_",
@@ -179,7 +184,7 @@ def _make_readout_actor(slug: str):
 import threading
 import time
 
-from pyface.qt.QtCore import Qt, QTimer, Signal
+from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtWidgets import (
     QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox,
     QSplitter, QStatusBar, QToolBar,
@@ -337,7 +342,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 extra_topics.append(self.config.phase_ack_topic)
             for r in self.config.status_readouts:
                 extra_topics.append(r.topic)
-            for topic in (*broker_topics_to_check, *extra_topics):
+            # Dedupe — phase_ack_topic often equals one of the standard
+            # electrode topics (default is ELECTRODES_STATE_APPLIED).
+            topics_to_check = {*broker_topics_to_check, *extra_topics}
+            for topic in topics_to_check:
                 try:
                     subs = router.message_router_data.get_subscribers_for_topic(topic)
                 except Exception:
@@ -348,7 +356,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                         continue
                     try:
                         broker.get_actor(actor_name)
-                    except Exception:
+                    except dramatiq.errors.ActorNotFound:
                         try:
                             router.message_router_data.remove_subscriber_from_topic(
                                 topic=topic,
@@ -591,8 +599,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     def _clear_all_highlights(self):
         """Restore an idle visual state at protocol end."""
-        from pyface.qt.QtCore import QModelIndex
-
         self.widget.highlight_active_row(None)
         self.widget.tree.clearSelection()
         self.widget.tree.setCurrentIndex(QModelIndex())

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -203,7 +203,23 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
         self.manager = RowManager(columns=config.columns_factory())
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
-        self.setCentralWidget(self.widget)
+
+        # Central layout: just the tree, OR a splitter with tree + side panel.
+        if self.config.side_panel_factory is not None:
+            side = self.config.side_panel_factory(self.manager)
+            if side is not None:
+                splitter = QSplitter(Qt.Horizontal)
+                splitter.addWidget(self.widget)
+                splitter.addWidget(side)
+                splitter.setSizes([
+                    int(self.config.window_size[0] * 0.65),
+                    int(self.config.window_size[0] * 0.35),
+                ])
+                self.setCentralWidget(splitter)
+            else:
+                self.setCentralWidget(self.widget)
+        else:
+            self.setCentralWidget(self.widget)
 
         # Pre-populate sample steps BEFORE the executor is built.
         config.pre_populate(self.manager)

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -84,3 +84,42 @@ def _slug(label: str) -> str:
     'Magnet Height (mm)' -> 'magnet_height_mm'
     """
     return _SLUG_RE.sub("_", label.lower()).strip("_")
+
+
+import threading
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtWidgets import (
+    QApplication, QMainWindow, QSplitter,
+)
+
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+class BasePluggableProtocolDemoWindow(QMainWindow):
+    """Hosts a ProtocolTreeWidget + ProtocolExecutor with the standard
+    UX scaffolding. See PPT-12 spec for the full feature list.
+
+    Construct with a DemoConfig; call .show() and .exec() OR use the
+    .run(config) classmethod for one-shot main() convenience."""
+
+    def __init__(self, config: DemoConfig):
+        super().__init__()
+        self.config = config
+        self.setWindowTitle(config.title)
+        self.resize(*config.window_size)
+
+        self.manager = RowManager(columns=config.columns_factory())
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        self.setCentralWidget(self.widget)
+
+        self.executor = ProtocolExecutor(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -126,7 +126,7 @@ def _slug(label: str) -> str:
 # planned PPT-11 demo refactor; no actors with that prefix exist yet.
 _DEMO_PREFIXES = (
     "ppt_demo_", "ppt4_demo_", "ppt5_demo_", "ppt11_demo_",
-    "ppt12_demo_", "ppt_vf_demo_",
+    "ppt12_demo_", "ppt_vf_demo_", "integration_demo_",
 )
 
 
@@ -232,10 +232,16 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.manager = RowManager(columns=config.columns_factory())
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
 
+        # Side panel widget if side_panel_factory yielded one, else None.
+        # post_build_setup callbacks should reach the side panel via this
+        # attribute rather than walking the central widget's children.
+        self._side_panel = None
+
         # Central layout: just the tree, OR a splitter with tree + side panel.
         if self.config.side_panel_factory is not None:
             side = self.config.side_panel_factory(self.manager)
             if side is not None:
+                self._side_panel = side
                 splitter = QSplitter(Qt.Horizontal)
                 splitter.addWidget(self.widget)
                 splitter.addWidget(side)

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -1,27 +1,13 @@
-"""Standalone demo — open ProtocolTreeWidget in a QMainWindow with
-Run / Pause / Stop toolbar buttons and active-row highlighting.
-
-No envisage, no dramatiq broker required for the in-process demo (the
-MessageColumn publishes to Dramatiq but the publish call no-ops if no
-broker is configured — the demo still exercises the executor's full
-control flow). For the round-trip with real subscribers, run the
-integration test or the full app.
+"""PPT-3 demo — protocol tree + electrodes/routes + device viewer +
+PPT-2 ack-roundtrip column.
 
 Run: pixi run python -m pluggable_protocol_tree.demos.run_widget
 """
 
 import json
 import logging
-import sys
-import threading
-import time
 
 import dramatiq
-from pyface.qt.QtCore import Qt, QTimer, Signal
-from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QLabel, QMainWindow, QMessageBox, QStatusBar,
-    QToolBar, QSplitter,
-)
 
 from pluggable_protocol_tree.builtins.duration_column import make_duration_column
 from pluggable_protocol_tree.builtins.electrodes_column import make_electrodes_column
@@ -49,32 +35,21 @@ from pluggable_protocol_tree.demos.ack_roundtrip_column import (
     DEMO_APPLIED_TOPIC, DEMO_REQUEST_TOPIC, RESPONDER_ACTOR_NAME,
     make_ack_roundtrip_column,
 )
-from pluggable_protocol_tree.demos.electrode_responder import (
-    DEMO_RESPONDER_ACTOR_NAME,
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig,
 )
 from pluggable_protocol_tree.demos.message_column import make_message_column
 from pluggable_protocol_tree.demos.simple_device_viewer import (
     GRID_H, GRID_W, SimpleDeviceViewer,
 )
-from pluggable_protocol_tree.execution.events import PauseEvent
-from pluggable_protocol_tree.execution.executor import ProtocolExecutor
-from pluggable_protocol_tree.execution.signals import ExecutorSignals
-from pluggable_protocol_tree.models.row_manager import RowManager
-from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+from pyface.qt.QtCore import Qt
 
-# remove prometheus metrics for now
-from microdrop_utils.broker_server_helpers import remove_middleware_from_dramatiq_broker
-remove_middleware_from_dramatiq_broker(middleware_name="dramatiq.middleware.prometheus", broker=dramatiq.get_broker())
-logger = logging.getLogger(__name__)
 
-# Module-level Dramatiq actor for live overlay updates. Captures
-# self.device_view via a global hook set by DemoWindow.__init__.
+# Module-level overlay listener — captures the device viewer via a
+# global hook set by the post_build_setup callback. Keeping the actor
+# at module level avoids duplicate-registration errors when the demo
+# is reloaded in the same process.
 _overlay_target = {"viewer": None}
-
-# Module-level hook for the phase-ack listener. The actor runs on a
-# Dramatiq worker thread; it emits a Qt signal that auto-connection
-# delivers on the GUI thread, where the timers are mutated.
-_ack_target = {"window": None}
 
 
 @dramatiq.actor(actor_name="ppt_demo_actuation_overlay_listener",
@@ -88,444 +63,95 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
-    # Cross-thread emit — auto-connection delivers on the GUI thread.
     viewer.actuation_changed.emit(list(electrodes))
-
-
-@dramatiq.actor(actor_name="ppt_demo_phase_ack_listener",
-                queue_name="default")
-def _phase_ack_listener(message: str, topic: str, timestamp: float = None):
-    """Fires on each ELECTRODES_STATE_APPLIED ack so the status bar
-    can start the per-phase / per-step timers from the moment hardware
-    actually confirmed the actuation, not from the upstream
-    publish_message call (which can sit in the worker queue for
-    1-2 seconds on a cold broker)."""
-    window = _ack_target["window"]
-    if window is None:
-        return
-    window.phase_acked.emit()
 
 
 def _columns():
     return [
-        make_type_column(),
-        make_id_column(),
-        make_name_column(),
-        make_repetitions_column(),
-        make_duration_column(),
-        make_electrodes_column(),
-        make_routes_column(),
-        make_trail_length_column(),
-        make_trail_overlay_column(),
-        make_soft_start_column(),
-        make_soft_end_column(),
-        make_repeat_duration_column(),
-        make_linear_repeats_column(),
-        make_message_column(),
-        make_ack_roundtrip_column(),
+        make_type_column(), make_id_column(), make_name_column(),
+        make_repetitions_column(), make_duration_column(),
+        make_electrodes_column(), make_routes_column(),
+        make_trail_length_column(), make_trail_overlay_column(),
+        make_soft_start_column(), make_soft_end_column(),
+        make_repeat_duration_column(), make_linear_repeats_column(),
+        make_message_column(), make_ack_roundtrip_column(),
     ]
 
 
-class DemoWindow(QMainWindow):
+def _pre_populate(rm):
+    """Seed the electrode→channel mapping. e00..e24 → channels 0..24."""
+    rm.protocol_metadata["electrode_to_channel"] = {
+        f"e{i:02d}": i for i in range(GRID_W * GRID_H)
+    }
 
-    # Cross-thread signal for the phase-ack listener. The Dramatiq
-    # worker thread emits via _phase_ack_listener; auto-connection
-    # delivers _on_phase_ack on the GUI thread.
-    phase_acked = Signal()
 
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle("Pluggable Protocol Tree — Demo (PPT-2)")
-        self.resize(1000, 600)
+def _routing_setup(router):
+    """PPT-2 ack-roundtrip column responder + actuation-overlay listener
+    subscription. The overlay actor itself is registered at module import."""
+    router.message_router_data.add_subscriber_to_topic(
+        topic=DEMO_REQUEST_TOPIC,
+        subscribing_actor_name=RESPONDER_ACTOR_NAME,
+    )
+    router.message_router_data.add_subscriber_to_topic(
+        topic=DEMO_APPLIED_TOPIC,
+        subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+    )
+    router.message_router_data.add_subscriber_to_topic(
+        topic=ELECTRODES_STATE_CHANGE,
+        subscribing_actor_name="ppt_demo_actuation_overlay_listener",
+    )
 
-        self.manager = RowManager(columns=_columns())
-        self.widget = ProtocolTreeWidget(self.manager, parent=self)
-        self.device_view = SimpleDeviceViewer(self.manager, parent=self)
 
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(self.widget)
-        splitter.addWidget(self.device_view)
-        splitter.setSizes([700, 400])
-        self.setCentralWidget(splitter)
+def _make_side_panel(rm):
+    return SimpleDeviceViewer(rm)
 
-        # Seed the electrode→channel mapping. e00..e24 → channels 0..24.
-        # The RoutesHandler reads this from ProtocolContext.scratch.
-        self.manager.protocol_metadata["electrode_to_channel"] = {
-            f"e{i:02d}": i for i in range(GRID_W * GRID_H)
-        }
 
-        # Wire the overlay + ack listener targets to this window.
-        _overlay_target["viewer"] = self.device_view
-        _ack_target["window"] = self
-        self.phase_acked.connect(self._on_phase_ack)
+def _post_build(window):
+    """Wire the PPT-3-specific side-panel signals: device viewer follows
+    the tree's current selection AND the executor's currently-running step.
+    Also bind the module-level overlay listener target to this window's
+    device viewer."""
+    # Find the device viewer in the splitter (it's the right widget).
+    central = window.centralWidget()
+    # The base wraps tree + side panel in a QSplitter when side_panel_factory
+    # is provided. The side panel is the second widget.
+    device_view = central.widget(1)
+    _overlay_target["viewer"] = device_view
 
-        self.executor = ProtocolExecutor(
-            row_manager=self.manager,
-            qsignals=ExecutorSignals(),
-            pause_event=PauseEvent(),
-            stop_event=threading.Event(),
+    sel_model = window.widget.tree.selectionModel()
+    sel_model.currentRowChanged.connect(
+        lambda cur, _prev: device_view.set_active_row(
+            cur.data(Qt.UserRole) if cur.isValid() else None
         )
+    )
+    window.executor.qsignals.step_started.connect(device_view.set_active_row)
 
-        # Per-step / per-phase timing state. All timestamps are
-        # ``time.monotonic()`` from the moment the corresponding ack
-        # arrives — not from when step_started fires. None means "not
-        # yet started; display 0.00s". Mutated from GUI thread only.
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None    # set on first ack of step
-        self._phase_started_at = None    # set on each ack
-        self._phase_target = None        # row.duration_s, captured at step_started
-        self._current_row = None
-        self._tick_timer = QTimer(self)
-        self._tick_timer.setInterval(100)   # 10 Hz elapsed-time display
-        self._tick_timer.timeout.connect(self._refresh_status)
 
-        # Set up Dramatiq routing + a worker so the ack-roundtrip
-        # column's publish → wait_for actually completes. Best-effort:
-        # if Redis isn't running, the column will time out at runtime
-        # and surface as protocol_error in the dialog.
-        self._dramatiq_worker = None
-        self._setup_dramatiq_routing()
-
-        self._build_status_bar()
-        self._wire_signals()
-        self._build_toolbar()
-        self._reset_status()
-
-    def _setup_dramatiq_routing(self):
-        """Best-effort: register subscriptions for the ack-roundtrip
-        column's request/applied topics, and spin up an in-process
-        Dramatiq worker so the responder + executor_listener actors
-        actually receive messages."""
-        try:
-            from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterActor
-            from dramatiq import Worker
-            import dramatiq
-
-            router = MessageRouterActor()
-            router.message_router_data.add_subscriber_to_topic(
-                topic=DEMO_REQUEST_TOPIC,
-                subscribing_actor_name=RESPONDER_ACTOR_NAME,
-            )
-            router.message_router_data.add_subscriber_to_topic(
-                topic=DEMO_APPLIED_TOPIC,
-                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
-            )
-            # PPT-3: actuation chain
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_CHANGE,
-                subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
-            )
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_APPLIED,
-                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
-            )
-            # And a tiny consumer that paints the live overlay in the demo.
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_CHANGE,
-                subscribing_actor_name="ppt_demo_actuation_overlay_listener",
-            )
-            # Status-bar phase-ack listener — drives the per-phase /
-            # per-step timers from the actual hardware ack moment.
-            router.message_router_data.add_subscriber_to_topic(
-                topic=ELECTRODES_STATE_APPLIED,
-                subscribing_actor_name="ppt_demo_phase_ack_listener",
-            )
-            self._router = router
-        except ValueError as e:
-            # MessageRouterActor() raises if message_router_actor is
-            # already registered (e.g. demo loaded a second time in
-            # the same process via Load…). Reuse — don't double-register.
-            if "already registered" not in str(e):
-                logger.warning("Demo Dramatiq routing setup failed: %s", e)
-        except Exception as e:
-            logger.warning(
-                "Demo Dramatiq routing setup failed (Redis not running?): %s", e,
-            )
-
-    def closeEvent(self, event):
-        if self._dramatiq_worker is not None:
-            try:
-                self._dramatiq_worker.stop()
-            except Exception:
-                logger.exception("Error stopping demo dramatiq worker")
-        super().closeEvent(event)
-
-    def _wire_signals(self):
-        # Active-row highlight. Only step_started + terminal signals
-        # touch the highlight — step_finished does NOT clear it, so the
-        # highlight stays on the just-finished row through the gap until
-        # the next step_started replaces it. (Clearing on step_finished
-        # makes the highlight flash off between steps and is invisible.)
-        self.executor.qsignals.step_started.connect(
-            self.widget.highlight_active_row
-        )
-
-        # PPT-3: device viewer follows the tree's selection AND the
-        # executor's currently-running step.
-        sel_model = self.widget.tree.selectionModel()
-        sel_model.currentRowChanged.connect(
-            lambda cur, _prev: self.device_view.set_active_row(
-                cur.data(Qt.UserRole) if cur.isValid() else None
-            )
-        )
-        self.executor.qsignals.step_started.connect(
-            self.device_view.set_active_row
-        )
-        # Status bar updates
-        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
-        self.executor.qsignals.step_started.connect(self._on_step_started)
-        self.executor.qsignals.step_finished.connect(self._on_step_finished)
-        # Button state machine
-        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
-        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
-        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
-        for sig in (
-            self.executor.qsignals.protocol_finished,
-            self.executor.qsignals.protocol_aborted,
-        ):
-            sig.connect(self._on_protocol_terminated)
-        self.executor.qsignals.protocol_error.connect(self._on_error)
-
-    def _build_toolbar(self):
-        tb = QToolBar("Protocol")
-        self.addToolBar(tb)
-        tb.addAction("Add Step", lambda: self.manager.add_step())
-        tb.addAction("Add Group", lambda: self.manager.add_group())
-        tb.addSeparator()
-        tb.addAction("Save…", self._save)
-        tb.addAction("Load…", self._load)
-        tb.addSeparator()
-        self._run_action = tb.addAction("Run", self.executor.start)
-        self._pause_action = tb.addAction("Pause", self._toggle_pause)
-        self._stop_action = tb.addAction("Stop", self.executor.stop)
-        # Initial state: only Run is enabled.
-        self._set_idle_button_state()
-
-    def _set_idle_button_state(self):
-        self._run_action.setEnabled(True)
-        self._pause_action.setEnabled(False)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(False)
-
-    def _set_running_button_state(self):
-        self._run_action.setEnabled(False)
-        self._pause_action.setEnabled(True)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(True)
-
-    def _toggle_pause(self):
-        if self.executor.pause_event.is_set():
-            self.executor.resume()
-        else:
-            self.executor.pause()
-
-    # --- status bar (step counter + elapsed time + step name/path) ---
-
-    def _build_status_bar(self):
-        sb = QStatusBar()
-        self.setStatusBar(sb)
-        self._status_step_label = QLabel("Idle")
-        self._status_row_label = QLabel("")
-        self._status_reps_label = QLabel("")
-        self._status_step_time_label = QLabel("")
-        self._status_phase_time_label = QLabel("")
-        # Row label takes any remaining width via stretch=1.
-        sb.addWidget(self._status_step_label)
-        sb.addWidget(self._status_row_label, stretch=1)
-        sb.addPermanentWidget(self._status_reps_label)
-        sb.addPermanentWidget(self._status_step_time_label)
-        sb.addPermanentWidget(self._status_phase_time_label)
-
-    def _reset_status(self):
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None
-        self._phase_started_at = None
-        self._phase_target = None
-        self._current_row = None
-        self._status_step_label.setText("Idle")
-        self._status_row_label.setText("")
-        self._status_reps_label.setText("")
-        self._status_step_time_label.setText("")
-        self._status_phase_time_label.setText("")
-
-    def _refresh_status(self):
-        """Recompute the two timer labels from the ack-driven
-        timestamps. Both show 0.00s until the corresponding ack lands."""
-        if self._current_row is None:
-            return
-        target = self._phase_target if self._phase_target is not None else 0.0
-        if self._step_started_at is None:
-            step_elapsed = 0.0
-        else:
-            step_elapsed = time.monotonic() - self._step_started_at
-        if self._phase_started_at is None:
-            phase_elapsed = 0.0
-        else:
-            phase_elapsed = time.monotonic() - self._phase_started_at
-        self._status_step_time_label.setText(
-            f"Step {step_elapsed:5.2f}s"
-        )
-        self._status_phase_time_label.setText(
-            f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
-        )
-
-    # --- protocol-state slot handlers ---
-
-    def _on_protocol_started(self):
-        self._set_running_button_state()
-        # Pre-count total steps after rep expansion. This forces a one-
-        # time walk of iter_execution_steps; for huge protocols the cost
-        # is O(N) but acceptable here. Re-counted because reps may have
-        # changed since last run.
-        try:
-            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
-        except Exception:
-            self._step_total = 0
-        self._step_index = 0
-        self._status_step_label.setText(f"Step 0 / {self._step_total}")
-
-    def _on_step_repetition(self, rep_chain):
-        """Render the active rep context — e.g. "rep 2/3 of 'Wash'" —
-        into the status bar. Empty chain (no repeating ancestor) clears."""
-        if not rep_chain:
-            self._status_reps_label.setText("")
-            return
-        parts = [f"rep {idx}/{total} of '{name}'"
-                 for name, idx, total in rep_chain]
-        self._status_reps_label.setText(" · ".join(parts))
-
-    def _on_step_started(self, row):
-        # Reset the timer state — both timers stay at 0.00s until the
-        # first phase ack lands. The ack handler (_on_phase_ack)
-        # bumps the timestamps from None to monotonic() at the actual
-        # hardware-confirmed moment.
-        self._step_index += 1
-        self._current_row = row
-        self._step_started_at = None
-        self._phase_started_at = None
-        try:
-            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            self._phase_target = None
-        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
-        path_str = f" (path {path})" if path else ""
-        self._status_step_label.setText(
-            f"Step {self._step_index} / {self._step_total}"
-        )
-        self._status_row_label.setText(f"{row.name}{path_str}")
-        self._refresh_status()
-        if not self._tick_timer.isActive():
-            self._tick_timer.start()
-
-    def _on_phase_ack(self):
-        """Each ELECTRODES_STATE_APPLIED ack (re)starts the per-phase
-        timer. The first ack of a step also starts the per-step timer.
-        Subsequent acks within the step leave the step timer running
-        and only restart the phase timer, so the phase value reflects
-        the dwell time on the current actuation snapshot."""
-        if self._current_row is None:
-            return     # ack outside an active step (e.g., late stragglers)
-        now = time.monotonic()
-        if self._step_started_at is None:
-            self._step_started_at = now
-        self._phase_started_at = now
-
-    def _on_step_finished(self, _row):
-        # Freeze the time labels at the step's actual elapsed; keep
-        # them visible until the next step_started resets to 0.00s.
-        # If no ack ever arrived (e.g., a step with no actuation), the
-        # labels already show 0.00s — leave them.
-        self._refresh_status()
-
-    def _on_protocol_paused(self):
-        self._pause_action.setText("Resume")
-        # Stop the elapsed-time tick during pause; resume restarts it.
-        self._tick_timer.stop()
-
-    def _on_protocol_resumed(self):
-        self._pause_action.setText("Pause")
-        if self._current_row is not None:
-            self._tick_timer.start()
-
-    def _on_protocol_terminated(self):
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        self._reset_status()
-
-    def _on_error(self, msg):
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        self._reset_status()
-        QMessageBox.critical(self, "Protocol error", msg)
-
-    def _clear_all_highlights(self):
-        """Restore an idle visual state at protocol end. Clears, in order:
-          - tree active-row highlight (blue executor cursor)
-          - device viewer (statics + routes + actuated overlay)
-          - tree selection AND current index (last so currentRowChanged
-            doesn't fight the explicit set_active_row(None) above)."""
-        from pyface.qt.QtCore import QModelIndex
-        self.widget.highlight_active_row(None)
-        self.device_view.set_active_row(None)
-        self.widget.tree.clearSelection()
-        self.widget.tree.setCurrentIndex(QModelIndex())
-
-    def _save(self):
-        path, _ = QFileDialog.getSaveFileName(
-            self, "Save Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(self.manager.to_json(), f, indent=2)
-
-    def _load(self):
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Load Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        try:
-            self.manager.set_state_from_json(data, columns=_columns())
-        except Exception as e:
-            QMessageBox.critical(self, "Load error", str(e))
-            return
-        # self.widget = ProtocolTreeWidget(self.manager, parent=self)
-        # self.setCentralWidget(self.widget)
-        # # Re-wire executor against the new manager
-        # self.executor = ProtocolExecutor(
-        #     row_manager=self.manager,
-        #     qsignals=ExecutorSignals(),
-        #     pause_event=PauseEvent(),
-        #     stop_event=threading.Event(),
-        # )
-        # self._wire_signals()
+config = DemoConfig(
+    columns_factory=_columns,
+    title="Pluggable Protocol Tree — PPT-3 Demo",
+    window_size=(1100, 650),
+    pre_populate=_pre_populate,
+    routing_setup=_routing_setup,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    side_panel_factory=_make_side_panel,
+    post_build_setup=_post_build,
+)
 
 
 def main():
-    # Surface the executor's INFO-level step transition logs so the
-    # demo user sees them in the terminal as the protocol runs.
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
     )
-    app = QApplication.instance() or QApplication(sys.argv)
-    w = DemoWindow()
-    w.show()
-    app.exec()
+    BasePluggableProtocolDemoWindow.run(config)
 
 
 if __name__ == "__main__":
-
-    from microdrop_utils.broker_server_helpers import redis_server_context, dramatiq_workers_context
-
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
     with redis_server_context():
         with dramatiq_workers_context():
             main()

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -111,11 +111,7 @@ def _post_build(window):
     the tree's current selection AND the executor's currently-running step.
     Also bind the module-level overlay listener target to this window's
     device viewer."""
-    # Find the device viewer in the splitter (it's the right widget).
-    central = window.centralWidget()
-    # The base wraps tree + side panel in a QSplitter when side_panel_factory
-    # is provided. The side panel is the second widget.
-    device_view = central.widget(1)
+    device_view = window._side_panel
     _overlay_target["viewer"] = device_view
 
     sel_model = window.widget.tree.selectionModel()

--- a/pluggable_protocol_tree/demos/run_widget_auto.py
+++ b/pluggable_protocol_tree/demos/run_widget_auto.py
@@ -204,7 +204,6 @@ class AutoDemoWindow(QMainWindow):
         self._phase_started_at = None
         self._phase_target = None
 
-        self._dramatiq_worker = None
         self._setup_dramatiq_routing()
 
         self._build_status_bar()
@@ -287,7 +286,6 @@ class AutoDemoWindow(QMainWindow):
 
     def _setup_dramatiq_routing(self):
         try:
-            from dramatiq import Worker
             broker = dramatiq.get_broker()
             # Drop any stale messages from a previous crashed run that
             # could be parked on the queue.
@@ -312,8 +310,6 @@ class AutoDemoWindow(QMainWindow):
                 router.message_router_data.add_subscriber_to_topic(
                     topic=topic, subscribing_actor_name=actor,
                 )
-            self._dramatiq_worker = Worker(broker, worker_timeout=100)
-            self._dramatiq_worker.start()
             print("[AUTO ROUTING] dramatiq worker + subscriptions ready",
                   flush=True)
         except Exception as e:
@@ -490,15 +486,7 @@ class AutoDemoWindow(QMainWindow):
             except Exception as e:
                 print(f"[AUTO SHUTDOWN] subscription cleanup failed: {e}",
                       flush=True)
-        # Stop the worker before quitting so the process can exit
-        # cleanly (worker threads aren't daemons).
-        if self._dramatiq_worker is not None:
-            try:
-                self._dramatiq_worker.stop()
-                print("[AUTO SHUTDOWN] dramatiq worker stopped", flush=True)
-            except Exception as e:
-                print(f"[AUTO SHUTDOWN] worker stop failed: {e}", flush=True)
-            self._dramatiq_worker = None
+
         QApplication.instance().setProperty("auto_exit_code", exit_code)
         QTimer.singleShot(self.POST_DONE_QUIT_MS, QApplication.instance().quit)
 

--- a/pluggable_protocol_tree/demos/run_widget_compound_demo.py
+++ b/pluggable_protocol_tree/demos/run_widget_compound_demo.py
@@ -1,118 +1,58 @@
-"""Headed demo for the compound column framework.
+"""PPT-11 demo — synthetic enabled+count compound column.
 
-Builds a protocol tree with the existing PPT-3 builtins + the
-synthetic enabled+count compound from enabled_count_compound.py.
-Auto-populates 3 sample steps so the user can immediately verify:
-
-  1. Two columns render ('Enabled' checkbox + 'Count' spinner) for the
-     one compound contribution
-  2. The Count cell is read-only when Enabled is unchecked (greyed out
-     spinner that won't accept clicks)
-  3. Toggling Enabled makes the Count cell editable
-  4. The compound handler's on_step fires exactly once per row (via
-     the logged invocation count line)
-
-(Save / load round-trip is verified by the test
-test_compound_round_trip_via_protocol_session — not exercised in this
-headed demo.)
+Now uses the BasePluggableProtocolDemoWindow + gains Run/Pause/Stop +
+status bar / step elapsed timer for free.
 
 Run: pixi run python -m pluggable_protocol_tree.demos.run_widget_compound_demo
 """
 
 import logging
-import sys
 
-import dramatiq
-
-# Centralised middleware strip — see broker_server_helpers.
-from microdrop_utils.broker_server_helpers import (
-    remove_middleware_from_dramatiq_broker,
-)
-remove_middleware_from_dramatiq_broker(
-    middleware_name="dramatiq.middleware.prometheus",
-    broker=dramatiq.get_broker(),
-)
-
-from pyface.qt.QtCore import Qt
-from pyface.qt.QtWidgets import QApplication, QMainWindow, QSplitter, QToolBar
-
-from pluggable_protocol_tree.builtins.duration_column import (
-    make_duration_column,
-)
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
 from pluggable_protocol_tree.builtins.id_column import make_id_column
 from pluggable_protocol_tree.builtins.name_column import make_name_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.demos.base_demo_window import (
+    BasePluggableProtocolDemoWindow, DemoConfig,
+)
 from pluggable_protocol_tree.demos.enabled_count_compound import (
     make_enabled_count_compound,
 )
-from pluggable_protocol_tree.models.compound_column import (
-    BaseCompoundColumnHandler,
-)
-from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
-from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
-
-
-logger = logging.getLogger(__name__)
-
-
-class _CountingHandler(BaseCompoundColumnHandler):
-    """Subclass of the demo's default handler that logs every on_step
-    invocation count — so the user can verify the owner-field guard
-    works (one log line per row, not two)."""
-    _on_step_count = 0
-    def on_step(self, row, ctx):
-        type(self)._on_step_count += 1
-        logger.info("[demo compound] on_step #%d for row %r",
-                    type(self)._on_step_count, getattr(row, "name", "<?>"))
 
 
 def _columns():
-    cc = make_enabled_count_compound()
-    cc.handler = _CountingHandler()
     return [
         make_type_column(), make_id_column(), make_name_column(),
         make_duration_column(),
-        *_expand_compound(cc),
+        *_expand_compound(make_enabled_count_compound()),
     ]
 
 
-class DemoWindow(QMainWindow):
-    def __init__(self):
-        super().__init__()
-        self.setWindowTitle("PPT-11 Demo — Compound Column Framework")
-        self.resize(900, 500)
+def _pre_populate(rm):
+    rm.add_step(values={
+        "name": "Step 1: enabled, count=5",
+        "duration_s": 0.2,
+        "ec_enabled": True, "ec_count": 5,
+    })
+    rm.add_step(values={
+        "name": "Step 2: disabled (count read-only)",
+        "duration_s": 0.2,
+        "ec_enabled": False, "ec_count": 0,
+    })
+    rm.add_step(values={
+        "name": "Step 3: enabled, count=99",
+        "duration_s": 0.2,
+        "ec_enabled": True, "ec_count": 99,
+    })
 
-        self.manager = RowManager(columns=_columns())
-        # Pre-populate so Run / save+load have something to work with.
-        self.manager.add_step(values={
-            "name": "Step 1: enabled, count=5",
-            "duration_s": 0.2,
-            "ec_enabled": True,
-            "ec_count": 5,
-        })
-        self.manager.add_step(values={
-            "name": "Step 2: disabled (count read-only)",
-            "duration_s": 0.2,
-            "ec_enabled": False,
-            "ec_count": 0,
-        })
-        self.manager.add_step(values={
-            "name": "Step 3: enabled, count=99",
-            "duration_s": 0.2,
-            "ec_enabled": True,
-            "ec_count": 99,
-        })
 
-        self.widget = ProtocolTreeWidget(self.manager, parent=self)
-
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(self.widget)
-        self.setCentralWidget(splitter)
-
-        tb = QToolBar("Demo")
-        self.addToolBar(tb)
-        tb.addAction("Add Step", lambda: self.manager.add_step())
+config = DemoConfig(
+    columns_factory=_columns,
+    title="PPT-11 Demo — Compound Column Framework",
+    pre_populate=_pre_populate,
+    phase_ack_topic=None,    # synthetic compound has no ack-emitting handlers
+)
 
 
 def main():
@@ -121,11 +61,13 @@ def main():
         format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
         datefmt="%H:%M:%S",
     )
-    app = QApplication.instance() or QApplication(sys.argv)
-    w = DemoWindow()
-    w.show()
-    app.exec()
+    BasePluggableProtocolDemoWindow.run(config)
 
 
 if __name__ == "__main__":
-    main()
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()

--- a/pluggable_protocol_tree/tests/conftest.py
+++ b/pluggable_protocol_tree/tests/conftest.py
@@ -1,0 +1,14 @@
+"""Shared fixtures for pluggable_protocol_tree tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Session-scoped QApplication so Qt widget tests can construct
+    QMainWindow + child widgets without crashing."""
+    from pyface.qt.QtWidgets import QApplication
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # Don't quit — pytest-qt doesn't either; lets subsequent test
+    # modules reuse the same QApplication.

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -56,3 +56,57 @@ def test_slug_lowercases_and_strips_punctuation():
 
 def test_slug_handles_empty_string():
     assert _slug("") == ""
+
+
+def test_window_constructs_with_minimum_config(qapp):
+    """Window builds successfully with just a columns_factory."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.windowTitle() == "Pluggable Protocol Tree Demo"
+    # Has the manager + executor + tree widget wired
+    assert w.manager is not None
+    assert w.executor is not None
+    assert w.widget is not None
+    # Window size matches default
+    assert (w.width(), w.height()) == (1100, 650)
+
+
+def test_window_applies_custom_title_and_size(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        title="My Demo",
+        window_size=(800, 500),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.windowTitle() == "My Demo"
+    assert (w.width(), w.height()) == (800, 500)
+
+
+def test_window_columns_match_factory_output(qapp):
+    """RowManager has the columns returned by columns_factory."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [
+        make_type_column(), make_id_column(), make_name_column(),
+    ])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    ids = [c.model.col_id for c in w.manager.columns]
+    assert ids == ["type", "id", "name"]

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -240,3 +240,47 @@ def test_window_tick_timer_runs_at_10_hz(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
     assert w._tick_timer.interval() == 100
+
+
+def test_phase_ack_topic_none_hides_phase_timer(qapp):
+    """When phase_ack_topic=None, no phase elapsed label in status bar."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic=None)
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_phase_time_label is None
+
+
+def test_phase_ack_topic_set_creates_phase_label(qapp):
+    """When phase_ack_topic set, phase elapsed label is in status bar."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic="x/applied")
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_phase_time_label is not None
+
+
+def test_phase_acked_signal_resets_phase_timer(qapp):
+    """Emitting the phase_acked signal sets _phase_started_at = monotonic()."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
+                     phase_ack_topic="x/applied")
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Set the current row so phase ack handler doesn't early-return.
+    w._current_row = object()
+    w._step_started_at = None
+    before = w._phase_started_at
+    w.phase_acked.emit()
+    assert w._phase_started_at is not None
+    assert w._phase_started_at != before
+    # First ack also sets step_started_at if it was None.
+    assert w._step_started_at is not None

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -483,3 +483,32 @@ def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
     w2._load()
     assert len(w2.manager.root.children) == 1
     assert w2.manager.root.children[0].name == "Saved Step"
+
+
+def test_window_no_side_panel_uses_tree_as_central(qapp):
+    """When side_panel_factory is None, the central widget IS the tree."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w.centralWidget() is w.widget
+
+
+def test_window_side_panel_uses_splitter(qapp):
+    """When side_panel_factory returns a widget, central is a splitter
+    holding tree + side panel."""
+    from pyface.qt.QtWidgets import QLabel, QSplitter
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        side_panel_factory=lambda rm: QLabel("side"),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    central = w.centralWidget()
+    assert isinstance(central, QSplitter)
+    assert central.count() == 2   # tree + side panel

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -1,0 +1,58 @@
+"""Tests for the demo base window + DemoConfig + StatusReadout."""
+
+import pytest
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.demos.base_demo_window import (
+    DemoConfig, StatusReadout, _slug,
+)
+
+
+def test_status_readout_required_fields():
+    r = StatusReadout(label="Voltage", topic="dropbot/signals/voltage_applied",
+                      fmt=lambda m: f"{int(m)} V")
+    assert r.label == "Voltage"
+    assert r.topic == "dropbot/signals/voltage_applied"
+    assert r.fmt("100") == "100 V"
+    assert r.initial == "--"   # default
+
+
+def test_status_readout_initial_overridable():
+    r = StatusReadout(label="Magnet", topic="x/applied",
+                      fmt=lambda m: m, initial="idle")
+    assert r.initial == "idle"
+
+
+def test_demo_config_minimum_required_fields():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    assert cfg.title == "Pluggable Protocol Tree Demo"
+    assert cfg.window_size == (1100, 650)
+    assert cfg.phase_ack_topic == ELECTRODES_STATE_APPLIED   # default
+    assert cfg.status_readouts == []
+    assert cfg.side_panel_factory is None
+
+
+def test_demo_config_pre_populate_default_is_no_op():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    cfg.pre_populate(None)   # must not raise
+
+
+def test_demo_config_routing_setup_default_is_no_op():
+    cfg = DemoConfig(columns_factory=lambda: [])
+    cfg.routing_setup(None)
+
+
+def test_demo_config_phase_ack_can_be_none():
+    cfg = DemoConfig(columns_factory=lambda: [], phase_ack_topic=None)
+    assert cfg.phase_ack_topic is None
+
+
+def test_slug_lowercases_and_strips_punctuation():
+    """slug('Voltage')='voltage'; slug('Magnet Height (mm)')='magnet_height_mm'."""
+    assert _slug("Voltage") == "voltage"
+    assert _slug("Magnet Height (mm)") == "magnet_height_mm"
+    assert _slug("Step Time") == "step_time"
+
+
+def test_slug_handles_empty_string():
+    assert _slug("") == ""

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -575,3 +575,125 @@ def test_run_classmethod_returns_int(qapp, monkeypatch):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     rc = BasePluggableProtocolDemoWindow.run(cfg)
     assert rc == 0
+
+
+def test_post_build_setup_called_with_window(qapp):
+    """post_build_setup runs as the final step of __init__ and receives
+    the constructed window. All scaffolding (executor, status bar, toolbar)
+    is already in place at the time it runs."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    captured = {}
+
+    def my_post_build(window):
+        captured["window"] = window
+        # Verify the scaffolding the hook is supposed to be able to use.
+        captured["has_executor"] = window.executor is not None
+        captured["has_toolbar"] = window._toolbar is not None
+        captured["has_status_bar"] = window.statusBar() is not None
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        post_build_setup=my_post_build,
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert captured["window"] is w
+    assert captured["has_executor"]
+    assert captured["has_toolbar"]
+    assert captured["has_status_bar"]
+
+
+def test_post_build_setup_default_is_no_op(qapp):
+    """Demos that don't need post-build wiring don't have to specify one."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    # Must not raise.
+    BasePluggableProtocolDemoWindow(cfg)
+
+
+def test_status_bar_has_reps_label(qapp):
+    """The status bar exposes _status_reps_label, initially empty."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_reps_label.text() == ""
+
+
+def test_step_repetition_renders_chain(qapp):
+    """step_repetition with a non-empty chain renders 'rep i/n of name'."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.executor.qsignals.step_repetition.emit([("Wash", 2, 3)])
+    assert w._status_reps_label.text() == "rep 2/3 of 'Wash'"
+
+
+def test_step_repetition_empty_chain_clears(qapp):
+    """An empty rep chain clears the reps label."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w._status_reps_label.setText("rep 1/3 of 'Wash'")
+    w.executor.qsignals.step_repetition.emit([])
+    assert w._status_reps_label.text() == ""
+
+
+def test_step_finished_freezes_step_elapsed_label(qapp):
+    """step_finished calls _refresh_status, which paints the final
+    elapsed value into _status_step_time_label."""
+    import time
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Simulate mid-step state: started a known duration ago.
+    w._step_started_at = time.monotonic() - 1.5
+    w.executor.qsignals.step_finished.emit(None)
+    text = w._status_step_time_label.text()
+    assert text.startswith("Step ")
+    assert "1." in text or "1.5" in text   # close enough — within tick window
+
+
+def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
+    """protocol_error → idle button state, tick timer stopped, dialog
+    shown via the styled pyface_wrapper.error helper (NOT raw QMessageBox)."""
+    import pluggable_protocol_tree.demos.base_demo_window as bdw
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    calls = []
+
+    def fake_error_dialog(parent=None, title="", message="", **kwargs):
+        calls.append((title, message))
+
+    monkeypatch.setattr(bdw, "error_dialog", fake_error_dialog)
+
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = bdw.BasePluggableProtocolDemoWindow(cfg)
+    # Simulate a running state, then fire the error.
+    w.executor.qsignals.protocol_started.emit()
+    assert not w._run_action.isEnabled()
+    w.executor.qsignals.protocol_error.emit("kaboom")
+    # Idle state restored.
+    assert w._run_action.isEnabled()
+    assert not w._pause_action.isEnabled()
+    assert not w._stop_action.isEnabled()
+    assert not w._tick_timer.isActive()
+    # Dialog called via the styled wrapper, with the error message.
+    assert calls == [("Protocol error", "kaboom")]

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -302,6 +302,7 @@ def test_status_readout_creates_label_with_initial_text(qapp):
     w = BasePluggableProtocolDemoWindow(cfg)
     labels = list(w._readout_labels.values())
     assert len(labels) == 2
+    # Assertion order matches status_readouts declaration order (Python 3.7+ dict guarantee).
     assert labels[0].text() == "Voltage: --"
     assert labels[1].text() == "Frequency: --"
 
@@ -344,3 +345,21 @@ def test_status_readout_actor_names_are_slug_prefixed(qapp):
     broker = dramatiq.get_broker()
     # Should not raise
     broker.get_actor(expected_name)
+
+
+def test_status_readout_format_error_shows_inline_error(qapp):
+    """When the format function raises, the label shows '<error: ...>'."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w._readout_signals["voltage"].emit("not-a-number")
+    text = w._readout_labels["voltage"].text()
+    assert text.startswith("Voltage: <error:")

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -110,3 +110,75 @@ def test_window_columns_match_factory_output(qapp):
     w = BasePluggableProtocolDemoWindow(cfg)
     ids = [c.model.col_id for c in w.manager.columns]
     assert ids == ["type", "id", "name"]
+
+
+def test_pre_populate_runs_after_manager_construction(qapp):
+    """The pre_populate callback receives the live RowManager and
+    rows added there are present after window construction."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    def populate(rm):
+        rm.add_step(values={"name": "S1", "duration_s": 0.1})
+        rm.add_step(values={"name": "S2", "duration_s": 0.2})
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+            make_duration_column(),
+        ],
+        pre_populate=populate,
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert len(w.manager.root.children) == 2
+    assert w.manager.root.children[0].name == "S1"
+    assert w.manager.root.children[1].name == "S2"
+
+
+def test_routing_setup_called_after_standard_chain(qapp, monkeypatch):
+    """The routing_setup callback receives the router AFTER the base
+    wires the PPT-3 electrode chain. Verify by recording the order."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    call_log = []
+
+    def fake_router_setup_inner(self):
+        # Replace the real broker setup with a recording fake.
+        call_log.append("base_routing_setup")
+        # Need to set self._router so routing_setup can be called with it.
+        self._router = "fake-router"
+
+    monkeypatch.setattr(
+        BasePluggableProtocolDemoWindow,
+        "_setup_dramatiq_routing_internal",
+        fake_router_setup_inner,
+    )
+
+    def my_routing(router):
+        call_log.append(("routing_setup", router))
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        routing_setup=my_routing,
+    )
+    BasePluggableProtocolDemoWindow(cfg)
+    assert call_log == ["base_routing_setup", ("routing_setup", "fake-router")]
+
+
+def test_window_has_router_attribute_after_construction(qapp):
+    """self._router exists (may be None if Redis unavailable, that's fine)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert hasattr(w, "_router")

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -363,3 +363,61 @@ def test_status_readout_format_error_shows_inline_error(qapp):
     w._readout_signals["voltage"].emit("not-a-number")
     text = w._readout_labels["voltage"].text()
     assert text.startswith("Voltage: <error:")
+
+
+def test_toolbar_has_standard_actions(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    actions = [a.text() for a in w.findChildren(__import__("pyface.qt.QtWidgets", fromlist=["QToolBar"]).QToolBar)[0].actions()]
+    assert "Add Step" in actions
+    assert "Add Group" in actions
+    assert "Run" in actions
+    assert "Pause" in actions
+    assert "Stop" in actions
+
+
+def test_idle_button_state(qapp):
+    """Initially: Run enabled; Pause + Stop disabled."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._run_action.isEnabled()
+    assert not w._pause_action.isEnabled()
+    assert not w._stop_action.isEnabled()
+
+
+def test_protocol_started_swaps_buttons(qapp):
+    """When protocol_started fires: Run disabled; Pause + Stop enabled."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.executor.qsignals.protocol_started.emit()
+    assert not w._run_action.isEnabled()
+    assert w._pause_action.isEnabled()
+    assert w._stop_action.isEnabled()
+
+
+def test_protocol_terminated_returns_to_idle(qapp):
+    """When protocol_finished fires: back to idle button state."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.executor.qsignals.protocol_started.emit()
+    w.executor.qsignals.protocol_finished.emit()
+    assert w._run_action.isEnabled()
+    assert not w._pause_action.isEnabled()
+    assert not w._stop_action.isEnabled()
+    assert w._pause_action.text() == "Pause"

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -372,7 +372,7 @@ def test_toolbar_has_standard_actions(qapp):
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    actions = [a.text() for a in w.findChildren(__import__("pyface.qt.QtWidgets", fromlist=["QToolBar"]).QToolBar)[0].actions()]
+    actions = [a.text() for a in w._toolbar.actions()]
     assert "Add Step" in actions
     assert "Add Group" in actions
     assert "Run" in actions

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -512,3 +512,66 @@ def test_window_side_panel_uses_splitter(qapp):
     central = w.centralWidget()
     assert isinstance(central, QSplitter)
     assert central.count() == 2   # tree + side panel
+
+
+def test_clear_all_highlights_resets_status(qapp):
+    """After protocol terminates, status labels reset and step counters cleared."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Simulate state mid-run.
+    w._step_index = 2
+    w._step_total = 3
+    w._step_started_at = 100.0
+    w._readout_labels["voltage"].setText("Voltage: 99 V")
+    w._status_step_label.setText("Step 2 / 3")
+    # Terminate.
+    w._on_protocol_terminated()
+    assert w._status_step_label.text() == "Idle"
+    assert w._step_started_at is None
+    assert w._readout_labels["voltage"].text() == "Voltage: --"
+
+
+def test_purge_stale_subscribers_only_touches_demo_prefixes(qapp):
+    """The purger should ONLY consider actor names with demo prefixes
+    (ppt_demo_, ppt4_demo_, ppt5_demo_, ppt11_demo_, ppt12_demo_,
+    ppt_vf_demo_). Real listeners are NEVER touched."""
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        _is_purgable_demo_actor_name,
+    )
+    assert _is_purgable_demo_actor_name("ppt_demo_electrode_responder")
+    assert _is_purgable_demo_actor_name("ppt4_demo_voltage_applied_listener")
+    assert _is_purgable_demo_actor_name("ppt5_demo_magnet_responder")
+    assert _is_purgable_demo_actor_name("ppt12_demo_voltage_listener")
+    assert _is_purgable_demo_actor_name("ppt_vf_demo_spy")
+    # Real listeners — must NOT be purgable.
+    assert not _is_purgable_demo_actor_name("dropbot_controller_listener")
+    assert not _is_purgable_demo_actor_name(
+        "dropbot_status_and_controls_listener",
+    )
+    assert not _is_purgable_demo_actor_name(
+        "pluggable_protocol_tree_executor_listener",
+    )
+
+
+def test_run_classmethod_returns_int(qapp, monkeypatch):
+    """The .run(config) classmethod calls app.exec() and returns its int result."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    from pyface.qt.QtWidgets import QApplication
+
+    # Patch QApplication.exec to return 0 immediately.
+    monkeypatch.setattr(QApplication, "exec", lambda self: 0)
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    rc = BasePluggableProtocolDemoWindow.run(cfg)
+    assert rc == 0

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -284,3 +284,63 @@ def test_phase_acked_signal_resets_phase_timer(qapp):
     assert w._phase_started_at != before
     # First ack also sets step_started_at if it was None.
     assert w._step_started_at is not None
+
+
+def test_status_readout_creates_label_with_initial_text(qapp):
+    """Each StatusReadout adds a QLabel with `<label>: <initial>` text."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+            StatusReadout("Frequency", "f/applied", lambda m: f"{int(m)} Hz"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    labels = list(w._readout_labels.values())
+    assert len(labels) == 2
+    assert labels[0].text() == "Voltage: --"
+    assert labels[1].text() == "Frequency: --"
+
+
+def test_status_readout_label_updates_on_signal(qapp):
+    """Emitting the per-readout Qt signal updates the label text."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Voltage", "v/applied", lambda m: f"{int(m)} V"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w._readout_signals["voltage"].emit("100")
+    assert w._readout_labels["voltage"].text() == "Voltage: 100 V"
+
+
+def test_status_readout_actor_names_are_slug_prefixed(qapp):
+    """Each readout's auto-registered Dramatiq actor uses the slug-based
+    naming convention. Verify by inspecting the broker's registered actors."""
+    import dramatiq
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(
+        columns_factory=lambda: [make_type_column()],
+        status_readouts=[
+            StatusReadout("Magnet Height (mm)", "m/applied",
+                          lambda m: f"{m} mm"),
+        ],
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Actor name = ppt12_demo_<slug>_listener
+    expected_name = "ppt12_demo_magnet_height_mm_listener"
+    broker = dramatiq.get_broker()
+    # Should not raise
+    broker.get_actor(expected_name)

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -182,3 +182,61 @@ def test_window_has_router_attribute_after_construction(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
     assert hasattr(w, "_router")
+
+
+def test_window_has_status_bar_with_step_label(qapp):
+    """Status bar exists with the step counter label."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    sb = w.statusBar()
+    assert sb is not None
+    # Step label and row label should be there.
+    assert w._status_step_label.text() == "Idle"
+    assert w._status_row_label.text() == ""
+
+
+def test_window_status_step_elapsed_label_exists(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._status_step_time_label is not None
+
+
+def test_window_executor_step_started_connected_to_tree_highlight(qapp):
+    """The executor's step_started signal must connect to the tree
+    widget's highlight_active_row slot — verifies the active-row
+    highlight wiring is in place."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    # Indirect check: emit step_started with a fake row, watch tree's
+    # highlight_active_row receive it.
+    received = []
+    orig = w.widget.highlight_active_row
+    w.widget.highlight_active_row = lambda r: received.append(r)
+    try:
+        w.executor.qsignals.step_started.emit("fake-row")
+        assert received == ["fake-row"]
+    finally:
+        w.widget.highlight_active_row = orig
+
+
+def test_window_tick_timer_runs_at_10_hz(qapp):
+    """Tick timer interval should be 100 ms (10 Hz)."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert w._tick_timer.interval() == 100

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -486,7 +486,8 @@ def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
 
 
 def test_window_no_side_panel_uses_tree_as_central(qapp):
-    """When side_panel_factory is None, the central widget IS the tree."""
+    """When side_panel_factory is None, the central widget IS the tree
+    and _side_panel is None."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -494,24 +495,28 @@ def test_window_no_side_panel_uses_tree_as_central(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
     assert w.centralWidget() is w.widget
+    assert w._side_panel is None
 
 
 def test_window_side_panel_uses_splitter(qapp):
     """When side_panel_factory returns a widget, central is a splitter
-    holding tree + side panel."""
+    holding tree + side panel, AND the side widget is exposed at
+    w._side_panel for post_build_setup callbacks."""
     from pyface.qt.QtWidgets import QLabel, QSplitter
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
+    side_widget = QLabel("side")
     cfg = DemoConfig(
         columns_factory=lambda: [make_type_column()],
-        side_panel_factory=lambda rm: QLabel("side"),
+        side_panel_factory=lambda rm: side_widget,
     )
     w = BasePluggableProtocolDemoWindow(cfg)
     central = w.centralWidget()
     assert isinstance(central, QSplitter)
     assert central.count() == 2   # tree + side panel
+    assert w._side_panel is side_widget
 
 
 def test_clear_all_highlights_resets_status(qapp):
@@ -552,6 +557,7 @@ def test_purge_stale_subscribers_only_touches_demo_prefixes(qapp):
     assert _is_purgable_demo_actor_name("ppt5_demo_magnet_responder")
     assert _is_purgable_demo_actor_name("ppt12_demo_voltage_listener")
     assert _is_purgable_demo_actor_name("ppt_vf_demo_spy")
+    assert _is_purgable_demo_actor_name("integration_demo_overlay_listener")
     # Real listeners — must NOT be purgable.
     assert not _is_purgable_demo_actor_name("dropbot_controller_listener")
     assert not _is_purgable_demo_actor_name(

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -421,3 +421,65 @@ def test_protocol_terminated_returns_to_idle(qapp):
     assert not w._pause_action.isEnabled()
     assert not w._stop_action.isEnabled()
     assert w._pause_action.text() == "Pause"
+
+
+def test_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
+    """Save button writes manager.to_json() to the chosen file."""
+    from pyface.qt.QtWidgets import QFileDialog
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+
+    cfg = DemoConfig(
+        columns_factory=lambda: [
+            make_type_column(), make_id_column(), make_name_column(),
+            make_duration_column(),
+        ],
+        pre_populate=lambda rm: rm.add_step(values={"name": "S1", "duration_s": 0.1}),
+    )
+    w = BasePluggableProtocolDemoWindow(cfg)
+    save_path = tmp_path / "out.json"
+    monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    w._save()
+    import json
+    payload = json.loads(save_path.read_text())
+    assert payload["columns"][0]["id"] == "type"
+    assert any(r[3] == "S1" for r in payload["rows"])
+
+
+def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
+    """Load button reads JSON and applies via manager.set_state_from_json."""
+    from pyface.qt.QtWidgets import QFileDialog
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    import json
+
+    cfg = DemoConfig(columns_factory=lambda: [
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+
+    # Build a window once, save its empty state, then load it back.
+    w = BasePluggableProtocolDemoWindow(cfg)
+    w.manager.add_step(values={"name": "Saved Step", "duration_s": 0.5})
+    save_path = tmp_path / "in.json"
+    save_path.write_text(json.dumps(w.manager.to_json()))
+
+    # Fresh window with empty state.
+    w2 = BasePluggableProtocolDemoWindow(cfg)
+    assert len(w2.manager.root.children) == 0
+    monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    w2._load()
+    assert len(w2.manager.root.children) == 1
+    assert w2.manager.root.children[0].name == "Saved Step"


### PR DESCRIPTION
## Summary

Extracts a composition-based `BasePluggableProtocolDemoWindow` from the four existing protocol-tree demos so all of them share the same UX scaffolding (active-row highlight, status bar with timers, toolbar, save/load, button state machine, stale-subscriber purge). Each demo collapses to a small declarative `DemoConfig`, and a new full-stack integration demo (PPT-3 routes + PPT-4 V/F + PPT-5 magnet) lives at `examples/demos/run_full_integration_demo.py`.

The original trigger was that the PPT-5 magnet demo lacked the active-row highlight and status labels the V/F demo had. After this PR, all four demos — and the new integration demo — share a single, well-tested base.

## Demo LOC reductions

| Demo | Before | After | Δ |
|---|---:|---:|---:|
| PPT-3 `run_widget.py` | 531 | 157 | −70% |
| PPT-11 `run_widget_compound_demo.py` | 131 | 68 | −48% |
| PPT-4 `run_widget_with_vf.py` | 658 | 140 | −87% |
| PPT-5 `run_widget_magnet_demo.py` | 213 | 72 | −66% |
| Integration demo (new) | — | 188 | new |

## What the base class provides

- `BasePluggableProtocolDemoWindow(QMainWindow)` — protocol tree widget + executor + standard scaffolding
- `DemoConfig` dataclass — declarative config: `columns_factory`, `pre_populate`, `routing_setup`, `phase_ack_topic`, `status_readouts`, `side_panel_factory`, `post_build_setup`
- `StatusReadout(label, topic, fmt, initial)` — one ack-driven label per readout (auto-named Dramatiq actor + Qt signal + status-bar QLabel)
- Toolbar: Add Step, Add Group, Save…, Load…, Run, Pause/Resume, Stop with full button state machine
- Status bar: step counter, row/path label, repetition chain, step elapsed timer, optional phase elapsed timer, per-readout labels
- `protocol_error` handler using the styled `microdrop_application.dialogs.pyface_wrapper.error` (no raw `QMessageBox`)
- Stale-subscriber purge for known demo prefixes on Redis startup
- `.run(config)` classmethod for one-line `if __name__ == \"__main__\"` use

## Demo-specific wiring

Demos inject custom behavior (overlay actor binding, side-panel signal wiring) via the `post_build_setup(window)` callback on `DemoConfig` — no inheritance required.

## Test plan

- [x] 43 new tests in `pluggable_protocol_tree/tests/test_base_demo_window.py` — all pass
- [x] All 5 demos import cleanly via `python -c \"import …\"`
- [x] Full non-Redis test suite: 407 passed, 1 pre-existing peripheral_controller failure (unrelated to PPT-12)
- [ ] **Manual:** \`pixi run python -m peripheral_protocol_controls.demos.run_widget_magnet_demo\` — verify active-row highlight + step/phase timers + magnet readout (the original PPT-5 UX gap)
- [ ] **Manual:** \`pixi run python -m examples.demos.run_full_integration_demo\` — verify all three column types animate correctly together; verify priority bucketing (V/F/magnet @ 20 complete before electrodes @ 30)
- [ ] **Manual:** \`pixi run python -m dropbot_protocol_controls.demos.run_widget_with_vf\` — sanity-check no regression
- [ ] **Manual:** \`pixi run python -m pluggable_protocol_tree.demos.run_widget\` — sanity-check PPT-3 overlay + selection-tracking still work

## Notes

- Spec: \`docs/superpowers/specs/2026-04-28-ppt-12-demo-base-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md\` (16 tasks, all complete)
- Composition over inheritance — \`DemoConfig\` is the load-bearing decision; four real consumers built fine on it
- Phase-ack listener uses per-demo Dramatiq actor + Qt signal pattern; #386 tracks the future executor-emitted \`step_phase_started\` signal that would replace it

🤖 Generated with [Claude Code](https://claude.com/claude-code)