### PR TITLE
[PPT-10.1] Build full-app dock pane: ProtocolTreePane refactor + service wiring (#411)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-ppt-3-electrodes-routes.md
+++ b/docs/superpowers/plans/2026-04-23-ppt-3-electrodes-routes.md
@@ -1693,12 +1693,12 @@ from pluggable_protocol_tree.models.column import (
 from pluggable_protocol_tree.services.phase_math import iter_phases
 from pluggable_protocol_tree.views.columns.base import BaseColumnView
 
-
 logger = logging.getLogger(__name__)
 
 
 class RoutesColumnModel(BaseColumnModel):
     """List[List[str]] trait. Default = empty list."""
+
     def trait_for_row(self):
         return List(List(Str), value=list(self.default_value or []),
                     desc="Per-step list of routes; each route is an "
@@ -1727,16 +1727,16 @@ class RoutesHandler(BaseColumnHandler):
     def on_step(self, row, ctx):
         mapping = ctx.protocol.scratch.get("electrode_to_channel", {})
         for phase in iter_phases(
-            static_electrodes=list(getattr(row, "electrodes", []) or []),
-            routes=list(getattr(row, "routes", []) or []),
-            trail_length=int(getattr(row, "trail_length", 1)),
-            trail_overlay=int(getattr(row, "trail_overlay", 0)),
-            soft_start=bool(getattr(row, "soft_start", False)),
-            soft_end=bool(getattr(row, "soft_end", False)),
-            repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
-            linear_repeats=bool(getattr(row, "linear_repeats", False)),
-            n_repeats=int(getattr(row, "repetitions", 1)),
-            step_duration_s=float(getattr(row, "duration_s", 1.0)),
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)),
+                soft_end=bool(getattr(row, "soft_end", False)),
+                repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
+                linear_repeats=bool(getattr(row, "linear_repeats", False)),
+                n_repeats=int(getattr(row, "repetitions", 1)),
+                step_duration_s=float(getattr(row, "duration_s", 1.0)),
         ):
             electrodes = sorted(phase)
             channels = sorted(mapping[e] for e in electrodes if e in mapping)
@@ -2810,7 +2810,6 @@ from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.execution import listener as _listener  # noqa
 from pluggable_protocol_tree.models.row_manager import RowManager
 
-
 PHASE_SPY_ACTOR_NAME = "ppt_test_phase_spy"
 _phase_spy_log: list = []
 
@@ -2866,7 +2865,7 @@ def test_routes_handler_publishes_phases_and_unblocks_on_ack(router_actor):
         }
         rm.add_step(values={
             "name": "S",
-            "duration_s": 0.1,    # short dwell so total test stays fast
+            "duration_s": 0.1,  # short dwell so total test stays fast
             "electrodes": ["e00", "e01"],
             "routes": [["e02", "e03", "e04"]],
             "trail_length": 1,
@@ -2888,30 +2887,31 @@ def test_routes_handler_publishes_phases_and_unblocks_on_ack(router_actor):
         worker.start()
         try:
             ex.start()
-            assert finished.wait(timeout=15.0), \
-                "protocol_finished did not fire within 15s"
-            ex.wait(timeout=2.0)
-        finally:
-            worker.stop()
-
-        # 3 phases — one per route position.
-        assert len(_phase_spy_log) == 3, f"phases: {_phase_spy_log!r}"
-        # Each phase = static ∪ {single route electrode}.
-        assert _phase_spy_log[0]["electrodes"] == ["e00", "e01", "e02"]
-        assert _phase_spy_log[1]["electrodes"] == ["e00", "e01", "e03"]
-        assert _phase_spy_log[2]["electrodes"] == ["e00", "e01", "e04"]
-        # Channel resolution from the seeded mapping.
-        assert _phase_spy_log[0]["channels"] == [0, 1, 2]
-        assert _phase_spy_log[1]["channels"] == [0, 1, 3]
-        assert _phase_spy_log[2]["channels"] == [0, 1, 4]
+            assert finished.wait(timeout=15.0),
+            "protocol_finished did not fire within 15s"
+        ex.wait(timeout=2.0)
     finally:
-        for topic, actor_name in subs:
-            try:
-                router_actor.message_router_data.remove_subscriber_from_topic(
-                    topic=topic, subscribing_actor_name=actor_name,
-                )
-            except Exception:
-                pass
+        worker.stop()
+
+    # 3 phases — one per route position.
+    assert len(_phase_spy_log) == 3, f"phases: {_phase_spy_log!r}"
+    # Each phase = static ∪ {single route electrode}.
+    assert _phase_spy_log[0]["electrodes"] == ["e00", "e01", "e02"]
+    assert _phase_spy_log[1]["electrodes"] == ["e00", "e01", "e03"]
+    assert _phase_spy_log[2]["electrodes"] == ["e00", "e01", "e04"]
+    # Channel resolution from the seeded mapping.
+    assert _phase_spy_log[0]["channels"] == [0, 1, 2]
+    assert _phase_spy_log[1]["channels"] == [0, 1, 3]
+    assert _phase_spy_log[2]["channels"] == [0, 1, 4]
+
+finally:
+for topic, actor_name in subs:
+    try:
+        router_actor.message_router_data.remove_subscriber_from_topic(
+            topic=topic, subscribing_actor_name=actor_name,
+        )
+    except Exception:
+        pass
 ```
 
 - [ ] **Step 2: Run the test (Redis must be up)**

--- a/docs/superpowers/plans/2026-04-24-ppt-4-voltage-frequency.md
+++ b/docs/superpowers/plans/2026-04-24-ppt-4-voltage-frequency.md
@@ -1589,7 +1589,6 @@ from dropbot_protocol_controls.demos.voltage_frequency_responder import (
     subscribe_demo_responder,
 )
 
-
 logger = logging.getLogger(__name__)
 
 # Spy that prints every voltage/frequency publish + ack so the demo
@@ -1786,7 +1785,6 @@ from dropbot_protocol_controls.protocol_columns.voltage_column import (
 from dropbot_protocol_controls.protocol_columns.frequency_column import (
     make_frequency_column,
 )
-
 
 # Recording spy actor — captures every relevant topic with timestamps
 # so we can assert on ordering.

--- a/docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md
+++ b/docs/superpowers/plans/2026-04-28-ppt-12-demo-base.md
@@ -472,9 +472,7 @@ from pluggable_protocol_tree.demos.electrode_responder import (
     DEMO_RESPONDER_ACTOR_NAME,
 )
 
-
 logger = logging.getLogger(__name__)
-
 
 # Strip Prometheus middleware once at module import time — every
 # downstream demo needs this and the stripping is idempotent.

--- a/docs/superpowers/plans/2026-04-28-ppt-5-magnet.md
+++ b/docs/superpowers/plans/2026-04-28-ppt-5-magnet.md
@@ -1402,7 +1402,6 @@ from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 from pluggable_protocol_tree.models.row_manager import RowManager
 
-
 # Recording spy actor — captures every relevant topic with timestamps
 # so we can assert ordering.
 EVENT_LOG = []

--- a/docs/superpowers/plans/2026-05-08-protocol-tree-pane.md
+++ b/docs/superpowers/plans/2026-05-08-protocol-tree-pane.md
@@ -1,0 +1,2352 @@
+# Protocol Tree Pane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a reusable `ProtocolTreePane(QWidget)` from `BasePluggableProtocolDemoWindow`, wire the experiment-bar against the live `ExperimentManager` + `StickyWindowManager` services in the Envisage dock pane, and register `PluggableProtocolTreePlugin` in the full-app run script so the new dock pane is usable beyond demos.
+
+**Architecture:** New `pluggable_protocol_tree/views/protocol_tree_pane.py` owns manager + tree + executor + nav/status/experiment bars + button state machine. Optional service params (`application`, `experiment_manager`, `sticky_manager`) activate production wiring; passing nothing keeps the demo's log-only stub behavior. `BasePluggableProtocolDemoWindow` delegates via `@property` aliases so the existing test suite passes unchanged. `PluggableProtocolDockPane` constructs the real services and passes them in. The two protocol panes (legacy `protocol_grid` and new pluggable) coexist for this PR; PPT-9 removes the legacy.
+
+**Tech Stack:** Python 3.13, PySide6/Qt (`QWidget`, `QVBoxLayout`), Traits/Pyface (`@observe`, `TraitsDockPane`), Envisage plugin framework, pytest with `qapp` session fixture.
+
+**Spec:** `src/docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md`
+
+**Branch:** `ppt-10.1-protocol-tree-pane` (already created from `main`; spec already committed).
+
+**Test runner:** Run tests from outer pixi repo root via `cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest <args>"`. The `cd src` puts pytest at the same root the application uses for imports.
+
+---
+
+## Task 1: Port `ExperimentLabel` to pluggable views
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/views/experiment_label.py`
+- Create: `src/pluggable_protocol_tree/tests/test_experiment_label.py`
+
+**Why:** `ProtocolTreePane` needs a clickable, theme-aware experiment label with the legacy UX (link colour on the experiment id, tooltip-toggle context menu). The legacy widget has it at `protocol_grid/extra_ui_elements.py:39-127`. Porting it now keeps the pane self-contained and decouples PPT-10.1 from PPT-9's eventual deletion of `protocol_grid`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# src/pluggable_protocol_tree/tests/test_experiment_label.py
+"""Tests for the ported ExperimentLabel widget."""
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtGui import QMouseEvent
+from pyface.qt.QtCore import QPointF
+
+
+def test_label_default_text_when_no_experiment(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    assert "Experiment" in lbl.text()
+
+
+def test_update_experiment_id_renders_id(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    lbl.update_experiment_id("2026-05-08T12-00-00Z")
+    assert "2026-05-08T12-00-00Z" in lbl.text()
+
+
+def test_update_experiment_id_remembers_last_value(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    lbl.update_experiment_id("exp-1")
+    # Calling with None re-renders the last set id (used by theme-change re-style).
+    lbl.update_experiment_id(None)
+    assert "exp-1" in lbl.text()
+
+
+def test_left_click_emits_clicked(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    fired = []
+    lbl.clicked.connect(lambda: fired.append(True))
+    event = QMouseEvent(
+        QMouseEvent.MouseButtonPress, QPointF(0, 0),
+        Qt.LeftButton, Qt.LeftButton, Qt.NoModifier,
+    )
+    lbl.mousePressEvent(event)
+    assert fired == [True]
+
+
+def test_right_click_does_not_emit_clicked(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    fired = []
+    lbl.clicked.connect(lambda: fired.append(True))
+    event = QMouseEvent(
+        QMouseEvent.MouseButtonPress, QPointF(0, 0),
+        Qt.RightButton, Qt.RightButton, Qt.NoModifier,
+    )
+    lbl.mousePressEvent(event)
+    assert fired == []
+
+
+def test_handle_tooltip_toggle_toggles_tooltip(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    assert lbl.toolTip() != ""
+    lbl.handle_tooltip_toggle(False)
+    assert lbl.toolTip() == ""
+    lbl.handle_tooltip_toggle(True)
+    assert lbl.toolTip() != ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_experiment_label.py -v"
+```
+Expected: `ModuleNotFoundError: No module named 'pluggable_protocol_tree.views.experiment_label'`.
+
+- [ ] **Step 3: Implement `ExperimentLabel`**
+
+```python
+# src/pluggable_protocol_tree/views/experiment_label.py
+"""Clickable, theme-aware experiment label.
+
+Ported from ``protocol_grid/extra_ui_elements.py`` ``ExperimentLabel``
+(legacy). Stays in pluggable_protocol_tree so PPT-9 can delete
+protocol_grid without breaking the new dock pane.
+"""
+
+from pyface.qt.QtCore import Qt, Signal
+from pyface.qt.QtGui import QAction, QContextMenuEvent
+from pyface.qt.QtWidgets import QApplication, QLabel, QMenu
+
+from microdrop_style.helpers import is_dark_mode
+
+
+class ExperimentLabel(QLabel):
+    """QLabel that emits ``clicked`` on left-click and renders the
+    active experiment id with a theme-aware link colour. Right-click
+    opens a context menu with an Enable Tooltip toggle."""
+
+    clicked = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setText("<b>Experiment: </b>")
+        self.setToolTip("Active Experiment (Click to open folder)")
+        self.setCursor(Qt.PointingHandCursor)
+
+        self._experiment_id = None
+        self._tooltip_visible = True
+
+        self.apply_styling()
+        QApplication.styleHints().colorSchemeChanged.connect(self.apply_styling)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit()
+            event.accept()
+        else:
+            super().mousePressEvent(event)
+
+    def handle_tooltip_toggle(self, checked):
+        self._tooltip_visible = checked
+        if checked:
+            self.setToolTip("Active Experiment (Click to open folder)")
+        else:
+            self.setToolTip("")
+
+    def contextMenuEvent(self, event: QContextMenuEvent):
+        menu = QMenu(self)
+        action = QAction("Enable Tooltip", checkable=True,
+                         checked=self._tooltip_visible)
+        action.triggered.connect(self.handle_tooltip_toggle)
+        menu.addAction(action)
+        menu.exec(event.globalPos())
+
+    def update_experiment_id(self, experiment_id=None):
+        if experiment_id is None:
+            experiment_id = self._experiment_id
+
+        link_color = "#82B1FF" if is_dark_mode() else "#0066CC"
+        self.setText(
+            f"<b>Experiment: </b> "
+            f"<span style='text-decoration: underline; color: {link_color};'>"
+            f"{experiment_id}</span>"
+        )
+        self._experiment_id = experiment_id
+
+    def apply_styling(self):
+        text_color = "#f0f0f0" if is_dark_mode() else "#333333"
+        hover_bg = "#3a3a3a" if is_dark_mode() else "#e0e0e0"
+        self.setStyleSheet(
+            f"QLabel {{ color: {text_color}; border: none; }}"
+            f"QLabel:hover {{ background-color: {hover_bg}; }}"
+        )
+        self.update_experiment_id()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_experiment_label.py -v"
+```
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/experiment_label.py src/pluggable_protocol_tree/tests/test_experiment_label.py
+git -C microdrop-py/src commit -m "[PPT-10.1] Port ExperimentLabel into pluggable views"
+```
+
+---
+
+## Task 2: `ProtocolTreePane` skeleton — manager + tree + bars + central layout
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Create: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Why:** Build the pane's structural skeleton first — constructor accepting either a column list or a pre-built `RowManager`, the layout (NavigationBar above StatusBar above the tree), and the experiment bar populated into the nav bar's left slot. No executor or button state machine yet — those land in Task 3.
+
+- [ ] **Step 1: Write the failing skeleton tests**
+
+```python
+# src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+"""Tests for ProtocolTreePane — the reusable host widget for the
+pluggable protocol tree's full UX (navigation, status, experiment
+bar, executor, button state machine)."""
+
+
+def test_pane_constructs_with_columns_list(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+    ])
+    assert pane.manager is not None
+    ids = [c.model.col_id for c in pane.manager.columns]
+    assert ids == ["type", "id", "name"]
+
+
+def test_pane_constructs_with_existing_manager(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    rm = RowManager(columns=[make_type_column()])
+    pane = ProtocolTreePane(rm)
+    assert pane.manager is rm
+
+
+def test_pane_has_tree_widget(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.widget, ProtocolTreeWidget)
+
+
+def test_pane_has_navigation_bar_with_play_button(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.navigation_bar is not None
+    assert pane.navigation_bar.btn_play is not None
+
+
+def test_pane_has_status_bar(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.status_bar is not None
+    assert pane.status_bar.lbl_step_progress.text() == "Step 0/0"
+
+
+def test_pane_has_experiment_bar_widgets(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.btn_new_exp is not None
+    assert pane.btn_new_note is not None
+    assert isinstance(pane.experiment_label, ExperimentLabel)
+
+
+def test_pane_phase_ack_topic_default_is_electrodes_state_applied(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.phase_ack_topic == ELECTRODES_STATE_APPLIED
+
+
+def test_pane_phase_ack_topic_can_be_none(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()], phase_ack_topic=None)
+    assert pane.phase_ack_topic is None
+    assert pane.status_bar.lbl_phase_time.isVisible() is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: `ModuleNotFoundError: No module named 'pluggable_protocol_tree.views.protocol_tree_pane'`.
+
+- [ ] **Step 3: Implement the skeleton**
+
+```python
+# src/pluggable_protocol_tree/views/protocol_tree_pane.py
+"""Reusable host widget for the pluggable protocol tree's full UX.
+
+Owns the RowManager + ProtocolTreeWidget + ProtocolExecutor + the
+NavigationBar / StatusBar / experiment-bar trio. Mounted by both the
+demo window (BasePluggableProtocolDemoWindow) and the full-app dock
+pane (PluggableProtocolDockPane).
+
+Service injection (``application``, ``experiment_manager``,
+``sticky_manager``) is optional. When None, the corresponding
+experiment-bar buttons stay log-only stubs (matches today's demo UX).
+When supplied, the pane connects the real handlers — see Task 6 of
+PPT-10.1 for the full wiring rules.
+"""
+
+from __future__ import annotations
+
+from pyface.qt.QtCore import Qt, QTimer, Signal
+from pyface.qt.QtGui import QFont
+from pyface.qt.QtWidgets import (
+    QLabel, QToolButton, QVBoxLayout, QWidget,
+)
+
+from microdrop_style.button_styles import ICON_FONT_FAMILY
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+from pluggable_protocol_tree.views.navigation_bar import (
+    NavigationBar, StatusBar, make_separator,
+)
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProtocolTreePane(QWidget):
+    """Hosts the pluggable protocol tree with full UX scaffolding.
+
+    Layered top-to-bottom:
+      NavigationBar  (playback + step nav + experiment bar in left slot)
+      StatusBar      (step/phase elapsed, repetition counter, recent/next labels)
+      separator
+      ProtocolTreeWidget
+    """
+
+    phase_acked = Signal()
+
+    def __init__(
+        self,
+        columns_or_manager,
+        *,
+        application=None,
+        experiment_manager=None,
+        sticky_manager=None,
+        phase_ack_topic=ELECTRODES_STATE_APPLIED,
+        executor_factory=None,
+        parent=None,
+    ):
+        super().__init__(parent)
+
+        if isinstance(columns_or_manager, RowManager):
+            self.manager = columns_or_manager
+        else:
+            self.manager = RowManager(columns=list(columns_or_manager))
+
+        self.application = application
+        self.experiment_manager = experiment_manager
+        self.sticky_manager = sticky_manager
+        self.phase_ack_topic = phase_ack_topic
+        self._executor_factory = executor_factory
+
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+
+        self._build_status_bar()
+        self._build_navigation_bar()
+        self._build_experiment_bar()
+        self._build_layout()
+
+    def _build_status_bar(self):
+        self.status_bar = StatusBar()
+        phase_enabled = self.phase_ack_topic is not None
+        self.status_bar.lbl_phase_time.setVisible(phase_enabled)
+
+    def _build_navigation_bar(self):
+        self.navigation_bar = NavigationBar()
+
+    def _build_experiment_bar(self):
+        icon_font = QFont(ICON_FONT_FAMILY)
+        icon_font.setPixelSize(20)
+
+        self.btn_new_exp = QToolButton()
+        self.btn_new_exp.setText("note_add")
+        self.btn_new_exp.setFont(icon_font)
+        self.btn_new_exp.setToolTip("New Experiment")
+        self.btn_new_exp.setCursor(Qt.PointingHandCursor)
+        self.btn_new_exp.clicked.connect(self._on_new_experiment)
+
+        self.experiment_label = ExperimentLabel()
+
+        self.btn_new_note = QToolButton()
+        self.btn_new_note.setText("sticky_note")
+        self.btn_new_note.setFont(icon_font)
+        self.btn_new_note.setToolTip("New Note")
+        self.btn_new_note.setCursor(Qt.PointingHandCursor)
+        self.btn_new_note.clicked.connect(self._on_new_note)
+
+        self.experiment_label.clicked.connect(self._on_experiment_label_clicked)
+
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_exp)
+        self.navigation_bar.add_widget_to_left_slot(self.experiment_label)
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.navigation_bar)
+        layout.addWidget(self.status_bar)
+        layout.addWidget(make_separator())
+        layout.addWidget(self.widget)
+
+    # --- experiment-bar stubs (Task 6 wires real services) -------------
+
+    def _on_new_experiment(self):
+        logger.info("New Experiment requested")
+
+    def _on_new_note(self):
+        logger.info("New Note requested")
+
+    def _on_experiment_label_clicked(self):
+        logger.info("Experiment label clicked")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: 8 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] ProtocolTreePane skeleton: manager+tree+nav/status/exp bars"
+```
+
+---
+
+## Task 3: Add executor + signal wiring + button state machine + tick timer
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Why:** Add the runtime guts of the pane — `ProtocolExecutor` construction, `qsignals` wiring, the state machine that swaps button states on protocol_started / paused / resumed / finished / aborted / error, and the 10 Hz tick timer that drives the elapsed-time labels. This is a verbatim move from `BasePluggableProtocolDemoWindow` `__init__` lines 267-302 and the `_wire_executor_signals` / `_set_*_button_state` methods. After this task, the pane runs an executor end-to-end without any external scaffolding.
+
+- [ ] **Step 1: Append the executor / button-state machine tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_has_executor_and_pause_event(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.executor, ProtocolExecutor)
+    assert pane.executor.pause_event is not None
+    assert pane.executor.stop_event is not None
+
+
+def test_pane_executor_factory_can_be_overridden(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    sentinel = object()
+
+    def fake_factory(row_manager, qsignals, pause_event, stop_event):
+        return sentinel
+
+    pane = ProtocolTreePane([make_type_column()], executor_factory=fake_factory)
+    assert pane.executor is sentinel
+
+
+def test_pane_idle_button_state(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    nb = pane.navigation_bar
+    assert nb.btn_play.isEnabled()
+    assert not nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert btn.isEnabled()
+
+
+def test_pane_running_button_state_after_protocol_started(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    nb = pane.navigation_bar
+    assert nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert not btn.isEnabled()
+
+
+def test_pane_returns_to_idle_after_protocol_finished(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_finished.emit()
+    nb = pane.navigation_bar
+    assert not nb.btn_stop.isEnabled()
+
+
+def test_pane_step_started_updates_status_label(qapp):
+    """Emitting step_started increments the step counter label."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = []
+        name = "Step A"
+        duration_s = 0.0
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._step_total = 3
+    pane.executor.qsignals.step_started.emit(FakeRow())
+    assert pane._status_step_label.text() == "Step 1 / 3"
+
+
+def test_pane_tick_timer_runs_at_10_hz(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane._tick_timer.interval() == 100
+
+
+def test_pane_phase_acked_signal_resets_phase_timer(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()], phase_ack_topic="x/applied")
+    pane._current_row = object()
+    pane._step_started_at = None
+    pane.phase_acked.emit()
+    assert pane._phase_started_at is not None
+    assert pane._step_started_at is not None
+
+
+def test_pane_protocol_error_resets_to_idle_and_calls_dialog(qapp, monkeypatch):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    calls = []
+
+    def fake_error_dialog(parent=None, title="", message="", **kwargs):
+        calls.append((title, message))
+
+    monkeypatch.setattr(ptp, "error_dialog", fake_error_dialog)
+
+    pane = ptp.ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    assert pane.navigation_bar.btn_stop.isEnabled()
+    pane.executor.qsignals.protocol_error.emit("kaboom")
+    assert not pane.navigation_bar.btn_stop.isEnabled()
+    assert not pane._tick_timer.isActive()
+    assert calls == [("Protocol error", "kaboom")]
+```
+
+- [ ] **Step 2: Run new tests to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_has_executor_and_pause_event -v"
+```
+Expected: `AttributeError: 'ProtocolTreePane' object has no attribute 'executor'`.
+
+- [ ] **Step 3: Add executor construction + signal wiring + state machine**
+
+Update the imports at the top of `src/pluggable_protocol_tree/views/protocol_tree_pane.py`:
+
+```python
+from __future__ import annotations
+
+import threading
+import time
+
+from pyface.qt.QtCore import Qt, QTimer, Signal
+from pyface.qt.QtGui import QFont
+from pyface.qt.QtWidgets import (
+    QLabel, QToolButton, QVBoxLayout, QWidget,
+)
+
+from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
+from microdrop_style.button_styles import ICON_FONT_FAMILY
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+from pluggable_protocol_tree.views.navigation_bar import (
+    NavigationBar, StatusBar, make_separator,
+)
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+```
+
+Replace the `__init__` body (everything after `self._build_layout()`) with the version that wires the executor and state machine. The full updated `__init__` plus the new methods:
+
+```python
+    def __init__(
+        self,
+        columns_or_manager,
+        *,
+        application=None,
+        experiment_manager=None,
+        sticky_manager=None,
+        phase_ack_topic=ELECTRODES_STATE_APPLIED,
+        executor_factory=None,
+        parent=None,
+    ):
+        super().__init__(parent)
+
+        if isinstance(columns_or_manager, RowManager):
+            self.manager = columns_or_manager
+        else:
+            self.manager = RowManager(columns=list(columns_or_manager))
+
+        self.application = application
+        self.experiment_manager = experiment_manager
+        self.sticky_manager = sticky_manager
+        self.phase_ack_topic = phase_ack_topic
+
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+
+        self._build_status_bar()
+        self._build_navigation_bar()
+        self._build_experiment_bar()
+        self._build_layout()
+
+        self.executor = self._build_executor(executor_factory)
+
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at: float | None = None
+        self._phase_started_at: float | None = None
+        self._phase_target: float | None = None
+        self._current_row = None
+        self._repeats_total = 1
+        self._repeats_completed = 0
+        self._current_run_preview_mode = False
+
+        self._status_step_label = self.status_bar.lbl_step_progress
+        self._status_step_time_label = self.status_bar.lbl_step_time
+        self._status_reps_label = self.status_bar.lbl_step_repetition
+        self._status_phase_time_label = (
+            self.status_bar.lbl_phase_time if self.phase_ack_topic is not None
+            else None
+        )
+
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(100)
+        self._tick_timer.timeout.connect(self._refresh_status)
+
+        self._wire_executor_signals()
+        self._wire_button_state_machine()
+        self._wire_navigation_buttons()
+        self._set_idle_button_state()
+
+    def _build_executor(self, executor_factory):
+        factory = executor_factory or self._default_executor_factory
+        return factory(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+    @staticmethod
+    def _default_executor_factory(row_manager, qsignals, pause_event, stop_event):
+        return ProtocolExecutor(
+            row_manager=row_manager,
+            qsignals=qsignals,
+            pause_event=pause_event,
+            stop_event=stop_event,
+        )
+
+    def _wire_executor_signals(self):
+        self.executor.qsignals.step_started.connect(
+            self.widget.highlight_active_row,
+        )
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.step_finished.connect(self._on_step_finished)
+        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        self.executor.qsignals.protocol_error.connect(self._on_error)
+        if self.phase_ack_topic is not None:
+            self.phase_acked.connect(self._on_phase_ack)
+
+    def _wire_button_state_machine(self):
+        self.executor.qsignals.protocol_started.connect(
+            self._set_running_button_state,
+        )
+        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
+        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
+        self.executor.qsignals.protocol_finished.connect(self._on_protocol_finished)
+        self.executor.qsignals.protocol_aborted.connect(self._on_protocol_aborted)
+
+    def _wire_navigation_buttons(self):
+        nb = self.navigation_bar
+        nb.btn_play.clicked.connect(self._on_play_clicked)
+        nb.btn_resume.clicked.connect(self._toggle_pause)
+        nb.btn_stop.clicked.connect(self.executor.stop)
+
+    # --- step lifecycle handlers --------------------------------------
+
+    def _on_protocol_started(self):
+        try:
+            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            self._step_total = 0
+        self._step_index = 0
+        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        self._step_started_at = time.monotonic()
+        self._phase_started_at = None
+        try:
+            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            self._phase_target = None
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name}")
+        self.status_bar.lbl_next_step.setText(
+            f"Next Step: {self._next_step_name(row)}"
+        )
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+
+    def _next_step_name(self, current):
+        steps = self.manager.iter_execution_steps()
+        cur_path = tuple(current.path)
+        for row in steps:
+            if tuple(row.path) == cur_path:
+                next_row = next(steps, None)
+                return next_row.name if next_row is not None else "-"
+        return "-"
+
+    def _on_phase_ack(self):
+        if self._current_row is None:
+            return
+        now = time.monotonic()
+        if self._step_started_at is None:
+            self._step_started_at = now
+        self._phase_started_at = now
+
+    def _on_step_repetition(self, rep_chain):
+        if not rep_chain:
+            self._status_reps_label.setText("")
+            self._status_reps_label.setVisible(False)
+            return
+        parts = [
+            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+        ]
+        self._status_reps_label.setText(" · ".join(parts))
+        self._status_reps_label.setVisible(True)
+
+    def _on_step_finished(self, _row):
+        self._refresh_status()
+
+    def _on_error(self, msg):
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self._tick_timer.stop()
+        self._set_idle_button_state()
+        error_dialog(parent=self, title="Protocol error", message=str(msg))
+
+    def _refresh_status(self):
+        if self._step_started_at is None:
+            return
+        step_elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
+        if self._status_phase_time_label is not None:
+            phase_elapsed = (
+                0.0 if self._phase_started_at is None
+                else time.monotonic() - self._phase_started_at
+            )
+            target = self._phase_target if self._phase_target is not None else 0.0
+            self._status_phase_time_label.setText(
+                f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
+            )
+
+    # --- button state machine ----------------------------------------
+
+    def _set_idle_button_state(self):
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)
+        nb.show_play_state()
+        nb.btn_stop.setEnabled(False)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(True)
+        nb.action_preview.setEnabled(True)
+
+    def _set_running_button_state(self):
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)
+        nb.show_pause_state()
+        nb.btn_stop.setEnabled(True)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(False)
+        nb.action_preview.setEnabled(False)
+
+    def _on_play_clicked(self):
+        if self._is_protocol_active():
+            self._toggle_pause()
+            return
+        self._start_protocol_run(
+            preview_mode=self.navigation_bar.is_preview_mode(),
+        )
+
+    def _start_protocol_run(self, preview_mode):
+        self._repeats_total = self.status_bar.edit_repeat_protocol.value()
+        self._repeats_completed = 0
+        self._current_run_preview_mode = preview_mode
+        self._update_repeat_status_label()
+        self.executor.start(
+            start_step_path=self._selected_step_path(),
+            preview_mode=preview_mode,
+        )
+
+    def _update_repeat_status_label(self):
+        self.status_bar.lbl_repeat_protocol_status.setText(
+            f"{self._repeats_completed}/"
+        )
+
+    def _selected_step_path(self):
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        path = self.widget._index_to_path(idx)
+        for row in self.manager.iter_execution_steps():
+            if tuple(row.path) == path:
+                return path
+        return None
+
+    def _is_protocol_active(self):
+        return self.navigation_bar.btn_stop.isEnabled()
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+        else:
+            self.executor.pause()
+
+    def _on_protocol_paused(self):
+        self.navigation_bar.show_resume_state()
+        self._tick_timer.stop()
+
+    def _on_protocol_resumed(self):
+        self.navigation_bar.show_pause_state()
+        if self._current_row is not None:
+            self._tick_timer.start()
+
+    def _on_protocol_finished(self):
+        self._repeats_completed += 1
+        self._update_repeat_status_label()
+        if self._repeats_completed < self._repeats_total:
+            QTimer.singleShot(50, self._restart_for_next_rep)
+            return
+        self._on_protocol_terminated()
+
+    def _restart_for_next_rep(self):
+        self.executor.start(preview_mode=self._current_run_preview_mode)
+
+    def _on_protocol_aborted(self):
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self._on_protocol_terminated()
+
+    def _on_protocol_terminated(self):
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+```
+
+(The phase-navigation pause logic is added in Task 4 — for now `_on_protocol_paused` / `_on_protocol_resumed` just toggle the pause/resume icon; the phase-controls swap arrives next.)
+
+- [ ] **Step 4: Run all pane tests to verify they pass**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: 17 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] ProtocolTreePane: executor + button state machine + tick timer"
+```
+
+---
+
+## Task 4: Phase-navigation pause logic
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Why:** When a running protocol pauses, the play button splits into a `prev_phase` / `resume` / `next_phase` trio that lets the user step through the paused row's phase list visually. Computed locally — the worker thread's iter_phases position isn't reachable. Verbatim move from `BasePluggableProtocolDemoWindow` lines 919-997.
+
+- [ ] **Step 1: Append phase-nav tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_pause_splits_play_button_into_phase_nav(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = [0]
+        name = "S"
+        duration_s = 1.0
+        electrodes = []
+        routes = []
+        trail_length = 1
+        trail_overlay = 0
+        soft_start = False
+        soft_end = False
+        repeat_duration = 0.0
+        linear_repeats = False
+        repetitions = 1
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._current_row = FakeRow()
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_paused.emit()
+    assert pane.navigation_bar.is_phase_navigation_active()
+
+
+def test_pane_resume_merges_phase_nav_back_to_play_button(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = [0]
+        name = "S"
+        duration_s = 1.0
+        electrodes = []
+        routes = []
+        trail_length = 1
+        trail_overlay = 0
+        soft_start = False
+        soft_end = False
+        repeat_duration = 0.0
+        linear_repeats = False
+        repetitions = 1
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._current_row = FakeRow()
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_paused.emit()
+    assert pane.navigation_bar.is_phase_navigation_active()
+    pane.executor.qsignals.protocol_resumed.emit()
+    assert not pane.navigation_bar.is_phase_navigation_active()
+
+
+def test_pane_phase_nav_publishes_electrodes_state_change(qapp, monkeypatch):
+    """next_phase click publishes ELECTRODES_STATE_CHANGE for the targeted phase."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    captured = []
+
+    def fake_publish(topic, message, **kwargs):
+        captured.append((topic, message))
+
+    monkeypatch.setattr(ptp, "publish_message", fake_publish)
+
+    pane = ptp.ProtocolTreePane([make_type_column()])
+    pane._pause_phases = [{"e1"}, {"e1", "e2"}]
+    pane._pause_phase_idx = 0
+    pane.manager.protocol_metadata["electrode_to_channel"] = {"e1": 1, "e2": 2}
+    pane._on_next_phase()
+    assert captured  # something was published
+    topic, _ = captured[0]
+    assert topic == ptp.ELECTRODES_STATE_CHANGE
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_pause_splits_play_button_into_phase_nav -v"
+```
+Expected: pause does NOT yet split the button — so `is_phase_navigation_active()` returns False.
+
+- [ ] **Step 3: Add the phase-nav module imports + state + handlers**
+
+Add to imports at top of `src/pluggable_protocol_tree/views/protocol_tree_pane.py`:
+
+```python
+import json
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.services.phase_math import iter_phases
+```
+
+(Replace the existing single-import line for `ELECTRODES_STATE_APPLIED` with the joint form above.)
+
+Add the phase-nav state to `__init__` (right after `self._current_run_preview_mode = False`):
+
+```python
+        self._pause_phases: list = []
+        self._pause_phase_idx: int = 0
+```
+
+Wire the navigation_bar's phase buttons in `_wire_navigation_buttons`:
+
+```python
+    def _wire_navigation_buttons(self):
+        nb = self.navigation_bar
+        nb.btn_play.clicked.connect(self._on_play_clicked)
+        nb.btn_resume.clicked.connect(self._toggle_pause)
+        nb.btn_stop.clicked.connect(self.executor.stop)
+        nb.btn_prev_phase.clicked.connect(self._on_prev_phase)
+        nb.btn_next_phase.clicked.connect(self._on_next_phase)
+        nb.set_phase_navigation_enabled(False, False)
+```
+
+Replace `_on_protocol_paused` / `_on_protocol_resumed` / `_on_protocol_terminated`:
+
+```python
+    def _on_protocol_paused(self):
+        self.navigation_bar.show_resume_state()
+        self._tick_timer.stop()
+        if self._current_row is not None:
+            self._compute_pause_phase_state(self._current_row)
+            self.navigation_bar.split_play_button_to_phase_controls()
+            self._update_phase_nav_buttons()
+
+    def _on_protocol_resumed(self):
+        self.navigation_bar.show_pause_state()
+        if self._current_row is not None:
+            self._tick_timer.start()
+        self.navigation_bar.merge_phase_controls_to_play_button()
+
+    def _on_protocol_terminated(self):
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+        self.navigation_bar.merge_phase_controls_to_play_button()
+        self._pause_phases = []
+        self._pause_phase_idx = 0
+```
+
+Append the phase-nav handlers:
+
+```python
+    # --- pause-time phase navigation ---------------------------------
+
+    def _compute_pause_phase_state(self, row):
+        try:
+            self._pause_phases = list(iter_phases(
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)),
+                soft_end=bool(getattr(row, "soft_end", False)),
+                repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
+                linear_repeats=bool(getattr(row, "linear_repeats", False)),
+                n_repeats=int(getattr(row, "repetitions", 1)),
+                step_duration_s=float(getattr(row, "duration_s", 1.0)),
+            ))
+        except Exception as e:
+            logger.warning(f"phase navigation: iter_phases failed: {e}")
+            self._pause_phases = []
+        self._pause_phase_idx = 0
+
+    def _on_prev_phase(self):
+        if self._pause_phases and self._pause_phase_idx > 0:
+            self._pause_phase_idx -= 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _on_next_phase(self):
+        if (self._pause_phases
+                and self._pause_phase_idx < len(self._pause_phases) - 1):
+            self._pause_phase_idx += 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _publish_paused_phase(self):
+        if not self._pause_phases:
+            return
+        phase = self._pause_phases[self._pause_phase_idx]
+        mapping = self.manager.protocol_metadata.get(
+            "electrode_to_channel", {},
+        )
+        electrodes = sorted(phase)
+        channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        payload = {"electrodes": electrodes, "channels": channels}
+        if self._current_run_preview_mode:
+            payload["preview"] = True
+        try:
+            publish_message(
+                topic=ELECTRODES_STATE_CHANGE,
+                message=json.dumps(payload),
+            )
+        except Exception as e:
+            logger.warning(f"phase navigation publish failed: {e}")
+
+    def _update_phase_nav_buttons(self):
+        prev_enabled = self._pause_phase_idx > 0
+        next_enabled = (
+            bool(self._pause_phases)
+            and self._pause_phase_idx < len(self._pause_phases) - 1
+        )
+        self.navigation_bar.set_phase_navigation_enabled(
+            prev_enabled, next_enabled,
+        )
+```
+
+**Important — the test `test_pane_phase_nav_publishes_electrodes_state_change` requires that the test target — the index used — is permitted to advance. The test uses `_pause_phases = [{"e1"}, {"e1","e2"}]` (length 2) and starts at index 0; `_on_next_phase` advances to index 1 and publishes.**
+
+- [ ] **Step 4: Run all pane tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: 20 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] ProtocolTreePane: phase-navigation pause logic"
+```
+
+---
+
+## Task 5: Step-cursor navigation + save/load helpers
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Why:** First/Prev/Next/Last buttons drive the tree's selection cursor (they don't mutate the protocol). The Next button at the end-of-protocol clones the last step. Save/Load helpers expose JSON round-trip via `QFileDialog`. Verbatim move from `BasePluggableProtocolDemoWindow` lines 999-1108 + 747-772.
+
+- [ ] **Step 1: Append step-cursor + save/load tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_navigate_to_first_step_selects_first_row(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "A", "duration_s": 0.1})
+    pane.manager.add_step(values={"name": "B", "duration_s": 0.1})
+    pane.navigate_to_first_step()
+    idx = pane.widget.tree.currentIndex()
+    assert idx.isValid()
+
+
+def test_pane_navigate_to_next_at_end_duplicates_step(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "A", "duration_s": 0.1})
+    pane.navigate_to_last_step()
+    pane.navigate_to_next_step()
+    assert len(pane.manager.root.children) == 2
+
+
+def test_pane_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
+    from pyface.qt.QtWidgets import QFileDialog
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    import json
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "S1", "duration_s": 0.1})
+
+    save_path = tmp_path / "out.json"
+    monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    pane.save_to_dialog()
+    payload = json.loads(save_path.read_text())
+    assert payload["columns"][0]["id"] == "type"
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_save_writes_manager_to_json -v"
+```
+Expected: `AttributeError: 'ProtocolTreePane' object has no attribute 'save_to_dialog'`.
+
+- [ ] **Step 3: Add navigation + save/load methods**
+
+Add to imports:
+
+```python
+from pyface.qt.QtCore import QModelIndex
+from pyface.qt.QtWidgets import QFileDialog
+```
+
+Wire the step-cursor buttons inside `_wire_navigation_buttons`:
+
+```python
+    def _wire_navigation_buttons(self):
+        nb = self.navigation_bar
+        nb.btn_play.clicked.connect(self._on_play_clicked)
+        nb.btn_resume.clicked.connect(self._toggle_pause)
+        nb.btn_stop.clicked.connect(self.executor.stop)
+        nb.btn_first.clicked.connect(self.navigate_to_first_step)
+        nb.btn_prev.clicked.connect(self.navigate_to_previous_step)
+        nb.btn_next.clicked.connect(self.navigate_to_next_step)
+        nb.btn_last.clicked.connect(self.navigate_to_last_step)
+        nb.btn_prev_phase.clicked.connect(self._on_prev_phase)
+        nb.btn_next_phase.clicked.connect(self._on_next_phase)
+        nb.set_phase_navigation_enabled(False, False)
+```
+
+Append the navigation + save/load helpers + `clear_highlights` (needed by Task 7):
+
+```python
+    # --- step-cursor navigation -------------------------------------
+
+    def navigate_to_first_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[0])
+
+    def navigate_to_last_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[-1])
+
+    def navigate_to_previous_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur > 0:
+            self._select_step(steps[cur - 1])
+
+    def navigate_to_next_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur < len(steps) - 1:
+            self._select_step(steps[cur + 1])
+            return
+        self._duplicate_step_after(steps[cur])
+
+    def _duplicate_step_after(self, row):
+        path = tuple(row.path)
+        parent_path = path[:-1]
+        insert_idx = path[-1] + 1
+        values = {}
+        for col in self.manager.columns:
+            cid = col.model.col_id
+            if hasattr(row, cid):
+                values[cid] = getattr(row, cid)
+        new_path = self.manager.add_step(
+            parent_path=parent_path, index=insert_idx, values=values,
+        )
+        new_row = self.manager.get_row(new_path)
+        self._select_step(new_row)
+
+    def _current_step_in(self, steps):
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        path = self.widget._index_to_path(idx)
+        for i, row in enumerate(steps):
+            if tuple(row.path) == path:
+                return i
+        return None
+
+    def _select_step(self, row):
+        idx = self.widget._node_to_index(row)
+        if not idx.isValid():
+            return
+        parent = idx.parent()
+        while parent.isValid():
+            self.widget.tree.expand(parent)
+            parent = parent.parent()
+        self.widget.tree.setCurrentIndex(idx)
+        self.widget.tree.scrollTo(idx)
+
+    def clear_highlights(self):
+        """Reset the tree's selection + active-row highlight + per-step
+        labels to the idle visual state."""
+        self.widget.highlight_active_row(None)
+        self.widget.tree.clearSelection()
+        self.widget.tree.setCurrentIndex(QModelIndex())
+
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._phase_started_at = None
+        self._phase_target = None
+        self._current_row = None
+
+        self._status_step_label.setText("Step 0/0")
+        self._status_step_time_label.setText("Step Time: 0 s")
+        self._status_reps_label.setText("Repetition 0/0")
+        self._status_reps_label.setVisible(True)
+        self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
+        self.status_bar.lbl_next_step.setText("Next Step: -")
+        if self._status_phase_time_label is not None:
+            self._status_phase_time_label.setText("Phase 0.00s / 0.00s")
+
+    # --- save / load -----------------------------------------------
+
+    def save_to_dialog(self, parent=None):
+        """Open a file dialog and persist the manager's JSON state."""
+        path, _ = QFileDialog.getSaveFileName(
+            parent or self, "Save Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(self.manager.to_json(), f, indent=2)
+        except Exception as e:
+            error_dialog(parent=parent or self,
+                         title="Save error", message=str(e))
+
+    def load_from_dialog(self, columns_factory, parent=None):
+        """Open a file dialog and replace the manager's state from JSON.
+
+        ``columns_factory`` rebuilds the column list (consumed by
+        ``set_state_from_json``); the dock pane and demo window each
+        own a different source of truth for it."""
+        path, _ = QFileDialog.getOpenFileName(
+            parent or self, "Load Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.manager.set_state_from_json(data, columns=columns_factory())
+        except Exception as e:
+            error_dialog(parent=parent or self,
+                         title="Load error", message=str(e))
+```
+
+Update `_on_protocol_terminated` to also call `clear_highlights`:
+
+```python
+    def _on_protocol_terminated(self):
+        self.clear_highlights()
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+        self.navigation_bar.merge_phase_controls_to_play_button()
+        self._pause_phases = []
+        self._pause_phase_idx = 0
+```
+
+Update `_on_error` to also call `clear_highlights`:
+
+```python
+    def _on_error(self, msg):
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self.clear_highlights()
+        self._set_idle_button_state()
+        self._tick_timer.stop()
+        error_dialog(parent=self, title="Protocol error", message=str(msg))
+```
+
+- [ ] **Step 4: Run all pane tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: 23 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] ProtocolTreePane: step-cursor nav + save/load + clear_highlights"
+```
+
+---
+
+## Task 6: Real-mode service wiring + experiment-changed observation
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Why:** Convert the experiment-bar stub handlers into real-mode handlers that invoke the injected services when present. `application` observation uses the `experiment_changed` Event (not the `current_experiment_directory` Property — that doesn't fire reliable notifications, see spec risks).
+
+- [ ] **Step 1: Append the real-mode service tests**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_stub_mode_buttons_log_only(qapp):
+    """Without injected services, button clicks log and never raise."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.btn_new_exp.click()
+    pane.btn_new_note.click()
+    pane.experiment_label.clicked.emit()
+
+
+def test_pane_real_mode_new_experiment_calls_service(qapp):
+    """With an experiment_manager + application, New Experiment dispatches."""
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    new_dir = Path("/tmp/new-exp-id")
+    exp_mgr = MagicMock()
+    exp_mgr.initialize_new_experiment.return_value = new_dir
+    exp_mgr.get_experiment_directory.return_value = new_dir
+
+    app = MagicMock()
+    app.current_experiment_directory = Path("/tmp/old-exp-id")
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        application=app,
+        experiment_manager=exp_mgr,
+    )
+    pane.btn_new_exp.click()
+    exp_mgr.initialize_new_experiment.assert_called_once()
+    assert app.current_experiment_directory == new_dir
+
+
+def test_pane_real_mode_new_experiment_returning_none_does_not_overwrite(qapp):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    exp_mgr = MagicMock()
+    exp_mgr.initialize_new_experiment.return_value = None
+    app = MagicMock()
+    app.current_experiment_directory = Path("/tmp/old-exp-id")
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        application=app,
+        experiment_manager=exp_mgr,
+    )
+    pane.btn_new_exp.click()
+    assert app.current_experiment_directory == Path("/tmp/old-exp-id")
+
+
+def test_pane_real_mode_new_note_calls_sticky_manager(qapp):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    base_dir = Path("/tmp/exp-1")
+    exp_mgr = MagicMock()
+    exp_mgr.get_experiment_directory.return_value = base_dir
+    sticky_mgr = MagicMock()
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        experiment_manager=exp_mgr,
+        sticky_manager=sticky_mgr,
+    )
+    pane.btn_new_note.click()
+    sticky_mgr.request_new_note.assert_called_once_with(base_dir, "exp-1")
+
+
+def test_pane_real_mode_label_click_opens_experiment_directory(qapp):
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    exp_mgr = MagicMock()
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        experiment_manager=exp_mgr,
+    )
+    pane.experiment_label.clicked.emit()
+    exp_mgr.open_experiment_directory.assert_called_once()
+
+
+def test_pane_observes_experiment_changed_event_to_update_label(qapp):
+    """When application.experiment_changed fires, the label re-reads
+    application.current_experiment_directory and updates."""
+    from pathlib import Path
+
+    from traits.api import Directory, Event, HasTraits, Property
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeApp(HasTraits):
+        current_experiment_directory = Property(Directory)
+        experiment_changed = Event()
+        _value = Path("/tmp/initial")
+
+        def _get_current_experiment_directory(self):
+            return self._value
+
+        def _set_current_experiment_directory(self, value):
+            self._value = Path(value)
+            self.experiment_changed = True
+
+    app = FakeApp()
+    pane = ProtocolTreePane([make_type_column()], application=app)
+    app.current_experiment_directory = "/tmp/2026-05-08T12-00-00Z"
+    assert "2026-05-08T12-00-00Z" in pane.experiment_label.text()
+```
+
+- [ ] **Step 2: Run the new tests to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_real_mode_new_experiment_calls_service -v"
+```
+Expected: FAIL — `initialize_new_experiment` not called (pane currently logs only).
+
+- [ ] **Step 3: Replace the experiment-bar stub handlers + add observation**
+
+Replace the three stub methods at the bottom of `src/pluggable_protocol_tree/views/protocol_tree_pane.py`:
+
+```python
+    # --- experiment-bar handlers ------------------------------------
+
+    def _on_new_experiment(self):
+        if self.experiment_manager is None or self.application is None:
+            logger.info("New Experiment requested (stub: no services injected)")
+            return
+        new_dir = self.experiment_manager.initialize_new_experiment()
+        if new_dir is None:
+            logger.warning("initialize_new_experiment returned None; label unchanged")
+            return
+        self.application.current_experiment_directory = new_dir
+        self.experiment_label.update_experiment_id(new_dir.stem)
+        logger.info(f"Started new experiment: {new_dir.stem}")
+
+    def _on_new_note(self):
+        if self.sticky_manager is None or self.experiment_manager is None:
+            logger.info("New Note requested (stub: no services injected)")
+            return
+        base_dir = self.experiment_manager.get_experiment_directory()
+        experiment_name = base_dir.stem
+        self.sticky_manager.request_new_note(base_dir, experiment_name)
+
+    def _on_experiment_label_clicked(self):
+        if self.experiment_manager is None:
+            logger.info("Experiment label clicked (stub: no service injected)")
+            return
+        self.experiment_manager.open_experiment_directory()
+```
+
+Wire the `experiment_changed` observation. Add to the bottom of `__init__` (after `self._set_idle_button_state()`):
+
+```python
+        if self.application is not None:
+            self.application.observe(
+                self._on_experiment_changed, "experiment_changed",
+            )
+            # Render the initial experiment id into the label.
+            try:
+                cur = self.application.current_experiment_directory
+                if cur is not None:
+                    self.experiment_label.update_experiment_id(cur.stem)
+            except Exception as e:
+                logger.warning(f"could not read initial experiment dir: {e}")
+```
+
+Add the handler method:
+
+```python
+    def _on_experiment_changed(self, _event):
+        try:
+            cur = self.application.current_experiment_directory
+        except Exception as e:
+            logger.warning(f"experiment_changed: failed to read dir: {e}")
+            return
+        if cur is None:
+            return
+        self.experiment_label.update_experiment_id(cur.stem)
+```
+
+- [ ] **Step 4: Run all pane tests to verify they pass**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v"
+```
+Expected: 29 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] ProtocolTreePane: real-mode service wiring + experiment_changed observe"
+```
+
+---
+
+## Task 7: Refactor `BasePluggableProtocolDemoWindow` to delegate
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/demos/base_demo_window.py`
+
+**Why:** Strip the now-duplicated scaffolding from the demo window (~600 LOC) and replace it with a `ProtocolTreePane` instance + thin window-only chrome (toolbar with Add/Save/Load, side-panel splitter, status-readout labels, Dramatiq routing). Keep `@property` aliases so the existing `test_base_demo_window.py` keeps passing without edits.
+
+- [ ] **Step 1: Run the existing demo-window tests as a baseline**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_base_demo_window.py -v"
+```
+Expected: all PASSED (current state). Note the count — must match after refactor.
+
+- [ ] **Step 2: Rewrite `base_demo_window.py`**
+
+Replace the entire content of `src/pluggable_protocol_tree/demos/base_demo_window.py` with the slimmed delegating version. Preserve the module-level Dramatiq actor / `DemoConfig` / `StatusReadout` / `_slug` / `_DEMO_PREFIXES` / `_is_purgable_demo_actor_name` / `_PerSlugEmitter` / `_phase_ack_target` / `_readout_target` / `_make_readout_actor` definitions verbatim from the existing file (lines 1-190 stay byte-for-byte the same). Only the `BasePluggableProtocolDemoWindow` class body changes.
+
+The new class body:
+
+```python
+class BasePluggableProtocolDemoWindow(QMainWindow):
+    """Hosts a ProtocolTreePane + the demo-only toolbar / readouts /
+    Dramatiq routing scaffolding. See PPT-10.1 for the pane refactor."""
+
+    phase_acked = Signal()                    # forwarded to pane.phase_acked
+    readout_acked = Signal(str, str)
+
+    def __init__(self, config: DemoConfig):
+        super().__init__()
+        self.config = config
+        self.setWindowTitle(config.title)
+        self.resize(*config.window_size)
+
+        from pluggable_protocol_tree.views.protocol_tree_pane import (
+            ProtocolTreePane,
+        )
+
+        self.pane = ProtocolTreePane(
+            config.columns_factory(),
+            phase_ack_topic=config.phase_ack_topic,
+            parent=self,
+        )
+
+        # Forward the pane's phase_acked into the window's signal so
+        # tests / external code that connect to ``window.phase_acked``
+        # keep working unchanged.
+        self.pane.phase_acked.connect(self.phase_acked.emit)
+
+        self._side_panel = None
+        if config.side_panel_factory is not None:
+            side = config.side_panel_factory(self.pane.manager)
+            if side is not None:
+                self._side_panel = side
+                splitter = QSplitter(Qt.Horizontal)
+                splitter.addWidget(self.pane)
+                splitter.addWidget(side)
+                splitter.setSizes([
+                    int(config.window_size[0] * 0.65),
+                    int(config.window_size[0] * 0.35),
+                ])
+                self._central_content = splitter
+            else:
+                self._central_content = self.pane
+        else:
+            self._central_content = self.pane
+
+        self.setCentralWidget(self._central_content)
+
+        # Pre-populate after manager is built; before executor starts.
+        config.pre_populate(self.pane.manager)
+
+        self._router = None
+        self._readout_labels: dict[str, QLabel] = {}
+        self._build_status_readouts()
+
+        self._readout_fmts = {
+            _slug(r.label): (r.label, r.fmt) for r in config.status_readouts
+        }
+        self._readout_signals: dict[str, _PerSlugEmitter] = {
+            slug: _PerSlugEmitter(self.readout_acked, slug)
+            for slug in self._readout_fmts
+        }
+        self.readout_acked.connect(self._on_readout_ack)
+
+        existing = _readout_target.get("window")
+        if existing is not None and existing is not self:
+            logger.warning(
+                "Multiple live BasePluggableProtocolDemoWindow instances detected. "
+                "Only the most recent window will receive readout messages."
+            )
+        _readout_target["window"] = self
+
+        for readout in config.status_readouts:
+            _make_readout_actor(_slug(readout.label))
+
+        self._setup_dramatiq_routing_internal()
+        if self._router is not None:
+            config.routing_setup(self._router)
+
+        self._build_toolbar()
+        config.post_build_setup(self)
+
+    # --- demo-window-only chrome -----------------------------------
+
+    def _build_status_readouts(self):
+        """Bottom QStatusBar hosts only the demo readouts now — the
+        legacy-style step / phase / repetition labels live on the
+        pane's StatusBar."""
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = QLabel(f"{readout.label}: {readout.initial}")
+            sb.addPermanentWidget(label)
+            self._readout_labels[slug] = label
+
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.pane.manager.add_step())
+        tb.addAction("Add Group", lambda: self.pane.manager.add_group())
+        tb.addSeparator()
+        tb.addAction("Save…", self._save)
+        tb.addAction("Load…", self._load)
+        self._toolbar = tb
+
+    def _save(self):
+        self.pane.save_to_dialog(parent=self)
+
+    def _load(self):
+        self.pane.load_from_dialog(self.config.columns_factory, parent=self)
+
+    def _on_readout_ack(self, slug: str, message: str):
+        spec = self._readout_fmts.get(slug)
+        if spec is None:
+            return
+        label_prefix, fmt = spec
+        label_widget = self._readout_labels.get(slug)
+        if label_widget is None:
+            return
+        try:
+            text = fmt(message)
+        except Exception as e:
+            text = f"<error: {e}>"
+        label_widget.setText(f"{label_prefix}: {text}")
+
+    # --- Dramatiq routing (unchanged behavior, just lives here) -----
+
+    def _setup_dramatiq_routing_internal(self):
+        try:
+            from microdrop_utils.dramatiq_pub_sub_helpers import (
+                MessageRouterActor,
+            )
+
+            broker = dramatiq.get_broker()
+            broker.flush_all()
+            router = MessageRouterActor()
+
+            broker_topics_to_check = (
+                ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED,
+            )
+            extra_topics = []
+            if self.config.phase_ack_topic is not None:
+                extra_topics.append(self.config.phase_ack_topic)
+            for r in self.config.status_readouts:
+                extra_topics.append(r.topic)
+            topics_to_check = {*broker_topics_to_check, *extra_topics}
+            for topic in topics_to_check:
+                try:
+                    subs = router.message_router_data.get_subscribers_for_topic(topic)
+                except Exception:
+                    continue
+                for entry in subs:
+                    actor_name = entry[0] if isinstance(entry, tuple) else entry
+                    if not _is_purgable_demo_actor_name(actor_name):
+                        continue
+                    try:
+                        broker.get_actor(actor_name)
+                    except dramatiq.errors.ActorNotFound:
+                        try:
+                            router.message_router_data.remove_subscriber_from_topic(
+                                topic=topic,
+                                subscribing_actor_name=actor_name,
+                            )
+                            logger.info(
+                                f"purged stale demo subscriber {actor_name} on {topic}"
+                            )
+                        except Exception:
+                            logger.warning(
+                                f"failed to purge {actor_name} on {topic} "
+                                "(likely wrong listener_queue from another router)"
+                            )
+
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_CHANGE,
+                subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
+            )
+            router.message_router_data.add_subscriber_to_topic(
+                topic=ELECTRODES_STATE_APPLIED,
+                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+            )
+
+            if self.config.phase_ack_topic is not None:
+                existing_phase = _phase_ack_target.get("window")
+                if existing_phase is not None and existing_phase is not self:
+                    logger.warning(
+                        "Multiple live BasePluggableProtocolDemoWindow instances "
+                        "detected. Only the most recent window will receive "
+                        "phase-ack messages."
+                    )
+                _phase_ack_target["window"] = self
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=self.config.phase_ack_topic,
+                    subscribing_actor_name="ppt12_demo_phase_ack_listener",
+                )
+
+            for readout in self.config.status_readouts:
+                slug = _slug(readout.label)
+                actor_name = f"ppt12_demo_{slug}_listener"
+                router.message_router_data.add_subscriber_to_topic(
+                    topic=readout.topic,
+                    subscribing_actor_name=actor_name,
+                )
+
+            self._router = router
+        except ValueError as e:
+            if "already registered" not in str(e):
+                logger.warning(f"Demo Dramatiq routing setup failed: {e}")
+        except Exception as e:
+            logger.warning(
+                f"Demo Dramatiq routing setup failed (Redis not running?): {e}"
+            )
+
+    # --- backwards-compat aliases -----------------------------------
+    #
+    # test_base_demo_window.py + existing demos reach into many of the
+    # pane's attributes via the window. These properties forward.
+
+    @property
+    def manager(self):
+        return self.pane.manager
+
+    @property
+    def widget(self):
+        return self.pane.widget
+
+    @property
+    def executor(self):
+        return self.pane.executor
+
+    @property
+    def navigation_bar(self):
+        return self.pane.navigation_bar
+
+    @property
+    def status_bar(self):
+        return self.pane.status_bar
+
+    @property
+    def btn_new_exp(self):
+        return self.pane.btn_new_exp
+
+    @property
+    def btn_new_note(self):
+        return self.pane.btn_new_note
+
+    @property
+    def experiment_label(self):
+        return self.pane.experiment_label
+
+    @property
+    def _status_step_label(self):
+        return self.pane._status_step_label
+
+    @property
+    def _status_step_time_label(self):
+        return self.pane._status_step_time_label
+
+    @property
+    def _status_reps_label(self):
+        return self.pane._status_reps_label
+
+    @property
+    def _status_phase_time_label(self):
+        return self.pane._status_phase_time_label
+
+    @property
+    def _tick_timer(self):
+        return self.pane._tick_timer
+
+    @property
+    def _step_index(self):
+        return self.pane._step_index
+
+    @_step_index.setter
+    def _step_index(self, value):
+        self.pane._step_index = value
+
+    @property
+    def _step_total(self):
+        return self.pane._step_total
+
+    @_step_total.setter
+    def _step_total(self, value):
+        self.pane._step_total = value
+
+    @property
+    def _step_started_at(self):
+        return self.pane._step_started_at
+
+    @_step_started_at.setter
+    def _step_started_at(self, value):
+        self.pane._step_started_at = value
+
+    @property
+    def _phase_started_at(self):
+        return self.pane._phase_started_at
+
+    @_phase_started_at.setter
+    def _phase_started_at(self, value):
+        self.pane._phase_started_at = value
+
+    @property
+    def _current_row(self):
+        return self.pane._current_row
+
+    @_current_row.setter
+    def _current_row(self, value):
+        self.pane._current_row = value
+
+    def _on_protocol_terminated(self):
+        """Test hook — calls the pane's terminator + resets demo readouts."""
+        self.pane._on_protocol_terminated()
+        # Reset readout labels to initial text — they're demo-only state.
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = self._readout_labels.get(slug)
+            if label is not None:
+                label.setText(f"{readout.label}: {readout.initial}")
+
+    @classmethod
+    def run(cls, config: DemoConfig) -> int:
+        """One-shot main(): build the window, show it, run app.exec()."""
+        from microdrop_style.helpers import style_app
+
+        app = QApplication.instance() or QApplication([])
+        style_app(app)
+        w = cls(config)
+        w.show()
+        return app.exec()
+```
+
+Drop the now-unused imports at the top of `base_demo_window.py`:
+
+```python
+# REMOVE these — no longer used after delegation:
+#   from pluggable_protocol_tree.execution.events import PauseEvent
+#   from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+#   from pluggable_protocol_tree.execution.signals import ExecutorSignals
+#   from pluggable_protocol_tree.models.row_manager import RowManager
+#   from pluggable_protocol_tree.views.navigation_bar import NavigationBar, StatusBar, make_separator
+#   from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+#   import threading, time
+#   from pyface.qt.QtCore import QModelIndex
+#   from pyface.qt.QtWidgets import QFileDialog
+#   from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
+```
+
+The remaining imports actually used by the new class body:
+
+```python
+import dramatiq
+
+from pyface.qt.QtCore import Qt, Signal
+from pyface.qt.QtWidgets import (
+    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar, QWidget,
+)
+
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.demos.electrode_responder import (
+    DEMO_RESPONDER_ACTOR_NAME,
+)
+```
+
+(`QWidget` import retained because the module-level dataclasses still reference it.)
+
+- [ ] **Step 3: Run the existing demo-window test suite to verify aliases hold**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_base_demo_window.py -v"
+```
+Expected: same number of PASSED tests as the baseline in Step 1, no failures.
+
+- [ ] **Step 4: Run the entire pluggable_protocol_tree test suite for regressions**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/ -v --ignore=pluggable_protocol_tree/tests/tests_with_redis_server_need"
+```
+Expected: all PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/demos/base_demo_window.py
+git -C microdrop-py/src commit -m "[PPT-10.1] BasePluggableProtocolDemoWindow delegates to ProtocolTreePane"
+```
+
+---
+
+## Task 8: Wire `PluggableProtocolDockPane` to real services
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/dock_pane.py`
+- Create: `src/pluggable_protocol_tree/tests/test_dock_pane.py`
+
+**Why:** The dock pane now constructs an `ExperimentManager` from the application's experiment directory, instantiates a `StickyWindowManager`, and passes both into the pane along with the application reference for trait observation. Title renamed to "Protocol (pluggable)" so it's distinguishable from the legacy pane during coexistence.
+
+- [ ] **Step 1: Write the failing dock-pane tests**
+
+```python
+# src/pluggable_protocol_tree/tests/test_dock_pane.py
+"""Tests for PluggableProtocolDockPane wiring."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _make_dock_pane_with_mocked_app(qapp, columns):
+    """Returns (dock_pane, mock_app, mock_task) — call create_contents
+    after attaching task->window->application chain."""
+    from pluggable_protocol_tree.views.dock_pane import PluggableProtocolDockPane
+
+    mock_app = MagicMock()
+    mock_app.current_experiment_directory = Path("/tmp/exp-1")
+    mock_window = MagicMock()
+    mock_window.application = mock_app
+    mock_task = MagicMock()
+    mock_task.window = mock_window
+
+    dp = PluggableProtocolDockPane(columns=columns)
+    dp.task = mock_task
+    return dp, mock_app, mock_task
+
+
+def test_dock_pane_id_and_name(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    assert dp.id == "pluggable_protocol_tree.dock_pane"
+    assert dp.name == "Protocol (pluggable)"
+
+
+def test_dock_pane_create_contents_returns_protocol_tree_pane(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    contents = dp.create_contents(parent=None)
+    assert isinstance(contents, ProtocolTreePane)
+
+
+def test_dock_pane_constructs_experiment_manager_with_app_dir(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, app, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    with patch(
+        "pluggable_protocol_tree.views.dock_pane.ExperimentManager"
+    ) as ExpMgrClass:
+        dp.create_contents(parent=None)
+    ExpMgrClass.assert_called_once_with(app.current_experiment_directory)
+
+
+def test_dock_pane_constructs_sticky_manager(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    with patch(
+        "pluggable_protocol_tree.views.dock_pane.StickyWindowManager"
+    ) as StickyClass:
+        dp.create_contents(parent=None)
+    StickyClass.assert_called_once_with()
+
+
+def test_dock_pane_passes_application_into_pane(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, app, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    contents = dp.create_contents(parent=None)
+    assert contents.application is app
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_dock_pane.py -v"
+```
+Expected: FAIL — current `PluggableProtocolDockPane.name` is `"Protocol"` and `create_contents` returns a `ProtocolTreeWidget`, not a `ProtocolTreePane`.
+
+- [ ] **Step 3: Rewrite `dock_pane.py`**
+
+Replace the contents of `src/pluggable_protocol_tree/views/dock_pane.py`:
+
+```python
+"""Pyface TaskPane hosting ProtocolTreePane.
+
+Receives its column set from the plugin on construction and constructs
+the experiment + sticky-note services from the live Envisage
+application so the experiment-bar buttons drive real handlers."""
+
+from pyface.tasks.api import TraitsDockPane
+from traits.api import Instance, List, Str
+
+from microdrop_utils.sticky_notes import StickyWindowManager
+from protocol_grid.services.experiment_manager import ExperimentManager
+
+from pluggable_protocol_tree.interfaces.i_column import IColumn
+
+
+class PluggableProtocolDockPane(TraitsDockPane):
+    id = "pluggable_protocol_tree.dock_pane"
+    name = Str("Protocol (pluggable)")
+
+    columns = List(Instance(IColumn))
+
+    def create_contents(self, parent):
+        # Local import to avoid pulling Qt at plugin-import time —
+        # ProtocolTreePane imports PySide6 widgets eagerly.
+        from pluggable_protocol_tree.views.protocol_tree_pane import (
+            ProtocolTreePane,
+        )
+
+        app = self.task.window.application
+        experiment_manager = ExperimentManager(app.current_experiment_directory)
+        sticky_manager = StickyWindowManager()
+
+        return ProtocolTreePane(
+            list(self.columns),
+            application=app,
+            experiment_manager=experiment_manager,
+            sticky_manager=sticky_manager,
+            parent=parent,
+        )
+```
+
+- [ ] **Step 4: Run dock-pane tests**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest pluggable_protocol_tree/tests/test_dock_pane.py -v"
+```
+Expected: 5 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git -C microdrop-py/src add src/pluggable_protocol_tree/views/dock_pane.py src/pluggable_protocol_tree/tests/test_dock_pane.py
+git -C microdrop-py/src commit -m "[PPT-10.1] PluggableProtocolDockPane wires real ExperimentManager + StickyWindowManager"
+```
+
+---
+
+## Task 9: Register `PluggableProtocolTreePlugin` + manual smoke
+
+**Files:**
+- Modify: `src/examples/plugin_consts.py`
+
+**Why:** Activate the new dock pane in the actual app launch path so coexistence with `protocol_grid` is testable end-to-end. Manual verification covers the launch path and click behavior — automated coverage at this layer would require a full Envisage application stand-up which is out of proportion for this PR.
+
+- [ ] **Step 1: Uncomment the import + the FRONTEND_PLUGINS entry**
+
+Edit `src/examples/plugin_consts.py`. Find:
+
+```python
+# from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin   # may not exist on disk
+```
+
+If a commented import line exists for `PluggableProtocolTreePlugin`, uncomment it. Otherwise add the import alongside the others (alphabetical block at the top is the convention here):
+
+```python
+from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
+```
+
+In the `FRONTEND_PLUGINS` list, change line 70 from:
+
+```python
+    # PluggableProtocolTreePlugin,
+```
+to:
+```python
+    PluggableProtocolTreePlugin,
+```
+
+Verify the rest of the commented-out plugins (`DropbotProtocolControlsPlugin`, etc.) **stay** commented — only `PluggableProtocolTreePlugin` is being activated.
+
+- [ ] **Step 2: Run the existing examples test suite as a regression check**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && pytest examples/tests/ -v --ignore=examples/tests/tests_with_redis_server_need --ignore=examples/tests/tests_with_dropbot_connection_need"
+```
+Expected: same pass/fail outcome as before this task (no new failures introduced by activating the plugin).
+
+- [ ] **Step 3: Manual smoke — launch the full app**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python examples/run_device_viewer_pluggable.py"
+```
+
+Verify in the live UI:
+
+1. Two protocol-related dock panes are visible. The old one is titled **"Protocol Grid Controller"** (or similar — legacy). The new one is **"Protocol (pluggable)"**.
+2. The new pane shows the navigation bar (play / step / stop), status row, and experiment row (`note_add` / `Experiment: …` / `sticky_note`).
+3. Click the **`note_add`** icon on the new pane → the experiment label updates to a new timestamped id.
+4. Click the **experiment label** itself → the OS file explorer opens at the new experiment directory.
+5. Click the **`sticky_note`** icon → a new sticky window opens with the experiment's name in the title.
+6. Verify the legacy pane's experiment label also updates (both observe `experiment_changed`).
+7. Close the app cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C microdrop-py/src add src/examples/plugin_consts.py
+git -C microdrop-py/src commit -m "[PPT-10.1] Register PluggableProtocolTreePlugin in FRONTEND_PLUGINS"
+```
+
+- [ ] **Step 5: Push the branch and open a PR**
+
+```bash
+git -C microdrop-py/src push -u origin ppt-10.1-protocol-tree-pane
+gh pr create --repo Blue-Ocean-Technologies-Inc/Microdrop --title "[PPT-10.1] Build full-app dock pane: ProtocolTreePane refactor + service wiring (#411)" --body "$(cat <<'EOF'
+## Summary
+- Extracts `ProtocolTreePane(QWidget)` from `BasePluggableProtocolDemoWindow` so the demo window and the full-app dock pane share scaffolding (NavigationBar + StatusBar + experiment-bar + executor + button state machine + phase-nav).
+- Optional service injection (`application`, `experiment_manager`, `sticky_manager`) — the dock pane supplies real services; demos pass nothing and keep today's stub UX.
+- `PluggableProtocolDockPane` constructs `ExperimentManager` + `StickyWindowManager` from the live Envisage application; observes `application.experiment_changed` to keep the label in sync.
+- Registers `PluggableProtocolTreePlugin` in `examples/plugin_consts.py` alongside the legacy `ProtocolGridControllerUIPlugin`. Pane title is **"Protocol (pluggable)"** for unambiguity during coexistence.
+- Resolves #411. Out of scope: legacy removal (#371 / PPT-9), full message-listener parity (separate follow-up).
+
+## Test plan
+- [ ] `pluggable_protocol_tree/tests/test_protocol_tree_pane.py` — 29 tests covering construction, executor wiring, button state machine, phase-nav pause logic, step-cursor navigation, save/load, real-mode service handlers, experiment_changed observation
+- [ ] `pluggable_protocol_tree/tests/test_dock_pane.py` — 5 tests covering create_contents wiring + service construction
+- [ ] `pluggable_protocol_tree/tests/test_experiment_label.py` — 6 tests covering ExperimentLabel mouse/text/tooltip behavior
+- [ ] `pluggable_protocol_tree/tests/test_base_demo_window.py` — full existing suite passes unchanged via `@property` aliases on the window
+- [ ] Manual: launch `examples/run_device_viewer_pluggable.py`, confirm two panes coexist, exercise New Experiment / experiment-label click / New Note on the new pane
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- [x] §1 architecture & file layout → Tasks 1–8 create/modify all listed files
+- [x] §2 constructor signature → Task 2 + Task 6 (services added later)
+- [x] §3 service wiring table → Task 6
+- [x] §4 dock-pane sketch → Task 8
+- [x] §5 demo-window slimming + alias contract → Task 7
+- [x] §6 data flow (Play click) → exercised by manual smoke in Task 9 + automated in Task 3 button-state-machine tests
+- [x] §7 plugin registration → Task 9
+- [x] §8 testing strategy enumerated tests → split across Tasks 1, 2, 3, 4, 5, 6, 7, 8
+- [x] §9 acceptance criteria → mapped 1:1 onto Task outputs and the Task 9 manual smoke
+- [x] §10 risks (StickyWindowManager singleton, ExperimentManager cleanup hooks, experiment_changed Event, coexistence) — captured in code (handler null-checks, dock-pane comments) and in the PR-body summary
+
+**Placeholder scan:** No "TBD"/"TODO"/"similar to"/"add appropriate"/etc.
+
+**Type/method consistency:**
+- `save_to_dialog` and `load_from_dialog` (Task 5) referenced from `_save` / `_load` on the demo window (Task 7) ✓
+- `clear_highlights` (Task 5) called from `_on_protocol_terminated` and `_on_error` ✓
+- `_on_experiment_changed` (Task 6) connected via `application.observe(..., "experiment_changed")` ✓
+- `experiment_label.clicked` signal wired to `_on_experiment_label_clicked` in Task 2, real-mode handler swapped in Task 6 ✓
+- All `@property` alias names in Task 7 match the pane attribute names introduced in Tasks 2–6 ✓

--- a/docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md
+++ b/docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md
@@ -1,0 +1,243 @@
+# Protocol Tree Pane — Full-app Dock Pane Refactor
+
+**Issue:** [#411 — PPT-10.1](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/411)
+**Parent:** #361 (PPT)
+**Predecessors:** #377 (PPT-10 navigation pane port)
+**Successors:** #371 (PPT-9 protocol_grid deletion)
+**Date:** 2026-05-08
+
+## Background
+
+PPT-10 (#377) ported `NavigationBar` + `StatusBar` + experiment-bar (new-experiment / experiment-label / new-note) into `pluggable_protocol_tree/views/navigation_bar.py`, and wired all of it into `BasePluggableProtocolDemoWindow` so the demos look and feel like the legacy `protocol_grid`. The full-app dock pane (`pluggable_protocol_tree/views/dock_pane.py`) is still the minimal wrapper from PPT-3 — it only mounts `ProtocolTreeWidget`, with no playback bar, no status bar, and no experiment controls.
+
+Before #371 can delete `protocol_grid`, the dock pane has to host the same scaffolding the legacy widget does **and** the experiment / sticky-note actions need to be wired against the live Envisage services rather than the demo's stub handlers. After this work the new dock pane is usable in the actual full app — not just in the demo windows.
+
+## Goals
+
+1. Extract the demo's standard UX scaffolding into a reusable `ProtocolTreePane(QWidget)` so the demo window and the dock pane mount one instance.
+2. Wire experiment-bar actions (New Experiment, experiment-label click, New Note) against the live `ExperimentManager` + `StickyWindowManager` services when those services are supplied.
+3. Make `BasePluggableProtocolDemoWindow` a thin shell around `ProtocolTreePane`, while keeping the existing test suite (`test_base_demo_window.py`) green via backward-compatibility aliases.
+4. Register `PluggableProtocolTreePlugin` in `examples/plugin_consts.py` so launching the full app shows the new dock pane alongside the legacy `protocol_grid` pane during transition.
+
+## Non-goals
+
+- Removing or modifying the legacy `protocol_grid` plugin (covered by #371).
+- Cleaning up `ExperimentManager` and `StickyWindowManager` beyond making them callable from the new dock pane (covered by #371 / PPT-9).
+- The Quick-Actions bar (`protocol_grid/quick_action_bar.py`).
+- Full message-listener parity with the legacy widget — capacitance overlays, droplet detection feedback, DropBot connection gating, voltage/frequency-range UI updates. Tracked as a follow-up.
+
+## Approach
+
+`ProtocolTreePane(QWidget)` owns everything that's currently in `BasePluggableProtocolDemoWindow.__init__` between the manager construction and the toolbar build:
+
+- Manager + ProtocolTreeWidget
+- ProtocolExecutor (+ pause/stop events) + executor-signal wiring
+- NavigationBar + StatusBar + ExperimentLabel + experiment-bar buttons
+- Phase-navigation pause logic (`_compute_pause_phase_state`, `_on_prev_phase`, `_on_next_phase`, `_publish_paused_phase`)
+- Step-cursor navigation (`_navigate_to_first_step` etc.)
+- Tick timer + button state machine (`_set_idle_button_state`, `_set_running_button_state`, `_on_protocol_paused`, `_on_protocol_resumed`, etc.)
+- Save/Load file pickers
+
+The window keeps:
+
+- Window chrome (title, size)
+- `Add Step / Add Group / Save / Load` `QToolBar` (separate from the pane's own internal save/load helpers)
+- Side-panel splitter
+- Bottom `QStatusBar` per-readout labels (StatusReadout machinery from `DemoConfig`)
+- Dramatiq routing setup (broker flush, demo-prefix subscriber purge, electrode chain wiring, phase-ack listener, status-readout listeners)
+
+The dock pane keeps:
+
+- Column assembly from the Envisage extension point
+- Service construction (`ExperimentManager`, `StickyWindowManager`)
+- Application trait observation for label sync
+
+### Service-injection contract
+
+`ProtocolTreePane` accepts optional service parameters:
+
+```python
+ProtocolTreePane(
+    columns_or_manager,                # list[IColumn] OR an existing RowManager
+    *,
+    application=None,                  # MicrodropApplication; observes current_experiment_directory when set
+    experiment_manager=None,           # ExperimentManager; if None, New-Exp button logs only
+    sticky_manager=None,               # StickyWindowManager; if None, New-Note button logs only
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    executor_factory=None,             # for tests — defaults to ProtocolExecutor(...)
+    parent=None,
+)
+```
+
+Rule: when a service is `None`, the corresponding button keeps the demo's log-only stub behavior. When supplied, the pane connects the real handler. This means demos do not need to change at all — passing no services preserves today's UX exactly.
+
+### Real-service wiring (used by the dock pane)
+
+| Trigger | Stub mode (demo) | Real mode (dock pane) |
+|---|---|---|
+| `btn_new_exp.clicked` | `logger.info("New Experiment requested")` | `experiment_manager.initialize_new_experiment()` → write to `application.current_experiment_directory` → `experiment_label.update_experiment_id(new_dir.stem)` |
+| `experiment_label.clicked` | non-clickable `QLabel` | `experiment_manager.open_experiment_directory()` |
+| `btn_new_note.clicked` | `logger.info("New Note requested")` | `sticky_manager.request_new_note(base_dir, experiment_name)` |
+| `application.current_experiment_directory` change | n/a | `experiment_label.update_experiment_id(new_dir.stem)` (Traits `@observe`) |
+
+The pane uses the legacy promoted `ExperimentLabel` (clickable, theme-aware link colour, tooltip-toggle context menu) — ported to `pluggable_protocol_tree/views/experiment_label.py`. It stays clickable in stub mode (the disconnected click is a harmless no-op), so demos get the same visual UX.
+
+### Dock-pane sketch
+
+```python
+class PluggableProtocolDockPane(TraitsDockPane):
+    id = "pluggable_protocol_tree.dock_pane"
+    name = "Protocol (pluggable)"   # renamed during legacy coexistence
+    columns = List(Instance(IColumn))
+
+    def create_contents(self, parent):
+        from protocol_grid.services.experiment_manager import ExperimentManager
+        from microdrop_utils.sticky_notes import StickyWindowManager
+        from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+        app = self.task.window.application
+        return ProtocolTreePane(
+            self.columns,
+            application=app,
+            experiment_manager=ExperimentManager(app.current_experiment_directory),
+            sticky_manager=StickyWindowManager(),
+            parent=parent,
+        )
+```
+
+The legacy `ExperimentManager` import crosses package boundaries intentionally — issue #411 explicitly defers `ExperimentManager` cleanup to PPT-9 (#371).
+
+### Demo-window slimming
+
+`BasePluggableProtocolDemoWindow.__init__` shrinks to:
+
+```python
+self.pane = ProtocolTreePane(
+    self.config.columns_factory(),
+    phase_ack_topic=self.config.phase_ack_topic,
+    parent=self,
+)
+self.config.pre_populate(self.pane.manager)
+self._build_central(self.pane)         # wraps pane in side-panel splitter if configured
+self._build_toolbar()                  # window-only: Add Step/Group, Save, Load
+self._build_status_readouts()          # window-only: bottom QStatusBar readout labels
+self._setup_dramatiq_routing_internal()
+self.config.routing_setup(self._router)
+self.config.post_build_setup(self)
+```
+
+#### Backward-compatibility aliases
+
+`test_base_demo_window.py` reaches into many private attributes. The window keeps these accessible via `@property` shims that forward to `self.pane.*`:
+
+| Attribute | Source after refactor |
+|---|---|
+| `manager`, `widget`, `executor`, `navigation_bar`, `status_bar` | `self.pane.<name>` |
+| `_status_step_label`, `_status_step_time_label`, `_status_reps_label`, `_status_phase_time_label` | `self.pane.<name>` |
+| `_tick_timer`, `_step_index`, `_step_total`, `_current_row`, etc. | `self.pane.<name>` |
+| `btn_new_exp`, `btn_new_note`, `experiment_label` | `self.pane.<name>` |
+| `phase_acked` (Qt Signal) | `self.pane.phase_acked` |
+| `_central_content`, `_side_panel`, `_toolbar`, `_router` | window (unchanged) |
+| `_readout_labels`, `_readout_signals`, `_readout_fmts`, `readout_acked` | window (unchanged — readouts are demo-only) |
+| `_clear_all_highlights` | window method that calls `self.pane.clear_highlights()` then resets readouts |
+
+Result: every existing test in `test_base_demo_window.py` keeps passing without test edits.
+
+### Plugin registration
+
+Uncomment in `examples/plugin_consts.py`:
+
+```python
+from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
+...
+FRONTEND_PLUGINS = [
+    ...
+    PluggableProtocolTreePlugin,   # was commented out
+    ...
+]
+```
+
+Both dock panes now mount at app start. The user can drag/dock either independently. Pane title rename to **"Protocol (pluggable)"** during transition keeps the two unambiguous in the dock-pane menu.
+
+### File layout
+
+```
+pluggable_protocol_tree/
+├── views/
+│   ├── protocol_tree_pane.py        # NEW — ProtocolTreePane(QWidget)
+│   ├── experiment_label.py          # NEW — ported from protocol_grid/extra_ui_elements.py
+│   ├── dock_pane.py                 # MODIFIED — wires real services
+│   └── navigation_bar.py            # unchanged
+├── demos/
+│   └── base_demo_window.py          # SHRINKS — delegates to ProtocolTreePane
+└── tests/
+    ├── test_protocol_tree_pane.py   # NEW — pane construction + handler wiring
+    ├── test_dock_pane.py            # NEW — dock-pane service construction + wiring
+    └── test_base_demo_window.py     # MODIFIED — passes via delegation
+```
+
+## Data flow
+
+Run-button click in the dock pane:
+
+```
+Play click
+  → ProtocolTreePane._on_play_clicked
+  → ProtocolExecutor.start(start_step_path, preview_mode)
+  → executor publishes ELECTRODES_STATE_CHANGE per phase
+  → device viewer overlays electrodes (existing subscriber, unchanged)
+  → backend ack ELECTRODES_STATE_APPLIED → phase_acked signal → tick timer + status bar
+  → on protocol end: button machine returns to idle; auto-repeat re-fires if configured
+```
+
+No new message topics are introduced. The pane reuses the same `ProtocolExecutor` and the same electrode chain that the demo already drives. Coexistence with `protocol_grid` is safe because only one pane runs a protocol at a time; both publish to the same topics; both observe `current_experiment_directory`, so they stay in sync.
+
+## Error handling
+
+- `protocol_error` → `ProtocolTreePane._on_error` resets repeat state, clears highlights, returns to idle button state, stops tick timer, shows a styled error dialog via `microdrop_application.dialogs.pyface_wrapper.error` (project convention).
+- Missing services (None passed for `experiment_manager` / `sticky_manager`) → button click logs only; never raises.
+- `ExperimentManager.initialize_new_experiment()` returning `None` (it logs and swallows on failure) → label is left unchanged; do not write `None` back to `application.current_experiment_directory`. (Match legacy behavior at `widget.py:1022`.)
+
+## Testing strategy
+
+`test_protocol_tree_pane.py`:
+
+- `test_constructs_with_columns_list` — passing a list builds an internal RowManager.
+- `test_constructs_with_existing_manager` — passing a RowManager skips the construction step.
+- `test_stub_mode_buttons_are_no_ops` — `btn_new_exp.click()` / `btn_new_note.click()` do not raise when no services supplied; logs only.
+- `test_real_mode_new_exp_calls_service` — with a `Mock(spec=ExperimentManager)`, click dispatches to `initialize_new_experiment()` and writes back to `application.current_experiment_directory`.
+- `test_real_mode_new_note_calls_service` — `Mock(spec=StickyWindowManager).request_new_note` called with `(base_dir, experiment_name)`.
+- `test_real_mode_label_click_opens_directory` — `experiment_label.clicked` → `experiment_manager.open_experiment_directory()`.
+- `test_application_trait_observed_updates_label` — setting `application.current_experiment_directory` triggers `experiment_label.update_experiment_id(new_dir.stem)`.
+- `test_initialize_returns_none_does_not_overwrite_app_dir` — when `initialize_new_experiment()` returns None, `application.current_experiment_directory` is not overwritten.
+
+`test_dock_pane.py`:
+
+- `test_create_contents_returns_protocol_tree_pane` — assert returned widget is a `ProtocolTreePane`.
+- `test_create_contents_passes_application_to_pane` — mock task/window/application chain.
+- `test_create_contents_constructs_experiment_manager` — `ExperimentManager` is constructed with `app.current_experiment_directory`.
+- `test_create_contents_constructs_sticky_manager` — `StickyWindowManager` is constructed once.
+
+`test_base_demo_window.py`:
+
+- All existing tests keep passing without edits, validated via the alias `@property` shims.
+
+Tests live under `pluggable_protocol_tree/tests/` (no Redis or hardware dependencies). Run via `pixi run pytest microdrop-py/src/pluggable_protocol_tree/tests/`.
+
+## Acceptance criteria
+
+- [ ] New `pluggable_protocol_tree/views/protocol_tree_pane.py` defines `ProtocolTreePane(QWidget)` hosting NavigationBar + StatusBar + ProtocolTreeWidget + experiment-bar + ProtocolExecutor with the wiring points listed above.
+- [ ] New `pluggable_protocol_tree/views/experiment_label.py` ports the legacy clickable, theme-aware `ExperimentLabel`.
+- [ ] `PluggableProtocolDockPane.create_contents` constructs a `ProtocolTreePane` and connects the experiment-manager / sticky-note / experiment-folder handlers via the Envisage application services.
+- [ ] `BasePluggableProtocolDemoWindow` delegates to `ProtocolTreePane` rather than building the scaffolding inline. Existing `test_base_demo_window.py` keeps passing without edits.
+- [ ] `examples/plugin_consts.py` registers `PluggableProtocolTreePlugin` alongside `ProtocolGridControllerUIPlugin`. The pluggable dock-pane title is "Protocol (pluggable)" so it's unambiguous in the dock-pane menu.
+- [ ] Launching `examples/run_device_viewer_pluggable.py` shows both panes; the new pane has working playback + experiment controls including a New Experiment click that creates an experiment via the live `experiment_manager`, a New Note click that opens a sticky note, and an experiment-label click that opens the experiment directory.
+- [ ] New tests cover `ProtocolTreePane` construction, experiment-bar handler wiring (with mocked services), application-trait observation, and the dock-pane's service construction.
+
+## Risks & non-obvious bits
+
+- **`StickyWindowManager()` is a singleton-ish manager.** Creating one in the dock pane while the legacy widget creates another is harmless — both manage independent windows. After PPT-9 deletion, only the new one remains.
+- **`ExperimentManager._register_cleanup_on_exit`** connects to `app.aboutToQuit`. Two managers register two cleanup hooks pointing at the same parent dir; the underlying `shutil.rmtree` of an empty dir is idempotent so this is harmless until PPT-9 unifies them.
+- **`application.current_experiment_directory` is a Traits `Property`, not a regular Trait** (`microdrop_application/application.py:105`). `@observe` works on Properties because the setter writes to an underlying trait; verify in tests with a mock application that exposes both the Property and its underlying private trait.
+- **Coexistence of two panes during transition** means a user could click Play on both. The existing executor design starts work on a worker thread, and clicking Play on the legacy pane while the new one is running will fire its own ELECTRODES_STATE_CHANGE messages on top — UX issue but not a data-corruption issue. We will not add cross-pane locking; legacy will be removed in #371.
+- **Issue #411 wording uses `experiment_manager.setup_new_experiment(...)`.** The actual API on `ExperimentManager` is `initialize_new_experiment()` (`protocol_grid/services/experiment_manager.py:97`). The spec follows the actual API.

--- a/docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md
+++ b/docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md
@@ -78,7 +78,7 @@ Rule: when a service is `None`, the corresponding button keeps the demo's log-on
 | `btn_new_exp.clicked` | `logger.info("New Experiment requested")` | `experiment_manager.initialize_new_experiment()` → write to `application.current_experiment_directory` → `experiment_label.update_experiment_id(new_dir.stem)` |
 | `experiment_label.clicked` | non-clickable `QLabel` | `experiment_manager.open_experiment_directory()` |
 | `btn_new_note.clicked` | `logger.info("New Note requested")` | `sticky_manager.request_new_note(base_dir, experiment_name)` |
-| `application.current_experiment_directory` change | n/a | `experiment_label.update_experiment_id(new_dir.stem)` (Traits `@observe`) |
+| `application.experiment_changed` Event fires | n/a | re-read `application.current_experiment_directory`; `experiment_label.update_experiment_id(new_dir.stem)` |
 
 The pane uses the legacy promoted `ExperimentLabel` (clickable, theme-aware link colour, tooltip-toggle context menu) — ported to `pluggable_protocol_tree/views/experiment_label.py`. It stays clickable in stub mode (the disconnected click is a harmless no-op), so demos get the same visual UX.
 
@@ -238,6 +238,6 @@ Tests live under `pluggable_protocol_tree/tests/` (no Redis or hardware dependen
 
 - **`StickyWindowManager()` is a singleton-ish manager.** Creating one in the dock pane while the legacy widget creates another is harmless — both manage independent windows. After PPT-9 deletion, only the new one remains.
 - **`ExperimentManager._register_cleanup_on_exit`** connects to `app.aboutToQuit`. Two managers register two cleanup hooks pointing at the same parent dir; the underlying `shutil.rmtree` of an empty dir is idempotent so this is harmless until PPT-9 unifies them.
-- **`application.current_experiment_directory` is a Traits `Property`, not a regular Trait** (`microdrop_application/application.py:105`). `@observe` works on Properties because the setter writes to an underlying trait; verify in tests with a mock application that exposes both the Property and its underlying private trait.
+- **`application.current_experiment_directory` is a Traits `Property`** (`microdrop_application/application.py:105`), but the application also exposes a sibling `experiment_changed = Event()` trait (line 106) that the setter `_set_current_experiment_directory` fires (line 185). The pane observes `experiment_changed` instead of the Property directly — Property notifications are unreliable, the Event is what the application explicitly publishes for this purpose. After receiving the event, the pane re-reads `application.current_experiment_directory` to get the new value.
 - **Coexistence of two panes during transition** means a user could click Play on both. The existing executor design starts work on a worker thread, and clicking Play on the legacy pane while the new one is running will fire its own ELECTRODES_STATE_CHANGE messages on top — UX issue but not a data-corruption issue. We will not add cross-pane locking; legacy will be removed in #371.
 - **Issue #411 wording uses `experiment_manager.setup_new_experiment(...)`.** The actual API on `ExperimentManager` is `initialize_new_experiment()` (`protocol_grid/services/experiment_manager.py:97`). The spec follows the actual API.

--- a/dropbot_controller/services/dropbot_states_setting_mixin_service.py
+++ b/dropbot_controller/services/dropbot_states_setting_mixin_service.py
@@ -105,26 +105,6 @@ class DropbotStatesSettingMixinService(HasTraits):
             logger.error(f"Error setting protocol voltage: {e}")
             raise
 
-    def on_protocol_set_frequency_request(self, message):
-        """Set frequency on the dropbot for protocol-driven writes.
-
-        Symmetric to on_set_frequency_request but bypasses the realtime-mode
-        gate and does NOT persist to DropbotPreferences.last_frequency.
-        Publishes FREQUENCY_APPLIED ack on RPC return. On hardware error,
-        the ack is NOT published — the executor's wait_for times out and
-        the protocol step fails.
-        """
-        try:
-            v = int(message)
-            with self.proxy.transaction_lock:
-                self.proxy.update_state(frequency=v)
-            publish_message(topic=FREQUENCY_APPLIED, message=str(v))
-        except (TimeoutError, RuntimeError) as e:
-            logger.error(f"Proxy error setting protocol frequency: {e}")
-        except Exception as e:
-            logger.error(f"Error setting protocol frequency: {e}")
-            raise
-
     def on_set_frequency_request(self, message):
         """Set frequency on the dropbot device.
 
