### PR TITLE
[PPT-10] Port navigation pane + status bar to pluggable_protocol_tree

### DIFF
--- a/dropbot_protocol_controls/demos/run_droplet_check_demo.py
+++ b/dropbot_protocol_controls/demos/run_droplet_check_demo.py
@@ -94,7 +94,8 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
-    viewer.actuation_changed.emit(list(electrodes))
+    preview = bool(payload.get("preview", False))
+    viewer.actuation_changed.emit(list(electrodes), preview)
 
 
 def _columns():

--- a/dropbot_protocol_controls/demos/run_force_demo.py
+++ b/dropbot_protocol_controls/demos/run_force_demo.py
@@ -40,6 +40,9 @@ from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from device_viewer.consts import CALIBRATION_DATA
 
 from dropbot_protocol_controls.consts import CALIBRATION_LISTENER_ACTOR_NAME
+from dropbot_protocol_controls.demos.voltage_frequency_responder import (
+    subscribe_demo_responder,
+)
 from dropbot_protocol_controls.protocol_columns.force_column import (
     make_force_column,
 )
@@ -111,8 +114,11 @@ def _pre_populate(rm):
 
 def _routing_setup(router):
     """Wire the calibration listener so the published CALIBRATION_DATA
-    message reaches the actor that updates the cache."""
+    message reaches the actor that updates the cache, plus the V/F
+    demo responder so FrequencyHandler/VoltageHandler wait_for() acks
+    arrive (without it, on_step times out at 5s)."""
     subscribe_calibration_listener(router)
+    subscribe_demo_responder(router)
 
 
 def _publish_demo_calibration():

--- a/dropbot_protocol_controls/demos/run_voltage_frequency_demo.py
+++ b/dropbot_protocol_controls/demos/run_voltage_frequency_demo.py
@@ -156,4 +156,10 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    from microdrop_utils.broker_server_helpers import (
+        redis_server_context, dramatiq_workers_context,
+    )
+
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()

--- a/dropbot_protocol_controls/demos/run_widget_with_vf.py
+++ b/dropbot_protocol_controls/demos/run_widget_with_vf.py
@@ -67,7 +67,8 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
-    viewer.actuation_changed.emit(list(electrodes))
+    preview = bool(payload.get("preview", False))
+    viewer.actuation_changed.emit(list(electrodes), preview)
 
 
 def _columns():

--- a/dropbot_protocol_controls/protocol_columns/droplet_check_column.py
+++ b/dropbot_protocol_controls/protocol_columns/droplet_check_column.py
@@ -79,6 +79,10 @@ class DropletCheckHandler(BaseColumnHandler):
     def on_post_step(self, row, ctx):
         if not row.check_droplets:
             return
+        # Preview mode: skip the detection RPC + ack-wait. With no
+        # hardware actuation in preview, there's nothing to detect.
+        if getattr(ctx.protocol, "preview_mode", False):
+            return
 
         electrode_to_channel = ctx.protocol.scratch.get("electrode_to_channel", {})
         expected = expected_channels_for_step(row, electrode_to_channel)

--- a/dropbot_protocol_controls/protocol_columns/frequency_column.py
+++ b/dropbot_protocol_controls/protocol_columns/frequency_column.py
@@ -48,6 +48,10 @@ class FrequencyHandler(BaseColumnHandler):
         DropbotPreferences().last_frequency = int(value)
 
     def on_step(self, row, ctx):
+        # Preview mode: skip the hardware-publish + ack-wait.
+        # Mirrors the legacy protocol_grid Preview Mode.
+        if getattr(ctx.protocol, "preview_mode", False):
+            return
         v = int(row.frequency)
         publish_message(topic=PROTOCOL_SET_FREQUENCY, message=str(v))
         ctx.wait_for(FREQUENCY_APPLIED, timeout=5.0)

--- a/dropbot_protocol_controls/protocol_columns/voltage_column.py
+++ b/dropbot_protocol_controls/protocol_columns/voltage_column.py
@@ -56,6 +56,11 @@ class VoltageHandler(BaseColumnHandler):
         DropbotPreferences().last_voltage = int(value)
 
     def on_step(self, row, ctx):
+        # Preview mode: skip the hardware-publish + ack-wait. The
+        # DropBot voltage RPC isn't sent and no VOLTAGE_APPLIED comes
+        # back. Mirrors the legacy protocol_grid Preview Mode.
+        if getattr(ctx.protocol, "preview_mode", False):
+            return
         v = int(row.voltage)
         publish_message(topic=PROTOCOL_SET_VOLTAGE, message=str(v))
         ctx.wait_for(VOLTAGE_APPLIED, timeout=5.0)

--- a/dropbot_protocol_controls/tests/test_frequency_column.py
+++ b/dropbot_protocol_controls/tests/test_frequency_column.py
@@ -82,6 +82,7 @@ def test_frequency_handler_on_step_publishes_and_waits():
     row = MagicMock()
     row.frequency = 8000
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(
@@ -102,6 +103,7 @@ def test_frequency_handler_on_step_publishes_int_payload():
     row = MagicMock()
     row.frequency = 5000.9  # float — should be coerced
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(

--- a/dropbot_protocol_controls/tests/test_voltage_column.py
+++ b/dropbot_protocol_controls/tests/test_voltage_column.py
@@ -85,6 +85,7 @@ def test_voltage_handler_on_step_publishes_and_waits():
     row = MagicMock()
     row.voltage = 120
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
     ctx.protocol.stop_event.is_set.return_value = False
 
     published = []
@@ -107,6 +108,7 @@ def test_voltage_handler_on_step_publishes_int_payload():
     row = MagicMock()
     row.voltage = 99.7  # float — should be coerced to int
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(

--- a/examples/demos/run_full_integration_demo.py
+++ b/examples/demos/run_full_integration_demo.py
@@ -83,7 +83,8 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
-    viewer.actuation_changed.emit(list(electrodes))
+    preview = bool(payload.get("preview", False))
+    viewer.actuation_changed.emit(list(electrodes), preview)
 
 
 def _columns():

--- a/microdrop_utils/pyside_helpers.py
+++ b/microdrop_utils/pyside_helpers.py
@@ -683,6 +683,79 @@ class MarqueeComboBox(QtWidgets.QComboBox):
         )
 
 
+class MarqueeLabel(QLabel):
+    """QLabel that marquee-scrolls overflow text on hover.
+
+    Behavior: when the rendered text is wider than the label's content
+    rect, hovering scrolls the text leftward at ~40 fps until its tail
+    is visible, then holds that position until the mouse leaves — at
+    which point the offset resets to the start. If the text already
+    fits, hover does nothing.
+
+    Mirrors the scroll-then-hold pattern used by MarqueeComboBox above.
+    """
+
+    SCROLL_INTERVAL_MS = 25   # ~40 fps
+    SCROLL_STEP_PX = 2
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._offset = 0
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self.SCROLL_INTERVAL_MS)
+        self._timer.timeout.connect(self._tick)
+
+    def setText(self, text):
+        super().setText(text)
+        self._reset_scroll()
+
+    def _max_offset(self):
+        """Pixels the text must travel so its tail reaches the right edge."""
+        text_w = self.fontMetrics().horizontalAdvance(self.text())
+        # 4 px margin matches MarqueeComboBox so chrome alignment is consistent.
+        return max(0, text_w - (self.width() - 4))
+
+    def _reset_scroll(self):
+        self._timer.stop()
+        self._offset = 0
+        self.update()
+
+    def enterEvent(self, event):
+        super().enterEvent(event)
+        if self._max_offset() > 0 and not self._timer.isActive():
+            self._offset = 0
+            self._timer.start()
+
+    def leaveEvent(self, event):
+        super().leaveEvent(event)
+        self._reset_scroll()
+
+    def _tick(self):
+        max_offset = self._max_offset()
+        self._offset = min(self._offset + self.SCROLL_STEP_PX, max_offset)
+        if self._offset >= max_offset:
+            # Tail reached; hold position until leaveEvent resets us.
+            self._timer.stop()
+        self.update()
+
+    def paintEvent(self, event):
+        # No active scroll AND no held offset → default QLabel rendering
+        # (preserves stylesheet/foreground role/alignment behaviour).
+        if self._offset == 0 and not self._timer.isActive():
+            super().paintEvent(event)
+            return
+        painter = QPainter(self)
+        painter.setPen(self.palette().color(self.foregroundRole()))
+        rect = self.contentsRect()
+        painter.setClipRect(rect)
+        text_w = painter.fontMetrics().horizontalAdvance(self.text())
+        painter.drawText(
+            rect.x() - self._offset, rect.y(),
+            text_w + self._offset, rect.height(),
+            self.alignment(), self.text(),
+        )
+
+
 class _ScalingPixmapLabel(QLabel):
     """QLabel that auto-scales its pixmap to fill available space on resize.
 

--- a/peripheral_protocol_controls/protocol_columns/magnet_column.py
+++ b/peripheral_protocol_controls/protocol_columns/magnet_column.py
@@ -98,6 +98,11 @@ class MagnetHandler(BaseCompoundColumnHandler):
     wait_for_topics = [MAGNET_APPLIED]
 
     def on_step(self, row, ctx):
