### PR TITLE
[FEAT](protocol): Add persistence for realtime mode post-protocol choice

### DIFF
--- a/microdrop_application/dialogs/pyface_wrapper.py
+++ b/microdrop_application/dialogs/pyface_wrapper.py
@@ -166,6 +166,11 @@ def information(
 ):
     """
     Pyface-compatible information dialog using styled BaseMessageDialog.
+
+        If *checkbox_text* is provided (via kwargs), a checkbox is added to the
+    dialog and the return value becomes a ``(result, checked)`` tuple.
+    Otherwise the return value is a plain ``int`` (YES / NO / CANCEL) for
+    full backward compatibility.
     """
 
     def create_dialog(**opts):
@@ -197,6 +202,11 @@ def success(
 ):
     """
     Pyface-compatible success dialog using styled BaseMessageDialog.
+
+        If *checkbox_text* is provided (via kwargs), a checkbox is added to the
+    dialog and the return value becomes a ``(result, checked)`` tuple.
+    Otherwise the return value is a plain ``int`` (YES / NO / CANCEL) for
+    full backward compatibility.
     """
 
     def create_dialog(**opts):
@@ -227,6 +237,11 @@ def warning(
 ):
     """
     Pyface-compatible warning dialog using styled BaseMessageDialog.
+
+        If *checkbox_text* is provided (via kwargs), a checkbox is added to the
+    dialog and the return value becomes a ``(result, checked)`` tuple.
+    Otherwise the return value is a plain ``int`` (YES / NO / CANCEL) for
+    full backward compatibility.
     """
 
     def create_dialog(**opts):
@@ -250,6 +265,15 @@ def disclaimer(
         ack_button_text: str = "I Understand",
         **kwargs,
 ):
+    """
+    Pyface-compatible disclaimer dialog using styled BaseMessageDialog.
+
+        If *checkbox_text* is provided (via kwargs), a checkbox is added to the
+    dialog and the return value becomes a ``(result, checked)`` tuple.
+    Otherwise the return value is a plain ``int`` (YES / NO / CANCEL) for
+    full backward compatibility.
+    """
+
     dialog = DisclaimerDialog(parent, title, message, ack_button_text, **kwargs)
 
     result = dialog.exec()
@@ -269,6 +293,11 @@ def error(
 ):
     """
     Pyface-compatible error dialog using styled BaseMessageDialog.
+
+        If *checkbox_text* is provided (via kwargs), a checkbox is added to the
+    dialog and the return value becomes a ``(result, checked)`` tuple.
+    Otherwise the return value is a plain ``int`` (YES / NO / CANCEL) for
+    full backward compatibility.
     """
 
     def create_dialog(**opts):

--- a/protocol_grid/preferences.py
+++ b/protocol_grid/preferences.py
@@ -3,7 +3,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import List, Enum, Directory
+from traits.api import List, Enum, Directory, Bool
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import View, Item
 from envisage.ui.tasks.api import PreferencesCategory
@@ -58,6 +58,9 @@ class ProtocolPreferences(PreferencesHelper):
         desc="Time to allow logs post protocol end"
     )
 
+    prompt_to_restore_realtime_mode = Bool(True)
+    keep_realtime_mode_after_protocol = Bool(True)
+
     capture_time = Enum(StepTime.START, StepTime.END, value=StepTime.START)
 
     PROTOCOL_REPO_DIR = Directory()
@@ -111,9 +114,19 @@ class ProtocolPreferencesPane(PreferencesPane):
         group_style_sheet=preferences_group_style_sheet,
     )
 