@@ -153,6 +133,26 @@ class DropbotStatesSettingMixinService(HasTraits):
             logger.error(f"Proxy error setting frequency: {e}")
         except Exception as e:
             logger.error(f"Error setting frequency: {e}")
+            raise
+
+    def on_protocol_set_frequency_request(self, message):
+        """Set frequency on the dropbot for protocol-driven writes.
+
+        Symmetric to on_set_frequency_request but bypasses the realtime-mode
+        gate and does NOT persist to DropbotPreferences.last_frequency.
+        Publishes FREQUENCY_APPLIED ack on RPC return. On hardware error,
+        the ack is NOT published — the executor's wait_for times out and
+        the protocol step fails.
+        """
+        try:
+            v = int(message)
+            with self.proxy.transaction_lock:
+                self.proxy.update_state(frequency=v)
+            publish_message(topic=FREQUENCY_APPLIED, message=str(v))
+        except (TimeoutError, RuntimeError) as e:
+            logger.error(f"Proxy error setting protocol frequency: {e}")
+        except Exception as e:
+            logger.error(f"Error setting protocol frequency: {e}")
             raise
 
     def on_set_realtime_mode_request(self, message):

--- a/electrode_controller/consts.py
+++ b/electrode_controller/consts.py
@@ -7,6 +7,7 @@ from dropbot_controller.consts import DISABLED_CHANNELS_CHANGED
 
 ELECTRODES_STATE_CHANGE = 'hardware/requests/electrodes_state_change'
 ELECTRODES_DISABLE_REQUEST = 'hardware/requests/electrodes_disable'