+        # Preview mode: skip the hardware-publish + ack-wait. The
+        # magnet stage doesn't move and no MAGNET_APPLIED comes
+        # back. Mirrors the legacy protocol_grid Preview Mode.
+        if getattr(ctx.protocol, "preview_mode", False):
+            return
         payload = json.dumps({
             "on": bool(row.magnet_on),
             "height_mm": float(row.magnet_height_mm),

--- a/peripheral_protocol_controls/tests/test_magnet_column.py
+++ b/peripheral_protocol_controls/tests/test_magnet_column.py
@@ -129,6 +129,7 @@ def test_magnet_handler_on_step_publishes_engage_payload():
     row.magnet_on = True
     row.magnet_height_mm = 5.0
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(
@@ -155,6 +156,7 @@ def test_magnet_handler_on_step_publishes_retract_payload():
     row.magnet_on = False
     row.magnet_height_mm = 0.0
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(
@@ -179,6 +181,7 @@ def test_magnet_handler_on_step_publishes_default_sentinel_payload():
     row.magnet_on = True
     row.magnet_height_mm = float(MIN_ZSTAGE_HEIGHT_MM - 0.5)
     ctx = MagicMock()
+    ctx.protocol.preview_mode = False
 
     published = []
     with patch(

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -85,6 +85,11 @@ class RoutesHandler(BaseColumnHandler):
         mapping = ctx.protocol.scratch.get("electrode_to_channel", {})
         per_phase_dwell = float(getattr(row, "duration_s", 0.0) or 0.0)
         stop_event = ctx.protocol.stop_event
+        # Preview mode: walk the same phase iteration and dwell
+        # accordingly, but skip the broker publish and the ack-wait —
+        # the protocol logic and timing still execute, just without
+        # touching hardware. Mirrors legacy protocol_grid preview.
+        preview_mode = bool(getattr(ctx.protocol, "preview_mode", False))
         for phase in iter_phases(
             static_electrodes=list(getattr(row, "electrodes", []) or []),
             routes=list(getattr(row, "routes", []) or []),
@@ -107,20 +112,22 @@ class RoutesHandler(BaseColumnHandler):
                         "electrode %r has no channel mapping; "
                         "actuation channel skipped", e,
                     )
-            publish_message(
-                topic=ELECTRODES_STATE_CHANGE,
-                message=json.dumps({
-                    "electrodes": electrodes,
-                    "channels": channels,
-                }),
-            )
-            # 5.0s matches ack_roundtrip_column. Keeps headroom for the
-            # first publish in a process (cold broker pays ~1-2s) and
-            # for queue contention when other handlers in the same
-            # priority bucket publish in parallel and serialize through
-            # the single dramatiq worker queue. Hardware controllers
-            # typically ack in <100ms.
-            ctx.wait_for(ELECTRODES_STATE_APPLIED, timeout=5.0)
+            if not preview_mode:
+                publish_message(
+                    topic=ELECTRODES_STATE_CHANGE,
+                    message=json.dumps({
+                        "electrodes": electrodes,
+                        "channels": channels,
+                    }),
+                )
+                # 5.0s matches ack_roundtrip_column. Keeps headroom
+                # for the first publish in a process (cold broker
+                # pays ~1-2s) and for queue contention when other
+                # handlers in the same priority bucket publish in
+                # parallel and serialize through the single dramatiq
+                # worker queue. Hardware controllers typically ack
+                # in <100ms.
+                ctx.wait_for(ELECTRODES_STATE_APPLIED, timeout=5.0)
             _cooperative_sleep(per_phase_dwell, stop_event)
         # Tell DurationColumnHandler we already covered the dwell.
         ctx.scratch[DURATION_CONSUMED_KEY] = True

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -85,10 +85,13 @@ class RoutesHandler(BaseColumnHandler):
         mapping = ctx.protocol.scratch.get("electrode_to_channel", {})
         per_phase_dwell = float(getattr(row, "duration_s", 0.0) or 0.0)
         stop_event = ctx.protocol.stop_event
-        # Preview mode: walk the same phase iteration and dwell
-        # accordingly, but skip the broker publish and the ack-wait —
-        # the protocol logic and timing still execute, just without
-        # touching hardware. Mirrors legacy protocol_grid preview.
+        # Preview mode publishes the electrode-state-change message AND
+        # waits for the ack just like a real run, so the device viewer's
+        # overlay listener still highlights each phase's electrodes —
+        # only the hardware-driving consumer (dropbot_controller, etc.)
+        # is expected to honour the embedded ``preview`` flag and skip
+        # actuation. This way the user gets a visual route playback
+        # without touching the chip.
         preview_mode = bool(getattr(ctx.protocol, "preview_mode", False))
         for phase in iter_phases(
             static_electrodes=list(getattr(row, "electrodes", []) or []),
@@ -112,22 +115,25 @@ class RoutesHandler(BaseColumnHandler):
                         "electrode %r has no channel mapping; "
                         "actuation channel skipped", e,
                     )
-            if not preview_mode:
-                publish_message(
-                    topic=ELECTRODES_STATE_CHANGE,
-                    message=json.dumps({
-                        "electrodes": electrodes,
-                        "channels": channels,
-                    }),
-                )
-                # 5.0s matches ack_roundtrip_column. Keeps headroom
-                # for the first publish in a process (cold broker
-                # pays ~1-2s) and for queue contention when other
-                # handlers in the same priority bucket publish in
-                # parallel and serialize through the single dramatiq
-                # worker queue. Hardware controllers typically ack
-                # in <100ms.
-                ctx.wait_for(ELECTRODES_STATE_APPLIED, timeout=5.0)
+            payload = {
+                "electrodes": electrodes,
+                "channels": channels,
+            }
+            if preview_mode:
+                # Tell hardware-driving consumers to skip actuation;
+                # visualizers (device viewer overlay) ignore the flag.
+                payload["preview"] = True
+            publish_message(
+                topic=ELECTRODES_STATE_CHANGE,
+                message=json.dumps(payload),
+            )
+            # 5.0s matches ack_roundtrip_column. Keeps headroom for the
+            # first publish in a process (cold broker pays ~1-2s) and
+            # for queue contention when other handlers in the same
+            # priority bucket publish in parallel and serialize through
+            # the single dramatiq worker queue. Hardware controllers
+            # typically ack in <100ms.
+            ctx.wait_for(ELECTRODES_STATE_APPLIED, timeout=5.0)
             _cooperative_sleep(per_phase_dwell, stop_event)
         # Tell DurationColumnHandler we already covered the dwell.
         ctx.scratch[DURATION_CONSUMED_KEY] = True

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -85,6 +85,7 @@ class RoutesHandler(BaseColumnHandler):
         mapping = ctx.protocol.scratch.get("electrode_to_channel", {})
         per_phase_dwell = float(getattr(row, "duration_s", 0.0) or 0.0)
         stop_event = ctx.protocol.stop_event
+        pause_event = ctx.protocol.pause_event
         # Preview mode publishes the electrode-state-change message AND
         # waits for the ack just like a real run, so the device viewer's
         # overlay listener still highlights each phase's electrodes —
@@ -107,6 +108,15 @@ class RoutesHandler(BaseColumnHandler):
         ):
             if stop_event.is_set():
                 break
+            # Pause check at the phase boundary — block here so the
+            # next phase's actuation doesn't fire until the user
+            # resumes. The executor's between-step pause check
+            # doesn't reach inside on_step's phase loop, so without
+            # this the routes keep playing through a Pause click.
+            if pause_event.is_set():
+                pause_event.wait_cleared()
+                if stop_event.is_set():
+                    break
             electrodes = sorted(phase)
             channels = sorted(mapping[e] for e in electrodes if e in mapping)
             for e in electrodes:
@@ -134,19 +144,26 @@ class RoutesHandler(BaseColumnHandler):
             # the single dramatiq worker queue. Hardware controllers
             # typically ack in <100ms.
             ctx.wait_for(ELECTRODES_STATE_APPLIED, timeout=5.0)
-            _cooperative_sleep(per_phase_dwell, stop_event)
+            _cooperative_sleep(per_phase_dwell, stop_event, pause_event)
         # Tell DurationColumnHandler we already covered the dwell.
         ctx.scratch[DURATION_CONSUMED_KEY] = True
 
 
-def _cooperative_sleep(seconds: float, stop_event) -> None:
-    """Sleep for ``seconds``, waking every _SLICE_S to check stop_event.
-    Used so a Stop press lands within ~50ms even mid-dwell. Returns
-    early on stop or when seconds reaches 0."""
+def _cooperative_sleep(seconds: float, stop_event, pause_event=None) -> None:
+    """Sleep for ``seconds``, waking every _SLICE_S to check stop_event
+    (and pause_event if provided). Used so a Stop or Pause press lands
+    within ~50ms even mid-dwell. On pause: block in
+    ``pause_event.wait_cleared()`` until the user resumes, then
+    continue with the remaining dwell. Returns early on stop or when
+    seconds reaches 0."""
     remaining = seconds
     while remaining > 0:
         if stop_event.is_set():
             return
+        if pause_event is not None and pause_event.is_set():
+            pause_event.wait_cleared()
+            if stop_event.is_set():
+                return
         slice_dur = min(_SLICE_S, remaining)
         time.sleep(slice_dur)
         remaining -= slice_dur

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -639,9 +639,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.navigation_bar.btn_play.clicked.connect(self._on_play_clicked)
         self.navigation_bar.btn_resume.clicked.connect(self._toggle_pause)
         self.navigation_bar.btn_stop.clicked.connect(self.executor.stop)
-        # Preview Mode / Droplet Check are persistent toggles on the
-        # play dropdown — the Run click reads them via
-        # is_preview_mode() / is_droplet_check_enabled(); no extra
+        # Preview Mode is a persistent toggle on the play dropdown —
+        # the Run click reads it via is_preview_mode(); no extra
         # signal wiring needed here.
 
         # Step navigation (cursor only — no protocol mutation).
@@ -712,9 +711,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(False)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(True)
-        # Re-enable the persistent run-mode toggles on the play dropdown.
+        # Re-enable the Preview-Mode toggle on the play dropdown.
         nb.action_preview.setEnabled(True)
-        nb.action_droplet_check.setEnabled(True)
 
     def _set_running_button_state(self):
         nb = self.navigation_bar
@@ -723,10 +721,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(True)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(False)
-        # Modes are locked once a run is in progress — don't let the
-        # user re-arm Preview / toggle Droplet Check mid-run.
+        # Mode is locked once a run is in progress — don't let the
+        # user re-arm Preview mid-run.
         nb.action_preview.setEnabled(False)
-        nb.action_droplet_check.setEnabled(False)
 
     def _on_play_clicked(self):
         """While idle: start the protocol from the currently-selected

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -71,7 +71,11 @@ class DemoConfig:
 
     # Cosmetic.
     title: str = "Pluggable Protocol Tree Demo"
-    window_size: tuple[int, int] = (1100, 650)
+    # Default width sized so the legacy-style StatusBar's full label
+    # row (Total Time / Step Time / Phase Time / Repeat Protocol /
+    # Step X/Y / Repetition X/Y / Most Recent Step / Next Step) fits
+    # without horizontal clipping at moderate step-name lengths.
+    window_size: tuple[int, int] = (1500, 650)
 
     # Optional sample steps populated after RowManager construction.
     pre_populate: Callable[[Any], None] = field(

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -71,11 +71,7 @@ class DemoConfig:
 
     # Cosmetic.
     title: str = "Pluggable Protocol Tree Demo"
-    # Default width sized so the legacy-style StatusBar's full label
-    # row (Total Time / Step Time / Phase Time / Repeat Protocol /
-    # Step X/Y / Repetition X/Y / Most Recent Step / Next Step) fits
-    # without horizontal clipping at moderate step-name lengths.
-    window_size: tuple[int, int] = (1500, 650)
+    window_size: tuple[int, int] = (1100, 650)
 
     # Optional sample steps populated after RowManager construction.
     pre_populate: Callable[[Any], None] = field(

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -289,6 +289,14 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         # button machine uses it to disable the dropdown so a user
         # can't switch modes mid-run.
         self._current_run_preview_mode = False
+        # Phase-navigation state: while paused mid-step the demo
+        # window splits the play button into prev/resume/next phase
+        # controls and lets the user step through the paused row's
+        # phase list (for visualization only — the worker thread's
+        # actual phase position is independent and resumes from
+        # wherever it was when paused).
+        self._pause_phases: list = []
+        self._pause_phase_idx: int = 0
         self._tick_timer = QTimer(self)
         self._tick_timer.setInterval(100)   # 10 Hz
         self._tick_timer.timeout.connect(self._refresh_status)
@@ -649,9 +657,14 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.navigation_bar.btn_next.clicked.connect(self._navigate_to_next_step)
         self.navigation_bar.btn_last.clicked.connect(self._navigate_to_last_step)
 
-        # Phase navigation: per-phase cursor isn't implemented yet (PPT-10
-        # scope item). Buttons stay visually present but disabled until
-        # the phase cursor arrives.
+        # Phase navigation — only useful while the protocol is paused
+        # mid-step. The handlers compute the paused step's phase list
+        # locally (no coordination with the worker thread) and publish
+        # ELECTRODES_STATE_CHANGE for the requested phase so the
+        # visualizer overlays it; the ``preview`` flag in the payload
+        # keeps the hardware driver from actuating.
+        self.navigation_bar.btn_prev_phase.clicked.connect(self._on_prev_phase)
+        self.navigation_bar.btn_next_phase.clicked.connect(self._on_next_phase)
         self.navigation_bar.set_phase_navigation_enabled(False, False)
 
         # Wrap navigation bar + status bar + existing central content
@@ -788,11 +801,21 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     def _on_protocol_paused(self):
         self.navigation_bar.show_resume_state()
         self._tick_timer.stop()
+        # Swap to the prev / resume / next-phase trio so the user can
+        # explore the paused row's phases visually. Computed locally —
+        # the worker thread's iter_phases position isn't reachable
+        # from the GUI thread without thread-safe shared state.
+        if self._current_row is not None:
+            self._compute_pause_phase_state(self._current_row)
+            self.navigation_bar.split_play_button_to_phase_controls()
+            self._update_phase_nav_buttons()
 
     def _on_protocol_resumed(self):
         self.navigation_bar.show_pause_state()
         if self._current_row is not None:
             self._tick_timer.start()
+        # Restore the unified play button.
+        self.navigation_bar.merge_phase_controls_to_play_button()
 
     def _on_protocol_finished(self):
         """Natural completion. Bump the repeat counter; if more reps
@@ -823,6 +846,89 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._clear_all_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
+        # If the protocol terminated while paused, the play button is
+        # still split into the phase-nav trio — merge it back so the
+        # idle UI is the unified play button again.
+        self.navigation_bar.merge_phase_controls_to_play_button()
+        self._pause_phases = []
+        self._pause_phase_idx = 0
+
+    # --- pause-time phase navigation ------------------------------------
+
+    def _compute_pause_phase_state(self, row):
+        """Build the paused row's phase list locally so prev/next phase
+        can step through it without touching the worker thread. Index
+        starts at 0 — we don't know the worker's actual phase position,
+        so the user explores from the start of the step."""
+        from pluggable_protocol_tree.services.phase_math import iter_phases
+        try:
+            self._pause_phases = list(iter_phases(
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)),
+                soft_end=bool(getattr(row, "soft_end", False)),
+                repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
+                linear_repeats=bool(getattr(row, "linear_repeats", False)),
+                n_repeats=int(getattr(row, "repetitions", 1)),
+                step_duration_s=float(getattr(row, "duration_s", 1.0)),
+            ))
+        except Exception as e:
+            logger.warning(f"phase navigation: iter_phases failed: {e}")
+            self._pause_phases = []
+        self._pause_phase_idx = 0
+
+    def _on_prev_phase(self):
+        if self._pause_phases and self._pause_phase_idx > 0:
+            self._pause_phase_idx -= 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _on_next_phase(self):
+        if (self._pause_phases
+                and self._pause_phase_idx < len(self._pause_phases) - 1):
+            self._pause_phase_idx += 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _publish_paused_phase(self):
+        """Publish ELECTRODES_STATE_CHANGE for the currently-pointed
+        phase so the device viewer overlays it. The ``preview`` flag
+        is set so any hardware-driving consumer (real DropBot, etc.)
+        ignores the message — we don't want pause-time exploration to
+        actuate the chip."""
+        from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+
+        if not self._pause_phases:
+            return
+        phase = self._pause_phases[self._pause_phase_idx]
+        mapping = self.manager.protocol_metadata.get(
+            "electrode_to_channel", {},
+        )
+        electrodes = sorted(phase)
+        channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        try:
+            publish_message(
+                topic=ELECTRODES_STATE_CHANGE,
+                message=json.dumps({
+                    "electrodes": electrodes,
+                    "channels": channels,
+                    "preview": True,
+                }),
+            )
+        except Exception as e:
+            logger.warning(f"phase navigation publish failed: {e}")
+
+    def _update_phase_nav_buttons(self):
+        prev_enabled = self._pause_phase_idx > 0
+        next_enabled = (
+            bool(self._pause_phases)
+            and self._pause_phase_idx < len(self._pause_phases) - 1
+        )
+        self.navigation_bar.set_phase_navigation_enabled(
+            prev_enabled, next_enabled,
+        )
 
     # --- step-cursor navigation ----------------------------------------
 

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -650,7 +650,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     def _set_idle_button_state(self):
         nb = self.navigation_bar
         nb.btn_play.setEnabled(True)
-        nb.btn_play.setToolTip("Play Protocol")
+        nb.show_play_state()
         nb.btn_stop.setEnabled(False)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(True)
@@ -658,18 +658,34 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     def _set_running_button_state(self):
         nb = self.navigation_bar
         nb.btn_play.setEnabled(True)         # acts as Pause while running
-        nb.btn_play.setToolTip("Pause Protocol")
+        nb.show_pause_state()
         nb.btn_stop.setEnabled(True)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(False)
 
     def _on_play_clicked(self):
-        """While idle: start the protocol. While running/paused: toggle
-        pause. Mirrors the legacy protocol_grid play-button behaviour."""
+        """While idle: start the protocol from the currently-selected
+        step (or from the beginning if nothing is selected). While
+        running/paused: toggle pause. Mirrors the legacy
+        protocol_grid play-button behaviour."""
         if self._is_protocol_active():
             self._toggle_pause()
         else:
-            self.executor.start()
+            self.executor.start(start_step_path=self._selected_step_path())
+
+    def _selected_step_path(self):
+        """Return the path tuple of the currently-selected row, but only
+        if it's a step row that actually appears in execution order;
+        else None (which causes the executor to start from the
+        beginning)."""
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        path = self.widget._index_to_path(idx)
+        for row in self.manager.iter_execution_steps():
+            if tuple(row.path) == path:
+                return path
+        return None
 
     def _is_protocol_active(self):
         """True iff the executor is currently running or paused. The
@@ -685,11 +701,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self.executor.pause()
 
     def _on_protocol_paused(self):
-        self.navigation_bar.btn_play.setToolTip("Resume Protocol")
+        self.navigation_bar.show_resume_state()
         self._tick_timer.stop()
 
     def _on_protocol_resumed(self):
-        self.navigation_bar.btn_play.setToolTip("Pause Protocol")
+        self.navigation_bar.show_pause_state()
         if self._current_row is not None:
             self._tick_timer.start()
 
@@ -731,6 +747,31 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             return
         if cur < len(steps) - 1:
             self._select_step(steps[cur + 1])
+            return
+        # At end of execution order — clone the currently-selected step
+        # and insert it after, at the same parent level. Mirrors the
+        # legacy protocol_grid Next-button behaviour where pressing
+        # Next at the end of the protocol creates a new step.
+        self._duplicate_step_after(steps[cur])
+
+    def _duplicate_step_after(self, row):
+        """Insert a copy of ``row`` immediately after it under the same
+        parent. Column values are read off the source row via each
+        column's model.col_id and round-tripped through the same
+        add_step API the toolbar uses."""
+        path = tuple(row.path)
+        parent_path = path[:-1]
+        insert_idx = path[-1] + 1
+        values = {}
+        for col in self.manager.columns:
+            cid = col.model.col_id
+            if hasattr(row, cid):
+                values[cid] = getattr(row, cid)
+        new_path = self.manager.add_step(
+            parent_path=parent_path, index=insert_idx, values=values,
+        )
+        new_row = self.manager.get_row(new_path)
+        self._select_step(new_row)
 
     def _current_step_in(self, steps):
         """Index of the tree's current row inside ``steps``, or None if

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -654,8 +654,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(False)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(True)
-        nb.set_droplet_check_enabled(True)
-        nb.set_preview_mode_enabled(True)
 
     def _set_running_button_state(self):
         nb = self.navigation_bar
@@ -664,8 +662,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(True)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(False)
-        nb.set_droplet_check_enabled(False)
-        nb.set_preview_mode_enabled(False)
 
     def _on_play_clicked(self):
         """While idle: start the protocol. While running/paused: toggle
@@ -791,8 +787,15 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     @classmethod
     def run(cls, config: DemoConfig) -> int:
         """One-shot main(): build the window, show it, run app.exec().
-        Reuses an existing QApplication if one is already running."""
+        Reuses an existing QApplication if one is already running.
+
+        Calls ``style_app`` so the Material Symbols icon font (used by
+        the NavigationBar buttons) is registered before the window
+        is built — without it the icon glyphs render as boxes."""
+        from microdrop_style.helpers import style_app
+
         app = QApplication.instance() or QApplication([])
+        style_app(app)
         w = cls(config)
         w.show()
         return app.exec()

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -566,14 +566,19 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     def _on_step_repetition(self, rep_chain):
         """Render the active rep context (e.g. "rep 2/3 of 'Wash'") into
-        the status bar. Empty chain (no repeating ancestor) clears."""
+        the status bar. Empty chain (no repeating ancestor) hides the
+        label so the layout collapses the slot — otherwise its
+        fixed-width box would leave a blank 100 px gap between the
+        Step counter and the Most-Recent-Step label."""
         if not rep_chain:
             self._status_reps_label.setText("")
+            self._status_reps_label.setVisible(False)
             return
         parts = [
             f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
         ]
         self._status_reps_label.setText(" · ".join(parts))
+        self._status_reps_label.setVisible(True)
 
     def _on_step_finished(self, _row):
         # Freeze the elapsed-time labels at the step's actual elapsed.
@@ -896,6 +901,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._status_step_label.setText("Step 0/0")
         self._status_step_time_label.setText("Step Time: 0 s")
         self._status_reps_label.setText("Repetition 0/0")
+        # _on_step_repetition may have hidden this slot during the run;
+        # restore visibility for the idle layout.
+        self._status_reps_label.setVisible(True)
         self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
         self.status_bar.lbl_next_step.setText("Next Step: -")
         if self._status_phase_time_label is not None:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -206,7 +206,7 @@ from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.navigation_bar import (
-    NavigationBar, make_separator,
+    NavigationBar, StatusBar, make_separator,
 )
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
@@ -441,20 +441,34 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             )
 
     def _build_status_bar(self):
+        """Build the legacy-style StatusBar widget (mounted under the nav
+        bar in _build_navigation_bar) plus a thin bottom QStatusBar that
+        only hosts demo-specific per-readout labels.
+
+        Old single-attribute names (``_status_step_label`` etc.) are
+        retained as aliases onto the StatusBar widget's labels so test
+        coverage and demo subclasses keep working.
+        """
+        self.status_bar = StatusBar()
+        # Reveal the phase time slot only when the demo cares about
+        # per-phase acks; otherwise it stays hidden so the top bar
+        # doesn't show a frozen "Phase 0.00s / 0.00s" forever.
+        phase_enabled = self.config.phase_ack_topic is not None
+        self.status_bar.lbl_phase_time.setVisible(phase_enabled)
+
+        # Aliases for backward compat with tests + demo subclasses.
+        # _status_row_label is intentionally dropped — the new layout
+        # has no row-name slot (per design discussion).
+        self._status_step_label = self.status_bar.lbl_step_progress
+        self._status_step_time_label = self.status_bar.lbl_step_time
+        self._status_reps_label = self.status_bar.lbl_step_repetition
+        self._status_phase_time_label = (
+            self.status_bar.lbl_phase_time if phase_enabled else None
+        )
+
+        # Bottom QStatusBar — only readouts live here now.
         sb = QStatusBar()
         self.setStatusBar(sb)
-        self._status_step_label = QLabel("Idle")
-        self._status_row_label = QLabel("")
-        self._status_reps_label = QLabel("")
-        self._status_step_time_label = QLabel("")
-        sb.addWidget(self._status_step_label)
-        sb.addWidget(self._status_row_label, stretch=1)
-        sb.addPermanentWidget(self._status_reps_label)
-        sb.addPermanentWidget(self._status_step_time_label)
-        if self.config.phase_ack_topic is not None:
-            self._status_phase_time_label = QLabel("")
-            sb.addPermanentWidget(self._status_phase_time_label)
-        # StatusReadout labels.
         for readout in self.config.status_readouts:
             slug = _slug(readout.label)
             label = QLabel(f"{readout.label}: {readout.initial}")
@@ -493,12 +507,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
         except (TypeError, ValueError):
             self._phase_target = None
-        path = ".".join(str(i + 1) for i in row.path) if row.path else ""
-        path_str = f" (path {path})" if path else ""
         self._status_step_label.setText(
             f"Step {self._step_index} / {self._step_total}"
         )
-        self._status_row_label.setText(f"{row.name}{path_str}")
         if not self._tick_timer.isActive():
             self._tick_timer.start()
 
@@ -600,12 +611,16 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         # the phase cursor arrives.
         self.navigation_bar.set_phase_navigation_enabled(False, False)
 
-        # Wrap navigation bar + existing central content in a vertical layout.
+        # Wrap navigation bar + status bar + existing central content
+        # in a vertical layout. The status bar (legacy-style) sits
+        # directly under the nav bar, mirroring the old protocol_grid
+        # layout — separator between status and tree only.
         container = QWidget()
         layout = QVBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.navigation_bar)
+        layout.addWidget(self.status_bar)
         layout.addWidget(make_separator())
         layout.addWidget(self._central_content)
         self.setCentralWidget(container)
@@ -811,12 +826,13 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._phase_started_at = None
         self._phase_target = None
         self._current_row = None
-        self._status_step_label.setText("Idle")
-        self._status_row_label.setText("")
-        self._status_reps_label.setText("")
-        self._status_step_time_label.setText("")
+        # Reset to the StatusBar widget's initial label texts so the
+        # idle visual state matches a freshly-constructed window.
+        self._status_step_label.setText("Step 0/0")
+        self._status_step_time_label.setText("Step Time: 0 s")
+        self._status_reps_label.setText("Repetition 0/0")
         if self._status_phase_time_label is not None:
-            self._status_phase_time_label.setText("")
+            self._status_phase_time_label.setText("Phase 0.00s / 0.00s")
 
         # Reset readout labels to initial text.
         for readout in self.config.status_readouts:

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -345,6 +345,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._wire_executor_signals()
         self._build_toolbar()
         self._build_navigation_bar()
+        self._build_experiment_bar()
         self._wire_button_state_machine()
         self._set_idle_button_state()
 
@@ -680,6 +681,68 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         layout.addWidget(make_separator())
         layout.addWidget(self._central_content)
         self.setCentralWidget(container)
+
+    def _build_experiment_bar(self):
+        """Populate the navigation bar's left slot with the legacy
+        protocol_grid trio: New Experiment button, Experiment label,
+        New Note button. The buttons are exposed as attributes
+        (``btn_new_exp``, ``btn_new_note``, ``experiment_label``) so
+        external plugins / demo subclasses can connect their own
+        slots; the base provides only stub click handlers that log.
+
+        ``add_widget_to_left_slot`` reveals the bar's bottom row
+        (hidden by default), so the experiment row appears below
+        the playback buttons.
+        """
+        from microdrop_style.button_styles import ICON_FONT_FAMILY
+        from pyface.qt.QtGui import QFont
+        from pyface.qt.QtWidgets import QToolButton
+
+        icon_font = QFont(ICON_FONT_FAMILY)
+        icon_font.setPixelSize(20)
+
+        self.btn_new_exp = QToolButton()
+        self.btn_new_exp.setText("note_add")
+        self.btn_new_exp.setFont(icon_font)
+        self.btn_new_exp.setToolTip("New Experiment")
+        self.btn_new_exp.setCursor(Qt.PointingHandCursor)
+        self.btn_new_exp.clicked.connect(self._on_new_experiment)
+
+        self.experiment_label = QLabel(
+            "<b>Experiment:</b> <i>(not set)</i>"
+        )
+        self.experiment_label.setToolTip("Active experiment")
+        self.experiment_label.setTextInteractionFlags(
+            Qt.TextSelectableByMouse,
+        )
+
+        self.btn_new_note = QToolButton()
+        self.btn_new_note.setText("sticky_note")
+        self.btn_new_note.setFont(icon_font)
+        self.btn_new_note.setToolTip("New Note")
+        self.btn_new_note.setCursor(Qt.PointingHandCursor)
+        self.btn_new_note.clicked.connect(self._on_new_note)
+
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_exp)
+        self.navigation_bar.add_widget_to_left_slot(self.experiment_label)
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
+
+    def set_experiment_id(self, experiment_id: str):
+        """Update the experiment label text. Demos / plugins call this
+        when the active experiment changes."""
+        self.experiment_label.setText(
+            f"<b>Experiment:</b> {experiment_id}"
+        )
+
+    def _on_new_experiment(self):
+        """Stub — log only. Demo subclasses or plugins should override
+        or reconnect ``btn_new_exp.clicked`` for real behaviour."""
+        logger.info("New Experiment requested")
+
+    def _on_new_note(self):
+        """Stub — log only. Demo subclasses or plugins should override
+        or reconnect ``btn_new_note.clicked`` for real behaviour."""
+        logger.info("New Note requested")
 
     def _save(self):
         path, _ = QFileDialog.getSaveFileName(

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -895,9 +895,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
     def _publish_paused_phase(self):
         """Publish ELECTRODES_STATE_CHANGE for the currently-pointed
         phase so the device viewer overlays it. The ``preview`` flag
-        is set so any hardware-driving consumer (real DropBot, etc.)
-        ignores the message — we don't want pause-time exploration to
-        actuate the chip."""
+        on the payload mirrors the current run's mode — pause-time
+        phase navigation during a real Run actuates hardware just like
+        the route playback would have; during a Preview run it stays
+        gated."""
         from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 
         if not self._pause_phases:
@@ -908,14 +909,16 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         )
         electrodes = sorted(phase)
         channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        payload = {
+            "electrodes": electrodes,
+            "channels": channels,
+        }
+        if self._current_run_preview_mode:
+            payload["preview"] = True
         try:
             publish_message(
                 topic=ELECTRODES_STATE_CHANGE,
-                message=json.dumps({
-                    "electrodes": electrodes,
-                    "channels": channels,
-                    "preview": True,
-                }),
+                message=json.dumps(payload),
             )
         except Exception as e:
             logger.warning(f"phase navigation publish failed: {e}")

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -639,12 +639,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.navigation_bar.btn_play.clicked.connect(self._on_play_clicked)
         self.navigation_bar.btn_resume.clicked.connect(self._toggle_pause)
         self.navigation_bar.btn_stop.clicked.connect(self.executor.stop)
-        # Preview entry on the play button's dropdown menu — starts the
-        # protocol with preview_mode=True so hardware-publishing hooks
-        # skip their broker writes.
-        self.navigation_bar.action_run_preview.triggered.connect(
-            self._on_preview_clicked
-        )
+        # Preview Mode / Droplet Check are persistent toggles on the
+        # play dropdown — the Run click reads them via
+        # is_preview_mode() / is_droplet_check_enabled(); no extra
+        # signal wiring needed here.
 
         # Step navigation (cursor only — no protocol mutation).
         self.navigation_bar.btn_first.clicked.connect(self._navigate_to_first_step)
@@ -714,8 +712,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(False)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(True)
-        # Re-enable mode-switching options on the play dropdown.
-        nb.action_run_preview.setEnabled(True)
+        # Re-enable the persistent run-mode toggles on the play dropdown.
+        nb.action_preview.setEnabled(True)
+        nb.action_droplet_check.setEnabled(True)
 
     def _set_running_button_state(self):
         nb = self.navigation_bar
@@ -724,28 +723,23 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(True)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(False)
-        # Mode is locked once a run is in progress — don't let the
-        # user pick Preview from the dropdown mid-run.
-        nb.action_run_preview.setEnabled(False)
+        # Modes are locked once a run is in progress — don't let the
+        # user re-arm Preview / toggle Droplet Check mid-run.
+        nb.action_preview.setEnabled(False)
+        nb.action_droplet_check.setEnabled(False)
 
     def _on_play_clicked(self):
         """While idle: start the protocol from the currently-selected
-        step (or from the beginning if nothing is selected), and prime
-        the auto-repeat counter from the StatusBar's spinbox. While
-        running/paused: toggle pause. Mirrors the legacy
+        step (or from the beginning if nothing is selected), reading
+        Preview / Droplet Check state from the play dropdown.
+        While running/paused: toggle pause. Mirrors the legacy
         protocol_grid play-button behaviour."""
         if self._is_protocol_active():
             self._toggle_pause()
             return
-        self._start_protocol_run(preview_mode=False)
-
-    def _on_preview_clicked(self):
-        """Dropdown 'Preview' entry — start the protocol in preview
-        mode (no hardware writes). Ignored while a run is already in
-        progress."""
-        if self._is_protocol_active():
-            return
-        self._start_protocol_run(preview_mode=True)
+        self._start_protocol_run(
+            preview_mode=self.navigation_bar.is_preview_mode(),
+        )
 
     def _start_protocol_run(self, preview_mode: bool):
         """Common entry point for both Run and Preview: prime the repeat

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -196,7 +196,7 @@ import time
 from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtWidgets import (
     QApplication, QFileDialog, QLabel, QMainWindow,
-    QSplitter, QStatusBar, QToolBar,
+    QSplitter, QStatusBar, QToolBar, QVBoxLayout, QWidget,
 )
 
 from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
@@ -205,6 +205,9 @@ from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.navigation_bar import (
+    NavigationBar, make_separator,
+)
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
 
@@ -237,7 +240,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         # attribute rather than walking the central widget's children.
         self._side_panel = None
 
-        # Central layout: just the tree, OR a splitter with tree + side panel.
+        # Tree-or-splitter goes inside a vertical container with the
+        # NavigationBar (built later in __init__) sitting above it. The
+        # nav bar is created after the executor so its button slots can
+        # bind directly to executor.start / .stop / pause-toggle.
         if self.config.side_panel_factory is not None:
             side = self.config.side_panel_factory(self.manager)
             if side is not None:
@@ -249,11 +255,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                     int(self.config.window_size[0] * 0.65),
                     int(self.config.window_size[0] * 0.35),
                 ])
-                self.setCentralWidget(splitter)
+                self._central_content = splitter
             else:
-                self.setCentralWidget(self.widget)
+                self._central_content = self.widget
         else:
-            self.setCentralWidget(self.widget)
+            self._central_content = self.widget
 
         # Pre-populate sample steps BEFORE the executor is built.
         config.pre_populate(self.manager)
@@ -321,6 +327,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
         self._wire_executor_signals()
         self._build_toolbar()
+        self._build_navigation_bar()
         self._wire_button_state_machine()
         self._set_idle_button_state()
 
@@ -559,6 +566,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             )
 
     def _build_toolbar(self):
+        """Top QToolBar holds the Add/Save/Load utility actions; the
+        playback + step-navigation buttons live on the NavigationBar
+        below the toolbar (built next in ``_build_navigation_bar``)."""
         tb = QToolBar("Protocol")
         self.addToolBar(tb)
         tb.addAction("Add Step", lambda: self.manager.add_step())
@@ -566,11 +576,39 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         tb.addSeparator()
         tb.addAction("Save…", self._save)
         tb.addAction("Load…", self._load)
-        tb.addSeparator()
-        self._run_action = tb.addAction("Run", self.executor.start)
-        self._pause_action = tb.addAction("Pause", self._toggle_pause)
-        self._stop_action = tb.addAction("Stop", self.executor.stop)
         self._toolbar = tb
+
+    def _build_navigation_bar(self):
+        """Build the NavigationBar (ported from protocol_grid) and wire
+        each button to the executor / step-cursor navigation. Mounts the
+        bar above the central content (tree or tree+side-panel splitter)."""
+        self.navigation_bar = NavigationBar()
+
+        # Playback.
+        self.navigation_bar.btn_play.clicked.connect(self._on_play_clicked)
+        self.navigation_bar.btn_resume.clicked.connect(self._toggle_pause)
+        self.navigation_bar.btn_stop.clicked.connect(self.executor.stop)
+
+        # Step navigation (cursor only — no protocol mutation).
+        self.navigation_bar.btn_first.clicked.connect(self._navigate_to_first_step)
+        self.navigation_bar.btn_prev.clicked.connect(self._navigate_to_previous_step)
+        self.navigation_bar.btn_next.clicked.connect(self._navigate_to_next_step)
+        self.navigation_bar.btn_last.clicked.connect(self._navigate_to_last_step)
+
+        # Phase navigation: per-phase cursor isn't implemented yet (PPT-10
+        # scope item). Buttons stay visually present but disabled until
+        # the phase cursor arrives.
+        self.navigation_bar.set_phase_navigation_enabled(False, False)
+
+        # Wrap navigation bar + existing central content in a vertical layout.
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.navigation_bar)
+        layout.addWidget(make_separator())
+        layout.addWidget(self._central_content)
+        self.setCentralWidget(container)
 
     def _save(self):
         path, _ = QFileDialog.getSaveFileName(
@@ -610,16 +648,39 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             sig.connect(self._on_protocol_terminated)
 
     def _set_idle_button_state(self):
-        self._run_action.setEnabled(True)
-        self._pause_action.setEnabled(False)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(False)
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)
+        nb.btn_play.setToolTip("Play Protocol")
+        nb.btn_stop.setEnabled(False)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(True)
+        nb.set_droplet_check_enabled(True)
+        nb.set_preview_mode_enabled(True)
 
     def _set_running_button_state(self):
-        self._run_action.setEnabled(False)
-        self._pause_action.setEnabled(True)
-        self._pause_action.setText("Pause")
-        self._stop_action.setEnabled(True)
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)         # acts as Pause while running
+        nb.btn_play.setToolTip("Pause Protocol")
+        nb.btn_stop.setEnabled(True)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(False)
+        nb.set_droplet_check_enabled(False)
+        nb.set_preview_mode_enabled(False)
+
+    def _on_play_clicked(self):
+        """While idle: start the protocol. While running/paused: toggle
+        pause. Mirrors the legacy protocol_grid play-button behaviour."""
+        if self._is_protocol_active():
+            self._toggle_pause()
+        else:
+            self.executor.start()
+
+    def _is_protocol_active(self):
+        """True iff the executor is currently running or paused. The
+        Stop button's enabled state tracks this exactly (via the
+        protocol_started / protocol_finished / protocol_aborted signal
+        chain), so use it as the source of truth."""
+        return self.navigation_bar.btn_stop.isEnabled()
 
     def _toggle_pause(self):
         if self.executor.pause_event.is_set():
@@ -628,11 +689,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self.executor.pause()
 
     def _on_protocol_paused(self):
-        self._pause_action.setText("Resume")
+        self.navigation_bar.btn_play.setToolTip("Resume Protocol")
         self._tick_timer.stop()
 
     def _on_protocol_resumed(self):
-        self._pause_action.setText("Pause")
+        self.navigation_bar.btn_play.setToolTip("Pause Protocol")
         if self._current_row is not None:
             self._tick_timer.start()
 
@@ -640,6 +701,65 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._clear_all_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
+
+    # --- step-cursor navigation ----------------------------------------
+
+    def _navigate_to_first_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[0])
+
+    def _navigate_to_last_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[-1])
+
+    def _navigate_to_previous_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur > 0:
+            self._select_step(steps[cur - 1])
+
+    def _navigate_to_next_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur < len(steps) - 1:
+            self._select_step(steps[cur + 1])
+
+    def _current_step_in(self, steps):
+        """Index of the tree's current row inside ``steps``, or None if
+        the current row isn't a step (e.g. a group is selected)."""
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        # Walk the QModelIndex chain back to a path tuple.
+        path = self.widget._index_to_path(idx)
+        for i, row in enumerate(steps):
+            if tuple(row.path) == path:
+                return i
+        return None
+
+    def _select_step(self, row):
+        idx = self.widget._node_to_index(row)
+        if not idx.isValid():
+            return
+        # Expand any collapsed ancestor groups so the row is visible.
+        parent = idx.parent()
+        while parent.isValid():
+            self.widget.tree.expand(parent)
+            parent = parent.parent()
+        self.widget.tree.setCurrentIndex(idx)
+        self.widget.tree.scrollTo(idx)
 
     def _clear_all_highlights(self):
         """Restore an idle visual state at protocol end."""

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -280,6 +280,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._phase_started_at: float | None = None
         self._phase_target: float | None = None
         self._current_row = None
