### PR TITLE
Wrap run_widget_auto __main__ with redis + dramatiq workers contexts

### DIFF
--- a/pluggable_protocol_tree/demos/run_widget_auto.py
+++ b/pluggable_protocol_tree/demos/run_widget_auto.py
@@ -513,4 +513,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            sys.exit(main())


### PR DESCRIPTION
## Summary

- Wraps `pluggable_protocol_tree/demos/run_widget_auto.py` `__main__` with the canonical `redis_server_context()` + `dramatiq_workers_context()` pattern used by the rest of the PPT demos.
- Preserves `sys.exit(main())` exit code semantics so CI/auto-test scripts still get the right return code.

Tiny PPT-12 follow-up: the rest of the PPT demos (PPT-3/4/5/11) already use this pattern (see master spec [§20 "Demo lifecycle gotchas"](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/blob/main/docs/superpowers/specs/2026-04-21-pluggable-protocol-tree-design.md#20-demo-lifecycle-gotchas)). `run_widget_auto.py` was the last holdout and required Redis + dramatiq workers to already be running externally. With these context managers the script is self-sufficient.

## Test plan

- [x] `pixi run python -m pluggable_protocol_tree.demos.run_widget_auto` runs to completion, prints `[AUTO EXIT] qt rc=… auto rc=… phases=…`, and exits with the auto exit code (no manual Redis/worker startup required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)