+ELECTRODES_STATE_APPLIED = 'hardware/electrodes_state_applied'
 
 electrode_state_change_publisher = ElectrodeStateChangePublisher(topic=ELECTRODES_STATE_CHANGE)
 electrode_disable_request_publisher = ElectrodeDisableRequestPublisher(topic=ELECTRODES_DISABLE_REQUEST)

--- a/electrode_controller/services/electrode_state_change_service.py
+++ b/electrode_controller/services/electrode_state_change_service.py
@@ -7,8 +7,9 @@ from dropbot_controller.interfaces.i_dropbot_control_mixin_service import IDropb
 
 from dropbot.threshold import actuate_channels
 
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from ..models import ElectrodeChannelsRequest
-from ..consts import disabled_channels_changed_publisher
+from ..consts import disabled_channels_changed_publisher, ELECTRODES_STATE_APPLIED
 # microdrop utils imports
 from logger.logger_service import get_logger
 
@@ -76,6 +77,9 @@ class ElectrodeStateChangeMixinService(HasTraits):
                     mask = np.array(self.proxy.disabled_channels_mask)
                     disabled_indices = set(int(i) for i in np.where(mask != 0)[0])
                     disabled_channels_changed_publisher.publish(disabled_indices)
+
+            # sending ack
+            publish_message(str(len(actuated_channels)), topic=ELECTRODES_STATE_APPLIED)
 
         except TimeoutError:
             logger.error("Timeout waiting for proxy access for electrode state change", exc_info=True)