+        # Auto-repeat state. Driven by the StatusBar's
+        # edit_repeat_protocol spinbox at play-button time.
+        self._repeats_total = 1
+        self._repeats_completed = 0
         self._tick_timer = QTimer(self)
         self._tick_timer.setInterval(100)   # 10 Hz
         self._tick_timer.timeout.connect(self._refresh_status)
@@ -510,8 +514,30 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._status_step_label.setText(
             f"Step {self._step_index} / {self._step_total}"
         )
+        # Recent / next-step labels — show the actual step name of the
+        # currently-running row plus the upcoming one. Walking
+        # iter_execution_steps once per step is fine; protocols stay
+        # under a few hundred steps.
+        self.status_bar.lbl_recent_step.setText(
+            f"Most Recent Step: {row.name}"
+        )
+        self.status_bar.lbl_next_step.setText(
+            f"Next Step: {self._next_step_name(row)}"
+        )
         if not self._tick_timer.isActive():
             self._tick_timer.start()
+
+    def _next_step_name(self, current):
+        """Return the display name of the step that follows ``current`` in
+        execution order, or "-" if ``current`` is the last step."""
+        steps = self.manager.iter_execution_steps()
+        cur_path = tuple(current.path)
+        # Advance past the current row, return the next one.
+        for row in steps:
+            if tuple(row.path) == cur_path:
+                next_row = next(steps, None)
+                return next_row.name if next_row is not None else "-"
+        return "-"
 
     def _on_phase_ack(self):
         """Each ack restarts the per-phase timer. The first ack of a step
@@ -555,7 +581,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._refresh_status()
 
     def _on_error(self, msg):
-        """protocol_error → reset to idle and show a styled error dialog."""
+        """protocol_error → reset to idle and show a styled error dialog.
+        Repeat state is cleared so a half-finished run doesn't auto-rerun."""
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
         self._clear_all_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
@@ -656,11 +686,10 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.executor.qsignals.protocol_started.connect(self._set_running_button_state)
         self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
         self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
-        for sig in (
-            self.executor.qsignals.protocol_finished,
-            self.executor.qsignals.protocol_aborted,
-        ):
-            sig.connect(self._on_protocol_terminated)
+        # Split protocol_finished from protocol_aborted so the auto-repeat
+        # logic only fires on natural completion (not user Stop).
+        self.executor.qsignals.protocol_finished.connect(self._on_protocol_finished)
+        self.executor.qsignals.protocol_aborted.connect(self._on_protocol_aborted)
 
     def _set_idle_button_state(self):
         nb = self.navigation_bar
@@ -680,13 +709,24 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     def _on_play_clicked(self):
         """While idle: start the protocol from the currently-selected
-        step (or from the beginning if nothing is selected). While
+        step (or from the beginning if nothing is selected), and prime
+        the auto-repeat counter from the StatusBar's spinbox. While
         running/paused: toggle pause. Mirrors the legacy
         protocol_grid play-button behaviour."""
         if self._is_protocol_active():
             self._toggle_pause()