+    realtime_mode_settings_grid = create_grid_group(
+        items=["prompt_to_restore_realtime_mode", "keep_realtime_mode_after_protocol"],
+        label_text = ["Prompt to keep Realtime Mode?", "Keep Realtime Mode active?"],
+        group_label="Realtime Mode Persistence",
+        group_show_border=True,
+        group_style_sheet=preferences_group_style_sheet,
+    )
+
     view = View(
         Item("_"),  # Separator
         general_protocol_settings_grid,
+        Item("_"),
+        realtime_mode_settings_grid,
         Item("_"),
         camera_settings_grid,
         Item("_"),  # Separator to space this out from further contributions to the pane.

--- a/protocol_grid/services/protocol_runner_controller.py
+++ b/protocol_grid/services/protocol_runner_controller.py
@@ -774,20 +774,32 @@ class ProtocolRunnerController(QObject):
             logger.info(f"Realtime mode was off before protocol start; turning it on...")
             publish_message(topic=SET_REALTIME_MODE, message=str(True))
 
-        else:
-            user_choice = confirm(
+        elif self.protocol_preferences.prompt_to_restore_realtime_mode:
+            user_choice, remember = confirm(
                 None,
                 title="Keep Realtime Mode Enabled Post-Protocol?",
                 message="<b>Realtime mode is currently ON.</b><br><br>Would you like to keep it enabled after the protocol finishes?",
-                cancel=False
+                cancel=False,
+                checkbox_text="Don't ask again (can be changed in preferences)"
             )
 
             if user_choice == YES:
                 logger.warning("Keeping Realtime Mode Enabled Post-Protocol.")
-
-            elif user_choice == NO:
+                self._restore_realtime_mode = True
+            else:
                 logger.info("Realtime Mode Disabled Post-Protocol.")
-                self._restore_realtime_mode = False # user wants realtime restoration changed to False
+                self._restore_realtime_mode = False
+
+            if remember:
+                self.protocol_preferences.prompt_to_restore_realtime_mode = False
+                self.protocol_preferences.keep_realtime_mode_after_protocol = self._restore_realtime_mode
+        else:
+            # Use the saved preference if prompt is disabled
+            self._restore_realtime_mode = self.protocol_preferences.keep_realtime_mode_after_protocol
+            if self._restore_realtime_mode:
+                logger.info("Automatically keeping Realtime Mode Enabled (per user preference).")
+            else:
+                logger.info("Automatically disabling Realtime Mode after protocol (per user preference).")
 
         # Get the fully calculated camera schedule
         video_on_mask, offset_seconds_arr = self._prepare_camera_schedule()


### PR DESCRIPTION
  # Persist Realtime Mode Post-Protocol Choice

 ##  Description
  This PR improves the user experience when running protocols while "Realtime Mode" is already enabled. Previously, users were prompted every time a protocol started to decide whether they wanted to keep Realtime Mode
  active after the protocol finished. 

  This change introduces persistence for that choice, allowing users to "Don't ask again" and managing that behavior via the application preferences.

##  Changes
  ### Preferences (protocol_grid/preferences.py)
   - Added two new persistent settings to ProtocolPreferences:
     - prompt_to_restore_realtime_mode: Boolean (default True) that controls whether the confirmation dialog is shown.
     - keep_realtime_mode_after_protocol: Boolean (default True) that stores the user's preferred post-protocol state.
   - Updated ProtocolPreferencesPane to include a new Realtime Mode Persistence section in the UI, enabling users to manually reset or change these behaviors.

  ### Logic (protocol_grid/services/protocol_runner_controller.py)
   - Updated _prepare_for_protocol_run to check the prompt_to_restore_realtime_mode preference.
   - Implemented logic to unpack the (result, checked) tuple from the confirm dialog (previously, the checkbox value was ignored).
   - If the "Don't ask again" checkbox is checked, the user's choice is saved directly to their preferences, and the prompt is disabled for future runs.
   - If the prompt is disabled, the controller automatically applies the saved preference.
   - Refined the dialog text to be more concise and standard: "Don't ask again (can be changed in preferences)".

  ### How to Verify
   1. Enable Realtime Mode in the main Microdrop interface.
   2. Start a Protocol: A confirmation dialog should appear asking if you'd like to keep Realtime Mode enabled post-run.
   3. Test "Don't ask again":
       - Check the "Don't ask again" box and select Yes.
       - Verify that after the protocol finishes, Realtime Mode remains ON.
       - Start the protocol again; verify that no prompt appears and Realtime Mode stays on afterwards.
   4. Test Preference Pane:
       - Go to File -> Preferences -> Protocol Settings.
       - Verify the new Realtime Mode Persistence group is visible.
       - Toggle "Prompt to keep Realtime Mode?" back to ON.
       - Verify the prompt reappears on the next protocol start.
   5. Verify Restoration:
       - Ensure that if Realtime Mode was OFF before the protocol, it is still automatically turned OFF afterwards without any prompt (preserving existing safety behavior).

  ## UI Changes
  A new section in the Protocol Settings tab:
  > Realtime Mode Persistence
  > - [x] Prompt to keep Realtime Mode?
  > - [x] Keep Realtime Mode active?