--- a/examples/plugin_consts.py
+++ b/examples/plugin_consts.py
@@ -11,6 +11,7 @@ from microdrop_application.plugin import MicrodropPlugin
 from dropbot_tools_menu.plugin import DropbotToolsMenuPlugin
 from opendrop_status_and_controls.plugin import OpendropStatusAndControlsPlugin
 from peripheral_controller.plugin import PeripheralControllerPlugin
+from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
 from protocol_grid.plugin import ProtocolGridControllerUIPlugin
 from dropbot_controller.plugin import DropbotControllerPlugin
 from electrode_controller.plugin import ElectrodeControllerPlugin
@@ -67,7 +68,7 @@ FRONTEND_PLUGINS = [
     PeripheralUiPlugin,
     UserHelpPlugin,
     SSHUIPlugin,
-    # PluggableProtocolTreePlugin,
+    PluggableProtocolTreePlugin,
     # DropbotProtocolControlsPlugin,
     # PeripheralProtocolControlsPlugin,
     # VideoProtocolControlsPlugin,

--- a/examples/plugin_consts.py
+++ b/examples/plugin_consts.py
@@ -1,6 +1,5 @@
-import os
-
 from dropbot_preferences_ui.plugin import DropbotPreferencesPlugin
+from dropbot_protocol_controls.plugin import DropbotProtocolControlsPlugin
 from dropbot_status_and_controls.plugin import DropbotStatusAndControlsPlugin
 from logger.plugin import LoggerPlugin
 from logger_ui.plugin import LoggerUIPlugin
@@ -68,10 +67,14 @@ FRONTEND_PLUGINS = [
     PeripheralUiPlugin,
     UserHelpPlugin,
     SSHUIPlugin,
+
+]
+
+EXPERIMENTAl_PLUGINS = [
     PluggableProtocolTreePlugin,
-    # DropbotProtocolControlsPlugin,
-    # PeripheralProtocolControlsPlugin,
-    # VideoProtocolControlsPlugin,
+    DropbotProtocolControlsPlugin,
+    PeripheralProtocolControlsPlugin,
+    VideoProtocolControlsPlugin,
 ]
 
 DROPBOT_FRONTEND_PLUGINS = [

--- a/examples/run_device_viewer_pluggable_experimental.py
+++ b/examples/run_device_viewer_pluggable_experimental.py
@@ -1,0 +1,111 @@
+import contextlib
+import os
+import sys
+import signal
+import time
+from functools import partial
+
+from envisage.ui.tasks.tasks_application import TasksApplication
+from pyface.qt.QtWidgets import QApplication
+
+from microdrop_utils.app_setup_helpers import microdrop_runner_setup
+microdrop_runner_setup()
+
+from examples.plugin_consts import REQUIRED_PLUGINS, FRONTEND_PLUGINS, BACKEND_PLUGINS, DROPBOT_BACKEND_PLUGINS, \
+    DROPBOT_FRONTEND_PLUGINS, OPENDROP_FRONTEND_PLUGINS, OPENDROP_BACKEND_PLUGINS, DEFAULT_APPLICATION, SERVER_CONTEXT, \
+    REQUIRED_CONTEXT, MOCK_DROPBOT_BACKEND_PLUGINS, MOCK_DROPBOT_FRONTEND_PLUGINS, SERVICE_PLUGINS, EXPERIMENTAl_PLUGINS
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+from microdrop_style.helpers import style_app
+
+from microdrop_utils.system_config import is_rpi
+# Set environment variables for Qt for pi
+if is_rpi():
+    os.environ["QT_MEDIA_BACKEND"] = "gstreamer"
+    print("Detected Raspberry Pi. Setting QT_MEDIA_BACKEND to gstreamer")
+
+def stop_app(app, signum, frame):
+    print("Shutting down...")
+    if isinstance(app,
+                  TasksApplication):  # It's a UI application, so we call exit so that the application can save its state via TasksApplication.exit()
+        app.exit()
+    else:  # It's a backend application, so we call Application.stop() since exit() doesn't exist
+        app.stop()
+    sys.exit(0)
+
+
+def main(plugins, contexts, application, persist):
+    """
+    Run the application.
+
+    **Note**
+    The order of plugins matters. This determines whose start routine will be run first, and whose contributions will be prioritized
+    For example: the microdrop plugin and the tasks contributes a preferences dialog service.
+    The dialog contributed by the plugin listed first will be used. That is how the envisage application get_service
+    method works.
+
+    """
+
+    app_instance = QApplication.instance() or QApplication(sys.argv)
+
+    style_app(app_instance)
+
+    print(f"Instantiating application {application} with plugins {plugins}")
+
+    # Instantiate plugins
+    plugin_instances = [plugin() for plugin in plugins]
+
+    #### Startup application with context
+
+    with contextlib.ExitStack() as stack:  # contextlib.ExitStack is a context manager that allows you to stack multiple context managers
+        for context, kwargs in contexts:
+            stack.enter_context(context(**kwargs))
+
+        # Instantiate application
+        app = application(plugins=plugin_instances)
+
+        # Register signal handlers
+        stop_app_func = partial(stop_app, app)
+        signal.signal(signal.SIGINT, stop_app_func)
+        signal.signal(signal.SIGTERM, stop_app_func)
+
+        app.run()
+
+        if persist:
+            while True:
+                time.sleep(0.001)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run the frontend device viewer plugins.")
+
+    parser.add_argument(
+        "--device",
+        type=str,
+        choices=["dropbot", "opendrop", "mock"],
+        default="dropbot", # Sets a default if the user doesn't provide the flag
+        help="Specify the device to use: 'dropbot' or 'opendrop'"
+    )
+
+    plugins = REQUIRED_PLUGINS + FRONTEND_PLUGINS + SERVICE_PLUGINS + BACKEND_PLUGINS + EXPERIMENTAl_PLUGINS
+
+    args = parser.parse_args()
+
+    if args.device == "dropbot":
+        plugins += DROPBOT_FRONTEND_PLUGINS + DROPBOT_BACKEND_PLUGINS
+    elif args.device == "opendrop":
+        plugins += OPENDROP_FRONTEND_PLUGINS + OPENDROP_BACKEND_PLUGINS
+
+    elif args.device == "mock":
+        plugins += MOCK_DROPBOT_FRONTEND_PLUGINS + MOCK_DROPBOT_BACKEND_PLUGINS + DROPBOT_FRONTEND_PLUGINS
+
+    main(
+        plugins=plugins,
+        contexts=SERVER_CONTEXT + REQUIRED_CONTEXT,
+        application=DEFAULT_APPLICATION,
+        persist=False # UI so no
+         )

--- a/mock_dropbot_controller/consts.py
+++ b/mock_dropbot_controller/consts.py
@@ -12,8 +12,10 @@ from dropbot_controller.consts import (
     TEST_ON_BOARD_FEEDBACK_CALIBRATION, TEST_SHORTS, TEST_CHANNELS,
     CHIP_CHECK, SELF_TEST_CANCEL, DETECT_DROPLETS, CHANGE_SETTINGS,
     HARDWARE_DEFAULT_VOLTAGE, HARDWARE_DEFAULT_FREQUENCY, TestEvent,
-    create_test_progress_message,
+    create_test_progress_message
 )
+
+from electrode_controller.consts import ELECTRODES_STATE_APPLIED
 
 # Mock-specific request topics (frontend → backend via pub/sub)
 MOCK_CHANGE_SIM_SETTINGS = "mock_dropbot/requests/change_simulation_settings"

--- a/mock_dropbot_controller/mock_controller.py
+++ b/mock_dropbot_controller/mock_controller.py
@@ -6,6 +6,7 @@ from datetime import datetime, UTC
 import dramatiq
 from traits.api import HasTraits, Instance, Bool, Str, Float, Int, Set, Dict
 
+from dropbot_controller.consts import VOLTAGE_APPLIED, FREQUENCY_APPLIED
 from microdrop_utils.dramatiq_controller_base import (
     generate_class_method_dramatiq_listener_actor,
     invoke_class_method,
@@ -29,6 +30,7 @@ from .consts import (
     MOCK_CHANGE_SIM_SETTINGS, MOCK_SIMULATE_CHIP_INSERT,
     MOCK_SIMULATE_SHORTS, MOCK_SIMULATE_HALT,
     MOCK_ACTUATED_CHANNELS_UPDATED, MOCK_STREAM_STATUS_UPDATED,
+    ELECTRODES_STATE_APPLIED
 )
 
 logger = get_logger(__name__, level="INFO")
@@ -146,6 +148,19 @@ class MockDropbotController(HasTraits):
         except (ValueError, TypeError) as e:
             logger.error(f"Mock: Invalid voltage: {e}")
 
+    def on_protocol_set_voltage_request(self, message):
+        """Set voltage on the dropbot for protocol-driven writes.
+
+        Symmetric to on_set_voltage_request but bypasses the realtime-mode
+        gate and does NOT persist to DropbotPreferences.last_voltage —
+        protocol writes are unconditional and transient. Publishes
+        VOLTAGE_APPLIED ack on RPC return so the protocol executor's
+        wait_for unblocks. On hardware error, the ack is NOT published —
+        the executor's wait_for times out and the protocol step fails.
+        """
+        self.on_set_voltage_request(message)
+        publish_message(topic=VOLTAGE_APPLIED, message=str(self.voltage))
+
     def on_set_frequency_request(self, message):
         try:
             f = float(message)
@@ -156,6 +171,19 @@ class MockDropbotController(HasTraits):
                 logger.error("Mock: Frequency must be between 100 and 20000 Hz")
         except (ValueError, TypeError) as e:
             logger.error(f"Mock: Invalid frequency: {e}")
+
+    def on_protocol_set_frequency_request(self, message):
+        """Set frequency on the dropbot for protocol-driven writes.
+
+        Symmetric to on_set_frequency_request but bypasses the realtime-mode
+        gate and does NOT persist to DropbotPreferences.last_frequency —
+        protocol writes are unconditional and transient. Publishes
+        FREQUENCY_APPLIED ack on RPC return so the protocol executor's
+        wait_for unblocks. On hardware error, the ack is NOT published —
+        the executor's wait_for times out and the protocol step fails.
+        """
+        self.on_set_frequency_request(message)
+        publish_message(topic=FREQUENCY_APPLIED, message=str(self.frequency))
 
     def on_set_realtime_mode_request(self, message):
         if message == "True":
@@ -187,6 +215,8 @@ class MockDropbotController(HasTraits):
             logger.info(f"Mock: {len(channels)} channels actuated: {sorted(channels)}")
         except (json.JSONDecodeError, TypeError) as e:
             logger.error(f"Mock: Invalid electrode state message: {e}")
+
+        publish_message(str(len(self.actuated_channels)), topic=ELECTRODES_STATE_APPLIED)
 
     def on_detect_shorts_request(self, message):
         publish_message(

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -130,8 +130,7 @@ class RoutesHandler(BaseColumnHandler):
                 "channels": channels,
             }
             if preview_mode:
-                # Tell hardware-driving consumers to skip actuation;
-                # visualizers (device viewer overlay) ignore the flag.
+                # Tell hardware-driving consumers to skip actuation.
                 payload["preview"] = True
             publish_message(
                 topic=ELECTRODES_STATE_CHANGE,

--- a/pluggable_protocol_tree/consts.py
+++ b/pluggable_protocol_tree/consts.py
@@ -5,6 +5,10 @@ defined here, ACTOR_TOPIC_DICT aggregating the listener→topic map."""
 
 import os
 
+from device_viewer.consts import PROTOCOL_RUNNING, PROTOCOL_GRID_DISPLAY_STATE
+
+from electrode_controller.consts import ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED
+
 PKG = ".".join(__name__.split(".")[:-1])
 PKG_name = PKG.title().replace("_", " ")
 
@@ -22,10 +26,6 @@ PERSISTENCE_SCHEMA_VERSION = 1
 # Topic constants (no executor topics yet — added in PPT-2)
 # Reserved namespace for future use:
 PROTOCOL_TOPIC_PREFIX = "microdrop/protocol_tree"
-
-# PPT-3: per-phase electrode actuation
-ELECTRODES_STATE_CHANGE  = f"{PROTOCOL_TOPIC_PREFIX}/electrodes_state_change"
-ELECTRODES_STATE_APPLIED = f"{PROTOCOL_TOPIC_PREFIX}/electrodes_state_applied"
 
 # No ACTOR_TOPIC_DICT entries yet — no listener in PPT-1.
 ACTOR_TOPIC_DICT: dict[str, list[str]] = {}

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -14,7 +14,6 @@ See PPT-12 spec for design rationale (composition vs inheritance).
 
 from __future__ import annotations
 
-import json
 import re
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -195,8 +194,6 @@ from pyface.qt.QtWidgets import (
     QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar,
 )
 
-from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
-
 
 class BasePluggableProtocolDemoWindow(QMainWindow):
     """Hosts a ProtocolTreePane + the demo-only toolbar / readouts /
@@ -230,15 +227,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if config.phase_ack_topic is not None:
             self.phase_acked.connect(self.pane._on_phase_ack)
 
-        # Re-route the pane's protocol_error → our own handler so that
-        # monkeypatching ``bdw.error_dialog`` from tests still gets the
-        # dialog call (the pane's _on_error uses its own module-level
-        # import; replacing it here gives us a single, predictable site).
-        self.pane.executor.qsignals.protocol_error.disconnect(
-            self.pane._on_error,
-        )
-        self.pane.executor.qsignals.protocol_error.connect(self._on_error)
-
         self._side_panel = None
         if config.side_panel_factory is not None:
             side = config.side_panel_factory(self.pane.manager)
@@ -251,21 +239,13 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                     int(config.window_size[0] * 0.65),
                     int(config.window_size[0] * 0.35),
                 ])
-                self.setCentralWidget(splitter)
-                # Test-visible bookkeeping: the legacy attribute name
-                # used to be the inner content (tree-or-splitter). With
-                # the pane refactor, the splitter still holds 2 widgets
-                # so the existing test_window_side_panel_uses_splitter
-                # assertions keep working.
                 self._central_content = splitter
             else:
-                self.setCentralWidget(self.pane)
-                # Legacy compat: tests assert
-                # ``w._central_content is w.widget`` (the bare tree).
-                self._central_content = self.pane.widget
+                self._central_content = self.pane
         else:
-            self.setCentralWidget(self.pane)
-            self._central_content = self.pane.widget
+            self._central_content = self.pane
+
+        self.setCentralWidget(self._central_content)
 
         # Pre-populate after manager is built; before executor starts.
         config.pre_populate(self.pane.manager)
@@ -344,18 +324,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         except Exception as e:
             text = f"<error: {e}>"
         label_widget.setText(f"{label_prefix}: {text}")
-
-    def _on_error(self, msg):
-        """protocol_error → reset to idle, show error dialog. Mirrors the
-        pane's _on_error but routes through this module's ``error_dialog``
-        so tests can monkeypatch it via ``bdw.error_dialog``."""
-        self.pane._repeats_total = 0
-        self.pane._repeats_completed = 0
-        self.pane._update_repeat_status_label()
-        self.pane.clear_highlights()
-        self.pane._set_idle_button_state()
-        self.pane._tick_timer.stop()
-        error_dialog(parent=self, title="Protocol error", message=str(msg))
 
     # --- Dramatiq routing (unchanged behavior, just lives here) -----
 

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -190,40 +190,19 @@ def _make_readout_actor(slug: str):
     return actor_name
 
 
-import threading
-import time
-
-from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
+from pyface.qt.QtCore import Qt, Signal
 from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QLabel, QMainWindow,
-    QSplitter, QStatusBar, QToolBar, QVBoxLayout, QWidget,
+    QApplication, QLabel, QMainWindow, QSplitter, QStatusBar, QToolBar,
 )
 
 from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
 
-from pluggable_protocol_tree.execution.events import PauseEvent
-from pluggable_protocol_tree.execution.executor import ProtocolExecutor
-from pluggable_protocol_tree.execution.signals import ExecutorSignals
-from pluggable_protocol_tree.models.row_manager import RowManager
-from pluggable_protocol_tree.views.navigation_bar import (
-    NavigationBar, StatusBar, make_separator,
-)
-from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
-
 
 class BasePluggableProtocolDemoWindow(QMainWindow):
-    """Hosts a ProtocolTreeWidget + ProtocolExecutor with the standard
-    UX scaffolding. See PPT-12 spec for the full feature list.
+    """Hosts a ProtocolTreePane + the demo-only toolbar / readouts /
+    Dramatiq routing scaffolding. See PPT-10.1 for the pane refactor."""
 
-    Construct with a DemoConfig; call .show() and .exec() OR use the
-    .run(config) classmethod for one-shot main() convenience."""
-
-    # Cross-thread signal — Dramatiq actor emits via the module-level
-    # listener (registered when phase_ack_topic is set); auto-connection
-    # delivers _on_phase_ack on the GUI thread.
-    phase_acked = Signal()
-
-    # Cross-thread signal for status-readout updates: (slug, message)
+    phase_acked = Signal()                    # forwarded from pane.phase_acked
     readout_acked = Signal(str, str)
 
     def __init__(self, config: DemoConfig):
@@ -232,97 +211,78 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         self.setWindowTitle(config.title)
         self.resize(*config.window_size)
 
-        self.manager = RowManager(columns=config.columns_factory())
-        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+        from pluggable_protocol_tree.views.protocol_tree_pane import (
+            ProtocolTreePane,
+        )
 
-        # Side panel widget if side_panel_factory yielded one, else None.
-        # post_build_setup callbacks should reach the side panel via this
-        # attribute rather than walking the central widget's children.
+        self.pane = ProtocolTreePane(
+            config.columns_factory(),
+            phase_ack_topic=config.phase_ack_topic,
+            parent=self,
+        )
+
+        # Forward the pane's phase_acked into the window's signal so
+        # tests / external code that connect to ``window.phase_acked``
+        # keep working unchanged. The phase-ack actor (module level)
+        # emits ``window.phase_acked``; route that into the pane so
+        # _on_phase_ack runs and resets the per-phase timer.
+        self.pane.phase_acked.connect(self.phase_acked.emit)
+        if config.phase_ack_topic is not None:
+            self.phase_acked.connect(self.pane._on_phase_ack)
+
+        # Re-route the pane's protocol_error → our own handler so that
+        # monkeypatching ``bdw.error_dialog`` from tests still gets the
+        # dialog call (the pane's _on_error uses its own module-level
+        # import; replacing it here gives us a single, predictable site).
+        self.pane.executor.qsignals.protocol_error.disconnect(
+            self.pane._on_error,
+        )
+        self.pane.executor.qsignals.protocol_error.connect(self._on_error)
+
         self._side_panel = None
-
-        # Tree-or-splitter goes inside a vertical container with the
-        # NavigationBar (built later in __init__) sitting above it. The
-        # nav bar is created after the executor so its button slots can
-        # bind directly to executor.start / .stop / pause-toggle.
-        if self.config.side_panel_factory is not None:
-            side = self.config.side_panel_factory(self.manager)
+        if config.side_panel_factory is not None:
+            side = config.side_panel_factory(self.pane.manager)
             if side is not None:
                 self._side_panel = side
                 splitter = QSplitter(Qt.Horizontal)
-                splitter.addWidget(self.widget)
+                splitter.addWidget(self.pane)
                 splitter.addWidget(side)
                 splitter.setSizes([
-                    int(self.config.window_size[0] * 0.65),
-                    int(self.config.window_size[0] * 0.35),
+                    int(config.window_size[0] * 0.65),
+                    int(config.window_size[0] * 0.35),
                 ])
+                self.setCentralWidget(splitter)
+                # Test-visible bookkeeping: the legacy attribute name
+                # used to be the inner content (tree-or-splitter). With
+                # the pane refactor, the splitter still holds 2 widgets
+                # so the existing test_window_side_panel_uses_splitter
+                # assertions keep working.
                 self._central_content = splitter
             else:
-                self._central_content = self.widget
+                self.setCentralWidget(self.pane)
+                # Legacy compat: tests assert
+                # ``w._central_content is w.widget`` (the bare tree).
+                self._central_content = self.pane.widget
         else:
-            self._central_content = self.widget
+            self.setCentralWidget(self.pane)
+            self._central_content = self.pane.widget
 
-        # Pre-populate sample steps BEFORE the executor is built.
-        config.pre_populate(self.manager)
-
-        self.executor = ProtocolExecutor(
-            row_manager=self.manager,
-            qsignals=ExecutorSignals(),
-            pause_event=PauseEvent(),
-            stop_event=threading.Event(),
-        )
+        # Pre-populate after manager is built; before executor starts.
+        config.pre_populate(self.pane.manager)
 
         self._router = None
-
-        # Per-step / per-phase timing state. Mutated from GUI thread only.
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at: float | None = None
-        self._phase_started_at: float | None = None
-        self._phase_target: float | None = None
-        self._current_row = None
-        # Auto-repeat state. Driven by the StatusBar's
-        # edit_repeat_protocol spinbox at play-button time.
-        self._repeats_total = 1
-        self._repeats_completed = 0
-        # Whichever mode (Run / Preview) the user picked for this run
-        # — auto-repeats reuse the same mode, and the running-state
-        # button machine uses it to disable the dropdown so a user
-        # can't switch modes mid-run.
-        self._current_run_preview_mode = False
-        # Phase-navigation state: while paused mid-step the demo
-        # window splits the play button into prev/resume/next phase
-        # controls and lets the user step through the paused row's
-        # phase list (for visualization only — the worker thread's
-        # actual phase position is independent and resumes from
-        # wherever it was when paused).
-        self._pause_phases: list = []
-        self._pause_phase_idx: int = 0
-        self._tick_timer = QTimer(self)
-        self._tick_timer.setInterval(100)   # 10 Hz
-        self._tick_timer.timeout.connect(self._refresh_status)
-
-        self._status_phase_time_label = None
-
-        # Per-readout state — _readout_labels is populated by _build_status_bar;
-        # _readout_signals is populated afterwards from _readout_fmts.
         self._readout_labels: dict[str, QLabel] = {}
+        self._build_status_readouts()
 
-        self._build_status_bar()
-
-        # Wire readout updates: one signal-emit handler per slug → label update.
         self._readout_fmts = {
-            _slug(r.label): (r.label, r.fmt) for r in self.config.status_readouts
+            _slug(r.label): (r.label, r.fmt) for r in config.status_readouts
         }
-        # Per-slug Signal accessors that just emit on the shared readout_acked.
-        # Tests can do w._readout_signals[slug].emit(msg).
         self._readout_signals: dict[str, _PerSlugEmitter] = {
             slug: _PerSlugEmitter(self.readout_acked, slug)
             for slug in self._readout_fmts
         }
         self.readout_acked.connect(self._on_readout_ack)
 
-        # Bind the module-level target so readout actor callbacks reach this window.
-        # Warn if a previous live window will be displaced (multi-window collision).
         existing = _readout_target.get("window")
         if existing is not None and existing is not self:
             logger.warning(
@@ -331,35 +291,75 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             )
         _readout_target["window"] = self
 
-        # Actor registration is broker-agnostic; topic subscription happens in
-        # _setup_dramatiq_routing_internal.
-        for readout in self.config.status_readouts:
+        for readout in config.status_readouts:
             _make_readout_actor(_slug(readout.label))
 
         self._setup_dramatiq_routing_internal()
         if self._router is not None:
-            # Demo-specific responders / listeners — called AFTER the
-            # standard chain so the demo can rely on it being in place.
             config.routing_setup(self._router)
 
-        self._wire_executor_signals()
         self._build_toolbar()
-        self._build_navigation_bar()
-        self._build_experiment_bar()
-        self._wire_button_state_machine()
-        self._set_idle_button_state()
-
-        # Final: demo-specific wiring that needs the constructed window.
         config.post_build_setup(self)
 
-    def _setup_dramatiq_routing_internal(self):
-        """Wires the standard PPT-3 electrode actuation chain
-        (electrode_responder + executor listener for ELECTRODES_STATE_APPLIED).
+    # --- demo-window-only chrome -----------------------------------
 
-        Best-effort: if Redis isn't reachable, sets self._router = None
-        and logs a warning. Runtime calls to ctx.wait_for() will then
-        time out at protocol-run time and surface as protocol_error.
-        """
+    def _build_status_readouts(self):
+        """Bottom QStatusBar hosts only the demo readouts now — the
+        legacy-style step / phase / repetition labels live on the
+        pane's StatusBar."""
+        sb = QStatusBar()
+        self.setStatusBar(sb)
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = QLabel(f"{readout.label}: {readout.initial}")
+            sb.addPermanentWidget(label)
+            self._readout_labels[slug] = label
+
+    def _build_toolbar(self):
+        tb = QToolBar("Protocol")
+        self.addToolBar(tb)
+        tb.addAction("Add Step", lambda: self.pane.manager.add_step())
+        tb.addAction("Add Group", lambda: self.pane.manager.add_group())
+        tb.addSeparator()
+        tb.addAction("Save…", self._save)
+        tb.addAction("Load…", self._load)
+        self._toolbar = tb
+
+    def _save(self):
+        self.pane.save_to_dialog(parent=self)
+
+    def _load(self):
+        self.pane.load_from_dialog(self.config.columns_factory, parent=self)
+
+    def _on_readout_ack(self, slug: str, message: str):
+        spec = self._readout_fmts.get(slug)
+        if spec is None:
+            return
+        label_prefix, fmt = spec
+        label_widget = self._readout_labels.get(slug)
+        if label_widget is None:
+            return
+        try:
+            text = fmt(message)
+        except Exception as e:
+            text = f"<error: {e}>"
+        label_widget.setText(f"{label_prefix}: {text}")
+
+    def _on_error(self, msg):
+        """protocol_error → reset to idle, show error dialog. Mirrors the
+        pane's _on_error but routes through this module's ``error_dialog``
+        so tests can monkeypatch it via ``bdw.error_dialog``."""
+        self.pane._repeats_total = 0
+        self.pane._repeats_completed = 0
+        self.pane._update_repeat_status_label()
+        self.pane.clear_highlights()
+        self.pane._set_idle_button_state()
+        self.pane._tick_timer.stop()
+        error_dialog(parent=self, title="Protocol error", message=str(msg))
+
+    # --- Dramatiq routing (unchanged behavior, just lives here) -----
+
+    def _setup_dramatiq_routing_internal(self):
         try:
             from microdrop_utils.dramatiq_pub_sub_helpers import (
                 MessageRouterActor,
@@ -369,14 +369,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             broker.flush_all()
             router = MessageRouterActor()
 
-            # Purge stale demo subscribers — actor names recorded in
-            # Redis by prior demo processes whose actors aren't
-            # registered in this process. Without this, a previous
-            # demo's spy/listener leaves behind a subscription that
-            # fires ActorNotFound on every publish to its topic.
-            #
-            # Only touch demo-prefixed names — leave real listeners
-            # belonging to other processes alone.
             broker_topics_to_check = (
                 ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED,
             )
@@ -385,8 +377,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                 extra_topics.append(self.config.phase_ack_topic)
             for r in self.config.status_readouts:
                 extra_topics.append(r.topic)
-            # Dedupe — phase_ack_topic often equals one of the standard
-            # electrode topics (default is ELECTRODES_STATE_APPLIED).
             topics_to_check = {*broker_topics_to_check, *extra_topics}
             for topic in topics_to_check:
                 try:
@@ -405,16 +395,15 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                                 topic=topic,
                                 subscribing_actor_name=actor_name,
                             )
-                            logger.info("purged stale demo subscriber %s on %s",
-                                        actor_name, topic)
+                            logger.info(
+                                f"purged stale demo subscriber {actor_name} on {topic}"
+                            )
                         except Exception:
                             logger.warning(
-                                "failed to purge %s on %s (likely wrong "
-                                "listener_queue from another router)",
-                                actor_name, topic,
+                                f"failed to purge {actor_name} on {topic} "
+                                "(likely wrong listener_queue from another router)"
                             )
 
-            # Standard PPT-3 electrode chain.
             router.message_router_data.add_subscriber_to_topic(
                 topic=ELECTRODES_STATE_CHANGE,
                 subscribing_actor_name=DEMO_RESPONDER_ACTOR_NAME,
@@ -438,8 +427,6 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
                     subscribing_actor_name="ppt12_demo_phase_ack_listener",
                 )
 
-            # StatusReadout listeners — actors already registered in __init__;
-            # here we only add the topic subscription.
             for readout in self.config.status_readouts:
                 slug = _slug(readout.label)
                 actor_name = f"ppt12_demo_{slug}_listener"
@@ -451,662 +438,109 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
             self._router = router
         except ValueError as e:
             if "already registered" not in str(e):
-                logger.warning("Demo Dramatiq routing setup failed: %s", e)
+                logger.warning(f"Demo Dramatiq routing setup failed: {e}")
         except Exception as e:
             logger.warning(
-                "Demo Dramatiq routing setup failed (Redis not running?): %s",
-                e,
+                f"Demo Dramatiq routing setup failed (Redis not running?): {e}"
             )
 
-    def _build_status_bar(self):
-        """Build the legacy-style StatusBar widget (mounted under the nav
-        bar in _build_navigation_bar) plus a thin bottom QStatusBar that
-        only hosts demo-specific per-readout labels.
+    # --- backwards-compat aliases -----------------------------------
 
-        Old single-attribute names (``_status_step_label`` etc.) are
-        retained as aliases onto the StatusBar widget's labels so test
-        coverage and demo subclasses keep working.
-        """
-        self.status_bar = StatusBar()
-        # Reveal the phase time slot only when the demo cares about
-        # per-phase acks; otherwise it stays hidden so the top bar
-        # doesn't show a frozen "Phase 0.00s / 0.00s" forever.
-        phase_enabled = self.config.phase_ack_topic is not None
-        self.status_bar.lbl_phase_time.setVisible(phase_enabled)
+    @property
+    def manager(self):
+        return self.pane.manager
 
-        # Aliases for backward compat with tests + demo subclasses.
-        # _status_row_label is intentionally dropped — the new layout
-        # has no row-name slot (per design discussion).
-        self._status_step_label = self.status_bar.lbl_step_progress
-        self._status_step_time_label = self.status_bar.lbl_step_time
-        self._status_reps_label = self.status_bar.lbl_step_repetition
-        self._status_phase_time_label = (
-            self.status_bar.lbl_phase_time if phase_enabled else None
-        )
+    @property
+    def widget(self):
+        return self.pane.widget
 
-        # Bottom QStatusBar — only readouts live here now.
-        sb = QStatusBar()
-        self.setStatusBar(sb)
-        for readout in self.config.status_readouts:
-            slug = _slug(readout.label)
-            label = QLabel(f"{readout.label}: {readout.initial}")
-            sb.addPermanentWidget(label)
-            self._readout_labels[slug] = label
+    @property
+    def executor(self):
+        return self.pane.executor
 
-    def _wire_executor_signals(self):
-        # Active-row highlight on each step start.
-        self.executor.qsignals.step_started.connect(
-            self.widget.highlight_active_row
-        )
-        # Status bar updates.
-        self.executor.qsignals.step_started.connect(self._on_step_started)
-        self.executor.qsignals.step_finished.connect(self._on_step_finished)
-        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
-        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
-        self.executor.qsignals.protocol_error.connect(self._on_error)
-        if self.config.phase_ack_topic is not None:
-            self.phase_acked.connect(self._on_phase_ack)
+    @property
+    def navigation_bar(self):
+        return self.pane.navigation_bar
 
-    def _on_protocol_started(self):
-        try:
-            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
-        except Exception:
-            self._step_total = 0
-        self._step_index = 0
-        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+    @property
+    def status_bar(self):
+        return self.pane.status_bar
 
-    def _on_step_started(self, row):
-        self._step_index += 1
-        self._current_row = row
-        # Reset phase timestamps; the phase ack handler restarts them.
-        self._step_started_at = time.monotonic()
-        self._phase_started_at = None
-        try:
-            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            self._phase_target = None
-        self._status_step_label.setText(
-            f"Step {self._step_index} / {self._step_total}"
-        )
-        # Recent / next-step labels — show the actual step name of the
-        # currently-running row plus the upcoming one. Walking
-        # iter_execution_steps once per step is fine; protocols stay
-        # under a few hundred steps.
-        self.status_bar.lbl_recent_step.setText(
-            f"Most Recent Step: {row.name}"
-        )
-        self.status_bar.lbl_next_step.setText(
-            f"Next Step: {self._next_step_name(row)}"
-        )
-        if not self._tick_timer.isActive():
-            self._tick_timer.start()
+    @property
+    def btn_new_exp(self):
+        return self.pane.btn_new_exp
 
-    def _next_step_name(self, current):
-        """Return the display name of the step that follows ``current`` in
-        execution order, or "-" if ``current`` is the last step."""
-        steps = self.manager.iter_execution_steps()
-        cur_path = tuple(current.path)
-        # Advance past the current row, return the next one.
-        for row in steps:
-            if tuple(row.path) == cur_path:
-                next_row = next(steps, None)
-                return next_row.name if next_row is not None else "-"
-        return "-"
+    @property
+    def btn_new_note(self):
+        return self.pane.btn_new_note
 
-    def _on_phase_ack(self):
-        """Each ack restarts the per-phase timer. The first ack of a step
-        also starts the per-step timer (overrides the time.monotonic()
-        set in _on_step_started so timers run from the actual ack moment)."""
-        if self._current_row is None:
-            return
-        now = time.monotonic()
-        if self._step_started_at is None:
-            self._step_started_at = now
-        self._phase_started_at = now
+    @property
+    def experiment_label(self):
+        return self.pane.experiment_label
 
-    def _on_readout_ack(self, slug: str, message: str):
-        spec = self._readout_fmts.get(slug)
-        if spec is None:
-            return
-        label_prefix, fmt = spec
-        label_widget = self._readout_labels.get(slug)
-        if label_widget is None:
-            return
-        try:
-            text = fmt(message)
-        except Exception as e:
-            text = f"<error: {e}>"
-        label_widget.setText(f"{label_prefix}: {text}")
+    @property
+    def _status_step_label(self):
+        return self.pane._status_step_label
 
-    def _on_step_repetition(self, rep_chain):
-        """Render the active rep context (e.g. "rep 2/3 of 'Wash'") into
-        the status bar. Empty chain (no repeating ancestor) hides the
-        label so the layout collapses the slot — otherwise its
-        fixed-width box would leave a blank 100 px gap between the
-        Step counter and the Most-Recent-Step label."""
-        if not rep_chain:
-            self._status_reps_label.setText("")
-            self._status_reps_label.setVisible(False)
-            return
-        parts = [
-            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
-        ]
-        self._status_reps_label.setText(" · ".join(parts))
-        self._status_reps_label.setVisible(True)
+    @property
+    def _status_step_time_label(self):
+        return self.pane._status_step_time_label
 
-    def _on_step_finished(self, _row):
-        # Freeze the elapsed-time labels at the step's actual elapsed.
-        # They stay visible until the next step_started resets to 0.00s.
-        self._refresh_status()
+    @property
+    def _status_reps_label(self):
+        return self.pane._status_reps_label
 
-    def _on_error(self, msg):
-        """protocol_error → reset to idle and show a styled error dialog.
-        Repeat state is cleared so a half-finished run doesn't auto-rerun."""
-        self._repeats_total = 0
-        self._repeats_completed = 0
-        self._update_repeat_status_label()
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        error_dialog(parent=self, title="Protocol error", message=str(msg))
+    @property
+    def _status_phase_time_label(self):
+        return self.pane._status_phase_time_label
 
-    def _refresh_status(self):
-        if self._step_started_at is None:
-            return
-        step_elapsed = time.monotonic() - self._step_started_at
-        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
-        if self._status_phase_time_label is not None:
-            phase_elapsed = (
-                0.0 if self._phase_started_at is None
-                else time.monotonic() - self._phase_started_at
-            )
-            target = self._phase_target if self._phase_target is not None else 0.0
-            self._status_phase_time_label.setText(
-                f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
-            )
+    @property
+    def _tick_timer(self):
+        return self.pane._tick_timer
 
-    def _build_toolbar(self):
-        """Top QToolBar holds the Add/Save/Load utility actions; the
-        playback + step-navigation buttons live on the NavigationBar
-        below the toolbar (built next in ``_build_navigation_bar``)."""
-        tb = QToolBar("Protocol")
-        self.addToolBar(tb)
-        tb.addAction("Add Step", lambda: self.manager.add_step())
-        tb.addAction("Add Group", lambda: self.manager.add_group())
-        tb.addSeparator()
-        tb.addAction("Save…", self._save)
-        tb.addAction("Load…", self._load)
-        self._toolbar = tb
+    @property
+    def _step_index(self):
+        return self.pane._step_index
 
-    def _build_navigation_bar(self):
-        """Build the NavigationBar (ported from protocol_grid) and wire
-        each button to the executor / step-cursor navigation. Mounts the
-        bar above the central content (tree or tree+side-panel splitter)."""
-        self.navigation_bar = NavigationBar()
+    @_step_index.setter
+    def _step_index(self, value):
+        self.pane._step_index = value
 
-        # Playback.
-        self.navigation_bar.btn_play.clicked.connect(self._on_play_clicked)
-        self.navigation_bar.btn_resume.clicked.connect(self._toggle_pause)
-        self.navigation_bar.btn_stop.clicked.connect(self.executor.stop)
-        # Preview Mode is a persistent toggle on the play dropdown —
-        # the Run click reads it via is_preview_mode(); no extra
-        # signal wiring needed here.
+    @property
+    def _step_total(self):
+        return self.pane._step_total
 
-        # Step navigation (cursor only — no protocol mutation).
-        self.navigation_bar.btn_first.clicked.connect(self._navigate_to_first_step)
-        self.navigation_bar.btn_prev.clicked.connect(self._navigate_to_previous_step)
-        self.navigation_bar.btn_next.clicked.connect(self._navigate_to_next_step)
-        self.navigation_bar.btn_last.clicked.connect(self._navigate_to_last_step)
+    @_step_total.setter
+    def _step_total(self, value):
+        self.pane._step_total = value
 
-        # Phase navigation — only useful while the protocol is paused
-        # mid-step. The handlers compute the paused step's phase list
-        # locally (no coordination with the worker thread) and publish
-        # ELECTRODES_STATE_CHANGE for the requested phase so the
-        # visualizer overlays it; the ``preview`` flag in the payload
-        # keeps the hardware driver from actuating.
-        self.navigation_bar.btn_prev_phase.clicked.connect(self._on_prev_phase)
-        self.navigation_bar.btn_next_phase.clicked.connect(self._on_next_phase)
-        self.navigation_bar.set_phase_navigation_enabled(False, False)
+    @property
+    def _step_started_at(self):
+        return self.pane._step_started_at
 
-        # Wrap navigation bar + status bar + existing central content
-        # in a vertical layout. The status bar (legacy-style) sits
-        # directly under the nav bar, mirroring the old protocol_grid
-        # layout — separator between status and tree only.
-        container = QWidget()
-        layout = QVBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
-        layout.addWidget(self.navigation_bar)
-        layout.addWidget(self.status_bar)
-        layout.addWidget(make_separator())
-        layout.addWidget(self._central_content)
-        self.setCentralWidget(container)
+    @_step_started_at.setter
+    def _step_started_at(self, value):
+        self.pane._step_started_at = value
 
-    def _build_experiment_bar(self):
-        """Populate the navigation bar's left slot with the legacy
-        protocol_grid trio: New Experiment button, Experiment label,
-        New Note button. The buttons are exposed as attributes
-        (``btn_new_exp``, ``btn_new_note``, ``experiment_label``) so
-        external plugins / demo subclasses can connect their own
-        slots; the base provides only stub click handlers that log.
+    @property
+    def _phase_started_at(self):
+        return self.pane._phase_started_at
 
-        ``add_widget_to_left_slot`` reveals the bar's bottom row
-        (hidden by default), so the experiment row appears below
-        the playback buttons.
-        """
-        from microdrop_style.button_styles import ICON_FONT_FAMILY
-        from pyface.qt.QtGui import QFont
-        from pyface.qt.QtWidgets import QToolButton
+    @_phase_started_at.setter
+    def _phase_started_at(self, value):
+        self.pane._phase_started_at = value
 
-        icon_font = QFont(ICON_FONT_FAMILY)
-        icon_font.setPixelSize(20)
+    @property
+    def _current_row(self):
+        return self.pane._current_row
 
-        self.btn_new_exp = QToolButton()
-        self.btn_new_exp.setText("note_add")
-        self.btn_new_exp.setFont(icon_font)
-        self.btn_new_exp.setToolTip("New Experiment")
-        self.btn_new_exp.setCursor(Qt.PointingHandCursor)
-        self.btn_new_exp.clicked.connect(self._on_new_experiment)
-
-        self.experiment_label = QLabel(
-            "<b>Experiment:</b> <i>(not set)</i>"
-        )
-        self.experiment_label.setToolTip("Active experiment")
-        self.experiment_label.setTextInteractionFlags(
-            Qt.TextSelectableByMouse,
-        )
-
-        self.btn_new_note = QToolButton()
-        self.btn_new_note.setText("sticky_note")
-        self.btn_new_note.setFont(icon_font)
-        self.btn_new_note.setToolTip("New Note")
-        self.btn_new_note.setCursor(Qt.PointingHandCursor)
-        self.btn_new_note.clicked.connect(self._on_new_note)
-
-        self.navigation_bar.add_widget_to_left_slot(self.btn_new_exp)
-        self.navigation_bar.add_widget_to_left_slot(self.experiment_label)
-        self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
-
-    def set_experiment_id(self, experiment_id: str):
-        """Update the experiment label text. Demos / plugins call this
-        when the active experiment changes."""
-        self.experiment_label.setText(
-            f"<b>Experiment:</b> {experiment_id}"
-        )
-
-    def _on_new_experiment(self):
-        """Stub — log only. Demo subclasses or plugins should override
-        or reconnect ``btn_new_exp.clicked`` for real behaviour."""
-        logger.info("New Experiment requested")
-
-    def _on_new_note(self):
-        """Stub — log only. Demo subclasses or plugins should override
-        or reconnect ``btn_new_note.clicked`` for real behaviour."""
-        logger.info("New Note requested")
-
-    def _save(self):
-        path, _ = QFileDialog.getSaveFileName(
-            self, "Save Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        try:
-            with open(path, "w", encoding="utf-8") as f:
-                json.dump(self.manager.to_json(), f, indent=2)
-        except Exception as e:
-            error_dialog(parent=self, title="Save error", message=str(e))
-
-    def _load(self):
-        path, _ = QFileDialog.getOpenFileName(
-            self, "Load Protocol", "", "Protocol JSON (*.json)",
-        )
-        if not path:
-            return
-        with open(path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        try:
-            self.manager.set_state_from_json(
-                data, columns=self.config.columns_factory(),
-            )
-        except Exception as e:
-            error_dialog(parent=self, title="Load error", message=str(e))
-
-    def _wire_button_state_machine(self):
-        self.executor.qsignals.protocol_started.connect(self._set_running_button_state)
-        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
-        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
-        # Split protocol_finished from protocol_aborted so the auto-repeat
-        # logic only fires on natural completion (not user Stop).
-        self.executor.qsignals.protocol_finished.connect(self._on_protocol_finished)
-        self.executor.qsignals.protocol_aborted.connect(self._on_protocol_aborted)
-
-    def _set_idle_button_state(self):
-        nb = self.navigation_bar
-        nb.btn_play.setEnabled(True)
-        nb.show_play_state()
-        nb.btn_stop.setEnabled(False)
-        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
-            btn.setEnabled(True)
-        # Re-enable the Preview-Mode toggle on the play dropdown.
-        nb.action_preview.setEnabled(True)
-
-    def _set_running_button_state(self):
-        nb = self.navigation_bar
-        nb.btn_play.setEnabled(True)         # acts as Pause while running
-        nb.show_pause_state()
-        nb.btn_stop.setEnabled(True)
-        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
-            btn.setEnabled(False)
-        # Mode is locked once a run is in progress — don't let the
-        # user re-arm Preview mid-run.
-        nb.action_preview.setEnabled(False)
-
-    def _on_play_clicked(self):
-        """While idle: start the protocol from the currently-selected
-        step (or from the beginning if nothing is selected), reading
-        Preview / Droplet Check state from the play dropdown.
-        While running/paused: toggle pause. Mirrors the legacy
-        protocol_grid play-button behaviour."""
-        if self._is_protocol_active():
-            self._toggle_pause()
-            return
-        self._start_protocol_run(
-            preview_mode=self.navigation_bar.is_preview_mode(),
-        )
-
-    def _start_protocol_run(self, preview_mode: bool):
-        """Common entry point for both Run and Preview: prime the repeat
-        counter, remember the chosen mode for auto-repeat continuations,
-        then start the executor."""
-        self._repeats_total = self.status_bar.edit_repeat_protocol.value()
-        self._repeats_completed = 0
-        self._current_run_preview_mode = preview_mode
-        self._update_repeat_status_label()
-        self.executor.start(
-            start_step_path=self._selected_step_path(),
-            preview_mode=preview_mode,
-        )
-
-    def _update_repeat_status_label(self):
-        """Reflect the current repeat counter into 'X/' (the X in
-        'X/<total>' shown on the status bar)."""
-        self.status_bar.lbl_repeat_protocol_status.setText(
-            f"{self._repeats_completed}/"
-        )
-
-    def _selected_step_path(self):
-        """Return the path tuple of the currently-selected row, but only
-        if it's a step row that actually appears in execution order;
-        else None (which causes the executor to start from the
-        beginning)."""
-        idx = self.widget.tree.currentIndex()
-        if not idx.isValid():
-            return None
-        path = self.widget._index_to_path(idx)
-        for row in self.manager.iter_execution_steps():
-            if tuple(row.path) == path:
-                return path
-        return None
-
-    def _is_protocol_active(self):
-        """True iff the executor is currently running or paused. The
-        Stop button's enabled state tracks this exactly (via the
-        protocol_started / protocol_finished / protocol_aborted signal
-        chain), so use it as the source of truth."""
-        return self.navigation_bar.btn_stop.isEnabled()
-
-    def _toggle_pause(self):
-        if self.executor.pause_event.is_set():
-            self.executor.resume()
-        else:
-            self.executor.pause()
-
-    def _on_protocol_paused(self):
-        self.navigation_bar.show_resume_state()
-        self._tick_timer.stop()
-        # Swap to the prev / resume / next-phase trio so the user can
-        # explore the paused row's phases visually. Computed locally —
-        # the worker thread's iter_phases position isn't reachable
-        # from the GUI thread without thread-safe shared state.
-        if self._current_row is not None:
-            self._compute_pause_phase_state(self._current_row)
-            self.navigation_bar.split_play_button_to_phase_controls()
-            self._update_phase_nav_buttons()
-
-    def _on_protocol_resumed(self):
-        self.navigation_bar.show_pause_state()
-        if self._current_row is not None:
-            self._tick_timer.start()
-        # Restore the unified play button.
-        self.navigation_bar.merge_phase_controls_to_play_button()
-
-    def _on_protocol_finished(self):
-        """Natural completion. Bump the repeat counter; if more reps
-        remain, re-queue executor.start() on the next event-loop tick
-        (the worker thread emits protocol_finished from inside its
-        finally block — calling start() now would no-op against
-        ``_thread.is_alive()``)."""
-        self._repeats_completed += 1
-        self._update_repeat_status_label()
-        if self._repeats_completed < self._repeats_total:
-            QTimer.singleShot(50, self._restart_for_next_rep)
-            return
-        self._on_protocol_terminated()
-
-    def _restart_for_next_rep(self):
-        # Each repeat runs the protocol from the beginning — start_step_path
-        # is intentionally None. Carry the original Run/Preview mode forward.
-        self.executor.start(preview_mode=self._current_run_preview_mode)
-
-    def _on_protocol_aborted(self):
-        """User pressed Stop. Clear the repeat state (no auto-restart)."""
-        self._repeats_total = 0
-        self._repeats_completed = 0
-        self._update_repeat_status_label()
-        self._on_protocol_terminated()
+    @_current_row.setter
+    def _current_row(self, value):
+        self.pane._current_row = value
 
     def _on_protocol_terminated(self):
-        self._clear_all_highlights()
-        self._set_idle_button_state()
-        self._tick_timer.stop()
-        # If the protocol terminated while paused, the play button is
-        # still split into the phase-nav trio — merge it back so the
-        # idle UI is the unified play button again.
-        self.navigation_bar.merge_phase_controls_to_play_button()
-        self._pause_phases = []
-        self._pause_phase_idx = 0
-
-    # --- pause-time phase navigation ------------------------------------
-
-    def _compute_pause_phase_state(self, row):
-        """Build the paused row's phase list locally so prev/next phase
-        can step through it without touching the worker thread. Index
-        starts at 0 — we don't know the worker's actual phase position,
-        so the user explores from the start of the step."""
-        from pluggable_protocol_tree.services.phase_math import iter_phases
-        try:
-            self._pause_phases = list(iter_phases(
-                static_electrodes=list(getattr(row, "electrodes", []) or []),
-                routes=list(getattr(row, "routes", []) or []),
-                trail_length=int(getattr(row, "trail_length", 1)),
-                trail_overlay=int(getattr(row, "trail_overlay", 0)),
-                soft_start=bool(getattr(row, "soft_start", False)),
-                soft_end=bool(getattr(row, "soft_end", False)),
-                repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
-                linear_repeats=bool(getattr(row, "linear_repeats", False)),
-                n_repeats=int(getattr(row, "repetitions", 1)),
-                step_duration_s=float(getattr(row, "duration_s", 1.0)),
-            ))
-        except Exception as e:
-            logger.warning(f"phase navigation: iter_phases failed: {e}")
-            self._pause_phases = []
-        self._pause_phase_idx = 0
-
-    def _on_prev_phase(self):
-        if self._pause_phases and self._pause_phase_idx > 0:
-            self._pause_phase_idx -= 1
-            self._publish_paused_phase()
-            self._update_phase_nav_buttons()
-
-    def _on_next_phase(self):
-        if (self._pause_phases
-                and self._pause_phase_idx < len(self._pause_phases) - 1):
-            self._pause_phase_idx += 1
-            self._publish_paused_phase()
-            self._update_phase_nav_buttons()
-
-    def _publish_paused_phase(self):
-        """Publish ELECTRODES_STATE_CHANGE for the currently-pointed
-        phase so the device viewer overlays it. The ``preview`` flag
-        on the payload mirrors the current run's mode — pause-time
-        phase navigation during a real Run actuates hardware just like
-        the route playback would have; during a Preview run it stays
-        gated."""
-        from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
-
-        if not self._pause_phases:
-            return
-        phase = self._pause_phases[self._pause_phase_idx]
-        mapping = self.manager.protocol_metadata.get(
-            "electrode_to_channel", {},
-        )
-        electrodes = sorted(phase)
-        channels = sorted(mapping[e] for e in electrodes if e in mapping)
-        payload = {
-            "electrodes": electrodes,
-            "channels": channels,
-        }
-        if self._current_run_preview_mode:
-            payload["preview"] = True
-        try:
-            publish_message(
-                topic=ELECTRODES_STATE_CHANGE,
-                message=json.dumps(payload),
-            )
-        except Exception as e:
-            logger.warning(f"phase navigation publish failed: {e}")
-
-    def _update_phase_nav_buttons(self):
-        prev_enabled = self._pause_phase_idx > 0
-        next_enabled = (
-            bool(self._pause_phases)
-            and self._pause_phase_idx < len(self._pause_phases) - 1
-        )
-        self.navigation_bar.set_phase_navigation_enabled(
-            prev_enabled, next_enabled,
-        )
-
-    # --- step-cursor navigation ----------------------------------------
-
-    def _navigate_to_first_step(self):
-        steps = list(self.manager.iter_execution_steps())
-        if steps:
-            self._select_step(steps[0])
-
-    def _navigate_to_last_step(self):
-        steps = list(self.manager.iter_execution_steps())
-        if steps:
-            self._select_step(steps[-1])
-
-    def _navigate_to_previous_step(self):
-        steps = list(self.manager.iter_execution_steps())
-        if not steps:
-            return
-        cur = self._current_step_in(steps)
-        if cur is None:
-            self._select_step(steps[0])
-            return
-        if cur > 0:
-            self._select_step(steps[cur - 1])
-
-    def _navigate_to_next_step(self):
-        steps = list(self.manager.iter_execution_steps())
-        if not steps:
-            return
-        cur = self._current_step_in(steps)
-        if cur is None:
-            self._select_step(steps[0])
-            return
-        if cur < len(steps) - 1:
-            self._select_step(steps[cur + 1])
-            return
-        # At end of execution order — clone the currently-selected step
-        # and insert it after, at the same parent level. Mirrors the
-        # legacy protocol_grid Next-button behaviour where pressing
-        # Next at the end of the protocol creates a new step.
-        self._duplicate_step_after(steps[cur])
-
-    def _duplicate_step_after(self, row):
-        """Insert a copy of ``row`` immediately after it under the same
-        parent. Column values are read off the source row via each
-        column's model.col_id and round-tripped through the same
-        add_step API the toolbar uses."""
-        path = tuple(row.path)
-        parent_path = path[:-1]
-        insert_idx = path[-1] + 1
-        values = {}
-        for col in self.manager.columns:
-            cid = col.model.col_id
-            if hasattr(row, cid):
-                values[cid] = getattr(row, cid)
-        new_path = self.manager.add_step(
-            parent_path=parent_path, index=insert_idx, values=values,
-        )
-        new_row = self.manager.get_row(new_path)
-        self._select_step(new_row)
-
-    def _current_step_in(self, steps):
-        """Index of the tree's current row inside ``steps``, or None if
-        the current row isn't a step (e.g. a group is selected)."""
-        idx = self.widget.tree.currentIndex()
-        if not idx.isValid():
-            return None
-        # Walk the QModelIndex chain back to a path tuple.
-        path = self.widget._index_to_path(idx)
-        for i, row in enumerate(steps):
-            if tuple(row.path) == path:
-                return i
-        return None
-
-    def _select_step(self, row):
-        idx = self.widget._node_to_index(row)
-        if not idx.isValid():
-            return
-        # Expand any collapsed ancestor groups so the row is visible.
-        parent = idx.parent()
-        while parent.isValid():
-            self.widget.tree.expand(parent)
-            parent = parent.parent()
-        self.widget.tree.setCurrentIndex(idx)
-        self.widget.tree.scrollTo(idx)
-
-    def _clear_all_highlights(self):
-        """Restore an idle visual state at protocol end."""
-        self.widget.highlight_active_row(None)
-        self.widget.tree.clearSelection()
-        self.widget.tree.setCurrentIndex(QModelIndex())
-
-        # Reset step / row / timer state.
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None
-        self._phase_started_at = None
-        self._phase_target = None
-        self._current_row = None
-        # Reset to the StatusBar widget's initial label texts so the
-        # idle visual state matches a freshly-constructed window.
-        self._status_step_label.setText("Step 0/0")
-        self._status_step_time_label.setText("Step Time: 0 s")
-        self._status_reps_label.setText("Repetition 0/0")
-        # _on_step_repetition may have hidden this slot during the run;
-        # restore visibility for the idle layout.
-        self._status_reps_label.setVisible(True)
-        self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
-        self.status_bar.lbl_next_step.setText("Next Step: -")
-        if self._status_phase_time_label is not None:
-            self._status_phase_time_label.setText("Phase 0.00s / 0.00s")
-
-        # Reset readout labels to initial text.
+        """Test hook — calls the pane's terminator + resets demo readouts."""
+        self.pane._on_protocol_terminated()
         for readout in self.config.status_readouts:
             slug = _slug(readout.label)
             label = self._readout_labels.get(slug)
@@ -1115,12 +549,7 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
 
     @classmethod
     def run(cls, config: DemoConfig) -> int:
-        """One-shot main(): build the window, show it, run app.exec().
-        Reuses an existing QApplication if one is already running.
-
-        Calls ``style_app`` so the Material Symbols icon font (used by
-        the NavigationBar buttons) is registered before the window
-        is built — without it the icon glyphs render as boxes."""
+        """One-shot main(): build the window, show it, run app.exec()."""
         from microdrop_style.helpers import style_app
 
         app = QApplication.instance() or QApplication([])

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -41,9 +41,17 @@ class PluggableProtocolTreePlugin(Plugin):
     #: ICompoundColumn instances here. Named with a leading underscore so
     #: tests can inject contributions directly via `contributed_columns`
     #: (a plain List) without needing a full Envisage application registry.
+    #:
+    #: The element type is untyped (plain ``List``) on purpose:
+    #: ``ICompoundColumn`` is parallel to (not a subtype of) ``IColumn``,
+    #: so a typed ``List(Instance(IColumn))`` would raise TraitError
+    #: whenever any plugin contributes a compound column, dropping every
+    #: other contribution along with it. ``_assemble_columns`` dispatches
+    #: on ``isinstance(c, ICompoundColumn)`` to expand compounds and
+    #: keep plain columns as-is.
     _column_extension_point = ExtensionPoint(
-        List(Instance(IColumn)), id=PROTOCOL_COLUMNS,
-        desc="Columns contributed by other plugins",
+        List, id=PROTOCOL_COLUMNS,
+        desc="Columns contributed by other plugins (IColumn or ICompoundColumn).",
     )
 
     #: Plain list — set directly in tests; populated from the extension
@@ -107,8 +115,13 @@ class PluggableProtocolTreePlugin(Plugin):
         # plain contributed_columns list so _assemble_columns sees them.
         try:
             self.contributed_columns = list(self._column_extension_point)
-        except Exception:
-            pass
+        except Exception as e:
+            # Don't swallow silently — a TraitError here used to drop
+            # every contribution from every plugin and surface only as
+            # an empty dock pane. Log it so the developer sees it.
+            logger.warning(
+                f"failed to read PROTOCOL_COLUMNS extension point: {e}"
+            )
         try:
             from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterData
         except ImportError:
@@ -116,15 +129,26 @@ class PluggableProtocolTreePlugin(Plugin):
             # construction must not require Redis; a missing broker is
             # only a problem at the moment a protocol actually runs.
             return
-        topics = sorted({
-            t for c in self._assemble_columns()
-            for t in (c.handler.wait_for_topics or [])
-        })
-        if not topics:
-            return
-        router_data = MessageRouterData()
-        for topic in topics:
-            router_data.add_subscriber_to_topic(
-                topic=topic,
-                subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+        try:
+            topics = sorted({
+                t for c in self._assemble_columns()
+                for t in (c.handler.wait_for_topics or [])
+            })
+            if not topics:
+                return
+            router_data = MessageRouterData()
+            for topic in topics:
+                router_data.add_subscriber_to_topic(
+                    topic=topic,
+                    subscribing_actor_name="pluggable_protocol_tree_executor_listener",
+                )
+        except Exception as e:
+            # Redis briefly unreachable at startup shouldn't block the
+            # plugin from contributing its dock pane. The protocol
+            # itself can't run without Redis but the UI should still
+            # mount so the user gets a meaningful error on play, not
+            # a missing pane.
+            logger.warning(
+                f"failed to wire executor listener subscriptions "
+                f"(Redis unreachable?): {e}"
             )

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -7,7 +7,7 @@ plugin class."""
 
 from envisage.api import ExtensionPoint, Plugin, TASK_EXTENSIONS
 from envisage.ui.tasks.task_extension import TaskExtension
-from traits.api import Instance, List, Str
+from traits.api import List, Str, Either
 
 from microdrop_application.consts import PKG as microdrop_application_PKG
 from message_router.consts import ACTOR_TOPIC_ROUTES
@@ -32,6 +32,9 @@ from pluggable_protocol_tree.interfaces.i_compound_column import ICompoundColumn
 from pluggable_protocol_tree.interfaces.i_column import IColumn
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
 
 class PluggableProtocolTreePlugin(Plugin):
     id = f"{PKG}.plugin"
@@ -50,7 +53,7 @@ class PluggableProtocolTreePlugin(Plugin):
     #: on ``isinstance(c, ICompoundColumn)`` to expand compounds and
     #: keep plain columns as-is.
     _column_extension_point = ExtensionPoint(
-        List, id=PROTOCOL_COLUMNS,
+        List(Either(IColumn, ICompoundColumn)), id=PROTOCOL_COLUMNS,
         desc="Columns contributed by other plugins (IColumn or ICompoundColumn).",
     )
 

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -495,8 +495,8 @@ def test_load_replaces_manager_state(qapp, tmp_path, monkeypatch):
 
 
 def test_window_no_side_panel_uses_tree_as_central(qapp):
-    """When side_panel_factory is None, the inner central content IS the
-    tree (now wrapped in a NavigationBar+content container) and
+    """When side_panel_factory is None, the inner central content IS
+    the pane (which itself wraps the tree + nav + status bars), and
     _side_panel is None."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
@@ -504,7 +504,7 @@ def test_window_no_side_panel_uses_tree_as_central(qapp):
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._central_content is w.widget
+    assert w._central_content is w.pane
     assert w._side_panel is None
 
 
@@ -694,7 +694,11 @@ def test_step_finished_freezes_step_elapsed_label(qapp):
 
 def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
     """protocol_error → idle button state, tick timer stopped, dialog
-    shown via the styled pyface_wrapper.error helper (NOT raw QMessageBox)."""
+    shown via the styled pyface_wrapper.error helper.
+
+    The pane is the owner of the error path now (post-PPT-10.1
+    delegation), so we patch the pane module's error_dialog."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
     import pluggable_protocol_tree.demos.base_demo_window as bdw
     from pluggable_protocol_tree.builtins.type_column import make_type_column
 
@@ -703,18 +707,15 @@ def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
     def fake_error_dialog(parent=None, title="", message="", **kwargs):
         calls.append((title, message))
 
-    monkeypatch.setattr(bdw, "error_dialog", fake_error_dialog)
+    monkeypatch.setattr(ptp, "error_dialog", fake_error_dialog)
 
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = bdw.BasePluggableProtocolDemoWindow(cfg)
     nb = w.navigation_bar
-    # Simulate a running state, then fire the error.
     w.executor.qsignals.protocol_started.emit()
     assert nb.btn_stop.isEnabled()
     w.executor.qsignals.protocol_error.emit("kaboom")
-    # Idle state restored.
     assert nb.btn_play.isEnabled()
     assert not nb.btn_stop.isEnabled()
     assert not w._tick_timer.isActive()
-    # Dialog called via the styled wrapper, with the error message.
     assert calls == [("Protocol error", "kaboom")]

--- a/pluggable_protocol_tree/tests/test_dock_pane.py
+++ b/pluggable_protocol_tree/tests/test_dock_pane.py
@@ -1,0 +1,69 @@
+"""Tests for PluggableProtocolDockPane wiring."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+def _make_dock_pane_with_mocked_app(qapp, columns):
+    """Returns (dock_pane, mock_app, mock_task) — call create_contents
+    after attaching task->window->application chain."""
+    from pyface.tasks.api import Task
+    from pluggable_protocol_tree.views.dock_pane import PluggableProtocolDockPane
+
+    mock_app = MagicMock()
+    mock_app.current_experiment_directory = Path("/tmp/exp-1")
+    mock_window = MagicMock()
+    mock_window.application = mock_app
+    # spec=Task so the strict Instance(Task) trait validator accepts it.
+    mock_task = MagicMock(spec=Task)
+    mock_task.window = mock_window
+
+    dp = PluggableProtocolDockPane(columns=columns)
+    dp.task = mock_task
+    return dp, mock_app, mock_task
+
+
+def test_dock_pane_id_and_name(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    assert dp.id == "pluggable_protocol_tree.dock_pane"
+    assert dp.name == "Protocol (pluggable)"
+
+
+def test_dock_pane_create_contents_returns_protocol_tree_pane(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    contents = dp.create_contents(parent=None)
+    assert isinstance(contents, ProtocolTreePane)
+
+
+def test_dock_pane_constructs_experiment_manager_with_app_dir(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, app, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    with patch(
+        "pluggable_protocol_tree.views.dock_pane.ExperimentManager"
+    ) as ExpMgrClass:
+        dp.create_contents(parent=None)
+    ExpMgrClass.assert_called_once_with(app.current_experiment_directory)
+
+
+def test_dock_pane_constructs_sticky_manager(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, _, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    with patch(
+        "pluggable_protocol_tree.views.dock_pane.StickyWindowManager"
+    ) as StickyClass:
+        dp.create_contents(parent=None)
+    StickyClass.assert_called_once_with()
+
+
+def test_dock_pane_passes_application_into_pane(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    dp, app, _ = _make_dock_pane_with_mocked_app(qapp, [make_type_column()])
+    contents = dp.create_contents(parent=None)
+    assert contents.application is app

--- a/pluggable_protocol_tree/tests/test_experiment_label.py
+++ b/pluggable_protocol_tree/tests/test_experiment_label.py
@@ -1,0 +1,63 @@
+"""Tests for the ported ExperimentLabel widget."""
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtGui import QMouseEvent
+from pyface.qt.QtCore import QPointF
+
+
+def test_label_default_text_when_no_experiment(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    assert "Experiment" in lbl.text()
+
+
+def test_update_experiment_id_renders_id(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    lbl.update_experiment_id("2026-05-08T12-00-00Z")
+    assert "2026-05-08T12-00-00Z" in lbl.text()
+
+
+def test_update_experiment_id_remembers_last_value(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    lbl.update_experiment_id("exp-1")
+    # Calling with None re-renders the last set id (used by theme-change re-style).
+    lbl.update_experiment_id(None)
+    assert "exp-1" in lbl.text()
+
+
+def test_left_click_emits_clicked(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    fired = []
+    lbl.clicked.connect(lambda: fired.append(True))
+    event = QMouseEvent(
+        QMouseEvent.MouseButtonPress, QPointF(0, 0),
+        Qt.LeftButton, Qt.LeftButton, Qt.NoModifier,
+    )
+    lbl.mousePressEvent(event)
+    assert fired == [True]
+
+
+def test_right_click_does_not_emit_clicked(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    fired = []
+    lbl.clicked.connect(lambda: fired.append(True))
+    event = QMouseEvent(
+        QMouseEvent.MouseButtonPress, QPointF(0, 0),
+        Qt.RightButton, Qt.RightButton, Qt.NoModifier,
+    )
+    lbl.mousePressEvent(event)
+    assert fired == []
+
+
+def test_handle_tooltip_toggle_toggles_tooltip(qapp):
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    lbl = ExperimentLabel()
+    assert lbl.toolTip() != ""
+    lbl.handle_tooltip_toggle(False)
+    assert lbl.toolTip() == ""
+    lbl.handle_tooltip_toggle(True)
+    assert lbl.toolTip() != ""

--- a/pluggable_protocol_tree/tests/test_experiment_label.py
+++ b/pluggable_protocol_tree/tests/test_experiment_label.py
@@ -8,7 +8,9 @@ from pyface.qt.QtCore import QPointF
 def test_label_default_text_when_no_experiment(qapp):
     from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
     lbl = ExperimentLabel()
-    assert "Experiment" in lbl.text()
+    text = lbl.text()
+    assert "Experiment" in text
+    assert "None" not in text
 
 
 def test_update_experiment_id_renders_id(qapp):

--- a/pluggable_protocol_tree/tests/test_plugin.py
+++ b/pluggable_protocol_tree/tests/test_plugin.py
@@ -66,3 +66,51 @@ def test_assemble_columns_canonical_order_after_ppt3():
         "trail_length", "trail_overlay", "soft_start", "soft_end",
         "repeat_duration", "linear_repeats",
     ]
+
+
+# --- PPT-10.1.1: contribution mixing regression -----------------------
+
+def test_extension_point_accepts_compound_columns_alongside_plain_columns():
+    """Regression: when one plugin contributes ICompoundColumn and
+    another contributes plain IColumn, the extension point must accept
+    both. Previously the consumer typed _column_extension_point as
+    List(Instance(IColumn)) which raised TraitError on compound-column
+    contributions and silently dropped EVERY contribution from EVERY
+    plugin — including the plain IColumn ones."""
+    from traits.api import HasTraits, Instance, List
+
+    from pluggable_protocol_tree.consts import PROTOCOL_COLUMNS
+    from pluggable_protocol_tree.interfaces.i_column import IColumn
+    from pluggable_protocol_tree.interfaces.i_compound_column import (
+        ICompoundColumn,
+    )
+    from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
+
+    # Sanity: ICompoundColumn does NOT extend IColumn. If this changes
+    # in the future the test below becomes redundant — that's fine.
+    assert not issubclass(ICompoundColumn, IColumn)
+
+    # Synthesize a fake compound column instance + a fake plain column
+    # instance and inject them via the plain `contributed_columns`
+    # trait (the same path Envisage uses after extension-point resolution).
+    from pluggable_protocol_tree.builtins.repetitions_column import (
+        make_repetitions_column,
+    )
+    from pluggable_protocol_tree.demos.enabled_count_compound import (
+        make_enabled_count_compound,
+    )
+
+    p = PluggableProtocolTreePlugin()
+    p.contributed_columns = [
+        make_repetitions_column(),       # IColumn
+        make_enabled_count_compound(),   # ICompoundColumn
+    ]
+
+    cols = p._assemble_columns()
+    ids = [c.model.col_id for c in cols]
+    # Plain IColumn contribution survives.
+    assert ids.count("repetitions") >= 2  # builtin + contributed
+    # Compound column expanded into its field cells.
+    # enabled_count_compound exposes 'ec_enabled' + 'ec_count' fields.
+    assert "ec_enabled" in ids
+    assert "ec_count" in ids

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -205,3 +205,77 @@ def test_pane_protocol_error_resets_to_idle_and_calls_dialog(qapp, monkeypatch):
     assert not pane.navigation_bar.btn_stop.isEnabled()
     assert not pane._tick_timer.isActive()
     assert calls == [("Protocol error", "kaboom")]
+
+
+def test_pane_pause_splits_play_button_into_phase_nav(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = [0]
+        name = "S"
+        duration_s = 1.0
+        electrodes = []
+        routes = []
+        trail_length = 1
+        trail_overlay = 0
+        soft_start = False
+        soft_end = False
+        repeat_duration = 0.0
+        linear_repeats = False
+        repetitions = 1
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._current_row = FakeRow()
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_paused.emit()
+    assert pane.navigation_bar.is_phase_navigation_active()
+
+
+def test_pane_resume_merges_phase_nav_back_to_play_button(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = [0]
+        name = "S"
+        duration_s = 1.0
+        electrodes = []
+        routes = []
+        trail_length = 1
+        trail_overlay = 0
+        soft_start = False
+        soft_end = False
+        repeat_duration = 0.0
+        linear_repeats = False
+        repetitions = 1
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._current_row = FakeRow()
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_paused.emit()
+    assert pane.navigation_bar.is_phase_navigation_active()
+    pane.executor.qsignals.protocol_resumed.emit()
+    assert not pane.navigation_bar.is_phase_navigation_active()
+
+
+def test_pane_phase_nav_publishes_electrodes_state_change(qapp, monkeypatch):
+    """next_phase click publishes ELECTRODES_STATE_CHANGE for the targeted phase."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    captured = []
+
+    def fake_publish(topic, message, **kwargs):
+        captured.append((topic, message))
+
+    monkeypatch.setattr(ptp, "publish_message", fake_publish)
+
+    pane = ptp.ProtocolTreePane([make_type_column()])
+    pane._pause_phases = [{"e1"}, {"e1", "e2"}]
+    pane._pause_phase_idx = 0
+    pane.manager.protocol_metadata["electrode_to_channel"] = {"e1": 1, "e2": 2}
+    pane._on_next_phase()
+    assert captured  # something was published
+    topic, _ = captured[0]
+    assert topic == ptp.ELECTRODES_STATE_CHANGE

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -95,16 +95,25 @@ def test_pane_has_executor_and_pause_event(qapp):
 
 
 def test_pane_executor_factory_can_be_overridden(qapp):
+    """The executor_factory kwarg lets tests substitute the executor.
+    The factory's return value must satisfy the wiring contract — a
+    bare object() would break _wire_executor_signals — so use a
+    MagicMock that exposes the attributes the wiring touches."""
+    from unittest.mock import MagicMock
+
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
 
-    sentinel = object()
+    fake_executor = MagicMock()
+    captured = {}
 
     def fake_factory(row_manager, qsignals, pause_event, stop_event):
-        return sentinel
+        captured["called"] = True
+        return fake_executor
 
     pane = ProtocolTreePane([make_type_column()], executor_factory=fake_factory)
-    assert pane.executor is sentinel
+    assert captured["called"] is True
+    assert pane.executor is fake_executor
 
 
 def test_pane_idle_button_state(qapp):

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -81,3 +81,118 @@ def test_pane_phase_ack_topic_can_be_none(qapp):
     pane = ProtocolTreePane([make_type_column()], phase_ack_topic=None)
     assert pane.phase_ack_topic is None
     assert pane.status_bar.lbl_phase_time.isVisible() is False
+
+
+def test_pane_has_executor_and_pause_event(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.executor, ProtocolExecutor)
+    assert pane.executor.pause_event is not None
+    assert pane.executor.stop_event is not None
+
+
+def test_pane_executor_factory_can_be_overridden(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    sentinel = object()
+
+    def fake_factory(row_manager, qsignals, pause_event, stop_event):
+        return sentinel
+
+    pane = ProtocolTreePane([make_type_column()], executor_factory=fake_factory)
+    assert pane.executor is sentinel
+
+
+def test_pane_idle_button_state(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    nb = pane.navigation_bar
+    assert nb.btn_play.isEnabled()
+    assert not nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert btn.isEnabled()
+
+
+def test_pane_running_button_state_after_protocol_started(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    nb = pane.navigation_bar
+    assert nb.btn_stop.isEnabled()
+    for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+        assert not btn.isEnabled()
+
+
+def test_pane_returns_to_idle_after_protocol_finished(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    pane.executor.qsignals.protocol_finished.emit()
+    nb = pane.navigation_bar
+    assert not nb.btn_stop.isEnabled()
+
+
+def test_pane_step_started_updates_status_label(qapp):
+    """Emitting step_started increments the step counter label."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeRow:
+        path = []
+        name = "Step A"
+        duration_s = 0.0
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane._step_total = 3
+    pane.executor.qsignals.step_started.emit(FakeRow())
+    assert pane._status_step_label.text() == "Step 1 / 3"
+
+
+def test_pane_tick_timer_runs_at_10_hz(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane._tick_timer.interval() == 100
+
+
+def test_pane_phase_acked_signal_resets_phase_timer(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()], phase_ack_topic="x/applied")
+    pane._current_row = object()
+    pane._step_started_at = None
+    pane.phase_acked.emit()
+    assert pane._phase_started_at is not None
+    assert pane._step_started_at is not None
+
+
+def test_pane_protocol_error_resets_to_idle_and_calls_dialog(qapp, monkeypatch):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    calls = []
+
+    def fake_error_dialog(parent=None, title="", message="", **kwargs):
+        calls.append((title, message))
+
+    monkeypatch.setattr(ptp, "error_dialog", fake_error_dialog)
+
+    pane = ptp.ProtocolTreePane([make_type_column()])
+    pane.executor.qsignals.protocol_started.emit()
+    assert pane.navigation_bar.btn_stop.isEnabled()
+    pane.executor.qsignals.protocol_error.emit("kaboom")
+    assert not pane.navigation_bar.btn_stop.isEnabled()
+    assert not pane._tick_timer.isActive()
+    assert calls == [("Protocol error", "kaboom")]

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -279,3 +279,68 @@ def test_pane_phase_nav_publishes_electrodes_state_change(qapp, monkeypatch):
     assert captured  # something was published
     topic, _ = captured[0]
     assert topic == ptp.ELECTRODES_STATE_CHANGE
+
+
+def test_pane_navigate_to_first_step_selects_first_row(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "A", "duration_s": 0.1})
+    pane.manager.add_step(values={"name": "B", "duration_s": 0.1})
+    pane.navigate_to_first_step()
+    idx = pane.widget.tree.currentIndex()
+    assert idx.isValid()
+
+
+def test_pane_navigate_to_next_at_end_duplicates_step(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "A", "duration_s": 0.1})
+    pane.navigate_to_last_step()
+    pane.navigate_to_next_step()
+    assert len(pane.manager.root.children) == 2
+
+
+def test_pane_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
+    from pyface.qt.QtWidgets import QFileDialog
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    import json
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(),
+    ])
+    pane.manager.add_step(values={"name": "S1", "duration_s": 0.1})
+
+    save_path = tmp_path / "out.json"
+    monkeypatch.setattr(QFileDialog, "getSaveFileName",
+                        lambda *a, **kw: (str(save_path), ""))
+    pane.save_to_dialog()
+    payload = json.loads(save_path.read_text())
+    assert payload["columns"][0]["id"] == "type"

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -505,3 +505,43 @@ def test_pane_real_mode_new_experiment_updates_label_via_observer(qapp):
     pane.btn_new_exp.click()
     assert app.current_experiment_directory == new_dir
     assert "2026-05-08T13-37-00Z" in pane.experiment_label.text()
+
+
+def test_pane_closeEvent_detaches_experiment_changed_observer(qapp):
+    """After closeEvent, the experiment_changed observer is unsubscribed
+    so a subsequent fire doesn't dispatch to a deleted widget."""
+    from pathlib import Path
+
+    from traits.api import Directory, Event, HasTraits, Property
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeApp(HasTraits):
+        current_experiment_directory = Property(Directory)
+        experiment_changed = Event()
+        _value = Path("/tmp/initial")
+
+        def _get_current_experiment_directory(self):
+            return self._value
+
+        def _set_current_experiment_directory(self, value):
+            self._value = Path(value)
+            self.experiment_changed = True
+
+    app = FakeApp()
+    pane = ProtocolTreePane([make_type_column()], application=app)
+
+    # Verify observer is wired pre-close.
+    app.current_experiment_directory = "/tmp/before-close"
+    assert "before-close" in pane.experiment_label.text()
+
+    # Trigger close — observer must detach.
+    from pyface.qt.QtGui import QCloseEvent
+    pane.closeEvent(QCloseEvent())
+
+    # Now firing should NOT update the label any more.
+    pane.experiment_label.update_experiment_id("sentinel")
+    app.current_experiment_directory = "/tmp/after-close"
+    assert "after-close" not in pane.experiment_label.text()
+    assert "sentinel" in pane.experiment_label.text()

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -466,3 +466,42 @@ def test_pane_observes_experiment_changed_event_to_update_label(qapp):
     pane = ProtocolTreePane([make_type_column()], application=app)
     app.current_experiment_directory = "/tmp/2026-05-08T12-00-00Z"
     assert "2026-05-08T12-00-00Z" in pane.experiment_label.text()
+
+
+def test_pane_real_mode_new_experiment_updates_label_via_observer(qapp):
+    """Clicking New Experiment with a real Traits-backed application
+    triggers the experiment_changed observer, which updates the label
+    — no explicit label update needed in the click handler."""
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from traits.api import Directory, Event, HasTraits, Property
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeApp(HasTraits):
+        current_experiment_directory = Property(Directory)
+        experiment_changed = Event()
+        _value = Path("/tmp/initial")
+
+        def _get_current_experiment_directory(self):
+            return self._value
+
+        def _set_current_experiment_directory(self, value):
+            self._value = Path(value)
+            self.experiment_changed = True
+
+    app = FakeApp()
+    new_dir = Path("/tmp/2026-05-08T13-37-00Z")
+    exp_mgr = MagicMock()
+    exp_mgr.initialize_new_experiment.return_value = new_dir
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        application=app,
+        experiment_manager=exp_mgr,
+    )
+    pane.btn_new_exp.click()
+    assert app.current_experiment_directory == new_dir
+    assert "2026-05-08T13-37-00Z" in pane.experiment_label.text()

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -344,3 +344,125 @@ def test_pane_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
     pane.save_to_dialog()
     payload = json.loads(save_path.read_text())
     assert payload["columns"][0]["id"] == "type"
+
+
+def test_pane_stub_mode_buttons_log_only(qapp):
+    """Without injected services, button clicks log and never raise."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    pane.btn_new_exp.click()
+    pane.btn_new_note.click()
+    pane.experiment_label.clicked.emit()
+
+
+def test_pane_real_mode_new_experiment_calls_service(qapp):
+    """With an experiment_manager + application, New Experiment dispatches."""
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    new_dir = Path("/tmp/new-exp-id")
+    exp_mgr = MagicMock()
+    exp_mgr.initialize_new_experiment.return_value = new_dir
+    exp_mgr.get_experiment_directory.return_value = new_dir
+
+    app = MagicMock()
+    app.current_experiment_directory = Path("/tmp/old-exp-id")
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        application=app,
+        experiment_manager=exp_mgr,
+    )
+    pane.btn_new_exp.click()
+    exp_mgr.initialize_new_experiment.assert_called_once()
+    assert app.current_experiment_directory == new_dir
+
+
+def test_pane_real_mode_new_experiment_returning_none_does_not_overwrite(qapp):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    exp_mgr = MagicMock()
+    exp_mgr.initialize_new_experiment.return_value = None
+    app = MagicMock()
+    app.current_experiment_directory = Path("/tmp/old-exp-id")
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        application=app,
+        experiment_manager=exp_mgr,
+    )
+    pane.btn_new_exp.click()
+    assert app.current_experiment_directory == Path("/tmp/old-exp-id")
+
+
+def test_pane_real_mode_new_note_calls_sticky_manager(qapp):
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    base_dir = Path("/tmp/exp-1")
+    exp_mgr = MagicMock()
+    exp_mgr.get_experiment_directory.return_value = base_dir
+    sticky_mgr = MagicMock()
+
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        experiment_manager=exp_mgr,
+        sticky_manager=sticky_mgr,
+    )
+    pane.btn_new_note.click()
+    sticky_mgr.request_new_note.assert_called_once_with(base_dir, "exp-1")
+
+
+def test_pane_real_mode_label_click_opens_experiment_directory(qapp):
+    from unittest.mock import MagicMock
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    exp_mgr = MagicMock()
+    pane = ProtocolTreePane(
+        [make_type_column()],
+        experiment_manager=exp_mgr,
+    )
+    pane.experiment_label.clicked.emit()
+    exp_mgr.open_experiment_directory.assert_called_once()
+
+
+def test_pane_observes_experiment_changed_event_to_update_label(qapp):
+    """When application.experiment_changed fires, the label re-reads
+    application.current_experiment_directory and updates."""
+    from pathlib import Path
+
+    from traits.api import Directory, Event, HasTraits, Property
+
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    class FakeApp(HasTraits):
+        current_experiment_directory = Property(Directory)
+        experiment_changed = Event()
+        _value = Path("/tmp/initial")
+
+        def _get_current_experiment_directory(self):
+            return self._value
+
+        def _set_current_experiment_directory(self, value):
+            self._value = Path(value)
+            self.experiment_changed = True
+
+    app = FakeApp()
+    pane = ProtocolTreePane([make_type_column()], application=app)
+    app.current_experiment_directory = "/tmp/2026-05-08T12-00-00Z"
+    assert "2026-05-08T12-00-00Z" in pane.experiment_label.text()

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1,0 +1,83 @@
+"""Tests for ProtocolTreePane — the reusable host widget for the
+pluggable protocol tree's full UX (navigation, status, experiment
+bar, executor, button state machine)."""
+
+
+def test_pane_constructs_with_columns_list(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.id_column import make_id_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([
+        make_type_column(), make_id_column(), make_name_column(),
+    ])
+    assert pane.manager is not None
+    ids = [c.model.col_id for c in pane.manager.columns]
+    assert ids == ["type", "id", "name"]
+
+
+def test_pane_constructs_with_existing_manager(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.models.row_manager import RowManager
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    rm = RowManager(columns=[make_type_column()])
+    pane = ProtocolTreePane(rm)
+    assert pane.manager is rm
+
+
+def test_pane_has_tree_widget(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.widget, ProtocolTreeWidget)
+
+
+def test_pane_has_navigation_bar_with_play_button(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.navigation_bar is not None
+    assert pane.navigation_bar.btn_play is not None
+
+
+def test_pane_has_status_bar(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.status_bar is not None
+    assert pane.status_bar.lbl_step_progress.text() == "Step 0/0"
+
+
+def test_pane_has_experiment_bar_widgets(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.btn_new_exp is not None
+    assert pane.btn_new_note is not None
+    assert isinstance(pane.experiment_label, ExperimentLabel)
+
+
+def test_pane_phase_ack_topic_default_is_electrodes_state_applied(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert pane.phase_ack_topic == ELECTRODES_STATE_APPLIED
+
+
+def test_pane_phase_ack_topic_can_be_none(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    pane = ProtocolTreePane([make_type_column()], phase_ack_topic=None)
+    assert pane.phase_ack_topic is None
+    assert pane.status_bar.lbl_phase_time.isVisible() is False

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -1,22 +1,39 @@
-"""Pyface TaskPane hosting ProtocolTreeWidget.
+"""Pyface TaskPane hosting ProtocolTreePane.
 
-Receives its column set from the plugin on construction."""
+Receives its column set from the plugin on construction and constructs
+the experiment + sticky-note services from the live Envisage
+application so the experiment-bar buttons drive real handlers."""
 
 from pyface.tasks.api import TraitsDockPane
 from traits.api import Instance, List, Str
 
+from microdrop_utils.sticky_notes import StickyWindowManager
+from protocol_grid.services.experiment_manager import ExperimentManager
+
 from pluggable_protocol_tree.interfaces.i_column import IColumn
-from pluggable_protocol_tree.models.row_manager import RowManager
 
 
 class PluggableProtocolDockPane(TraitsDockPane):
     id = "pluggable_protocol_tree.dock_pane"
-    name = "Protocol"
+    name = Str("Protocol (pluggable)")
 
     columns = List(Instance(IColumn))
-    manager = Instance(RowManager)
 
     def create_contents(self, parent):
-        from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
-        self.manager = RowManager(columns=self.columns)
-        return ProtocolTreeWidget(self.manager, parent=parent)
+        # Local import to avoid pulling Qt at plugin-import time —
+        # ProtocolTreePane imports PySide6 widgets eagerly.
+        from pluggable_protocol_tree.views.protocol_tree_pane import (
+            ProtocolTreePane,
+        )
+
+        app = self.task.window.application
+        experiment_manager = ExperimentManager(app.current_experiment_directory)
+        sticky_manager = StickyWindowManager()
+
+        return ProtocolTreePane(
+            list(self.columns),
+            application=app,
+            experiment_manager=experiment_manager,
+            sticky_manager=sticky_manager,
+            parent=parent,
+        )

--- a/pluggable_protocol_tree/views/experiment_label.py
+++ b/pluggable_protocol_tree/views/experiment_label.py
@@ -56,7 +56,9 @@ class ExperimentLabel(QLabel):
     def update_experiment_id(self, experiment_id=None):
         if experiment_id is None:
             experiment_id = self._experiment_id
-
+        if experiment_id is None:
+            self.setText("<b>Experiment: </b>")
+            return
         link_color = "#82B1FF" if is_dark_mode() else "#0066CC"
         self.setText(
             f"<b>Experiment: </b> "

--- a/pluggable_protocol_tree/views/experiment_label.py
+++ b/pluggable_protocol_tree/views/experiment_label.py
@@ -1,0 +1,75 @@
+"""Clickable, theme-aware experiment label.
+
+Ported from ``protocol_grid/extra_ui_elements.py`` ``ExperimentLabel``
+(legacy). Stays in pluggable_protocol_tree so PPT-9 can delete
+protocol_grid without breaking the new dock pane.
+"""
+
+from pyface.qt.QtCore import Qt, Signal
+from pyface.qt.QtGui import QAction, QContextMenuEvent
+from pyface.qt.QtWidgets import QApplication, QLabel, QMenu
+
+from microdrop_style.helpers import is_dark_mode
+
+
+class ExperimentLabel(QLabel):
+    """QLabel that emits ``clicked`` on left-click and renders the
+    active experiment id with a theme-aware link colour. Right-click
+    opens a context menu with an Enable Tooltip toggle."""
+
+    clicked = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setText("<b>Experiment: </b>")
+        self.setToolTip("Active Experiment (Click to open folder)")
+        self.setCursor(Qt.PointingHandCursor)
+
+        self._experiment_id = None
+        self._tooltip_visible = True
+
+        self.apply_styling()
+        QApplication.styleHints().colorSchemeChanged.connect(self.apply_styling)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self.clicked.emit()
+            event.accept()
+        else:
+            super().mousePressEvent(event)
+
+    def handle_tooltip_toggle(self, checked):
+        self._tooltip_visible = checked
+        if checked:
+            self.setToolTip("Active Experiment (Click to open folder)")
+        else:
+            self.setToolTip("")
+
+    def contextMenuEvent(self, event: QContextMenuEvent):
+        menu = QMenu(self)
+        action = QAction("Enable Tooltip", checkable=True,
+                         checked=self._tooltip_visible)
+        action.triggered.connect(self.handle_tooltip_toggle)
+        menu.addAction(action)
+        menu.exec(event.globalPos())
+
+    def update_experiment_id(self, experiment_id=None):
+        if experiment_id is None:
+            experiment_id = self._experiment_id
+
+        link_color = "#82B1FF" if is_dark_mode() else "#0066CC"
+        self.setText(
+            f"<b>Experiment: </b> "
+            f"<span style='text-decoration: underline; color: {link_color};'>"
+            f"{experiment_id}</span>"
+        )
+        self._experiment_id = experiment_id
+
+    def apply_styling(self):
+        text_color = "#f0f0f0" if is_dark_mode() else "#333333"
+        hover_bg = "#3a3a3a" if is_dark_mode() else "#e0e0e0"
+        self.setStyleSheet(
+            f"QLabel {{ color: {text_color}; border: none; }}"
+            f"QLabel:hover {{ background-color: {hover_bg}; }}"
+        )
+        self.update_experiment_id()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -26,7 +26,14 @@ from pyface.qt.QtWidgets import (
 from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
 from microdrop_style.button_styles import ICON_FONT_FAMILY
 
-from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+import json
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+
+from pluggable_protocol_tree.consts import (
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+)
+from pluggable_protocol_tree.services.phase_math import iter_phases
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
@@ -95,6 +102,8 @@ class ProtocolTreePane(QWidget):
         self._repeats_total = 1
         self._repeats_completed = 0
         self._current_run_preview_mode = False
+        self._pause_phases: list = []
+        self._pause_phase_idx: int = 0
 
         self._status_step_label = self.status_bar.lbl_step_progress
         self._status_step_time_label = self.status_bar.lbl_step_time
@@ -200,6 +209,9 @@ class ProtocolTreePane(QWidget):
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)
         nb.btn_stop.clicked.connect(self.executor.stop)
+        nb.btn_prev_phase.clicked.connect(self._on_prev_phase)
+        nb.btn_next_phase.clicked.connect(self._on_next_phase)
+        nb.set_phase_navigation_enabled(False, False)
 
     # --- step lifecycle handlers --------------------------------------
 
@@ -349,11 +361,16 @@ class ProtocolTreePane(QWidget):
     def _on_protocol_paused(self):
         self.navigation_bar.show_resume_state()
         self._tick_timer.stop()
+        if self._current_row is not None:
+            self._compute_pause_phase_state(self._current_row)
+            self.navigation_bar.split_play_button_to_phase_controls()
+            self._update_phase_nav_buttons()
 
     def _on_protocol_resumed(self):
         self.navigation_bar.show_pause_state()
         if self._current_row is not None:
             self._tick_timer.start()
+        self.navigation_bar.merge_phase_controls_to_play_button()
 
     def _on_protocol_finished(self):
         self._repeats_completed += 1
@@ -375,6 +392,73 @@ class ProtocolTreePane(QWidget):
     def _on_protocol_terminated(self):
         self._set_idle_button_state()
         self._tick_timer.stop()
+        self.navigation_bar.merge_phase_controls_to_play_button()
+        self._pause_phases = []
+        self._pause_phase_idx = 0
+
+    # --- pause-time phase navigation ---------------------------------
+
+    def _compute_pause_phase_state(self, row):
+        try:
+            self._pause_phases = list(iter_phases(
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)),
+                soft_end=bool(getattr(row, "soft_end", False)),
+                repeat_duration_s=float(getattr(row, "repeat_duration", 0.0)),
+                linear_repeats=bool(getattr(row, "linear_repeats", False)),
+                n_repeats=int(getattr(row, "repetitions", 1)),
+                step_duration_s=float(getattr(row, "duration_s", 1.0)),
+            ))
+        except Exception as e:
+            logger.warning(f"phase navigation: iter_phases failed: {e}")
+            self._pause_phases = []
+        self._pause_phase_idx = 0
+
+    def _on_prev_phase(self):
+        if self._pause_phases and self._pause_phase_idx > 0:
+            self._pause_phase_idx -= 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _on_next_phase(self):
+        if (self._pause_phases
+                and self._pause_phase_idx < len(self._pause_phases) - 1):
+            self._pause_phase_idx += 1
+            self._publish_paused_phase()
+            self._update_phase_nav_buttons()
+
+    def _publish_paused_phase(self):
+        if not self._pause_phases:
+            return
+        phase = self._pause_phases[self._pause_phase_idx]
+        mapping = self.manager.protocol_metadata.get(
+            "electrode_to_channel", {},
+        )
+        electrodes = sorted(phase)
+        channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        payload = {"electrodes": electrodes, "channels": channels}
+        if self._current_run_preview_mode:
+            payload["preview"] = True
+        try:
+            publish_message(
+                topic=ELECTRODES_STATE_CHANGE,
+                message=json.dumps(payload),
+            )
+        except Exception as e:
+            logger.warning(f"phase navigation publish failed: {e}")
+
+    def _update_phase_nav_buttons(self):
+        prev_enabled = self._pause_phase_idx > 0
+        next_enabled = (
+            bool(self._pause_phases)
+            and self._pause_phase_idx < len(self._pause_phases) - 1
+        )
+        self.navigation_bar.set_phase_navigation_enabled(
+            prev_enabled, next_enabled,
+        )
 
     # --- experiment-bar stubs (Task 6 wires real services) -------------
 

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -14,15 +14,22 @@ PPT-10.1 for the full wiring rules.
 
 from __future__ import annotations
 
-from pyface.qt.QtCore import Qt, Signal
+import threading
+import time
+
+from pyface.qt.QtCore import Qt, QTimer, Signal
 from pyface.qt.QtGui import QFont
 from pyface.qt.QtWidgets import (
-    QToolButton, QVBoxLayout, QWidget,
+    QLabel, QToolButton, QVBoxLayout, QWidget,
 )
 
+from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
 from microdrop_style.button_styles import ICON_FONT_FAMILY
 
 from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.execution.events import PauseEvent
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.execution.signals import ExecutorSignals
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
 from pluggable_protocol_tree.views.navigation_bar import (
@@ -69,7 +76,6 @@ class ProtocolTreePane(QWidget):
         self.experiment_manager = experiment_manager
         self.sticky_manager = sticky_manager
         self.phase_ack_topic = phase_ack_topic
-        self._executor_factory = executor_factory
 
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
 
@@ -77,6 +83,38 @@ class ProtocolTreePane(QWidget):
         self._build_navigation_bar()
         self._build_experiment_bar()
         self._build_layout()
+
+        self.executor = self._build_executor(executor_factory)
+
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at: float | None = None
+        self._phase_started_at: float | None = None
+        self._phase_target: float | None = None
+        self._current_row = None
+        self._repeats_total = 1
+        self._repeats_completed = 0
+        self._current_run_preview_mode = False
+
+        self._status_step_label = self.status_bar.lbl_step_progress
+        self._status_step_time_label = self.status_bar.lbl_step_time
+        self._status_reps_label = self.status_bar.lbl_step_repetition
+        self._status_phase_time_label = (
+            self.status_bar.lbl_phase_time if self.phase_ack_topic is not None
+            else None
+        )
+
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(100)
+        self._tick_timer.timeout.connect(self._refresh_status)
+
+        # Skip wiring if the factory returned a stub without qsignals
+        # (lets tests inject a sentinel executor for override checks).
+        if hasattr(self.executor, "qsignals"):
+            self._wire_executor_signals()
+            self._wire_button_state_machine()
+            self._wire_navigation_buttons()
+        self._set_idle_button_state()
 
     def _build_status_bar(self):
         self.status_bar = StatusBar()
@@ -120,6 +158,226 @@ class ProtocolTreePane(QWidget):
         layout.addWidget(self.status_bar)
         layout.addWidget(make_separator())
         layout.addWidget(self.widget)
+
+    def _build_executor(self, executor_factory):
+        factory = executor_factory or self._default_executor_factory
+        return factory(
+            row_manager=self.manager,
+            qsignals=ExecutorSignals(),
+            pause_event=PauseEvent(),
+            stop_event=threading.Event(),
+        )
+
+    @staticmethod
+    def _default_executor_factory(row_manager, qsignals, pause_event, stop_event):
+        return ProtocolExecutor(
+            row_manager=row_manager,
+            qsignals=qsignals,
+            pause_event=pause_event,
+            stop_event=stop_event,
+        )
+
+    def _wire_executor_signals(self):
+        self.executor.qsignals.step_started.connect(
+            self.widget.highlight_active_row,
+        )
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.step_finished.connect(self._on_step_finished)
+        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
+        self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
+        self.executor.qsignals.protocol_error.connect(self._on_error)
+        if self.phase_ack_topic is not None:
+            self.phase_acked.connect(self._on_phase_ack)
+
+    def _wire_button_state_machine(self):
+        self.executor.qsignals.protocol_started.connect(
+            self._set_running_button_state,
+        )
+        self.executor.qsignals.protocol_paused.connect(self._on_protocol_paused)
+        self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
+        self.executor.qsignals.protocol_finished.connect(self._on_protocol_finished)
+        self.executor.qsignals.protocol_aborted.connect(self._on_protocol_aborted)
+
+    def _wire_navigation_buttons(self):
+        nb = self.navigation_bar
+        nb.btn_play.clicked.connect(self._on_play_clicked)
+        nb.btn_resume.clicked.connect(self._toggle_pause)
+        nb.btn_stop.clicked.connect(self.executor.stop)
+
+    # --- step lifecycle handlers --------------------------------------
+
+    def _on_protocol_started(self):
+        try:
+            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            self._step_total = 0
+        self._step_index = 0
+        self._status_step_label.setText(f"Step 0 / {self._step_total}")
+
+    def _on_step_started(self, row):
+        self._step_index += 1
+        self._current_row = row
+        self._step_started_at = time.monotonic()
+        self._phase_started_at = None
+        try:
+            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            self._phase_target = None
+        self._status_step_label.setText(
+            f"Step {self._step_index} / {self._step_total}"
+        )
+        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name}")
+        self.status_bar.lbl_next_step.setText(
+            f"Next Step: {self._next_step_name(row)}"
+        )
+        if not self._tick_timer.isActive():
+            self._tick_timer.start()
+
+    def _next_step_name(self, current):
+        steps = self.manager.iter_execution_steps()
+        cur_path = tuple(current.path)
+        for row in steps:
+            if tuple(row.path) == cur_path:
+                next_row = next(steps, None)
+                return next_row.name if next_row is not None else "-"
+        return "-"
+
+    def _on_phase_ack(self):
+        if self._current_row is None:
+            return
+        now = time.monotonic()
+        if self._step_started_at is None:
+            self._step_started_at = now
+        self._phase_started_at = now
+
+    def _on_step_repetition(self, rep_chain):
+        if not rep_chain:
+            self._status_reps_label.setText("")
+            self._status_reps_label.setVisible(False)
+            return
+        parts = [
+            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+        ]
+        self._status_reps_label.setText(" · ".join(parts))
+        self._status_reps_label.setVisible(True)
+
+    def _on_step_finished(self, _row):
+        self._refresh_status()
+
+    def _on_error(self, msg):
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self._tick_timer.stop()
+        self._set_idle_button_state()
+        error_dialog(parent=self, title="Protocol error", message=str(msg))
+
+    def _refresh_status(self):
+        if self._step_started_at is None:
+            return
+        step_elapsed = time.monotonic() - self._step_started_at
+        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
+        if self._status_phase_time_label is not None:
+            phase_elapsed = (
+                0.0 if self._phase_started_at is None
+                else time.monotonic() - self._phase_started_at
+            )
+            target = self._phase_target if self._phase_target is not None else 0.0
+            self._status_phase_time_label.setText(
+                f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
+            )
+
+    # --- button state machine ----------------------------------------
+
+    def _set_idle_button_state(self):
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)
+        nb.show_play_state()
+        nb.btn_stop.setEnabled(False)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(True)
+        nb.action_preview.setEnabled(True)
+
+    def _set_running_button_state(self):
+        nb = self.navigation_bar
+        nb.btn_play.setEnabled(True)
+        nb.show_pause_state()
+        nb.btn_stop.setEnabled(True)
+        for btn in (nb.btn_first, nb.btn_prev, nb.btn_next, nb.btn_last):
+            btn.setEnabled(False)
+        nb.action_preview.setEnabled(False)
+
+    def _on_play_clicked(self):
+        if self._is_protocol_active():
+            self._toggle_pause()
+            return
+        self._start_protocol_run(
+            preview_mode=self.navigation_bar.is_preview_mode(),
+        )
+
+    def _start_protocol_run(self, preview_mode):
+        self._repeats_total = self.status_bar.edit_repeat_protocol.value()
+        self._repeats_completed = 0
+        self._current_run_preview_mode = preview_mode
+        self._update_repeat_status_label()
+        self.executor.start(
+            start_step_path=self._selected_step_path(),
+            preview_mode=preview_mode,
+        )
+
+    def _update_repeat_status_label(self):
+        self.status_bar.lbl_repeat_protocol_status.setText(
+            f"{self._repeats_completed}/"
+        )
+
+    def _selected_step_path(self):
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        path = self.widget._index_to_path(idx)
+        for row in self.manager.iter_execution_steps():
+            if tuple(row.path) == path:
+                return path
+        return None
+
+    def _is_protocol_active(self):
+        return self.navigation_bar.btn_stop.isEnabled()
+
+    def _toggle_pause(self):
+        if self.executor.pause_event.is_set():
+            self.executor.resume()
+        else:
+            self.executor.pause()
+
+    def _on_protocol_paused(self):
+        self.navigation_bar.show_resume_state()
+        self._tick_timer.stop()
+
+    def _on_protocol_resumed(self):
+        self.navigation_bar.show_pause_state()
+        if self._current_row is not None:
+            self._tick_timer.start()
+
+    def _on_protocol_finished(self):
+        self._repeats_completed += 1
+        self._update_repeat_status_label()
+        if self._repeats_completed < self._repeats_total:
+            QTimer.singleShot(50, self._restart_for_next_rep)
+            return
+        self._on_protocol_terminated()
+
+    def _restart_for_next_rep(self):
+        self.executor.start(preview_mode=self._current_run_preview_mode)
+
+    def _on_protocol_aborted(self):
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+        self._on_protocol_terminated()
+
+    def _on_protocol_terminated(self):
+        self._set_idle_button_state()
+        self._tick_timer.stop()
 
     # --- experiment-bar stubs (Task 6 wires real services) -------------
 

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -122,6 +122,17 @@ class ProtocolTreePane(QWidget):
         self._wire_navigation_buttons()
         self._set_idle_button_state()
 
+        if self.application is not None:
+            self.application.observe(
+                self._on_experiment_changed, "experiment_changed",
+            )
+            try:
+                cur = self.application.current_experiment_directory
+                if cur is not None:
+                    self.experiment_label.update_experiment_id(cur.stem)
+            except Exception as e:
+                logger.warning(f"could not read initial experiment dir: {e}")
+
     def _build_status_bar(self):
         self.status_bar = StatusBar()
         phase_enabled = self.phase_ack_topic is not None
@@ -596,13 +607,40 @@ class ProtocolTreePane(QWidget):
             error_dialog(parent=parent or self,
                          title="Load error", message=str(e))
 
-    # --- experiment-bar stubs (Task 6 wires real services) -------------
+    # --- experiment-bar handlers ------------------------------------
 
     def _on_new_experiment(self):
-        logger.info("New Experiment requested")
+        if self.experiment_manager is None or self.application is None:
+            logger.info("New Experiment requested (stub: no services injected)")
+            return
+        new_dir = self.experiment_manager.initialize_new_experiment()
+        if new_dir is None:
+            logger.warning("initialize_new_experiment returned None; label unchanged")
+            return
+        self.application.current_experiment_directory = new_dir
+        self.experiment_label.update_experiment_id(new_dir.stem)
+        logger.info(f"Started new experiment: {new_dir.stem}")
 
     def _on_new_note(self):
-        logger.info("New Note requested")
+        if self.sticky_manager is None or self.experiment_manager is None:
+            logger.info("New Note requested (stub: no services injected)")
+            return
+        base_dir = self.experiment_manager.get_experiment_directory()
+        experiment_name = base_dir.stem
+        self.sticky_manager.request_new_note(base_dir, experiment_name)
 
     def _on_experiment_label_clicked(self):
-        logger.info("Experiment label clicked")
+        if self.experiment_manager is None:
+            logger.info("Experiment label clicked (stub: no service injected)")
+            return
+        self.experiment_manager.open_experiment_directory()
+
+    def _on_experiment_changed(self, _event):
+        try:
+            cur = self.application.current_experiment_directory
+        except Exception as e:
+            logger.warning(f"experiment_changed: failed to read dir: {e}")
+            return
+        if cur is None:
+            return
+        self.experiment_label.update_experiment_id(cur.stem)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import threading
 import time
 
-from pyface.qt.QtCore import Qt, QTimer, Signal
+from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtGui import QFont
 from pyface.qt.QtWidgets import (
-    QLabel, QToolButton, QVBoxLayout, QWidget,
+    QFileDialog, QLabel, QToolButton, QVBoxLayout, QWidget,
 )
 
 from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
@@ -209,6 +209,10 @@ class ProtocolTreePane(QWidget):
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)
         nb.btn_stop.clicked.connect(self.executor.stop)
+        nb.btn_first.clicked.connect(self.navigate_to_first_step)
+        nb.btn_prev.clicked.connect(self.navigate_to_previous_step)
+        nb.btn_next.clicked.connect(self.navigate_to_next_step)
+        nb.btn_last.clicked.connect(self.navigate_to_last_step)
         nb.btn_prev_phase.clicked.connect(self._on_prev_phase)
         nb.btn_next_phase.clicked.connect(self._on_next_phase)
         nb.set_phase_navigation_enabled(False, False)
@@ -277,8 +281,9 @@ class ProtocolTreePane(QWidget):
         self._repeats_total = 0
         self._repeats_completed = 0
         self._update_repeat_status_label()
-        self._tick_timer.stop()
+        self.clear_highlights()
         self._set_idle_button_state()
+        self._tick_timer.stop()
         error_dialog(parent=self, title="Protocol error", message=str(msg))
 
     def _refresh_status(self):
@@ -390,6 +395,7 @@ class ProtocolTreePane(QWidget):
         self._on_protocol_terminated()
 
     def _on_protocol_terminated(self):
+        self.clear_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
         self.navigation_bar.merge_phase_controls_to_play_button()
@@ -459,6 +465,136 @@ class ProtocolTreePane(QWidget):
         self.navigation_bar.set_phase_navigation_enabled(
             prev_enabled, next_enabled,
         )
+
+    # --- step-cursor navigation -------------------------------------
+
+    def navigate_to_first_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[0])
+
+    def navigate_to_last_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if steps:
+            self._select_step(steps[-1])
+
+    def navigate_to_previous_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur > 0:
+            self._select_step(steps[cur - 1])
+
+    def navigate_to_next_step(self):
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        cur = self._current_step_in(steps)
+        if cur is None:
+            self._select_step(steps[0])
+            return
+        if cur < len(steps) - 1:
+            self._select_step(steps[cur + 1])
+            return
+        self._duplicate_step_after(steps[cur])
+
+    def _duplicate_step_after(self, row):
+        path = tuple(row.path)
+        parent_path = path[:-1]
+        insert_idx = path[-1] + 1
+        values = {}
+        for col in self.manager.columns:
+            cid = col.model.col_id
+            if hasattr(row, cid):
+                values[cid] = getattr(row, cid)
+        new_path = self.manager.add_step(
+            parent_path=parent_path, index=insert_idx, values=values,
+        )
+        new_row = self.manager.get_row(new_path)
+        self._select_step(new_row)
+
+    def _current_step_in(self, steps):
+        idx = self.widget.tree.currentIndex()
+        if not idx.isValid():
+            return None
+        path = self.widget._index_to_path(idx)
+        for i, row in enumerate(steps):
+            if tuple(row.path) == path:
+                return i
+        return None
+
+    def _select_step(self, row):
+        idx = self.widget._node_to_index(row)
+        if not idx.isValid():
+            return
+        parent = idx.parent()
+        while parent.isValid():
+            self.widget.tree.expand(parent)
+            parent = parent.parent()
+        self.widget.tree.setCurrentIndex(idx)
+        self.widget.tree.scrollTo(idx)
+
+    def clear_highlights(self):
+        """Reset the tree's selection + active-row highlight + per-step
+        labels to the idle visual state."""
+        self.widget.highlight_active_row(None)
+        self.widget.tree.clearSelection()
+        self.widget.tree.setCurrentIndex(QModelIndex())
+
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at = None
+        self._phase_started_at = None
+        self._phase_target = None
+        self._current_row = None
+
+        self._status_step_label.setText("Step 0/0")
+        self._status_step_time_label.setText("Step Time: 0 s")
+        self._status_reps_label.setText("Repetition 0/0")
+        self._status_reps_label.setVisible(True)
+        self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
+        self.status_bar.lbl_next_step.setText("Next Step: -")
+        if self._status_phase_time_label is not None:
+            self._status_phase_time_label.setText("Phase 0.00s / 0.00s")
+
+    # --- save / load -----------------------------------------------
+
+    def save_to_dialog(self, parent=None):
+        """Open a file dialog and persist the manager's JSON state."""
+        path, _ = QFileDialog.getSaveFileName(
+            parent or self, "Save Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(self.manager.to_json(), f, indent=2)
+        except Exception as e:
+            error_dialog(parent=parent or self,
+                         title="Save error", message=str(e))
+
+    def load_from_dialog(self, columns_factory, parent=None):
+        """Open a file dialog and replace the manager's state from JSON.
+
+        ``columns_factory`` rebuilds the column list (consumed by
+        ``set_state_from_json``); the dock pane and demo window each
+        own a different source of truth for it."""
+        path, _ = QFileDialog.getOpenFileName(
+            parent or self, "Load Protocol", "", "Protocol JSON (*.json)",
+        )
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.manager.set_state_from_json(data, columns=columns_factory())
+        except Exception as e:
+            error_dialog(parent=parent or self,
+                         title="Load error", message=str(e))
 
     # --- experiment-bar stubs (Task 6 wires real services) -------------
 

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1,0 +1,133 @@
+"""Reusable host widget for the pluggable protocol tree's full UX.
+
+Owns the RowManager + ProtocolTreeWidget + ProtocolExecutor + the
+NavigationBar / StatusBar / experiment-bar trio. Mounted by both the
+demo window (BasePluggableProtocolDemoWindow) and the full-app dock
+pane (PluggableProtocolDockPane).
+
+Service injection (``application``, ``experiment_manager``,
+``sticky_manager``) is optional. When None, the corresponding
+experiment-bar buttons stay log-only stubs (matches today's demo UX).
+When supplied, the pane connects the real handlers — see Task 6 of
+PPT-10.1 for the full wiring rules.
+"""
+
+from __future__ import annotations
+
+from pyface.qt.QtCore import Qt, Signal
+from pyface.qt.QtGui import QFont
+from pyface.qt.QtWidgets import (
+    QToolButton, QVBoxLayout, QWidget,
+)
+
+from microdrop_style.button_styles import ICON_FONT_FAMILY
+
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.experiment_label import ExperimentLabel
+from pluggable_protocol_tree.views.navigation_bar import (
+    NavigationBar, StatusBar, make_separator,
+)
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProtocolTreePane(QWidget):
+    """Hosts the pluggable protocol tree with full UX scaffolding.
+
+    Layered top-to-bottom:
+      NavigationBar  (playback + step nav + experiment bar in left slot)
+      StatusBar      (step/phase elapsed, repetition counter, recent/next labels)
+      separator
+      ProtocolTreeWidget
+    """
+
+    phase_acked = Signal()
+
+    def __init__(
+        self,
+        columns_or_manager,
+        *,
+        application=None,
+        experiment_manager=None,
+        sticky_manager=None,
+        phase_ack_topic=ELECTRODES_STATE_APPLIED,
+        executor_factory=None,
+        parent=None,
+    ):
+        super().__init__(parent)
+
+        if isinstance(columns_or_manager, RowManager):
+            self.manager = columns_or_manager
+        else:
+            self.manager = RowManager(columns=list(columns_or_manager))
+
+        self.application = application
+        self.experiment_manager = experiment_manager
+        self.sticky_manager = sticky_manager
+        self.phase_ack_topic = phase_ack_topic
+        self._executor_factory = executor_factory
+
+        self.widget = ProtocolTreeWidget(self.manager, parent=self)
+
+        self._build_status_bar()
+        self._build_navigation_bar()
+        self._build_experiment_bar()
+        self._build_layout()
+
+    def _build_status_bar(self):
+        self.status_bar = StatusBar()
+        phase_enabled = self.phase_ack_topic is not None
+        self.status_bar.lbl_phase_time.setVisible(phase_enabled)
+
+    def _build_navigation_bar(self):
+        self.navigation_bar = NavigationBar()
+
+    def _build_experiment_bar(self):
+        icon_font = QFont(ICON_FONT_FAMILY)
+        icon_font.setPixelSize(20)
+
+        self.btn_new_exp = QToolButton()
+        self.btn_new_exp.setText("note_add")
+        self.btn_new_exp.setFont(icon_font)
+        self.btn_new_exp.setToolTip("New Experiment")
+        self.btn_new_exp.setCursor(Qt.PointingHandCursor)
+        self.btn_new_exp.clicked.connect(self._on_new_experiment)
+
+        self.experiment_label = ExperimentLabel()
+
+        self.btn_new_note = QToolButton()
+        self.btn_new_note.setText("sticky_note")
+        self.btn_new_note.setFont(icon_font)
+        self.btn_new_note.setToolTip("New Note")
+        self.btn_new_note.setCursor(Qt.PointingHandCursor)
+        self.btn_new_note.clicked.connect(self._on_new_note)
+
+        self.experiment_label.clicked.connect(self._on_experiment_label_clicked)
+
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_exp)
+        self.navigation_bar.add_widget_to_left_slot(self.experiment_label)
+        self.navigation_bar.add_widget_to_left_slot(self.btn_new_note)
+
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.navigation_bar)
+        layout.addWidget(self.status_bar)
+        layout.addWidget(make_separator())
+        layout.addWidget(self.widget)
+
+    # --- experiment-bar stubs (Task 6 wires real services) -------------
+
+    def _on_new_experiment(self):
+        logger.info("New Experiment requested")
+
+    def _on_new_note(self):
+        logger.info("New Note requested")
+
+    def _on_experiment_label_clicked(self):
+        logger.info("Experiment label clicked")

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -108,12 +108,9 @@ class ProtocolTreePane(QWidget):
         self._tick_timer.setInterval(100)
         self._tick_timer.timeout.connect(self._refresh_status)
 
-        # Skip wiring if the factory returned a stub without qsignals
-        # (lets tests inject a sentinel executor for override checks).
-        if hasattr(self.executor, "qsignals"):
-            self._wire_executor_signals()
-            self._wire_button_state_machine()
-            self._wire_navigation_buttons()
+        self._wire_executor_signals()
+        self._wire_button_state_machine()
+        self._wire_navigation_buttons()
         self._set_idle_button_state()
 
     def _build_status_bar(self):

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -14,19 +14,18 @@ PPT-10.1 for the full wiring rules.
 
 from __future__ import annotations
 
+import json
 import threading
 import time
 
 from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtGui import QFont
 from pyface.qt.QtWidgets import (
-    QFileDialog, QLabel, QToolButton, QVBoxLayout, QWidget,
+    QFileDialog, QToolButton, QVBoxLayout, QWidget,
 )
 
 from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
 from microdrop_style.button_styles import ICON_FONT_FAMILY
-
-import json
 
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 
@@ -607,6 +606,21 @@ class ProtocolTreePane(QWidget):
             error_dialog(parent=parent or self,
                          title="Load error", message=str(e))
 
+    def closeEvent(self, event):
+        """Detach Traits observers before the underlying QWidget is
+        destroyed. Without this, application.experiment_changed firing
+        after pane destruction dispatches to a deleted Qt object."""
+        if self.application is not None:
+            try:
+                self.application.observe(
+                    self._on_experiment_changed,
+                    "experiment_changed",
+                    remove=True,
+                )
+            except Exception as e:
+                logger.warning(f"failed to detach experiment_changed observer: {e}")
+        super().closeEvent(event)
+
     # --- experiment-bar handlers ------------------------------------
 
     def _on_new_experiment(self):
@@ -637,6 +651,8 @@ class ProtocolTreePane(QWidget):
         self.experiment_manager.open_experiment_directory()
 
     def _on_experiment_changed(self, _event):
+        if self.experiment_label is None:
+            return
         try:
             cur = self.application.current_experiment_directory
         except Exception as e:

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -617,8 +617,9 @@ class ProtocolTreePane(QWidget):
         if new_dir is None:
             logger.warning("initialize_new_experiment returned None; label unchanged")
             return
+        # The setter fires application.experiment_changed; the
+        # _on_experiment_changed observer updates the label.
         self.application.current_experiment_directory = new_dir
-        self.experiment_label.update_experiment_id(new_dir.stem)
         logger.info(f"Started new experiment: {new_dir.stem}")
 
     def _on_new_note(self):


### PR DESCRIPTION
## Summary

Resolves #411 (PPT-10.1).

- Extracts `ProtocolTreePane(QWidget)` from `BasePluggableProtocolDemoWindow` so the demo window and the full-app dock pane share scaffolding (NavigationBar + StatusBar + experiment-bar + executor + button state machine + phase-nav pause logic + step-cursor navigation + save/load).
- Optional service injection (`application`, `experiment_manager`, `sticky_manager`) — the dock pane supplies real services; demos pass nothing and keep today's stub UX. New `_on_experiment_changed` observer keeps the experiment label in sync via the application's `experiment_changed` Trait Event (the explicit publication channel; Property notifications are unreliable).
- Ports the legacy clickable, theme-aware `ExperimentLabel` into `pluggable_protocol_tree/views/experiment_label.py` (PPT-9 / #371 will retire its source).
- `PluggableProtocolDockPane.create_contents` constructs `ExperimentManager` + `StickyWindowManager` from the live Envisage application and wires them into the pane.
- `BasePluggableProtocolDemoWindow` slimmed from 1130 LOC → 559 LOC; delegates to `ProtocolTreePane` via `@property` aliases. Existing `test_base_demo_window.py` keeps passing (with two test edits to update assertions that were coupled to the pre-refactor implementation).
- Registers `PluggableProtocolTreePlugin` in `examples/plugin_consts.py` alongside the legacy `ProtocolGridControllerUIPlugin`. Pane title is **"Protocol (pluggable)"** for unambiguity during coexistence.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-08-protocol-tree-pane-design.md`
- Plan: `docs/superpowers/plans/2026-05-08-protocol-tree-pane.md`

## Test plan

- [ ] `pluggable_protocol_tree/tests/test_protocol_tree_pane.py` — 31 tests covering construction, executor wiring, button state machine, phase-nav pause logic, step-cursor navigation, save/load, real-mode service handlers, `experiment_changed` observation, observer detachment on close
- [ ] `pluggable_protocol_tree/tests/test_dock_pane.py` — 5 tests covering `create_contents` wiring + service construction with mocked Envisage application
- [ ] `pluggable_protocol_tree/tests/test_experiment_label.py` — 6 tests covering ExperimentLabel mouse/text/tooltip behavior
- [ ] `pluggable_protocol_tree/tests/test_base_demo_window.py` — full existing suite (43 tests) passes via `@property` aliases on the window
- [ ] **Manual verification:** launch `examples/run_device_viewer_pluggable.py`, confirm two protocol panes coexist, exercise New Experiment / experiment-label click / New Note on the new pane

Total automated coverage: **85 tests passing**.

## Out of scope

- Legacy `protocol_grid` removal — covered by #371 / PPT-9.
- Full message-listener parity (capacitance overlays, droplet detection, DropBot-connection gating, voltage/frequency-range UI) — tracked by #414 (PPT-10.2).

## Known coexistence behavior (transitional, eliminated by #371)

While both `protocol_grid` and `pluggable_protocol_tree` plugins are mounted simultaneously:
- The legacy `protocol_grid` widget creates its own `ExperimentManager` at startup that does not observe `application.experiment_changed`. If a user creates a new experiment via the **new** pane, the legacy `ExperimentManager._experiment_directory` and the legacy widget's experiment label go stale — subsequent legacy auto-saves would target the old directory.
- Both panes register independent `aboutToQuit` cleanup hooks pointing to the same parent dir. The underlying empty-dir `rmtree` is idempotent so this is harmless.

These are exactly the kinds of cross-pane consistency gaps that #371 (PPT-9) eliminates by deleting the legacy plugin. During the transition window, users should preferentially drive the experiment via one pane only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)