-        else:
-            self.executor.start(start_step_path=self._selected_step_path())
+            return
+        self._repeats_total = self.status_bar.edit_repeat_protocol.value()
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self.executor.start(start_step_path=self._selected_step_path())
+
+    def _update_repeat_status_label(self):
+        """Reflect the current repeat counter into 'X/' (the X in
+        'X/<total>' shown on the status bar)."""
+        self.status_bar.lbl_repeat_protocol_status.setText(
+            f"{self._repeats_completed}/"
+        )
 
     def _selected_step_path(self):
         """Return the path tuple of the currently-selected row, but only
@@ -723,6 +763,31 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.navigation_bar.show_pause_state()
         if self._current_row is not None:
             self._tick_timer.start()
+
+    def _on_protocol_finished(self):
+        """Natural completion. Bump the repeat counter; if more reps
+        remain, re-queue executor.start() on the next event-loop tick
+        (the worker thread emits protocol_finished from inside its
+        finally block — calling start() now would no-op against
+        ``_thread.is_alive()``)."""
+        self._repeats_completed += 1
+        self._update_repeat_status_label()
+        if self._repeats_completed < self._repeats_total:
+            QTimer.singleShot(50, self._restart_for_next_rep)
+            return
+        self._on_protocol_terminated()
+
+    def _restart_for_next_rep(self):
+        # Each repeat runs the protocol from the beginning — start_step_path
+        # is intentionally None.
+        self.executor.start()
+
+    def _on_protocol_aborted(self):
+        """User pressed Stop. Clear the repeat state (no auto-restart)."""
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self._on_protocol_terminated()
 
     def _on_protocol_terminated(self):
         self._clear_all_highlights()
@@ -831,6 +896,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self._status_step_label.setText("Step 0/0")
         self._status_step_time_label.setText("Step Time: 0 s")
         self._status_reps_label.setText("Repetition 0/0")
+        self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
+        self.status_bar.lbl_next_step.setText("Next Step: -")
         if self._status_phase_time_label is not None:
             self._status_phase_time_label.setText("Phase 0.00s / 0.00s")
 

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -284,6 +284,11 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         # edit_repeat_protocol spinbox at play-button time.
         self._repeats_total = 1
         self._repeats_completed = 0
+        # Whichever mode (Run / Preview) the user picked for this run
+        # — auto-repeats reuse the same mode, and the running-state
+        # button machine uses it to disable the dropdown so a user
+        # can't switch modes mid-run.
+        self._current_run_preview_mode = False
         self._tick_timer = QTimer(self)
         self._tick_timer.setInterval(100)   # 10 Hz
         self._tick_timer.timeout.connect(self._refresh_status)
@@ -634,6 +639,12 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.navigation_bar.btn_play.clicked.connect(self._on_play_clicked)
         self.navigation_bar.btn_resume.clicked.connect(self._toggle_pause)
         self.navigation_bar.btn_stop.clicked.connect(self.executor.stop)
+        # Preview entry on the play button's dropdown menu — starts the
+        # protocol with preview_mode=True so hardware-publishing hooks
+        # skip their broker writes.
+        self.navigation_bar.action_run_preview.triggered.connect(
+            self._on_preview_clicked
+        )
 
         # Step navigation (cursor only — no protocol mutation).
         self.navigation_bar.btn_first.clicked.connect(self._navigate_to_first_step)
@@ -703,6 +714,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(False)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(True)
+        # Re-enable mode-switching options on the play dropdown.
+        nb.action_run_preview.setEnabled(True)
 
     def _set_running_button_state(self):
         nb = self.navigation_bar
@@ -711,6 +724,9 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         nb.btn_stop.setEnabled(True)
         for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
             btn.setEnabled(False)
+        # Mode is locked once a run is in progress — don't let the
+        # user pick Preview from the dropdown mid-run.
+        nb.action_run_preview.setEnabled(False)
 
     def _on_play_clicked(self):
         """While idle: start the protocol from the currently-selected
@@ -721,10 +737,28 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if self._is_protocol_active():
             self._toggle_pause()
             return
+        self._start_protocol_run(preview_mode=False)
+
+    def _on_preview_clicked(self):
+        """Dropdown 'Preview' entry — start the protocol in preview
+        mode (no hardware writes). Ignored while a run is already in
+        progress."""
+        if self._is_protocol_active():
+            return
+        self._start_protocol_run(preview_mode=True)
+
+    def _start_protocol_run(self, preview_mode: bool):
+        """Common entry point for both Run and Preview: prime the repeat
+        counter, remember the chosen mode for auto-repeat continuations,
+        then start the executor."""
         self._repeats_total = self.status_bar.edit_repeat_protocol.value()
         self._repeats_completed = 0
+        self._current_run_preview_mode = preview_mode
         self._update_repeat_status_label()
-        self.executor.start(start_step_path=self._selected_step_path())
+        self.executor.start(
+            start_step_path=self._selected_step_path(),
+            preview_mode=preview_mode,
+        )
 
     def _update_repeat_status_label(self):
         """Reflect the current repeat counter into 'X/' (the X in
@@ -784,8 +818,8 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     def _restart_for_next_rep(self):
         # Each repeat runs the protocol from the beginning — start_step_path
-        # is intentionally None.
-        self.executor.start()
+        # is intentionally None. Carry the original Run/Preview mode forward.
+        self.executor.start(preview_mode=self._current_run_preview_mode)
 
     def _on_protocol_aborted(self):
         """User pressed Stop. Clear the repeat state (no auto-restart)."""

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -63,7 +63,8 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
-    viewer.actuation_changed.emit(list(electrodes))
+    preview = bool(payload.get("preview", False))
+    viewer.actuation_changed.emit(list(electrodes), preview)
 
 
 def _columns():

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -126,7 +126,7 @@ def _post_build(window):
 config = DemoConfig(
     columns_factory=_columns,
     title="Pluggable Protocol Tree — PPT-3 Demo",
-    window_size=(1100, 650),
+    window_size=(1500, 650),
     pre_populate=_pre_populate,
     routing_setup=_routing_setup,
     phase_ack_topic=ELECTRODES_STATE_APPLIED,

--- a/pluggable_protocol_tree/demos/run_widget.py
+++ b/pluggable_protocol_tree/demos/run_widget.py
@@ -126,7 +126,7 @@ def _post_build(window):
 config = DemoConfig(
     columns_factory=_columns,
     title="Pluggable Protocol Tree — PPT-3 Demo",
-    window_size=(1500, 650),
+    window_size=(1100, 650),
     pre_populate=_pre_populate,
     routing_setup=_routing_setup,
     phase_ack_topic=ELECTRODES_STATE_APPLIED,

--- a/pluggable_protocol_tree/demos/run_widget_auto.py
+++ b/pluggable_protocol_tree/demos/run_widget_auto.py
@@ -134,8 +134,9 @@ def _overlay_listener(message: str, topic: str, timestamp: float = None):
     except (TypeError, ValueError):
         return
     electrodes = payload.get("electrodes", []) or []
+    preview = bool(payload.get("preview", False))
     print(f"[OVERLAY] painting cells: {electrodes}", flush=True)
-    viewer.actuation_changed.emit(list(electrodes))
+    viewer.actuation_changed.emit(list(electrodes), preview)
 
 
 def _columns():

--- a/pluggable_protocol_tree/demos/simple_device_viewer.py
+++ b/pluggable_protocol_tree/demos/simple_device_viewer.py
@@ -41,13 +41,18 @@ class SimpleDeviceViewer(QWidget):
     # thread emits this; auto-connection delivers it on the GUI thread
     # via the Qt event loop. Avoids QMetaObject.invokeMethod, which under
     # PySide6 cannot find a QMetaType for "object" / generic Python types.
-    actuation_changed = Signal(list)
+    #
+    # Second arg is a preview flag — actuated cells paint yellow instead
+    # of the normal bright green when the run is in preview mode, so
+    # users get a clear visual cue that no hardware is being driven.
+    actuation_changed = Signal(list, bool)
 
     def __init__(self, manager, parent=None):
         super().__init__(parent)
         self._manager = manager
         self._active_row = None
         self._actuated: Set[str] = set()
+        self._actuated_preview = False
         self._mode = "static"
         self._in_progress_route: list = []
         self.actuation_changed.connect(self.set_actuated)
@@ -101,11 +106,13 @@ class SimpleDeviceViewer(QWidget):
         self._update_route_button_state()
         self.update()
 
-    def set_actuated(self, electrode_ids: Iterable[str]):
+    def set_actuated(self, electrode_ids: Iterable[str], preview: bool = False):
         """Called by the actuation subscription with the current phase's
         electrode set. Paints those cells green on top of the static /
-        route layers."""
+        route layers — or gold yellow if ``preview`` is True, signalling
+        a route playback that isn't actually driving hardware."""
         self._actuated = set(electrode_ids or [])
+        self._actuated_preview = bool(preview)
         self.update()
 
     # ---------- mode ----------
@@ -190,7 +197,12 @@ class SimpleDeviceViewer(QWidget):
             eid = _electrode_id(i)
             r = self._cell_rect(i)
             if eid in self._actuated:
-                p.setBrush(QBrush(QColor(40, 220, 80)))    # bright green
+                if self._actuated_preview:
+                    # Gold yellow — distinguishable from the pale
+                    # static-electrode yellow (255, 230, 90).
+                    p.setBrush(QBrush(QColor(255, 200, 0)))
+                else:
+                    p.setBrush(QBrush(QColor(40, 220, 80)))    # bright green
             elif eid in statics:
                 p.setBrush(QBrush(QColor(255, 230, 90)))   # yellow
             else:

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -61,6 +61,10 @@ class ProtocolExecutor(HasTraits):
     # encounters this path, then proceeds normally. Cleared on every
     # start() so a previous "play from selected" doesn't carry over.
     _start_step_path = Any
+    # When True, the next run() builds the ProtocolContext with
+    # preview_mode=True so hardware-publishing hooks skip their
+    # broker writes (legacy protocol_grid "Preview Mode" semantics).
+    _preview_mode = Any
 
     # Injectable for tests (e.g. a synchronous executor for determinism).
     bucket_pool_factory = CallableTrait
@@ -103,13 +107,25 @@ class ProtocolExecutor(HasTraits):
 
     # ------- public control API (called from the GUI thread) -------
 
-    def start(self, start_step_path: Optional[tuple] = None) -> None:
+    def start(
+        self,
+        start_step_path: Optional[tuple] = None,
+        preview_mode: bool = False,
+    ) -> None:
         """Spawn a worker thread and call run() on it. Idempotent —
         a second call while already running is ignored.
 
         If ``start_step_path`` is given, run() skips frames in execution
         order until it encounters a row whose ``path`` equals it, then
         proceeds normally. Useful for "play from currently-selected step".
+
+        If ``preview_mode`` is True, the ProtocolContext built by run()
+        carries ``preview_mode=True``; hardware-publishing hooks (e.g.
+        the routes column's electrode-state publishes) check this flag
+        and skip their broker writes. Step iteration, dwells, signals
+        and column logic all run normally — only the hardware-touching
+        side effects are gated. Mirrors the legacy protocol_grid
+        "Preview Mode" checkbox semantics.
         """
         if self._thread is not None and self._thread.is_alive():
             return
@@ -119,6 +135,7 @@ class ProtocolExecutor(HasTraits):
         self._start_step_path = (
             tuple(start_step_path) if start_step_path is not None else None
         )
+        self._preview_mode = bool(preview_mode)
         self._thread = threading.Thread(
             target=self.run,
             name="pluggable_protocol_tree_executor",
@@ -164,6 +181,7 @@ class ProtocolExecutor(HasTraits):
             stop_event=self.stop_event,
             pause_event=self.pause_event,
             qsignals=self.qsignals,
+            preview_mode=bool(self._preview_mode),
         )
         # PPT-3: hydrate per-protocol metadata (e.g. electrode_to_channel)
         # into the context's scratch so handlers can reach it without

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -57,6 +57,10 @@ class ProtocolExecutor(HasTraits):
     # Internal — set by start() / cleared by run()'s finally.
     _thread = Any
     _error  = Any
+    # Optional row.path tuple — when set, run() skips frames until it
+    # encounters this path, then proceeds normally. Cleared on every
+    # start() so a previous "play from selected" doesn't carry over.
+    _start_step_path = Any
 
     # Injectable for tests (e.g. a synchronous executor for determinism).
     bucket_pool_factory = CallableTrait
@@ -99,14 +103,22 @@ class ProtocolExecutor(HasTraits):
 
     # ------- public control API (called from the GUI thread) -------
 
-    def start(self) -> None:
+    def start(self, start_step_path: Optional[tuple] = None) -> None:
         """Spawn a worker thread and call run() on it. Idempotent —
-        a second call while already running is ignored."""
+        a second call while already running is ignored.
+
+        If ``start_step_path`` is given, run() skips frames in execution
+        order until it encounters a row whose ``path`` equals it, then
+        proceeds normally. Useful for "play from currently-selected step".
+        """
         if self._thread is not None and self._thread.is_alive():
             return
         self.pause_event.clear()
         self.stop_event.clear()
         self._error = None
+        self._start_step_path = (
+            tuple(start_step_path) if start_step_path is not None else None
+        )
         self._thread = threading.Thread(
             target=self.run,
             name="pluggable_protocol_tree_executor",
@@ -167,9 +179,16 @@ class ProtocolExecutor(HasTraits):
             logger.info("Protocol started")
 
             step_index = 0
+            # Pop into a local — once we've found the start path, the
+            # rest of the loop runs without the per-frame check.
+            skip_until = self._start_step_path
             for row, rep_chain in self.row_manager.iter_execution_frames():
                 if self.stop_event.is_set():
                     break
+                if skip_until is not None:
+                    if tuple(row.path) != skip_until:
+                        continue
+                    skip_until = None
                 if self.pause_event.is_set():
                     logger.info("Protocol paused at step %d", step_index + 1)
                     # Emitted here so a hook setting pause_event still

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -102,7 +102,7 @@ class Mailbox:
 
 # --- contexts ---
 
-from traits.api import Any, Dict, HasTraits, Instance, Str, List
+from traits.api import Any, Bool, Dict, HasTraits, Instance, Str, List
 
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.interfaces.i_column import IColumn
@@ -138,6 +138,13 @@ class ProtocolContext(HasTraits):
     qsignals    = Any(desc="ExecutorSignals (QObject) — hooks may emit "
                            "protocol_paused / protocol_resumed for "
                            "in-hook waits the UI should reflect")
+
+    # When True, hooks that drive hardware (e.g. publishing electrode
+    # actuation requests) must skip their broker publishes and any
+    # ack-waiting tied to them — the protocol runs through its step
+    # iteration, dwells, signals, etc., but does not touch hardware.
+    # Mirrors the legacy protocol_grid "Preview Mode" checkbox.
+    preview_mode = Bool(False)
 
 
 class StepContext(HasTraits):

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -375,26 +375,29 @@ def test_toolbar_has_standard_actions(qapp):
     actions = [a.text() for a in w._toolbar.actions()]
     assert "Add Step" in actions
     assert "Add Group" in actions
-    assert "Run" in actions
-    assert "Pause" in actions
-    assert "Stop" in actions
+    # Playback buttons live on the NavigationBar, not the QToolBar.
+    nb = w.navigation_bar
+    assert nb.btn_play is not None
+    assert nb.btn_stop is not None
 
 
 def test_idle_button_state(qapp):
-    """Initially: Run enabled; Pause + Stop disabled."""
+    """Initially: Play + step-nav enabled; Stop disabled."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._run_action.isEnabled()
-    assert not w._pause_action.isEnabled()
-    assert not w._stop_action.isEnabled()
+    nb = w.navigation_bar
+    assert nb.btn_play.isEnabled()
+    assert not nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert btn.isEnabled()
 
 
 def test_protocol_started_swaps_buttons(qapp):
-    """When protocol_started fires: Run disabled; Pause + Stop enabled."""
+    """When protocol_started fires: step-nav disabled; Stop enabled."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -402,9 +405,11 @@ def test_protocol_started_swaps_buttons(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
     w.executor.qsignals.protocol_started.emit()
-    assert not w._run_action.isEnabled()
-    assert w._pause_action.isEnabled()
-    assert w._stop_action.isEnabled()
+    nb = w.navigation_bar
+    assert nb.btn_play.isEnabled()       # toggles to pause while running
+    assert nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert not btn.isEnabled()
 
 
 def test_protocol_terminated_returns_to_idle(qapp):
@@ -417,10 +422,11 @@ def test_protocol_terminated_returns_to_idle(qapp):
     w = BasePluggableProtocolDemoWindow(cfg)
     w.executor.qsignals.protocol_started.emit()
     w.executor.qsignals.protocol_finished.emit()
-    assert w._run_action.isEnabled()
-    assert not w._pause_action.isEnabled()
-    assert not w._stop_action.isEnabled()
-    assert w._pause_action.text() == "Pause"
+    nb = w.navigation_bar
+    assert nb.btn_play.isEnabled()
+    assert not nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert btn.isEnabled()
 
 
 def test_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
@@ -486,22 +492,23 @@ def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
 
 
 def test_window_no_side_panel_uses_tree_as_central(qapp):
-    """When side_panel_factory is None, the central widget IS the tree
-    and _side_panel is None."""
+    """When side_panel_factory is None, the inner central content IS the
+    tree (now wrapped in a NavigationBar+content container) and
+    _side_panel is None."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w.centralWidget() is w.widget
+    assert w._central_content is w.widget
     assert w._side_panel is None
 
 
 def test_window_side_panel_uses_splitter(qapp):
-    """When side_panel_factory returns a widget, central is a splitter
-    holding tree + side panel, AND the side widget is exposed at
-    w._side_panel for post_build_setup callbacks."""
+    """When side_panel_factory returns a widget, the inner central
+    content is a splitter holding tree + side panel, AND the side
+    widget is exposed at w._side_panel for post_build_setup callbacks."""
     from pyface.qt.QtWidgets import QLabel, QSplitter
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
@@ -513,7 +520,7 @@ def test_window_side_panel_uses_splitter(qapp):
         side_panel_factory=lambda rm: side_widget,
     )
     w = BasePluggableProtocolDemoWindow(cfg)
-    central = w.centralWidget()
+    central = w._central_content
     assert isinstance(central, QSplitter)
     assert central.count() == 2   # tree + side panel
     assert w._side_panel is side_widget
@@ -692,14 +699,14 @@ def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
 
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = bdw.BasePluggableProtocolDemoWindow(cfg)
+    nb = w.navigation_bar
     # Simulate a running state, then fire the error.
     w.executor.qsignals.protocol_started.emit()
-    assert not w._run_action.isEnabled()
+    assert nb.btn_stop.isEnabled()
     w.executor.qsignals.protocol_error.emit("kaboom")
     # Idle state restored.
-    assert w._run_action.isEnabled()
-    assert not w._pause_action.isEnabled()
-    assert not w._stop_action.isEnabled()
+    assert nb.btn_play.isEnabled()
+    assert not nb.btn_stop.isEnabled()
     assert not w._tick_timer.isActive()
     # Dialog called via the styled wrapper, with the error message.
     assert calls == [("Protocol error", "kaboom")]

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -26,7 +26,7 @@ def test_status_readout_initial_overridable():
 def test_demo_config_minimum_required_fields():
     cfg = DemoConfig(columns_factory=lambda: [])
     assert cfg.title == "Pluggable Protocol Tree Demo"
-    assert cfg.window_size == (1500, 650)
+    assert cfg.window_size == (1100, 650)
     assert cfg.phase_ack_topic == ELECTRODES_STATE_APPLIED   # default
     assert cfg.status_readouts == []
     assert cfg.side_panel_factory is None
@@ -78,7 +78,7 @@ def test_window_constructs_with_minimum_config(qapp):
     assert w.executor is not None
     assert w.widget is not None
     # Window size matches default
-    assert (w.width(), w.height()) == (1500, 650)
+    assert (w.width(), w.height()) == (1100, 650)
 
 
 def test_window_applies_custom_title_and_size(qapp):

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -185,18 +185,21 @@ def test_window_has_router_attribute_after_construction(qapp):
 
 
 def test_window_has_status_bar_with_step_label(qapp):
-    """Status bar exists with the step counter label."""
+    """Status bar exists with the step counter label.
+
+    The legacy-style top StatusBar starts at "Step 0/0" instead of the
+    old "Idle" sentinel — matches the legacy protocol_grid look. The
+    bottom QStatusBar still exists but only hosts demo readout labels.
+    """
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    sb = w.statusBar()
-    assert sb is not None
-    # Step label and row label should be there.
-    assert w._status_step_label.text() == "Idle"
-    assert w._status_row_label.text() == ""
+    assert w.statusBar() is not None        # bottom (readouts only)
+    assert w.status_bar is not None         # top (legacy-look StatusBar)
+    assert w._status_step_label.text() == "Step 0/0"
 
 
 def test_window_status_step_elapsed_label_exists(qapp):
@@ -547,7 +550,7 @@ def test_clear_all_highlights_resets_status(qapp):
     w._status_step_label.setText("Step 2 / 3")
     # Terminate.
     w._on_protocol_terminated()
-    assert w._status_step_label.text() == "Idle"
+    assert w._status_step_label.text() == "Step 0/0"
     assert w._step_started_at is None
     assert w._readout_labels["voltage"].text() == "Voltage: --"
 
@@ -631,14 +634,19 @@ def test_post_build_setup_default_is_no_op(qapp):
 
 
 def test_status_bar_has_reps_label(qapp):
-    """The status bar exposes _status_reps_label, initially empty."""
+    """The status bar exposes _status_reps_label.
+
+    Initial text is the StatusBar widget's "Repetition 0/0" placeholder
+    (legacy protocol_grid look) — was the empty string when the label
+    was a permanent widget on the bottom QStatusBar.
+    """
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._status_reps_label.text() == ""
+    assert w._status_reps_label.text() == "Repetition 0/0"
 
 
 def test_step_repetition_renders_chain(qapp):

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -26,7 +26,7 @@ def test_status_readout_initial_overridable():
 def test_demo_config_minimum_required_fields():
     cfg = DemoConfig(columns_factory=lambda: [])
     assert cfg.title == "Pluggable Protocol Tree Demo"
-    assert cfg.window_size == (1100, 650)
+    assert cfg.window_size == (1500, 650)
     assert cfg.phase_ack_topic == ELECTRODES_STATE_APPLIED   # default
     assert cfg.status_readouts == []
     assert cfg.side_panel_factory is None
@@ -78,7 +78,7 @@ def test_window_constructs_with_minimum_config(qapp):
     assert w.executor is not None
     assert w.widget is not None
     # Window size matches default
-    assert (w.width(), w.height()) == (1100, 650)
+    assert (w.width(), w.height()) == (1500, 650)
 
 
 def test_window_applies_custom_title_and_size(qapp):

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -1,0 +1,320 @@
+"""Navigation pane and status bar for the pluggable protocol tree.
+
+Ported from ``protocol_grid/extra_ui_elements.py`` (legacy
+``NavigationBar`` + ``StatusBar``). The legacy widgets stay in place
+until PPT-9 deletes ``protocol_grid``; this module is the canonical
+location going forward.
+"""
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtWidgets import (
+    QApplication, QCheckBox, QFrame, QHBoxLayout, QLabel, QLineEdit,
+    QPushButton, QScrollArea, QSizePolicy, QVBoxLayout, QWidget,
+)
+
+from microdrop_style.button_styles import BUTTON_SPACING
+from microdrop_style.colors import BLACK, WHITE
+from microdrop_style.helpers import is_dark_mode
+from microdrop_style.icons.icons import (
+    ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PLAY,
+    ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
+)
+
+
+class NavigationBar(QWidget):
+    """Two-row toolbar: playback/step/phase buttons on top, left-slot +
+    mode-toggle checkboxes on bottom.
+
+    The play button can be split into a Prev-phase / Resume / Next-phase
+    cluster via ``split_play_button_to_phase_controls`` for protocols
+    being driven phase-by-phase.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        main_layout = QVBoxLayout(self)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(0)
+
+        # Top row: navigation buttons.
+        self.nav_container = QWidget()
+        nav_layout = QHBoxLayout(self.nav_container)
+        nav_layout.setContentsMargins(5, 5, 5, 5)
+        nav_layout.setSpacing(BUTTON_SPACING)
+
+        self.btn_first = QPushButton(ICON_FIRST)
+        self.btn_first.setToolTip("First Step")
+
+        self.btn_prev = QPushButton(ICON_PREVIOUS)
+        self.btn_prev.setToolTip("Previous Step")
+
+        self.btn_stop = QPushButton(ICON_STOP)
+        self.btn_stop.setToolTip("Stop Protocol")
+        self.btn_stop.setEnabled(False)
+
+        self.btn_next = QPushButton(ICON_NEXT)
+        self.btn_next.setToolTip("Next Step")
+
+        self.btn_last = QPushButton(ICON_LAST)
+        self.btn_last.setToolTip("Last Step")
+
+        self.btn_play = QPushButton(ICON_PLAY)
+        self.btn_play.setToolTip("Play Protocol")
+
+        self.btn_prev_phase = QPushButton(ICON_PREVIOUS_PHASE)
+        self.btn_prev_phase.setToolTip("Previous Phase")
+
+        self.btn_resume = QPushButton(ICON_RESUME)
+        self.btn_resume.setToolTip("Resume Protocol")
+
+        self.btn_next_phase = QPushButton(ICON_NEXT_PHASE)
+        self.btn_next_phase.setToolTip("Next Phase")
+
+        self.play_phase_container = QWidget()
+        self.play_phase_container.setObjectName("play_phase_subcontainer")
+        self.play_phase_layout = QHBoxLayout(self.play_phase_container)
+        self.play_phase_layout.setContentsMargins(0, 0, 0, 0)
+        self.play_phase_layout.setSpacing(BUTTON_SPACING)
+
+        self.play_phase_layout.addWidget(self.btn_play)
+        for btn in (self.btn_prev_phase, self.btn_resume, self.btn_next_phase):
+            btn.setVisible(False)
+            self.play_phase_layout.addWidget(btn)
+
+        all_buttons = [
+            self.btn_first, self.btn_prev, self.btn_play, self.btn_stop,
+            self.btn_next, self.btn_last,
+            self.btn_prev_phase, self.btn_resume, self.btn_next_phase,
+        ]
+        for btn in all_buttons:
+            btn.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.play_phase_container.setSizePolicy(
+            QSizePolicy.Expanding, QSizePolicy.Fixed,
+        )
+
+        nav_layout.addWidget(self.btn_first)
+        nav_layout.addWidget(self.btn_prev)
+        nav_layout.addWidget(self.play_phase_container)
+        nav_layout.addWidget(self.btn_stop)
+        nav_layout.addWidget(self.btn_next)
+        nav_layout.addWidget(self.btn_last)
+
+        self._phase_navigation_active = False
+
+        # Bottom row: left slot + mode-toggle checkboxes.
+        self.bottom_container = QWidget()
+        bottom_layout = QHBoxLayout(self.bottom_container)
+        bottom_layout.setContentsMargins(5, 5, 5, 5)
+        bottom_layout.setSpacing(10)
+
+        self.left_slot_container = QWidget()
+        self.left_slot_layout = QHBoxLayout(self.left_slot_container)
+        self.left_slot_layout.setContentsMargins(0, 0, 0, 0)
+        self.left_slot_layout.setSpacing(5)
+
+        self.right_slot_container = QWidget()
+        self.right_slot_layout = QHBoxLayout(self.right_slot_container)
+        self.right_slot_layout.setContentsMargins(0, 0, 0, 0)
+        self.right_slot_layout.setSpacing(10)
+
+        self.droplet_check_checkbox = QCheckBox("Droplet Check")
+        self.droplet_check_checkbox.setToolTip("Droplet Detection on step end")
+
+        self.preview_mode_checkbox = QCheckBox("Preview Mode")
+        preview_msg = (
+            "Send no hardware messages on protocol run and do not trigger errors."
+        )
+        self.preview_mode_checkbox.setToolTip(
+            f"<div style='width: 150px;'>{preview_msg}</div>"
+        )
+
+        self.right_slot_layout.addWidget(self.preview_mode_checkbox)
+        self.right_slot_layout.addWidget(self.droplet_check_checkbox)
+
+        bottom_layout.addWidget(self.left_slot_container)
+        bottom_layout.addStretch()
+        bottom_layout.addWidget(self.right_slot_container)
+
+        main_layout.addWidget(self.nav_container)
+        main_layout.addWidget(self.bottom_container)
+
+    def is_droplet_check_enabled(self):
+        return self.droplet_check_checkbox.isChecked()
+
+    def is_preview_mode(self):
+        return self.preview_mode_checkbox.isChecked()
+
+    def set_droplet_check_enabled(self, enabled):
+        self.droplet_check_checkbox.setEnabled(enabled)
+
+    def set_preview_mode_enabled(self, enabled):
+        self.preview_mode_checkbox.setEnabled(enabled)
+
+    def split_play_button_to_phase_controls(self):
+        if self._phase_navigation_active:
+            return
+        self._phase_navigation_active = True
+        self.btn_play.setVisible(False)
+        self.btn_prev_phase.setVisible(True)
+        self.btn_resume.setVisible(True)
+        self.btn_next_phase.setVisible(True)
+        self.play_phase_container.update()
+        self.update()
+
+    def merge_phase_controls_to_play_button(self):
+        if not self._phase_navigation_active:
+            return
+        self._phase_navigation_active = False
+        self.btn_prev_phase.setVisible(False)
+        self.btn_resume.setVisible(False)
+        self.btn_next_phase.setVisible(False)
+        self.btn_play.setVisible(True)
+        self.play_phase_container.update()
+        self.update()
+
+    def set_phase_navigation_enabled(self, prev_enabled, next_enabled):
+        self.btn_prev_phase.setEnabled(prev_enabled)
+        self.btn_next_phase.setEnabled(next_enabled)
+
+    def is_phase_navigation_active(self):
+        return self._phase_navigation_active
+
+    def add_widget_to_left_slot(self, widget):
+        """Helper for plugin-contributed widgets in the bottom-left area."""
+        self.left_slot_layout.addWidget(widget)
+
+
+class StatusBar(QScrollArea):
+    """Horizontal scrollable status row: total/step time, repeat counter,
+    step progress, repetition counter, recent/next-step labels.
+
+    All labels are exposed as public attributes so callers can update
+    text directly (matches the legacy ``protocol_grid`` API).
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        scroll_content = QWidget()
+        layout = QHBoxLayout(scroll_content)
+        layout.setContentsMargins(5, 0, 5, 0)
+        layout.setSpacing(10)
+
+        self.lbl_total_time = QLabel("Total Time: 0 s")
+        self.lbl_total_time.setFixedWidth(120)
+        self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_step_time = QLabel("Step Time: 0 s")
+        self.lbl_step_time.setFixedWidth(115)
+        self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        repeat_layout = QHBoxLayout()
+        repeat_layout.setContentsMargins(0, 0, 0, 0)
+        repeat_layout.setSpacing(2)
+
+        self.lbl_repeat_protocol = QLabel("Repeat Protocol:")
+        self.lbl_repeat_protocol.setFixedWidth(140)
+        self.lbl_repeat_protocol.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_repeat_protocol_status = QLabel("0/")
+        self.lbl_repeat_protocol_status.setFixedWidth(20)
+        self.lbl_repeat_protocol_status.setAlignment(
+            Qt.AlignRight | Qt.AlignVCenter,
+        )
+        self.edit_repeat_protocol = QLineEdit("1")
+        self.edit_repeat_protocol.setFixedWidth(30)
+        self.edit_repeat_protocol.setAlignment(Qt.AlignCenter)
+        self.edit_repeat_protocol.setFixedHeight(20)
+
+        repeat_layout.addWidget(self.lbl_repeat_protocol)
+        repeat_layout.addWidget(self.lbl_repeat_protocol_status)
+        repeat_layout.addWidget(self.edit_repeat_protocol)
+
+        repeat_widget = QWidget()
+        repeat_widget.setLayout(repeat_layout)
+        repeat_widget.setFixedWidth(170)
+        repeat_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        repeat_widget.setFixedHeight(20)
+
+        self.lbl_step_progress = QLabel("Step 0/0")
+        self.lbl_step_progress.setFixedWidth(80)
+        self.lbl_step_progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_step_repetition = QLabel("Repetition 0/0")
+        self.lbl_step_repetition.setFixedWidth(100)
+        self.lbl_step_repetition.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_recent_step = QLabel("Most Recent Step: -")
+        self.lbl_recent_step.setFixedWidth(200)
+        self.lbl_recent_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_next_step = QLabel("Next Step: -")
+        self.lbl_next_step.setFixedWidth(180)
+        self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        for w in (
+            self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress,
+            self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
+        ):
+            w.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            w.setFixedHeight(20)
+
+        layout.addWidget(self.lbl_total_time)
+        layout.addWidget(self.lbl_step_time)
+        layout.addWidget(repeat_widget)
+        layout.addWidget(self.lbl_step_progress)
+        layout.addWidget(self.lbl_step_repetition)
+        layout.addWidget(self.lbl_recent_step)
+        layout.addWidget(self.lbl_next_step)
+        layout.addStretch()
+
+        self.setWidget(scroll_content)
+        self.setWidgetResizable(True)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setFixedHeight(40)
+
+        self._apply_styling()
+        QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)
+
+    def _apply_styling(self):
+        if is_dark_mode():
+            text_color = WHITE
+            input_style = f"""
+                QLineEdit {{
+                    color: {WHITE};
+                    background-color: #2d2d2d;
+                    border: 1px solid #555555;
+                    border-radius: 3px;
+                    padding: 2px;
+                }}
+            """
+        else:
+            text_color = BLACK
+            input_style = f"""
+                QLineEdit {{
+                    color: {BLACK};
+                    background-color: white;
+                    border: 1px solid #cccccc;
+                    border-radius: 3px;
+                    padding: 2px;
+                }}
+            """
+
+        label_style = f"QLabel {{ color: {text_color}; }}"
+        for label in (
+            self.lbl_total_time, self.lbl_step_time, self.lbl_repeat_protocol,
+            self.lbl_repeat_protocol_status, self.lbl_step_progress,
+            self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
+        ):
+            label.setStyleSheet(label_style)
+        self.edit_repeat_protocol.setStyleSheet(input_style)
+
+
+def make_separator():
+    line = QFrame()
+    line.setFrameShape(QFrame.HLine)
+    line.setFrameShadow(QFrame.Sunken)
+    line.setLineWidth(1)
+    return line

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -7,7 +7,6 @@ location going forward.
 """
 
 from pyface.qt.QtCore import Qt, QTimer
-from pyface.qt.QtGui import QPainter
 from pyface.qt.QtWidgets import (
     QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QScrollArea,
     QSizePolicy, QSpinBox, QVBoxLayout, QWidget,
@@ -22,6 +21,7 @@ from microdrop_style.icons.icons import (
     ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PAUSE,
     ICON_PLAY, ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
 )
+from microdrop_utils.pyside_helpers import MarqueeLabel
 
 
 class NavigationBar(QWidget):
@@ -221,84 +221,6 @@ class NavigationBar(QWidget):
         """Paused: ▶▶ icon, 'Resume Protocol' tooltip."""
         self.btn_play.setText(ICON_RESUME)
         self.btn_play.setToolTip("Resume Protocol")
-
-
-class MarqueeLabel(QLabel):
-    """QLabel that horizontally scrolls its text on mouse hover when the
-    text is too wide to fit the widget — useful for fixed-width status
-    labels showing variable-length values like step names.
-
-    On enterEvent: starts a 20 Hz timer that increments a horizontal
-    pixel offset; the paint event draws the text at -offset, plus a
-    second copy ``_GAP_PX`` px after the first, so the scroll loops
-    seamlessly. On leaveEvent: stops the timer and resets to offset=0,
-    so the label returns to its initial truncated appearance.
-
-    If the text already fits inside the widget, marquee animation is
-    skipped and the label paints with the default QLabel rendering.
-    """
-
-    _GAP_PX = 30      # space between the text and its repeat
-    _TICK_MS = 30     # ~33 Hz update
-    _STEP_PX = 3      # offset increment per tick
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._offset = 0
-        self._scrolling = False
-        self._timer = QTimer(self)
-        self._timer.setInterval(self._TICK_MS)
-        self._timer.timeout.connect(self._tick)
-
-    def setText(self, text):
-        super().setText(text)
-        # New text → cancel any in-flight scroll. The next hover will
-        # restart it if the new text overflows.
-        self._stop_scroll()
-
-    def enterEvent(self, event):
-        if self._text_overflows():
-            self._scrolling = True
-            self._timer.start()
-            self.update()
-        super().enterEvent(event)
-
-    def leaveEvent(self, event):
-        self._stop_scroll()
-        super().leaveEvent(event)
-
-    def _stop_scroll(self):
-        self._scrolling = False
-        self._timer.stop()
-        self._offset = 0
-        self.update()
-
-    def _text_overflows(self):
-        fm = self.fontMetrics()
-        # 4 px tolerance for the label's content margin.
-        return fm.horizontalAdvance(self.text()) > self.width() - 4
-
-    def _tick(self):
-        fm = self.fontMetrics()
-        period = fm.horizontalAdvance(self.text()) + self._GAP_PX
-        self._offset = (self._offset + self._STEP_PX) % period
-        self.update()
-
-    def paintEvent(self, event):
-        if not self._scrolling:
-            super().paintEvent(event)
-            return
-        painter = QPainter(self)
-        painter.setPen(self.palette().color(self.foregroundRole()))
-        fm = self.fontMetrics()
-        text_w = fm.horizontalAdvance(self.text())
-        period = text_w + self._GAP_PX
-        baseline = (self.height() + fm.ascent() - fm.descent()) // 2
-        x = -self._offset
-        # Two copies — when the first scrolls past the right edge, the
-        # second is already entering from the right, no visible seam.
-        painter.drawText(x, baseline, self.text())
-        painter.drawText(x + period, baseline, self.text())
 
 
 class StatusBar(QScrollArea):

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -8,8 +8,8 @@ location going forward.
 
 from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
-    QApplication, QFrame, QHBoxLayout, QLabel, QLineEdit, QPushButton,
-    QScrollArea, QSizePolicy, QVBoxLayout, QWidget,
+    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QScrollArea,
+    QSizePolicy, QSpinBox, QVBoxLayout, QWidget,
 )
 
 from microdrop_style.button_styles import (
@@ -268,8 +268,13 @@ class StatusBar(QScrollArea):
         self.lbl_repeat_protocol_status.setAlignment(
             Qt.AlignRight | Qt.AlignVCenter,
         )
-        self.edit_repeat_protocol = QLineEdit("1")
-        self.edit_repeat_protocol.setFixedWidth(30)
+        # Bounded integer input — replaces the legacy QLineEdit("1")
+        # which let users type arbitrary text. SpinBox enforces the
+        # int range and avoids needing a try/except on .text().
+        self.edit_repeat_protocol = QSpinBox()
+        self.edit_repeat_protocol.setRange(1, 999)
+        self.edit_repeat_protocol.setValue(1)
+        self.edit_repeat_protocol.setFixedWidth(50)
         self.edit_repeat_protocol.setAlignment(Qt.AlignCenter)
         self.edit_repeat_protocol.setFixedHeight(20)
 
@@ -279,7 +284,7 @@ class StatusBar(QScrollArea):
 
         repeat_widget = QWidget()
         repeat_widget.setLayout(repeat_layout)
-        repeat_widget.setFixedWidth(170)
+        repeat_widget.setFixedWidth(190)
         repeat_widget.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         repeat_widget.setFixedHeight(20)
 
@@ -330,7 +335,7 @@ class StatusBar(QScrollArea):
         if is_dark_mode():
             text_color = WHITE
             input_style = f"""
-                QLineEdit {{
+                QSpinBox {{
                     color: {WHITE};
                     background-color: #2d2d2d;
                     border: 1px solid #555555;
@@ -341,7 +346,7 @@ class StatusBar(QScrollArea):
         else:
             text_color = BLACK
             input_style = f"""
-                QLineEdit {{
+                QSpinBox {{
                     color: {BLACK};
                     background-color: white;
                     border: 1px solid #cccccc;

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -8,8 +8,8 @@ location going forward.
 
 from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
-    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QScrollArea,
-    QSizePolicy, QSpinBox, QVBoxLayout, QWidget,
+    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy,
+    QSpinBox, QVBoxLayout, QWidget,
 )
 
 from microdrop_style.button_styles import (
@@ -222,28 +222,38 @@ class NavigationBar(QWidget):
         self.btn_play.setToolTip("Resume Protocol")
 
 
-class StatusBar(QScrollArea):
-    """Horizontal scrollable status row: total/step time, repeat counter,
-    step progress, repetition counter, recent/next-step labels.
+class StatusBar(QWidget):
+    """Horizontal status row: total/step time, repeat counter, step
+    progress, repetition counter, recent/next-step labels.
 
     All labels are exposed as public attributes so callers can update
     text directly (matches the legacy ``protocol_grid`` API).
+
+    Sized to the sum of its labels' content widths — pushing the bar
+    wider when step names get long — so callers should size the
+    enclosing window accordingly. Vertically Fixed at the row height.
     """
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        scroll_content = QWidget()
-        layout = QHBoxLayout(scroll_content)
+        # Horizontal: take whatever the layout asks for (so the bar
+        # grows with content); Vertical: hug the 20 px label row.
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
+        layout = QHBoxLayout(self)
         layout.setContentsMargins(5, 0, 5, 0)
         layout.setSpacing(10)
 
+        # Data-bearing labels use minimum widths (sensible defaults for
+        # the placeholder text) but are free to grow with content. Fixed
+        # widths previously truncated longer step names / counters.
         self.lbl_total_time = QLabel("Total Time: 0 s")
-        self.lbl_total_time.setFixedWidth(120)
+        self.lbl_total_time.setMinimumWidth(120)
         self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_step_time = QLabel("Step Time: 0 s")
-        self.lbl_step_time.setFixedWidth(115)
+        self.lbl_step_time.setMinimumWidth(115)
         self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         # Phase time slot — not in the legacy StatusBar layout, but
@@ -251,7 +261,7 @@ class StatusBar(QScrollArea):
         # the per-phase ack timer here. Hidden by default; the demo
         # window reveals it iff DemoConfig.phase_ack_topic is set.
         self.lbl_phase_time = QLabel("Phase 0.00s / 0.00s")
-        self.lbl_phase_time.setFixedWidth(170)
+        self.lbl_phase_time.setMinimumWidth(170)
         self.lbl_phase_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.lbl_phase_time.setVisible(False)
 
@@ -289,27 +299,29 @@ class StatusBar(QScrollArea):
         repeat_widget.setFixedHeight(20)
 
         self.lbl_step_progress = QLabel("Step 0/0")
-        self.lbl_step_progress.setFixedWidth(80)
+        self.lbl_step_progress.setMinimumWidth(80)
         self.lbl_step_progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_step_repetition = QLabel("Repetition 0/0")
-        self.lbl_step_repetition.setFixedWidth(100)
+        self.lbl_step_repetition.setMinimumWidth(100)
         self.lbl_step_repetition.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_recent_step = QLabel("Most Recent Step: -")
-        self.lbl_recent_step.setFixedWidth(200)
+        self.lbl_recent_step.setMinimumWidth(200)
         self.lbl_recent_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_next_step = QLabel("Next Step: -")
-        self.lbl_next_step.setFixedWidth(180)
+        self.lbl_next_step.setMinimumWidth(180)
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
+        # Preferred horizontally so labels grow with their text content;
+        # Fixed vertically + 20 px height keeps the bar a single row.
         for w in (
             self.lbl_total_time, self.lbl_step_time, self.lbl_phase_time,
             self.lbl_step_progress, self.lbl_step_repetition,
             self.lbl_recent_step, self.lbl_next_step,
         ):
-            w.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+            w.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
             w.setFixedHeight(20)
 
         layout.addWidget(self.lbl_total_time)
@@ -320,13 +332,12 @@ class StatusBar(QScrollArea):
         layout.addWidget(self.lbl_step_repetition)
         layout.addWidget(self.lbl_recent_step)
         layout.addWidget(self.lbl_next_step)
+        # Trailing stretch absorbs any extra horizontal space when the
+        # window is wider than the bar's content — keeps labels packed
+        # to the left rather than spreading across the bar.
         layout.addStretch()
 
-        self.setWidget(scroll_content)
-        self.setWidgetResizable(True)
-        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
-        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
-        self.setFixedHeight(40)
+        self.setFixedHeight(28)
 
         self._apply_styling()
         QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -319,7 +319,7 @@ class StatusBar(QScrollArea):
         scroll_content = QWidget()
         layout = QHBoxLayout(scroll_content)
         layout.setContentsMargins(5, 0, 5, 0)
-        layout.setSpacing(10)
+        layout.setSpacing(5)
 
         self.lbl_total_time = QLabel("Total Time: 0 s")
         self.lbl_total_time.setFixedWidth(120)

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -43,6 +43,11 @@ class NavigationBar(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
+        # Bar should hug its sizeHint vertically — only stretch
+        # horizontally — so the tree fills the rest of the window
+        # rather than the bar growing into empty space.
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+
         main_layout = QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
         main_layout.setSpacing(0)
@@ -50,7 +55,9 @@ class NavigationBar(QWidget):
         # Top row: navigation buttons.
         self.nav_container = QWidget()
         nav_layout = QHBoxLayout(self.nav_container)
-        nav_layout.setContentsMargins(5, 5, 5, 5)
+        # Horizontal padding keeps the buttons off the edges; vertical
+        # padding is zero so the bar doesn't add bands above/below.
+        nav_layout.setContentsMargins(5, 0, 5, 0)
         nav_layout.setSpacing(BUTTON_SPACING)
 
         self.btn_first = QPushButton(ICON_FIRST)
@@ -115,7 +122,8 @@ class NavigationBar(QWidget):
         # Bottom row: plugin-fillable left slot.
         self.bottom_container = QWidget()
         bottom_layout = QHBoxLayout(self.bottom_container)
-        bottom_layout.setContentsMargins(5, 5, 5, 5)
+        # Same horizontal-only padding as the nav row.
+        bottom_layout.setContentsMargins(5, 0, 5, 0)
         bottom_layout.setSpacing(10)
 
         self.left_slot_container = QWidget()

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -22,6 +22,11 @@ from microdrop_style.icons.icons import (
     ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PAUSE,
     ICON_PLAY, ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
 )
+
+# Material Symbols ligature used while Preview Mode is armed —
+# replaces the play-arrow glyph so the button reads as a "preview"
+# action at a glance.
+ICON_PREVIEW = "video_search"
 from microdrop_utils.pyside_helpers import MarqueeLabel
 
 
@@ -102,9 +107,11 @@ class NavigationBar(QWidget):
         self.play_menu.addAction(self.action_preview)
         self.btn_play.setMenu(self.play_menu)
 
-        # Toggling Preview re-applies the play-button stylesheet so the
-        # button background flips to yellow while preview is armed.
-        self.action_preview.toggled.connect(lambda _: self.apply_styling())
+        # Toggling Preview re-applies the play-button stylesheet (so
+        # background + hover flip to yellow) and refreshes the play
+        # state so the icon swaps to ``video_search`` and the tooltip
+        # picks up the "Preview" wording.
+        self.action_preview.toggled.connect(lambda _: self._on_preview_toggled())
 
         self.btn_prev_phase = QPushButton(ICON_PREVIOUS_PHASE)
         self.btn_prev_phase.setToolTip("Previous Phase")
@@ -211,19 +218,31 @@ class NavigationBar(QWidget):
             bg_disabled = BLACK
             fg_disabled = GREY['light']
             border_disabled = GREY['dark']
-            preview_bg = "#a68f00"
-            preview_border = "#ffd54f"
-            preview_fg = BLACK
+            preview_bg, preview_border, preview_fg = "#a68f00", "#ffd54f", BLACK
+            preview_hover_bg, preview_hover_border = "#bfa200", "#ffe082"
+            normal_hover_bg = GREY['light']
+            normal_hover_border = SECONDARY_SHADE[300]
+            normal_hover_fg = SECONDARY_SHADE[700]
         else:
             bg, fg, border = WHITE, BLACK, GREY['light']
             bg_disabled = GREY['light']
             fg_disabled = GREY['dark']
             border_disabled = GREY['lighter']
-            preview_bg = "#fff59d"
-            preview_border = "#fbc02d"
-            preview_fg = BLACK
+            preview_bg, preview_border, preview_fg = "#fff59d", "#fbc02d", BLACK
+            preview_hover_bg, preview_hover_border = "#ffe082", "#fb8c00"
+            normal_hover_bg = GREY['light']
+            normal_hover_border = SECONDARY_SHADE[300]
+            normal_hover_fg = SECONDARY_SHADE[700]
+
         if self.action_preview.isChecked():
             bg, fg, border = preview_bg, preview_fg, preview_border
+            hover_bg, hover_border, hover_fg = (
+                preview_hover_bg, preview_hover_border, preview_fg,
+            )
+        else:
+            hover_bg, hover_border, hover_fg = (
+                normal_hover_bg, normal_hover_border, normal_hover_fg,
+            )
         return f"""
             QToolButton {{
                 font-family: "{ICON_FONT_FAMILY}";
@@ -237,9 +256,9 @@ class NavigationBar(QWidget):
                 color: {fg};
             }}
             QToolButton:hover {{
-                color: {SECONDARY_SHADE[700]};
-                background-color: {GREY['light']};
-                border-color: {SECONDARY_SHADE[300]};
+                color: {hover_fg};
+                background-color: {hover_bg};
+                border-color: {hover_border};
             }}
             QToolButton:pressed {{
                 background-color: {GREY['dark']};
@@ -264,6 +283,22 @@ class NavigationBar(QWidget):
         """True when the user has armed Preview Mode in the play
         dropdown — the legacy ``preview_mode_checkbox.isChecked()``."""
         return self.action_preview.isChecked()
+
+    def _on_preview_toggled(self):
+        """Re-apply styling and refresh whichever play-button state is
+        currently showing so the icon + tooltip flip to / from the
+        preview variant. The pause/resume icons themselves don't need
+        a per-toggle rewrite — only their tooltips read different text
+        in preview — so reading the button's current text decides
+        which show_* helper re-runs."""
+        self.apply_styling()
+        current_text = self.btn_play.text()
+        if current_text == ICON_PAUSE:
+            self.show_pause_state()
+        elif current_text == ICON_RESUME:
+            self.show_resume_state()
+        else:
+            self.show_play_state()
 
     def _on_color_scheme_changed(self, *_):
         """Defer the re-style by one event-loop tick — when this signal
@@ -309,21 +344,39 @@ class NavigationBar(QWidget):
         self.bottom_container.setVisible(True)
 
     # --- play-button visual state -----------------------------------------
+    #
+    # Each show_*_state() reads ``action_preview.isChecked()`` and picks
+    # the matching icon + tooltip — so toggling Preview Mode while the
+    # button is in any state correctly relabels it. A "Preview" prefix
+    # in the tooltip and the ``video_search`` glyph signal that the
+    # next click won't drive hardware.
+
+    def _preview_armed(self):
+        return self.action_preview.isChecked()
 
     def show_play_state(self):
-        """Idle: ▶ icon, 'Play Protocol' tooltip."""
-        self.btn_play.setText(ICON_PLAY)
-        self.btn_play.setToolTip("Play Protocol")
+        """Idle: video_search + 'Preview Protocol' if armed, else
+        play_arrow + 'Play Protocol'."""
+        if self._preview_armed():
+            self.btn_play.setText(ICON_PREVIEW)
+            self.btn_play.setToolTip("Preview Protocol")
+        else:
+            self.btn_play.setText(ICON_PLAY)
+            self.btn_play.setToolTip("Play Protocol")
 
     def show_pause_state(self):
-        """Running: ⏸ icon, 'Pause Protocol' tooltip."""
+        """Running: ⏸ icon. Tooltip notes preview state when armed."""
         self.btn_play.setText(ICON_PAUSE)
-        self.btn_play.setToolTip("Pause Protocol")
+        self.btn_play.setToolTip(
+            "Pause Preview" if self._preview_armed() else "Pause Protocol"
+        )
 
     def show_resume_state(self):
-        """Paused: ▶▶ icon, 'Resume Protocol' tooltip."""
+        """Paused: ▶▶ icon. Tooltip notes preview state when armed."""
         self.btn_play.setText(ICON_RESUME)
-        self.btn_play.setToolTip("Resume Protocol")
+        self.btn_play.setToolTip(
+            "Resume Preview" if self._preview_armed() else "Resume Protocol"
+        )
 
 
 class StatusBar(QScrollArea):

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -80,9 +80,11 @@ class NavigationBar(QWidget):
 
         # Play is a QToolButton with a menu-button split: the main face
         # behaves like before (click → start/pause/resume the protocol),
-        # while the dropdown arrow exposes alternate run modes — currently
-        # only "Preview" (skip hardware writes). Plugins can add more
-        # via ``play_menu``.
+        # while the dropdown arrow exposes the persistent run-mode
+        # toggles that used to live as checkboxes on the legacy
+        # protocol_grid bottom row — Preview Mode and Droplet Check.
+        # Both are checkable QActions; main-button click reads their
+        # state via is_preview_mode() / is_droplet_check_enabled().
         self.btn_play = QToolButton()
         self.btn_play.setPopupMode(QToolButton.MenuButtonPopup)
         self.btn_play.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
@@ -90,13 +92,27 @@ class NavigationBar(QWidget):
         self.btn_play.setToolTip("Play Protocol")
 
         self.play_menu = QMenu(self.btn_play)
-        self.action_run_preview = QAction("Preview", self.play_menu)
-        self.action_run_preview.setToolTip(
+
+        self.action_preview = QAction("Preview Mode", self.play_menu)
+        self.action_preview.setCheckable(True)
+        self.action_preview.setToolTip(
             "Run the protocol without sending any hardware messages "
             "(useful when no DropBot is connected)"
         )
-        self.play_menu.addAction(self.action_run_preview)
+
+        self.action_droplet_check = QAction("Droplet Check", self.play_menu)
+        self.action_droplet_check.setCheckable(True)
+        self.action_droplet_check.setToolTip(
+            "Run droplet detection at the end of each step"
+        )
+
+        self.play_menu.addAction(self.action_preview)
+        self.play_menu.addAction(self.action_droplet_check)
         self.btn_play.setMenu(self.play_menu)
+
+        # Toggling Preview re-applies the play-button stylesheet so the
+        # button background flips to yellow while preview is armed.
+        self.action_preview.toggled.connect(lambda _: self.apply_styling())
 
         self.btn_prev_phase = QPushButton(ICON_PREVIOUS_PHASE)
         self.btn_prev_phase.setToolTip("Previous Phase")
@@ -189,22 +205,33 @@ class NavigationBar(QWidget):
         )
         self.btn_play.setStyleSheet(self._play_btn_stylesheet(theme))
 
-    @staticmethod
-    def _play_btn_stylesheet(theme):
+    def _play_btn_stylesheet(self, theme):
         """QToolButton stylesheet mirroring the default QPushButton look
-        (icon font + theme-aware colours) plus a ``::menu-button``
-        sub-control rule so the dropdown arrow has a clean separator
-        instead of inheriting the main face's borders."""
+        (icon font + theme-aware colours). When ``action_preview`` is
+        checked the main face flips to a soft yellow so it's obvious
+        at a glance that the next click won't touch hardware. The
+        ``::menu-button`` arrow is kept deliberately subtle — no
+        separator border, narrower width — so it doesn't compete
+        visually with the main play face.
+        """
         if theme == "dark":
             bg, fg, border = GREY['dark'], WHITE, GREY['lighter']
             bg_disabled = BLACK
             fg_disabled = GREY['light']
             border_disabled = GREY['dark']
+            preview_bg = "#a68f00"
+            preview_border = "#ffd54f"
+            preview_fg = BLACK
         else:
             bg, fg, border = WHITE, BLACK, GREY['light']
             bg_disabled = GREY['light']
             fg_disabled = GREY['dark']
             border_disabled = GREY['lighter']
+            preview_bg = "#fff59d"
+            preview_border = "#fbc02d"
+            preview_fg = BLACK
+        if self.action_preview.isChecked():
+            bg, fg, border = preview_bg, preview_fg, preview_border
         return f"""
             QToolButton {{
                 font-family: "{ICON_FONT_FAMILY}";
@@ -231,10 +258,25 @@ class NavigationBar(QWidget):
                 border-color: {border_disabled};
             }}
             QToolButton::menu-button {{
-                border-left: 1px solid {border};
-                width: 16px;
+                border: none;
+                background: transparent;
+                width: 12px;
+            }}
+            QToolButton::menu-arrow {{
+                width: 6px;
+                height: 6px;
             }}
         """
+
+    def is_preview_mode(self):
+        """True when the user has armed Preview Mode in the play
+        dropdown — the legacy ``preview_mode_checkbox.isChecked()``."""
+        return self.action_preview.isChecked()
+
+    def is_droplet_check_enabled(self):
+        """True when the user has enabled Droplet Check in the play
+        dropdown — the legacy ``droplet_check_checkbox.isChecked()``."""
+        return self.action_droplet_check.isChecked()
 
     def _on_color_scheme_changed(self, *_):
         """Defer the re-style by one event-loop tick — when this signal

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -239,8 +239,8 @@ class MarqueeLabel(QLabel):
     """
 
     _GAP_PX = 30      # space between the text and its repeat
-    _TICK_MS = 50     # 20 Hz update
-    _STEP_PX = 1      # offset increment per tick
+    _TICK_MS = 30     # ~33 Hz update
+    _STEP_PX = 3      # offset increment per tick
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -246,6 +246,15 @@ class StatusBar(QScrollArea):
         self.lbl_step_time.setFixedWidth(115)
         self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
+        # Phase time slot — not in the legacy StatusBar layout, but
+        # callers (BasePluggableProtocolDemoWindow) want to surface
+        # the per-phase ack timer here. Hidden by default; the demo
+        # window reveals it iff DemoConfig.phase_ack_topic is set.
+        self.lbl_phase_time = QLabel("Phase 0.00s / 0.00s")
+        self.lbl_phase_time.setFixedWidth(170)
+        self.lbl_phase_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.lbl_phase_time.setVisible(False)
+
         repeat_layout = QHBoxLayout()
         repeat_layout.setContentsMargins(0, 0, 0, 0)
         repeat_layout.setSpacing(2)
@@ -291,14 +300,16 @@ class StatusBar(QScrollArea):
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         for w in (
-            self.lbl_total_time, self.lbl_step_time, self.lbl_step_progress,
-            self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
+            self.lbl_total_time, self.lbl_step_time, self.lbl_phase_time,
+            self.lbl_step_progress, self.lbl_step_repetition,
+            self.lbl_recent_step, self.lbl_next_step,
         ):
             w.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             w.setFixedHeight(20)
 
         layout.addWidget(self.lbl_total_time)
         layout.addWidget(self.lbl_step_time)
+        layout.addWidget(self.lbl_phase_time)
         layout.addWidget(repeat_widget)
         layout.addWidget(self.lbl_step_progress)
         layout.addWidget(self.lbl_step_repetition)
@@ -341,9 +352,10 @@ class StatusBar(QScrollArea):
 
         label_style = f"QLabel {{ color: {text_color}; }}"
         for label in (
-            self.lbl_total_time, self.lbl_step_time, self.lbl_repeat_protocol,
-            self.lbl_repeat_protocol_status, self.lbl_step_progress,
-            self.lbl_step_repetition, self.lbl_recent_step, self.lbl_next_step,
+            self.lbl_total_time, self.lbl_step_time, self.lbl_phase_time,
+            self.lbl_repeat_protocol, self.lbl_repeat_protocol_status,
+            self.lbl_step_progress, self.lbl_step_repetition,
+            self.lbl_recent_step, self.lbl_next_step,
         ):
             label.setStyleSheet(label_style)
         self.edit_repeat_protocol.setStyleSheet(input_style)

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -7,15 +7,16 @@ location going forward.
 """
 
 from pyface.qt.QtCore import Qt, QTimer
+from pyface.qt.QtGui import QAction
 from pyface.qt.QtWidgets import (
-    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QScrollArea,
-    QSizePolicy, QSpinBox, QVBoxLayout, QWidget,
+    QApplication, QFrame, QHBoxLayout, QLabel, QMenu, QPushButton,
+    QScrollArea, QSizePolicy, QSpinBox, QToolButton, QVBoxLayout, QWidget,
 )
 
 from microdrop_style.button_styles import (
-    BUTTON_SPACING, get_button_style,
+    BUTTON_SPACING, ICON_FONT_FAMILY, get_button_style,
 )
-from microdrop_style.colors import BLACK, WHITE
+from microdrop_style.colors import BLACK, GREY, SECONDARY_SHADE, WHITE
 from microdrop_style.helpers import get_complete_stylesheet, is_dark_mode
 from microdrop_style.icons.icons import (
     ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PAUSE,
@@ -77,8 +78,25 @@ class NavigationBar(QWidget):
         self.btn_last = QPushButton(ICON_LAST)
         self.btn_last.setToolTip("Last Step")
 
-        self.btn_play = QPushButton(ICON_PLAY)
+        # Play is a QToolButton with a menu-button split: the main face
+        # behaves like before (click → start/pause/resume the protocol),
+        # while the dropdown arrow exposes alternate run modes — currently
+        # only "Preview" (skip hardware writes). Plugins can add more
+        # via ``play_menu``.
+        self.btn_play = QToolButton()
+        self.btn_play.setPopupMode(QToolButton.MenuButtonPopup)
+        self.btn_play.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
+        self.btn_play.setText(ICON_PLAY)
         self.btn_play.setToolTip("Play Protocol")
+
+        self.play_menu = QMenu(self.btn_play)
+        self.action_run_preview = QAction("Preview", self.play_menu)
+        self.action_run_preview.setToolTip(
+            "Run the protocol without sending any hardware messages "
+            "(useful when no DropBot is connected)"
+        )
+        self.play_menu.addAction(self.action_run_preview)
+        self.btn_play.setMenu(self.play_menu)
 
         self.btn_prev_phase = QPushButton(ICON_PREVIOUS_PHASE)
         self.btn_prev_phase.setToolTip("Previous Phase")
@@ -153,7 +171,15 @@ class NavigationBar(QWidget):
     def apply_styling(self):
         """Apply the same stylesheet the legacy protocol_grid uses for
         its NavigationBar: full app sheet on the nav button row, tool
-        button sheet on the left-slot row."""
+        button sheet on the left-slot row.
+
+        The play button is a QToolButton, which the default stylesheet
+        only targets via its ``QPushButton`` rules — leaving the play
+        button without the Material Symbols font (so the glyph name
+        ``play_arrow`` renders as literal text). _play_btn_stylesheet
+        applies a QToolButton-targeting equivalent so the icon font,
+        colours, and hover behaviour all match its QPushButton siblings.
+        """
         theme = "dark" if is_dark_mode() else "light"
         self.nav_container.setStyleSheet(
             get_complete_stylesheet(theme, "default"),
@@ -161,6 +187,54 @@ class NavigationBar(QWidget):
         self.left_slot_container.setStyleSheet(
             get_button_style(theme, "tool"),
         )
+        self.btn_play.setStyleSheet(self._play_btn_stylesheet(theme))
+
+    @staticmethod
+    def _play_btn_stylesheet(theme):
+        """QToolButton stylesheet mirroring the default QPushButton look
+        (icon font + theme-aware colours) plus a ``::menu-button``
+        sub-control rule so the dropdown arrow has a clean separator
+        instead of inheriting the main face's borders."""
+        if theme == "dark":
+            bg, fg, border = GREY['dark'], WHITE, GREY['lighter']
+            bg_disabled = BLACK
+            fg_disabled = GREY['light']
+            border_disabled = GREY['dark']
+        else:
+            bg, fg, border = WHITE, BLACK, GREY['light']
+            bg_disabled = GREY['light']
+            fg_disabled = GREY['dark']
+            border_disabled = GREY['lighter']
+        return f"""
+            QToolButton {{
+                font-family: "{ICON_FONT_FAMILY}";
+                font-size: 22px;
+                padding: 4px 8px;
+                border-radius: 4px;
+                min-width: 60px;
+                min-height: 26px;
+                border: 1px solid {border};
+                background-color: {bg};
+                color: {fg};
+            }}
+            QToolButton:hover {{
+                color: {SECONDARY_SHADE[700]};
+                background-color: {GREY['light']};
+                border-color: {SECONDARY_SHADE[300]};
+            }}
+            QToolButton:pressed {{
+                background-color: {GREY['dark']};
+            }}
+            QToolButton:disabled {{
+                color: {fg_disabled};
+                background-color: {bg_disabled};
+                border-color: {border_disabled};
+            }}
+            QToolButton::menu-button {{
+                border-left: 1px solid {border};
+                width: 16px;
+            }}
+        """
 
     def _on_color_scheme_changed(self, *_):
         """Defer the re-style by one event-loop tick — when this signal

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -7,9 +7,10 @@ location going forward.
 """
 
 from pyface.qt.QtCore import Qt, QTimer
+from pyface.qt.QtGui import QPainter
 from pyface.qt.QtWidgets import (
-    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QSizePolicy,
-    QSpinBox, QVBoxLayout, QWidget,
+    QApplication, QFrame, QHBoxLayout, QLabel, QPushButton, QScrollArea,
+    QSizePolicy, QSpinBox, QVBoxLayout, QWidget,
 )
 
 from microdrop_style.button_styles import (
@@ -222,38 +223,110 @@ class NavigationBar(QWidget):
         self.btn_play.setToolTip("Resume Protocol")
 
 
-class StatusBar(QWidget):
-    """Horizontal status row: total/step time, repeat counter, step
-    progress, repetition counter, recent/next-step labels.
+class MarqueeLabel(QLabel):
+    """QLabel that horizontally scrolls its text on mouse hover when the
+    text is too wide to fit the widget — useful for fixed-width status
+    labels showing variable-length values like step names.
+
+    On enterEvent: starts a 20 Hz timer that increments a horizontal
+    pixel offset; the paint event draws the text at -offset, plus a
+    second copy ``_GAP_PX`` px after the first, so the scroll loops
+    seamlessly. On leaveEvent: stops the timer and resets to offset=0,
+    so the label returns to its initial truncated appearance.
+
+    If the text already fits inside the widget, marquee animation is
+    skipped and the label paints with the default QLabel rendering.
+    """
+
+    _GAP_PX = 30      # space between the text and its repeat
+    _TICK_MS = 50     # 20 Hz update
+    _STEP_PX = 1      # offset increment per tick
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._offset = 0
+        self._scrolling = False
+        self._timer = QTimer(self)
+        self._timer.setInterval(self._TICK_MS)
+        self._timer.timeout.connect(self._tick)
+
+    def setText(self, text):
+        super().setText(text)
+        # New text → cancel any in-flight scroll. The next hover will
+        # restart it if the new text overflows.
+        self._stop_scroll()
+
+    def enterEvent(self, event):
+        if self._text_overflows():
+            self._scrolling = True
+            self._timer.start()
+            self.update()
+        super().enterEvent(event)
+
+    def leaveEvent(self, event):
+        self._stop_scroll()
+        super().leaveEvent(event)
+
+    def _stop_scroll(self):
+        self._scrolling = False
+        self._timer.stop()
+        self._offset = 0
+        self.update()
+
+    def _text_overflows(self):
+        fm = self.fontMetrics()
+        # 4 px tolerance for the label's content margin.
+        return fm.horizontalAdvance(self.text()) > self.width() - 4
+
+    def _tick(self):
+        fm = self.fontMetrics()
+        period = fm.horizontalAdvance(self.text()) + self._GAP_PX
+        self._offset = (self._offset + self._STEP_PX) % period
+        self.update()
+
+    def paintEvent(self, event):
+        if not self._scrolling:
+            super().paintEvent(event)
+            return
+        painter = QPainter(self)
+        painter.setPen(self.palette().color(self.foregroundRole()))
+        fm = self.fontMetrics()
+        text_w = fm.horizontalAdvance(self.text())
+        period = text_w + self._GAP_PX
+        baseline = (self.height() + fm.ascent() - fm.descent()) // 2
+        x = -self._offset
+        # Two copies — when the first scrolls past the right edge, the
+        # second is already entering from the right, no visible seam.
+        painter.drawText(x, baseline, self.text())
+        painter.drawText(x + period, baseline, self.text())
+
+
+class StatusBar(QScrollArea):
+    """Horizontal scrollable status row: total/step time, repeat
+    counter, step progress, repetition counter, recent/next-step labels.
 
     All labels are exposed as public attributes so callers can update
     text directly (matches the legacy ``protocol_grid`` API).
 
-    Sized to the sum of its labels' content widths — pushing the bar
-    wider when step names get long — so callers should size the
-    enclosing window accordingly. Vertically Fixed at the row height.
+    The recent/next step labels are MarqueeLabel instances with fixed
+    widths — long step names truncate by default, but auto-scroll
+    horizontally when the user hovers over the label.
     """
 
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        # Horizontal: take whatever the layout asks for (so the bar
-        # grows with content); Vertical: hug the 20 px label row.
-        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-
-        layout = QHBoxLayout(self)
+        scroll_content = QWidget()
+        layout = QHBoxLayout(scroll_content)
         layout.setContentsMargins(5, 0, 5, 0)
         layout.setSpacing(10)
 
-        # Data-bearing labels use minimum widths (sensible defaults for
-        # the placeholder text) but are free to grow with content. Fixed
-        # widths previously truncated longer step names / counters.
         self.lbl_total_time = QLabel("Total Time: 0 s")
-        self.lbl_total_time.setMinimumWidth(120)
+        self.lbl_total_time.setFixedWidth(120)
         self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_step_time = QLabel("Step Time: 0 s")
-        self.lbl_step_time.setMinimumWidth(115)
+        self.lbl_step_time.setFixedWidth(115)
         self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         # Phase time slot — not in the legacy StatusBar layout, but
@@ -261,7 +334,7 @@ class StatusBar(QWidget):
         # the per-phase ack timer here. Hidden by default; the demo
         # window reveals it iff DemoConfig.phase_ack_topic is set.
         self.lbl_phase_time = QLabel("Phase 0.00s / 0.00s")
-        self.lbl_phase_time.setMinimumWidth(170)
+        self.lbl_phase_time.setFixedWidth(170)
         self.lbl_phase_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.lbl_phase_time.setVisible(False)
 
@@ -299,29 +372,30 @@ class StatusBar(QWidget):
         repeat_widget.setFixedHeight(20)
 
         self.lbl_step_progress = QLabel("Step 0/0")
-        self.lbl_step_progress.setMinimumWidth(80)
+        self.lbl_step_progress.setFixedWidth(80)
         self.lbl_step_progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_step_repetition = QLabel("Repetition 0/0")
-        self.lbl_step_repetition.setMinimumWidth(100)
+        self.lbl_step_repetition.setFixedWidth(100)
         self.lbl_step_repetition.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        self.lbl_recent_step = QLabel("Most Recent Step: -")
-        self.lbl_recent_step.setMinimumWidth(200)
+        # Recent / next step labels: fixed width truncates long step
+        # names by default; on hover the MarqueeLabel auto-scrolls the
+        # full text into view.
+        self.lbl_recent_step = MarqueeLabel("Most Recent Step: -")
+        self.lbl_recent_step.setFixedWidth(200)
         self.lbl_recent_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        self.lbl_next_step = QLabel("Next Step: -")
-        self.lbl_next_step.setMinimumWidth(180)
+        self.lbl_next_step = MarqueeLabel("Next Step: -")
+        self.lbl_next_step.setFixedWidth(180)
         self.lbl_next_step.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        # Preferred horizontally so labels grow with their text content;
-        # Fixed vertically + 20 px height keeps the bar a single row.
         for w in (
             self.lbl_total_time, self.lbl_step_time, self.lbl_phase_time,
             self.lbl_step_progress, self.lbl_step_repetition,
             self.lbl_recent_step, self.lbl_next_step,
         ):
-            w.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed)
+            w.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             w.setFixedHeight(20)
 
         layout.addWidget(self.lbl_total_time)
@@ -332,12 +406,13 @@ class StatusBar(QWidget):
         layout.addWidget(self.lbl_step_repetition)
         layout.addWidget(self.lbl_recent_step)
         layout.addWidget(self.lbl_next_step)
-        # Trailing stretch absorbs any extra horizontal space when the
-        # window is wider than the bar's content — keeps labels packed
-        # to the left rather than spreading across the bar.
         layout.addStretch()
 
-        self.setFixedHeight(28)
+        self.setWidget(scroll_content)
+        self.setWidgetResizable(True)
+        self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        self.setFixedHeight(40)
 
         self._apply_styling()
         QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -6,15 +6,17 @@ until PPT-9 deletes ``protocol_grid``; this module is the canonical
 location going forward.
 """
 
-from pyface.qt.QtCore import Qt
+from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtWidgets import (
-    QApplication, QCheckBox, QFrame, QHBoxLayout, QLabel, QLineEdit,
-    QPushButton, QScrollArea, QSizePolicy, QVBoxLayout, QWidget,
+    QApplication, QFrame, QHBoxLayout, QLabel, QLineEdit, QPushButton,
+    QScrollArea, QSizePolicy, QVBoxLayout, QWidget,
 )
 
-from microdrop_style.button_styles import BUTTON_SPACING
+from microdrop_style.button_styles import (
+    BUTTON_SPACING, get_button_style,
+)
 from microdrop_style.colors import BLACK, WHITE
-from microdrop_style.helpers import is_dark_mode
+from microdrop_style.helpers import get_complete_stylesheet, is_dark_mode
 from microdrop_style.icons.icons import (
     ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PLAY,
     ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
@@ -22,12 +24,20 @@ from microdrop_style.icons.icons import (
 
 
 class NavigationBar(QWidget):
-    """Two-row toolbar: playback/step/phase buttons on top, left-slot +
-    mode-toggle checkboxes on bottom.
+    """Two-row toolbar: playback/step/phase buttons on top, plugin-fillable
+    left slot on bottom.
 
     The play button can be split into a Prev-phase / Resume / Next-phase
     cluster via ``split_play_button_to_phase_controls`` for protocols
     being driven phase-by-phase.
+
+    Styling matches the legacy ``protocol_grid`` NavigationBar exactly:
+    ``nav_container`` gets the full app stylesheet (so the icon font and
+    button look match the rest of MicroDrop), ``left_slot_container``
+    gets the tool-button stylesheet. Both are re-applied on
+    ``colorSchemeChanged`` via a deferred QTimer.singleShot — the OS
+    palette flag is briefly stale at signal time, so we let the event
+    loop drain before re-reading ``is_dark_mode()``.
     """
 
     def __init__(self, parent=None):
@@ -102,7 +112,7 @@ class NavigationBar(QWidget):
 
         self._phase_navigation_active = False
 
-        # Bottom row: left slot + mode-toggle checkboxes.
+        # Bottom row: plugin-fillable left slot.
         self.bottom_container = QWidget()
         bottom_layout = QHBoxLayout(self.bottom_container)
         bottom_layout.setContentsMargins(5, 5, 5, 5)
@@ -113,43 +123,37 @@ class NavigationBar(QWidget):
         self.left_slot_layout.setContentsMargins(0, 0, 0, 0)
         self.left_slot_layout.setSpacing(5)
 
-        self.right_slot_container = QWidget()
-        self.right_slot_layout = QHBoxLayout(self.right_slot_container)
-        self.right_slot_layout.setContentsMargins(0, 0, 0, 0)
-        self.right_slot_layout.setSpacing(10)
-
-        self.droplet_check_checkbox = QCheckBox("Droplet Check")
-        self.droplet_check_checkbox.setToolTip("Droplet Detection on step end")
-
-        self.preview_mode_checkbox = QCheckBox("Preview Mode")
-        preview_msg = (
-            "Send no hardware messages on protocol run and do not trigger errors."
-        )
-        self.preview_mode_checkbox.setToolTip(
-            f"<div style='width: 150px;'>{preview_msg}</div>"
-        )
-
-        self.right_slot_layout.addWidget(self.preview_mode_checkbox)
-        self.right_slot_layout.addWidget(self.droplet_check_checkbox)
-
         bottom_layout.addWidget(self.left_slot_container)
         bottom_layout.addStretch()
-        bottom_layout.addWidget(self.right_slot_container)
 
         main_layout.addWidget(self.nav_container)
         main_layout.addWidget(self.bottom_container)
 
-    def is_droplet_check_enabled(self):
-        return self.droplet_check_checkbox.isChecked()
+        # Apply the legacy protocol_grid stylesheet and re-apply on
+        # OS theme changes.
+        self.apply_styling()
+        QApplication.styleHints().colorSchemeChanged.connect(
+            self._on_color_scheme_changed,
+        )
 
-    def is_preview_mode(self):
-        return self.preview_mode_checkbox.isChecked()
+    def apply_styling(self):
+        """Apply the same stylesheet the legacy protocol_grid uses for
+        its NavigationBar: full app sheet on the nav button row, tool
+        button sheet on the left-slot row."""
+        theme = "dark" if is_dark_mode() else "light"
+        self.nav_container.setStyleSheet(
+            get_complete_stylesheet(theme, "default"),
+        )
+        self.left_slot_container.setStyleSheet(
+            get_button_style(theme, "tool"),
+        )
 
-    def set_droplet_check_enabled(self, enabled):
-        self.droplet_check_checkbox.setEnabled(enabled)
-
-    def set_preview_mode_enabled(self, enabled):
-        self.preview_mode_checkbox.setEnabled(enabled)
+    def _on_color_scheme_changed(self, *_):
+        """Defer the re-style by one event-loop tick — when this signal
+        first fires, ``is_dark_mode()`` may still report the previous
+        theme. A 0 ms timer pushes the work to after the OS flags
+        settle. Mirrors the legacy widget.py:497 pattern verbatim."""
+        QTimer.singleShot(0, self.apply_styling)
 
     def split_play_button_to_phase_controls(self):
         if self._phase_navigation_active:

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -81,10 +81,9 @@ class NavigationBar(QWidget):
         # Play is a QToolButton with a menu-button split: the main face
         # behaves like before (click → start/pause/resume the protocol),
         # while the dropdown arrow exposes the persistent run-mode
-        # toggles that used to live as checkboxes on the legacy
-        # protocol_grid bottom row — Preview Mode and Droplet Check.
-        # Both are checkable QActions; main-button click reads their
-        # state via is_preview_mode() / is_droplet_check_enabled().
+        # toggle Preview Mode (the legacy protocol_grid checkbox).
+        # Droplet detection is owned by its own column now, so it
+        # doesn't need a slot here.
         self.btn_play = QToolButton()
         self.btn_play.setPopupMode(QToolButton.MenuButtonPopup)
         self.btn_play.setToolButtonStyle(Qt.ToolButtonTextBesideIcon)
@@ -100,14 +99,7 @@ class NavigationBar(QWidget):
             "(useful when no DropBot is connected)"
         )
 
-        self.action_droplet_check = QAction("Droplet Check", self.play_menu)
-        self.action_droplet_check.setCheckable(True)
-        self.action_droplet_check.setToolTip(
-            "Run droplet detection at the end of each step"
-        )
-
         self.play_menu.addAction(self.action_preview)
-        self.play_menu.addAction(self.action_droplet_check)
         self.btn_play.setMenu(self.play_menu)
 
         # Toggling Preview re-applies the play-button stylesheet so the
@@ -272,11 +264,6 @@ class NavigationBar(QWidget):
         """True when the user has armed Preview Mode in the play
         dropdown — the legacy ``preview_mode_checkbox.isChecked()``."""
         return self.action_preview.isChecked()
-
-    def is_droplet_check_enabled(self):
-        """True when the user has enabled Droplet Check in the play
-        dropdown — the legacy ``droplet_check_checkbox.isChecked()``."""
-        return self.action_droplet_check.isChecked()
 
     def _on_color_scheme_changed(self, *_):
         """Defer the re-style by one event-loop tick — when this signal

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -18,8 +18,8 @@ from microdrop_style.button_styles import (
 from microdrop_style.colors import BLACK, WHITE
 from microdrop_style.helpers import get_complete_stylesheet, is_dark_mode
 from microdrop_style.icons.icons import (
-    ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PLAY,
-    ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
+    ICON_FIRST, ICON_LAST, ICON_NEXT, ICON_NEXT_PHASE, ICON_PAUSE,
+    ICON_PLAY, ICON_PREVIOUS, ICON_PREVIOUS_PHASE, ICON_RESUME, ICON_STOP,
 )
 
 
@@ -129,6 +129,11 @@ class NavigationBar(QWidget):
         main_layout.addWidget(self.nav_container)
         main_layout.addWidget(self.bottom_container)
 
+        # The bottom row is dead space until a plugin contributes a
+        # widget via add_widget_to_left_slot — keep it hidden so the
+        # nav buttons sit flush against the tree.
+        self.bottom_container.setVisible(False)
+
         # Apply the legacy protocol_grid stylesheet and re-apply on
         # OS theme changes.
         self.apply_styling()
@@ -185,8 +190,28 @@ class NavigationBar(QWidget):
         return self._phase_navigation_active
 
     def add_widget_to_left_slot(self, widget):
-        """Helper for plugin-contributed widgets in the bottom-left area."""
+        """Helper for plugin-contributed widgets in the bottom-left area.
+        Reveals the bottom container — it's hidden by default to avoid
+        an empty band between the nav buttons and the tree."""
         self.left_slot_layout.addWidget(widget)
+        self.bottom_container.setVisible(True)
+
+    # --- play-button visual state -----------------------------------------
+
+    def show_play_state(self):
+        """Idle: ▶ icon, 'Play Protocol' tooltip."""
+        self.btn_play.setText(ICON_PLAY)
+        self.btn_play.setToolTip("Play Protocol")
+
+    def show_pause_state(self):
+        """Running: ⏸ icon, 'Pause Protocol' tooltip."""
+        self.btn_play.setText(ICON_PAUSE)
+        self.btn_play.setToolTip("Pause Protocol")
+
+    def show_resume_state(self):
+        """Paused: ▶▶ icon, 'Resume Protocol' tooltip."""
+        self.btn_play.setText(ICON_RESUME)
+        self.btn_play.setToolTip("Resume Protocol")
 
 
 class StatusBar(QScrollArea):

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -252,11 +252,11 @@ class NavigationBar(QWidget):
             QToolButton::menu-button {{
                 border: none;
                 background: transparent;
-                width: 12px;
+                width: 18px;
             }}
             QToolButton::menu-arrow {{
-                width: 6px;
-                height: 6px;
+                width: 10px;
+                height: 10px;
             }}
         """
 


### PR DESCRIPTION
Resolves #377. Follow-up work tracked in #411 (full-app dock pane); PPT-9 (#371 — protocol_grid teardown) is unblocked once #411 lands.

## Summary

Ports the legacy `protocol_grid` navigation pane + status bar to the pluggable protocol tree, replacing `BasePluggableProtocolDemoWindow`'s minimal `Run / Pause / Stop` toolbar. The full bar — playback controls, step navigation, phase navigation, status row, experiment-bar — is wired end-to-end in the demos; the dock-pane refactor that brings the same composition to the full app is the explicit follow-up #411.

### Navigation bar — `pluggable_protocol_tree/views/navigation_bar.py`

- `NavigationBar(QWidget)` — port from `protocol_grid.extra_ui_elements.NavigationBar`. Two-row layout: top row hosts playback (▶/⏸/⏹ + step nav + phase-nav split), bottom row is a plugin-fillable left slot (hidden until `add_widget_to_left_slot` is called). Sized `Expanding × Fixed` so the bar hugs its content vertically and only stretches horizontally. Same per-container stylesheets the legacy widget uses (`get_complete_stylesheet` on the nav row, tool-button sheet on the slot row), re-applied on `colorSchemeChanged` via the same `QTimer.singleShot(0, …)` deferral.
- `StatusBar(QScrollArea)` — port of the legacy status row. Total/step/phase time, Repeat Protocol counter (now a `QSpinBox`), Step X/Y, Repetition X/Y, Most Recent Step, Next Step. Recent/Next labels are `MarqueeLabel`s — fixed-width by default, scroll-on-hover when the text overflows.
- `MarqueeLabel` (in `microdrop_utils/pyside_helpers.py`, alongside `MarqueeComboBox`) — `QLabel` subclass that scrolls to the text's tail on mouse enter (~40 fps × 2 px) and resets on leave. Same scroll-then-hold behaviour as `MarqueeComboBox`.
- Play button is a `QToolButton(MenuButtonPopup)` with a checkable `Preview Mode` action in its dropdown — replaces the legacy bottom-row checkbox. Glyph and palette respond to the toggle: `play_arrow` + standard hover when off, `video_search` + yellow background + yellow hover when on. Tooltips read "Play / Pause / Resume Protocol" or "Preview / Pause / Resume Preview" matching state.

### Demo window — `pluggable_protocol_tree/demos/base_demo_window.py`

- Mounts `NavigationBar` + `StatusBar` above the tree. Bottom `QStatusBar` is now demo-only — hosts per-readout labels (`StatusReadout` system) and nothing else.
- Play-button click reads the dropdown's Preview state and calls `executor.start(preview_mode=…)`. Auto-repeat counter (`Repeat Protocol`) loops in the same mode the user picked; restart is queued via `QTimer.singleShot(50, …)` because `protocol_finished` fires from inside the worker's `finally` and a direct `start()` would no-op against `_thread.is_alive()`.
- Step navigation: ⏮ ⏪ ⏩ ⏭ jump the tree's current row. Pressing ⏭ at the end of execution order clones the current step at the same parent level (mirrors legacy behaviour).
- Phase navigation: when paused mid-step, the play button splits into prev-phase / resume / next-phase. Local `iter_phases` walk computes the phase list; prev/next publish `ELECTRODES_STATE_CHANGE` so the device viewer overlays the requested phase. The payload's `preview` flag mirrors the run's mode — pause-time phase nav drives hardware on a real Run, stays gated on a Preview run.
- Experiment bar: `New Experiment` button + experiment label + `New Note` button mounted in the navigation bar's left slot, mirroring the legacy `protocol_grid` layout. Stub click handlers for now — real wiring lands at the dock-pane / plugin layer in #411.
- Window default widened to `(1100 → fit-the-bar)`; status-bar inter-label spacing tightened from 10 px to 5 px; recent/next-step labels truncate-then-marquee instead of pushing the bar wider.

### Preview Mode plumbing

- `ProtocolContext` gains a `Bool preview_mode` trait; `ProtocolExecutor.start(start_step_path=…, preview_mode=…)` plumbs both through.
- `RoutesHandler.on_step` always publishes `ELECTRODES_STATE_CHANGE` (so the device viewer overlays each phase even in preview) but adds `"preview": true` to the payload when armed, so a hardware-driving consumer can skip actuation. The phase loop honours `pause_event` at every phase boundary, and `_cooperative_sleep` honours pause + stop so a Pause click takes effect mid-dwell.
- `MagnetHandler`, `VoltageHandler`, `FrequencyHandler`, `DropletCheckHandler` all early-return on preview_mode — these handlers produce hardware effect with no visualization, so the source-side gate is correct for them.

### Visual cue for preview

- Device viewer overlay (`SimpleDeviceViewer`) gains a second arg on `actuation_changed = Signal(list, bool)`. Actuated cells paint **gold** when the second arg is true, **bright green** otherwise. All five overlay listeners (`run_widget`, `run_widget_auto`, `run_widget_with_vf`, `run_droplet_check_demo`, `run_full_integration_demo`) extract `preview` from the payload and forward it.

## Test plan

- [x] `pytest pluggable_protocol_tree/tests/test_base_demo_window.py` — 43/43 pass; covers idle/running/terminated/error button-state machine, save/load, post-build hook, status readouts, phase-ack timer, repeat-label rendering, idle-state `_clear_all_highlights`, and the new central-content wrapper.
- [x] `pytest peripheral_protocol_controls/tests/test_magnet_column.py dropbot_protocol_controls/tests/test_voltage_column.py dropbot_protocol_controls/tests/test_frequency_column.py dropbot_protocol_controls/tests/test_droplet_check_column.py` — column tests updated to set `ctx.protocol.preview_mode = False` on their `MagicMock` ctx so the new gate doesn't short-circuit before the publish assertion. All pass.
- [x] `pytest pluggable_protocol_tree/tests/test_electrodes_routes_columns.py` — routes column behaviour with the new `"preview"` flag in the payload + pause-aware phase loop.
- [x] Manual: `pixi run python -m pluggable_protocol_tree.demos.run_widget` — playback drives the device viewer overlay; Pause stops routes mid-step; Preview Mode (yellow + outlined glyph + gold overlay) runs without hardware writes; pause-time phase nav arrows step the visualizer through the paused row; Repeat Protocol counter loops the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)