### PR TITLE
[PPT-10.3] Wire &Protocol file menu + dirty-state title (resolves #416)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/results.txt
 **/*.log
 **/*test*.html
+**/plotly_*.html
 *.svg
 *.json
 demo*.png

--- a/docs/superpowers/specs/2026-05-12-issue-416-pluggable-protocol-file-menu-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-416-pluggable-protocol-file-menu-design.md
@@ -30,7 +30,7 @@ This spec covers:
 | 1 | Where does "dirty" come from? | Observe `RowManager.rows_changed` event | It already fires on every mutation path (add_step, add_group, remove, move, paste, set_value(s), apply, set_state_from_json). Single observer. No per-callsite `_mark_modified` plumbing like legacy widget.py. |
 | 2 | How to avoid marking dirty during load/new? | Post-event reset: helper explicitly sets `is_modified = False` after `set_state_from_json`/root-reset returns | `set_state_from_json` fires `rows_changed`, which would flip the tracker dirty. Trait observers are synchronous — by the time the helper returns, the flip has already happened. Resetting after the fact is clean and avoids a `_loading_from_file` boolean. |
 | 3 | Tracker owns dock_pane reference? | Yes — direct rewrite of `dock_pane.name` from observer | Matches legacy `ProtocolStateTracker`. Tracker accepts `dock_pane=None` so unit tests can construct it headlessly. The pane wires the reference when mounting. |
-| 4 | Menu location | Top-level `&Protocol` in MenuBar | Issue wording: "the `&Protocol` menu in the main menubar." Legacy buries it under File / before-Exit, which is awkward. Top-level matches the issue and is cleaner. (If the user prefers File-submenu placement we can flip the SchemaAddition `path` in one line.) |
+| 4 | Menu location | `&Protocol` submenu under File / before-Exit, plus `New Experiment` at File / first | Matches legacy `protocol_grid` layout exactly. Users have muscle memory for the legacy placement and the spec's earlier top-level choice was rejected in review. The two SchemaAdditions live next to each other in the plugin's `_contributed_task_extensions_default`. |
 | 5 | Guard decorator vs inline check | Inline `_confirm_proceed_or_abort()` helper called at the top of `new_protocol` / `load_protocol_dialog` | Legacy `@ensure_protocol_saved` decorator coupled the dirty check to method signatures. Pane methods are short enough that a 2-line inline call is clearer than reaching through `self` for the tracker inside a closure-style decorator. Save / Save-As skip the guard (they don't risk losing data). |
 | 6 | App-exit guard | Observe `application_exiting` Vetoable event; on dirty + NO, set `event.veto = True` | New behavior beyond legacy (legacy only saves column settings on exit). Veto is the right primitive — keeps the app open so the user can save. |
 | 7 | "New protocol" reset mechanism | Direct `manager.root = GroupRow(name="Root")` + `protocol_metadata = {}` + `selection = []` + fire `rows_changed` | Simpler than round-tripping an empty payload through `set_state_from_json`. RowManager already exposes the necessary traits. |
@@ -42,7 +42,7 @@ This spec covers:
 
 ```
 microdrop-py/src/pluggable_protocol_tree/
-├── menus.py                                            # NEW — 4 DockPaneAction factories + protocol_menu_factory()
+├── menus.py                                            # NEW — 4 SMenu DockPaneAction factories + new_experiment_factory() + protocol_menu_factory()
 ├── services/
 │   └── protocol_state_tracker.py                       # NEW — PluggableProtocolStateTracker(HasTraits)
 ├── views/
@@ -143,15 +143,20 @@ TaskExtension(
     dock_pane_factories=[self._make_dock_pane],
     actions=[
         SchemaAddition(
+            factory=new_experiment_factory,
+            path="MenuBar/File",
+            absolute_position="first",
+        ),
+        SchemaAddition(
             factory=protocol_menu_factory,
-            path="MenuBar",
-            after="File",
+            path="MenuBar/File",
+            before="Exit",
         ),
     ],
 )
 ```
 
-`path="MenuBar"` + `after="File"` slots the menu in the top menubar right after `&File` (matches the issue's "main menubar" phrasing).
+`path="MenuBar/File"` + `before="Exit"` slots the `&Protocol` submenu inside File just above Exit; the `New Experiment` action lives at the top of File. Both match the legacy `protocol_grid` layout so user muscle memory carries over.
 
 ## 4. Behaviors / acceptance criteria mapping
 

--- a/docs/superpowers/specs/2026-05-12-issue-416-pluggable-protocol-file-menu-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-416-pluggable-protocol-file-menu-design.md
@@ -1,0 +1,211 @@
+# PPT-10.3 Design — Wire `&Protocol` file menu + dirty-state title for the pluggable protocol tree
+
+**Date:** 2026-05-12
+**Status:** Draft, pre-implementation
+**Issue:** [#416 — PPT-10.3 wire protocol file menu (New / Load / Save / Save As) and dirty-state title for the pluggable protocol tree](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/416)
+**Parent:** [#361 — Pluggable Protocol Tree umbrella]
+**Predecessors:** PPT-10.1 ([#411]) — `ProtocolTreePane` extraction + `save_to_dialog`/`load_from_dialog`. PPT-10.2 ([#414]) — device-viewer sync.
+**Blocker for:** PPT-9 ([#371]) — legacy `protocol_grid` deletion (this brings the new pane to feature parity).
+
+## 0. Scope
+
+The persistence APIs already exist: `RowManager.to_json` / `from_json` / `set_state_from_json` (PPT-1), and `ProtocolTreePane.save_to_dialog` / `load_from_dialog` (PPT-10.1). What's missing is the menu wiring + dirty-state bookkeeping + title display + warn-on-unsaved that the legacy `protocol_grid` plugin provides.
+
+This spec covers:
+- A `&Protocol` top-level menu with `&Create New`, `&Load`, `&Save`, `Save &as`.
+- A `PluggableProtocolStateTracker` HasTraits service that tracks `protocol_name`, `loaded_protocol_path`, `is_modified` and rewrites the dock-pane title.
+- Pane methods that wrap save/load/new with the unsaved-changes confirm dialog.
+- An `application_exiting` observer that vetoes app exit on unsaved changes if the user picks NO.
+
+**Out of scope:**
+- Auto-save / crash-recovery — separate spec if desired.
+- Changes to the legacy `protocol_grid` plugin — slated for deletion in PPT-9.
+- Persistence format / schema migration — PPT-1's JSON contract is the source of truth.
+- Sticky-notes / experiment-bar wiring — already in PPT-10.1.
+
+## 1. Decisions locked in during brainstorming
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| 1 | Where does "dirty" come from? | Observe `RowManager.rows_changed` event | It already fires on every mutation path (add_step, add_group, remove, move, paste, set_value(s), apply, set_state_from_json). Single observer. No per-callsite `_mark_modified` plumbing like legacy widget.py. |
+| 2 | How to avoid marking dirty during load/new? | Post-event reset: helper explicitly sets `is_modified = False` after `set_state_from_json`/root-reset returns | `set_state_from_json` fires `rows_changed`, which would flip the tracker dirty. Trait observers are synchronous — by the time the helper returns, the flip has already happened. Resetting after the fact is clean and avoids a `_loading_from_file` boolean. |
+| 3 | Tracker owns dock_pane reference? | Yes — direct rewrite of `dock_pane.name` from observer | Matches legacy `ProtocolStateTracker`. Tracker accepts `dock_pane=None` so unit tests can construct it headlessly. The pane wires the reference when mounting. |
+| 4 | Menu location | Top-level `&Protocol` in MenuBar | Issue wording: "the `&Protocol` menu in the main menubar." Legacy buries it under File / before-Exit, which is awkward. Top-level matches the issue and is cleaner. (If the user prefers File-submenu placement we can flip the SchemaAddition `path` in one line.) |
+| 5 | Guard decorator vs inline check | Inline `_confirm_proceed_or_abort()` helper called at the top of `new_protocol` / `load_protocol_dialog` | Legacy `@ensure_protocol_saved` decorator coupled the dirty check to method signatures. Pane methods are short enough that a 2-line inline call is clearer than reaching through `self` for the tracker inside a closure-style decorator. Save / Save-As skip the guard (they don't risk losing data). |
+| 6 | App-exit guard | Observe `application_exiting` Vetoable event; on dirty + NO, set `event.veto = True` | New behavior beyond legacy (legacy only saves column settings on exit). Veto is the right primitive — keeps the app open so the user can save. |
+| 7 | "New protocol" reset mechanism | Direct `manager.root = GroupRow(name="Root")` + `protocol_metadata = {}` + `selection = []` + fire `rows_changed` | Simpler than round-tripping an empty payload through `set_state_from_json`. RowManager already exposes the necessary traits. |
+| 8 | Where the tracker lives | On `ProtocolTreePane` (`self.protocol_state_tracker`) | Both demo and dock-pane mount the same `ProtocolTreePane`. Putting the tracker on the pane means both contexts get the dirty/title behavior for free — though only the dock-pane path has a `DockPane.name` to rewrite (demo uses a `QMainWindow.setWindowTitle` if we ever wire it; out of scope here). |
+| 9 | DockPaneAction wiring (4 methods on dock pane) | Add `new_protocol` / `load_protocol_dialog` / `save_protocol_dialog` / `save_as_protocol_dialog` to `PluggableProtocolDockPane`, each delegating to `self.control.widget()` (the `ProtocolTreePane`) | Matches legacy `PGCDockPane` exactly. The `control.widget()` accessor is how Pyface dock panes expose their hosted widget to `DockPaneAction(method=...)`. |
+| 10 | Where the actual save/load implementation lives | Stays on `ProtocolTreePane` (extends existing `save_to_dialog` / `load_from_dialog`) | Existing methods become the inner half; new wrapper methods (`save_protocol_dialog`, etc.) layer dirty bookkeeping + guard prompts on top. Keeps the file-IO and the bookkeeping in the same class. |
+
+## 2. File layout
+
+```
+microdrop-py/src/pluggable_protocol_tree/
+├── menus.py                                            # NEW — 4 DockPaneAction factories + protocol_menu_factory()
+├── services/
+│   └── protocol_state_tracker.py                       # NEW — PluggableProtocolStateTracker(HasTraits)
+├── views/
+│   ├── protocol_tree_pane.py                           # MODIFIED — own tracker; wrap save/load/new; exit-guard observer; mutation observer
+│   └── dock_pane.py                                    # MODIFIED — add 4 delegate methods + wire tracker to self.name
+├── plugin.py                                           # MODIFIED — contribute protocol_menu_factory via SchemaAddition
+└── tests/
+    ├── test_protocol_state_tracker.py                  # NEW — pure HasTraits unit tests
+    ├── test_menus.py                                   # NEW — factory shape, ids/methods
+    └── test_protocol_tree_pane_file_menu.py            # NEW — qapp-level integration
+
+docs/superpowers/specs/
+└── 2026-05-12-issue-416-pluggable-protocol-file-menu-design.md   # this file
+```
+
+## 3. Architecture
+
+### 3.1 `PluggableProtocolStateTracker(HasTraits)`
+
+```
+protocol_name           : Str("untitled")
+loaded_protocol_path    : File("")
+is_modified             : Bool(False)
+modified_tag            : Str(" [modified]")
+dock_pane               : Instance(DockPane, None)   # optional — None in tests
+pkg_display_name        : Str(PKG_name)              # "Pluggable Protocol Tree"
+
+display_name()                                       # returns the formatted dock-pane title
+update_display_name()                                # rewrites self.dock_pane.name when set
+@observe("protocol_name, is_modified")               # triggers update_display_name
+set_loaded(path: str)                                # path/name/is_modified=False
+set_saved(path: str)                                 # path/name/is_modified=False
+reset()                                              # untitled, "", is_modified=False
+mark_modified()                                      # is_modified = True
+```
+
+Title format: `"<PKG_name> - <protocol_name><modified_tag if dirty>"`, e.g., `"Pluggable Protocol Tree - my_assay [modified]"`.
+
+### 3.2 Integration on `ProtocolTreePane`
+
+```
+self.protocol_state_tracker = PluggableProtocolStateTracker()
+self.manager.observe(self._on_manager_rows_changed, "rows_changed")
+
+# new methods (called by dock-pane delegates):
+def save_protocol_dialog(self): ...      # save to known path, else delegate to save_as
+def save_as_protocol_dialog(self): ...   # extends save_to_dialog -> set_saved on success
+def load_protocol_dialog(self): ...      # guard -> extends load_from_dialog -> set_loaded on success
+def new_protocol(self): ...              # guard -> reset manager + reset tracker
+
+# helpers:
+def _confirm_proceed_or_abort(self) -> bool: ...
+def _on_manager_rows_changed(self, event): ...   # is_modified = True
+def _on_application_exiting(self, event): ...    # vetoes on dirty + NO
+```
+
+The `_on_manager_rows_changed` observer is unconditional — it always sets `is_modified = True`. `set_loaded` / `set_saved` / `reset` (called *after* the manager mutation completes) override the flag back to False.
+
+The `application_exiting` observer is attached only when `self.application is not None` and detached in `closeEvent`.
+
+### 3.3 Dock-pane delegates + name binding
+
+```python
+class PluggableProtocolDockPane(TraitsDockPane):
+    ...
+    def new_protocol(self):              self.control.widget().new_protocol()
+    def load_protocol_dialog(self):      self.control.widget().load_protocol_dialog()
+    def save_protocol_dialog(self):      self.control.widget().save_protocol_dialog()
+    def save_as_protocol_dialog(self):   self.control.widget().save_as_protocol_dialog()
+```
+
+In `create_contents`, after constructing `ProtocolTreePane`, set `pane.protocol_state_tracker.dock_pane = self` so the title-rewrite observer has a target.
+
+### 3.4 Menu + plugin contribution
+
+```python
+# menus.py
+def new_protocol_factory():     DockPaneAction(..., method="new_protocol",          name="&Create New")
+def load_dialog_factory():      DockPaneAction(..., method="load_protocol_dialog",  name="&Load")
+def save_dialog_factory():      DockPaneAction(..., method="save_protocol_dialog",  name="&Save")
+def save_as_dialog_factory():   DockPaneAction(..., method="save_as_protocol_dialog", name="Save &as")
+
+def protocol_menu_factory():
+    return SMenu(
+        new_protocol_factory(),
+        load_dialog_factory(),
+        save_dialog_factory(),
+        save_as_dialog_factory(),
+        id="pluggable_protocol_tree.tools_menu",
+        name="&Protocol",
+    )
+```
+
+```python
+# plugin.py — _contributed_task_extensions_default
+TaskExtension(
+    task_id=self.task_id_to_contribute_view,
+    dock_pane_factories=[self._make_dock_pane],
+    actions=[
+        SchemaAddition(
+            factory=protocol_menu_factory,
+            path="MenuBar",
+            after="File",
+        ),
+    ],
+)
+```
+
+`path="MenuBar"` + `after="File"` slots the menu in the top menubar right after `&File` (matches the issue's "main menubar" phrasing).
+
+## 4. Behaviors / acceptance criteria mapping
+
+| Issue checkbox | Where it's satisfied |
+|---|---|
+| `menus.py exports protocol_menu_factory()` | §3.4 |
+| `PluggableProtocolDockPane` has 4 methods | §3.3 |
+| `PluggableProtocolStateTracker(HasTraits)` with named traits | §3.1 |
+| DockPane name updates: untitled → name → name [modified] | tracker observer in §3.1 |
+| Save → write JSON to loaded path or fall back to Save As; clear dirty | `save_protocol_dialog` in §3.2 |
+| Save As → dialog → JSON → set path/name/clean | `save_as_protocol_dialog` in §3.2 |
+| Load → guard → dialog → set_state_from_json → set path/name/clean | `load_protocol_dialog` in §3.2 |
+| New → guard → reset manager + tracker | `new_protocol` in §3.2 |
+| App-exit guard prompts on unsaved | `_on_application_exiting` in §3.2 |
+| Tests (six listed scenarios) | §5 |
+| Manual smoke (run_device_viewer_pluggable.py) | §6 |
+
+## 5. Test plan
+
+### 5.1 `test_protocol_state_tracker.py` (no Qt, no DockPane required)
+- `test_default_state` — `protocol_name == "untitled"`, `is_modified is False`, `loaded_protocol_path == ""`.
+- `test_set_loaded_sets_name_path_clears_dirty`
+- `test_set_saved_sets_name_path_clears_dirty`
+- `test_reset_returns_to_defaults`
+- `test_display_name_format_clean_dirty_and_untitled`
+- `test_dock_pane_name_rewritten_on_change` — pass a stub object exposing a writable `name` attribute; observe both `protocol_name` and `is_modified` changes.
+
+### 5.2 `test_menus.py` (no Qt)
+- `test_factory_returns_smenu_with_four_actions`
+- `test_action_ids_and_methods_match_expected` — verifies each DockPaneAction's `method=` and `dock_pane_id=`.
+
+### 5.3 `test_protocol_tree_pane_file_menu.py` (uses `qapp` fixture)
+- `test_mutation_marks_dirty` — add a step → tracker.is_modified True, dock-pane name has `[modified]`.
+- `test_save_clears_dirty` — patch QFileDialog.getSaveFileName, call `save_as_protocol_dialog`, assert file written and tracker.is_modified False.
+- `test_save_uses_loaded_path_when_set` — after `set_saved("/x.json")`, calling `save_protocol_dialog` writes to `/x.json` without a dialog.
+- `test_save_without_loaded_path_falls_back_to_save_as` — after default state, `save_protocol_dialog` invokes the dialog.
+- `test_load_clears_dirty_and_sets_path` — patch QFileDialog + provide a fixture JSON, call `load_protocol_dialog`, assert tracker reflects loaded protocol.
+- `test_load_aborts_on_user_no_when_dirty` — patch `confirm` to return NO, assert no file dialog is opened and manager untouched.
+- `test_new_protocol_resets_tracker_and_manager` — load a protocol, then `new_protocol` after NO is confirmed; ensure manager.root has no children and tracker reset.
+- `test_application_exiting_vetos_on_dirty_no` — fake `application_exiting` event with `veto` attribute, dirty manager, mock confirm to NO; assert event.veto True.
+
+## 6. Manual smoke
+
+1. `python examples/run_device_viewer_pluggable.py`
+2. Open `&Protocol` menu — see four entries.
+3. Edit a step → title shows `Pluggable Protocol Tree - untitled [modified]`.
+4. `Save &as` → choose path → title becomes `Pluggable Protocol Tree - <name>`.
+5. Edit again → title gets `[modified]` back.
+6. `&Save` → title returns to clean.
+7. With unsaved edits, `&Load` → confirm dialog appears; NO aborts.
+8. With unsaved edits, close window → confirm dialog appears; NO keeps the app open.
+
+## 7. Risks & open questions
+
+- **Veto plumbing on `application_exiting`.** Envisage's `application_exiting` is an `Event(Vetoable)`. Test environment will fake the event object. Worst case: if veto plumbing differs in this version of Envisage, the app-exit guard becomes a "log + warn" instead of a hard veto — degraded but not broken. Will be verified during implementation.
+- **Save path encoding on Windows.** `QFileDialog` returns backslashed paths on Windows. `Path(p).stem` handles both — no special-case needed. Tests use `Path` consistently.
+- **Concurrent dirty flag flipping during executor highlight events.** `RowManager.rows_changed` does NOT fire on selection changes or highlight, only on structure/value mutations — verified by reading row_manager.py. So executor-driven UI does not falsely dirty the protocol.

--- a/dropbot_protocol_controls/protocol_columns/frequency_column.py
+++ b/dropbot_protocol_controls/protocol_columns/frequency_column.py
@@ -43,9 +43,15 @@ class FrequencyHandler(BaseColumnHandler):
     wait_for_topics = [FREQUENCY_APPLIED]
 
     def on_interact(self, row, model, value):
-        """User edited a frequency cell — write through AND persist to prefs."""
-        super().on_interact(row, model, value)
+        """User edited a frequency cell — write through AND persist to prefs.
+
+        Must return the super's return value so the delegate fires
+        dataChanged and the manager fires rows_changed — without it the
+        protocol state tracker never sees frequency edits.
+        """
+        result = super().on_interact(row, model, value)
         DropbotPreferences().last_frequency = int(value)
+        return result
 
     def on_step(self, row, ctx):
         # Preview mode: skip the hardware-publish + ack-wait.

--- a/dropbot_protocol_controls/protocol_columns/voltage_column.py
+++ b/dropbot_protocol_controls/protocol_columns/voltage_column.py
@@ -51,9 +51,14 @@ class VoltageHandler(BaseColumnHandler):
         see dropbot_controller/preferences.py:22-25). Storing here means
         the next session's status-panel boot value matches the last
         cell-edit, just like editing the spinner in the dropbot status panel.
+
+        Must return the super's return value so QtTreeModel.setData
+        signals dataChanged and the manager fires rows_changed — without
+        it the protocol state tracker never sees voltage edits.
         """
-        super().on_interact(row, model, value)
+        result = super().on_interact(row, model, value)
         DropbotPreferences().last_voltage = int(value)
+        return result
 
     def on_step(self, row, ctx):
         # Preview mode: skip the hardware-publish + ack-wait. The

--- a/examples/run_device_viewer_pluggable_experimental.py
+++ b/examples/run_device_viewer_pluggable_experimental.py
@@ -9,6 +9,8 @@ from envisage.ui.tasks.tasks_application import TasksApplication
 from pyface.qt.QtWidgets import QApplication
 
 from microdrop_utils.app_setup_helpers import microdrop_runner_setup
+from protocol_grid.plugin import ProtocolGridControllerUIPlugin
+
 microdrop_runner_setup()
 
 from examples.plugin_consts import REQUIRED_PLUGINS, FRONTEND_PLUGINS, BACKEND_PLUGINS, DROPBOT_BACKEND_PLUGINS, \
@@ -91,7 +93,7 @@ if __name__ == "__main__":
         help="Specify the device to use: 'dropbot' or 'opendrop'"
     )
 
-    plugins = REQUIRED_PLUGINS + FRONTEND_PLUGINS + SERVICE_PLUGINS + BACKEND_PLUGINS + EXPERIMENTAl_PLUGINS
+    plugins = REQUIRED_PLUGINS + [el for el in FRONTEND_PLUGINS if el != ProtocolGridControllerUIPlugin] + SERVICE_PLUGINS + BACKEND_PLUGINS + EXPERIMENTAl_PLUGINS
 
     args = parser.parse_args()
 

--- a/examples/terminal_ui_example.py
+++ b/examples/terminal_ui_example.py
@@ -1,0 +1,170 @@
+import asyncio
+from prompt_toolkit.application import Application
+from prompt_toolkit.layout.containers import HSplit, Window, WindowAlign
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.layout import Layout
+from prompt_toolkit.widgets import Frame, TextArea, Label
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.styles import Style
+
+# --- Timer State ---
+timer_state = {
+    "seconds": 0,
+    "running": False,
+    "paused": False
+}
+
+# --- Key Bindings ---
+kb = KeyBindings()
+
+@kb.add('c-c')
+@kb.add('q')
+def exit_(event):
+    """Exit the application."""
+    event.app.exit()
+
+# --- UI Components & Logic ---
+def get_title_text():
+    return [('class:title', ' Microdrop Terminal UI v2.0 ')]
+
+def get_status_text():
+    ts = timer_state["seconds"]
+    mins, secs = divmod(ts, 60)
+    timer_display = f"{mins:02d}:{secs:02d}"
+    
+    if not timer_state["running"]:
+        status = "STOPPED"
+    elif timer_state["paused"]:
+        status = "PAUSED"
+    else:
+        status = "RUNNING"
+        
+    return [
+        ('class:status', f' Status: Idle | Device: MockDropBot | Timer: [{status}] {timer_display} ')
+    ]
+
+title_window = Window(
+    content=FormattedTextControl(get_title_text),
+    height=1,
+    align=WindowAlign.CENTER,
+    style='class:title-bar'
+)
+
+status_bar = Window(
+    content=FormattedTextControl(get_status_text),
+    height=1,
+    style='class:status-bar'
+)
+
+output_area = TextArea(
+    text="Welcome to Microdrop TUI\nType 'help' for commands.\nReady...",
+    read_only=True,
+    scrollbar=True
+)
+
+command_input = TextArea(
+    height=1,
+    prompt='microdrop> ',
+    multiline=False,
+    wrap_lines=False
+)
+
+def accept_command(buffer):
+    """Handle command entry."""
+    full_cmd = command_input.text.strip().lower()
+    if not full_cmd:
+        return
+
+    output_area.text += f"\n> {full_cmd}"
+    parts = full_cmd.split()
+    cmd = parts[0]
+    args = parts[1:] if len(parts) > 1 else []
+
+    if cmd == "help":
+        output_area.text += "\nAvailable commands:\n  timer start  - Start/Resume the timer\n  timer pause  - Pause the timer\n  timer stop   - Stop and reset timer\n  timer reset  - Reset timer to 0\n  clear        - Clear logs\n  exit/q       - Quit application"
+    
+    elif cmd == "timer":
+        sub = args[0] if args else ""
+        if sub == "start":
+            timer_state["running"] = True
+            timer_state["paused"] = False
+            output_area.text += "\n[Timer] Started."
+        elif sub == "pause":
+            timer_state["paused"] = True
+            output_area.text += "\n[Timer] Paused."
+        elif sub == "stop":
+            timer_state["running"] = False
+            timer_state["paused"] = False
+            timer_state["seconds"] = 0
+            output_area.text += "\n[Timer] Stopped and reset."
+        elif sub == "reset":
+            timer_state["seconds"] = 0
+            output_area.text += "\n[Timer] Reset to 0."
+        else:
+            output_area.text += f"\n[Error] Unknown timer command: {sub}"
+            
+    elif cmd == "clear":
+        output_area.text = "Output cleared."
+    elif cmd in ("exit", "quit"):
+        Application.get_current().exit()
+    else:
+        output_area.text += f"\n[Error] Unknown command: {cmd}"
+        
+    command_input.text = ""
+
+command_input.accept_handler = accept_command
+
+# --- Layout Definition ---
+root_container = HSplit([
+    title_window,
+    Frame(output_area, title="Logs/Output"),
+    status_bar,
+    Frame(command_input, title="Command Input"),
+    Label(text=" (Press 'q' or Ctrl-C to exit) ", style='class:footer')
+])
+
+# --- Styling ---
+style = Style.from_dict({
+    'title-bar': 'bg:#4444ff #ffffff bold',
+    'status-bar': 'bg:#222222 #00ff00',
+    'title': 'bold',
+    'status': 'italic',
+    'footer': '#888888',
+    'frame.border': '#555555',
+})
+
+layout = Layout(root_container, focused_element=command_input)
+
+# --- Background Task ---
+async def timer_counter(app):
+    """Background task to increment the timer every second."""
+    while True:
+        await asyncio.sleep(1)
+        if timer_state["running"] and not timer_state["paused"]:
+            timer_state["seconds"] += 1
+            # Trigger a redraw of the UI
+            app.invalidate()
+
+# --- Application Entry Point ---
+async def main():
+    app = Application(
+        layout=layout,
+        key_bindings=kb,
+        style=style,
+        full_screen=True
+    )
+    
+    # Start background timer task
+    timer_task = asyncio.create_task(timer_counter(app))
+    
+    try:
+        await app.run_async()
+    finally:
+        timer_task.cancel()
+
+if __name__ == '__main__':
+    print("Starting Terminal UI...")
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/microdrop_application/views/microdrop_pane.py
+++ b/microdrop_application/views/microdrop_pane.py
@@ -61,7 +61,7 @@ class MicrodropCentralCanvas(TaskPane):
              "app_preferences:canvas_background_opacity")
     def _on_canvas_preferences_changed(self, event):
         """Re-style the canvas whenever any of the three canvas prefs change."""
-        logger.debug(f"Canvas preference changed: {event.name} → {event.new}")
+        logger.debug(f"Canvas preference changed: {event.name} --> {event.new}")
         self._apply_background_styling()
 
     def _apply_background_styling(self, *_args):

--- a/pluggable_protocol_tree/menus.py
+++ b/pluggable_protocol_tree/menus.py
@@ -46,6 +46,7 @@ def save_dialog_factory():
         dock_pane_id=_DOCK_PANE_ID,
         name="&Save",
         method="save_protocol_dialog",
+        accelerator = "Ctrl+S"
     )
 
 

--- a/pluggable_protocol_tree/menus.py
+++ b/pluggable_protocol_tree/menus.py
@@ -1,0 +1,60 @@
+"""DockPaneAction factories for the pluggable protocol tree's
+``&Protocol`` file menu (New / Load / Save / Save As).
+
+Each action targets a method on ``PluggableProtocolDockPane`` which
+delegates to the hosted ``ProtocolTreePane``.
+"""
+
+from pyface.tasks.action.api import DockPaneAction, SMenu
+
+from pluggable_protocol_tree.consts import PKG
+
+
+_DOCK_PANE_ID = f"{PKG}.dock_pane"
+
+
+def new_protocol_factory():
+    return DockPaneAction(
+        id=f"{PKG}.new_protocol",
+        dock_pane_id=_DOCK_PANE_ID,
+        name="&Create New",
+        method="new_protocol",
+    )
+
+
+def load_dialog_factory():
+    return DockPaneAction(
+        id=f"{PKG}.load_protocol_dialog",
+        dock_pane_id=_DOCK_PANE_ID,
+        name="&Load",
+        method="load_protocol_dialog",
+    )
+
+
+def save_dialog_factory():
+    return DockPaneAction(
+        id=f"{PKG}.save_protocol_dialog",
+        dock_pane_id=_DOCK_PANE_ID,
+        name="&Save",
+        method="save_protocol_dialog",
+    )
+
+
+def save_as_dialog_factory():
+    return DockPaneAction(
+        id=f"{PKG}.save_as_protocol_dialog",
+        dock_pane_id=_DOCK_PANE_ID,
+        name="Save &as",
+        method="save_as_protocol_dialog",
+    )
+
+
+def protocol_menu_factory():
+    return SMenu(
+        new_protocol_factory(),
+        load_dialog_factory(),
+        save_dialog_factory(),
+        save_as_dialog_factory(),
+        id=f"{PKG}.protocol_menu",
+        name="&Protocol",
+    )

--- a/pluggable_protocol_tree/menus.py
+++ b/pluggable_protocol_tree/menus.py
@@ -22,6 +22,15 @@ def new_protocol_factory():
     )
 
 
+def new_experiment_factory():
+    return DockPaneAction(
+        id=f"{PKG}.create_new_experiment",
+        dock_pane_id=_DOCK_PANE_ID,
+        name="New &Experiment",
+        method="setup_new_experiment",
+    )
+
+
 def load_dialog_factory():
     return DockPaneAction(
         id=f"{PKG}.load_protocol_dialog",

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -45,7 +45,15 @@ class RowManager(HasTraits):
              "run start.")
 
     rows_changed = Event(
-        desc="Fires on structure or value changes. Batch-coalesced by UI.")
+        desc="Fires on structural mutations (add/remove/move/paste/"
+             "set_state_from_json/apply). For cell value edits use "
+             "``cell_changed`` instead.")
+
+    cell_changed = Event(
+        desc="Fires on a single cell value edit. Payload is "
+             "``{'path': (i, j, ...), 'col_id': '<col_id>'}``. Enables "
+             "O(1) incremental dirty tracking; the protocol state "
+             "tracker observes this for per-cell diff bookkeeping.")
 
     # --- construction ---
 
@@ -455,15 +463,18 @@ class RowManager(HasTraits):
         col = self._column_by_id(col_id)
         row = self.get_row(path)
         col.model.set_value(row, value)
-        self.rows_changed = True
+        self.cell_changed = {"path": tuple(path), "col_id": col_id}
 
     def set_values(self, paths: List[Path], col_id: str, value) -> None:
         col = self._column_by_id(col_id)
         for p in paths:
             col.model.set_value(self.get_row(p), value)
-        self.rows_changed = True
+            self.cell_changed = {"path": tuple(p), "col_id": col_id}
 
     def apply(self, paths: List[Path], fn) -> None:
+        # `fn` is arbitrary — could touch any column on any row, or
+        # even mutate structure indirectly. Fire rows_changed as the
+        # umbrella signal so the tracker forces a full rescan.
         for p in paths:
             fn(self.get_row(p))
         self.rows_changed = True

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -69,16 +69,23 @@ class PluggableProtocolTreePlugin(Plugin):
     contributed_task_extensions = List(contributes_to=TASK_EXTENSIONS)
 
     def _contributed_task_extensions_default(self):
-        from pluggable_protocol_tree.menus import protocol_menu_factory
+        from pluggable_protocol_tree.menus import (
+            new_experiment_factory, protocol_menu_factory,
+        )
         return [
             TaskExtension(
                 task_id=self.task_id_to_contribute_view,
                 dock_pane_factories=[self._make_dock_pane],
                 actions=[
                     SchemaAddition(
+                        factory=new_experiment_factory,
+                        path='MenuBar/File',
+                        absolute_position="first",
+                    ),
+                    SchemaAddition(
                         factory=protocol_menu_factory,
-                        path="MenuBar",
-                        after="File",
+                        path="MenuBar/File",
+                        before="Exit",
                     ),
                 ],
             ),

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -7,6 +7,7 @@ plugin class."""
 
 from envisage.api import ExtensionPoint, Plugin, TASK_EXTENSIONS
 from envisage.ui.tasks.task_extension import TaskExtension
+from pyface.action.schema.schema_addition import SchemaAddition
 from traits.api import List, Str, Either
 
 from microdrop_application.consts import PKG as microdrop_application_PKG
@@ -68,10 +69,18 @@ class PluggableProtocolTreePlugin(Plugin):
     contributed_task_extensions = List(contributes_to=TASK_EXTENSIONS)
 
     def _contributed_task_extensions_default(self):
+        from pluggable_protocol_tree.menus import protocol_menu_factory
         return [
             TaskExtension(
                 task_id=self.task_id_to_contribute_view,
                 dock_pane_factories=[self._make_dock_pane],
+                actions=[
+                    SchemaAddition(
+                        factory=protocol_menu_factory,
+                        path="MenuBar",
+                        after="File",
+                    ),
+                ],
             ),
         ]
 

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -173,7 +173,7 @@ class DeviceViewerSyncController(HasTraits):
         step-scoped or empty message."""
         try:
             dv_msg = DeviceViewerMessageModel.deserialize(payload)
-            logger.critical(f"Protocol Tree: Device View Sync recieved message: {dv_msg}")
+            logger.info(f"Protocol Tree: Device View Sync recieved message: {dv_msg}")
         except Exception as e:
             logger.warning(f"failed to parse DV state: {e}")
             return
@@ -247,7 +247,7 @@ class DeviceViewerSyncController(HasTraits):
             msg = ProtocolTreeDisplayMessage(free_mode=True)
             self._last_selected_uuid = ""
             if prev_uuid:
-                logger.info("DV display → free mode")
+                logger.info("DV display --> free mode")
         else:
             # 1-indexed dotted-path id (matches the ID column display)
             # so the DV's status bar shows e.g. "Editing: Step 1.2"
@@ -263,7 +263,7 @@ class DeviceViewerSyncController(HasTraits):
             )
             if row.uuid != prev_uuid:
                 logger.info(
-                    f"DV display → Step {dotted_id} {row.name!r} "
+                    f"DV display  Step {dotted_id} {row.name} "
                     f"({len(msg.electrodes)} electrodes, "
                     f"{len(msg.routes)} routes)"
                 )

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -201,19 +201,21 @@ class DeviceViewerSyncController(HasTraits):
             row = self.row_manager.get_row_by_uuid(dv_msg.step_id)
             if row is None or isinstance(row, GroupRow):
                 return
-            mutated = False
+            path = tuple(row.path)
+            # Direct trait writes bypass both QtTreeModel.setData and
+            # the delegate, so fire cell_changed for each column the
+            # user actually changed — the protocol state tracker uses
+            # this for O(1) incremental dirty bookkeeping.
             if list(getattr(row, "electrodes", []) or []) != electrodes:
                 row.electrodes = electrodes
-                mutated = True
+                self.row_manager.cell_changed = {
+                    "path": path, "col_id": "electrodes",
+                }
             if list(getattr(row, "routes", []) or []) != routes:
                 row.routes = routes
-                mutated = True
-            # Direct trait writes bypass both QtTreeModel.setData and the
-            # delegate, so fire the manager's rows_changed event here to
-            # honour its "Fires on structure or value changes" contract
-            # — the protocol state tracker observes it for dirty bookkeeping.
-            if mutated:
-                self.row_manager.rows_changed = True
+                self.row_manager.cell_changed = {
+                    "path": path, "col_id": "routes",
+                }
             return
 
         if not electrodes and not routes:

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -263,7 +263,7 @@ class DeviceViewerSyncController(HasTraits):
             )
             if row.uuid != prev_uuid:
                 logger.info(
-                    f"DV display  Step {dotted_id} {row.name} "
+                    f"DV display  Step {dotted_id} {row.name!r} "
                     f"({len(msg.electrodes)} electrodes, "
                     f"{len(msg.routes)} routes)"
                 )

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -201,10 +201,19 @@ class DeviceViewerSyncController(HasTraits):
             row = self.row_manager.get_row_by_uuid(dv_msg.step_id)
             if row is None or isinstance(row, GroupRow):
                 return
+            mutated = False
             if list(getattr(row, "electrodes", []) or []) != electrodes:
                 row.electrodes = electrodes
+                mutated = True
             if list(getattr(row, "routes", []) or []) != routes:
                 row.routes = routes
+                mutated = True
+            # Direct trait writes bypass both QtTreeModel.setData and the
+            # delegate, so fire the manager's rows_changed event here to
+            # honour its "Fires on structure or value changes" contract
+            # — the protocol state tracker observes it for dirty bookkeeping.
+            if mutated:
+                self.row_manager.rows_changed = True
             return
 
         if not electrodes and not routes:

--- a/pluggable_protocol_tree/services/protocol_state_tracker.py
+++ b/pluggable_protocol_tree/services/protocol_state_tracker.py
@@ -10,8 +10,7 @@ in headless tests it stays ``None`` and the observers are no-ops.
 
 from pathlib import Path
 
-from pyface.tasks.dock_pane import DockPane
-from traits.api import Bool, File, HasTraits, Instance, Str, observe
+from traits.api import Any, Bool, File, HasTraits, Str, observe
 
 from logger.logger_service import get_logger
 from pluggable_protocol_tree.consts import PKG_name
@@ -27,7 +26,10 @@ class PluggableProtocolStateTracker(HasTraits):
     modified_tag = Str(" [modified]")
     pkg_display_name = Str(PKG_name)
 
-    dock_pane = Instance(DockPane)
+    # Duck-typed: anything with a writable `name` attribute. Avoids
+    # importing pyface.DockPane just for an Instance() validator and
+    # keeps the tracker headlessly testable with a plain stub.
+    dock_pane = Any()
 
     def display_name(self) -> str:
         tag = self.modified_tag if self.is_modified else ""

--- a/pluggable_protocol_tree/services/protocol_state_tracker.py
+++ b/pluggable_protocol_tree/services/protocol_state_tracker.py
@@ -1,0 +1,68 @@
+"""Tracks current protocol file state and dirty bookkeeping.
+
+Owned by ``ProtocolTreePane``. Observers on ``protocol_name`` and
+``is_modified`` rewrite ``self.dock_pane.name`` so the title reflects
+the loaded file and unsaved-changes state.
+
+The pane wires the ``dock_pane`` reference when the dock pane mounts;
+in headless tests it stays ``None`` and the observers are no-ops.
+"""
+
+from pathlib import Path
+
+from pyface.tasks.dock_pane import DockPane
+from traits.api import Bool, File, HasTraits, Instance, Str, observe
+
+from logger.logger_service import get_logger
+from pluggable_protocol_tree.consts import PKG_name
+
+logger = get_logger(__name__)
+
+
+class PluggableProtocolStateTracker(HasTraits):
+    protocol_name = Str("untitled")
+    loaded_protocol_path = File("")
+    is_modified = Bool(False)
+
+    modified_tag = Str(" [modified]")
+    pkg_display_name = Str(PKG_name)
+
+    dock_pane = Instance(DockPane)
+
+    def display_name(self) -> str:
+        tag = self.modified_tag if self.is_modified else ""
+        return f"{self.pkg_display_name} - {self.protocol_name}{tag}"
+
+    def update_display_name(self) -> None:
+        if self.dock_pane is None:
+            return
+        self.dock_pane.name = self.display_name()
+
+    @observe("protocol_name, is_modified, dock_pane")
+    def _on_display_relevant_change(self, event):
+        self.update_display_name()
+
+    def set_loaded(self, file_path: str) -> None:
+        if not file_path:
+            raise ValueError("set_loaded requires a non-empty file path")
+        path = Path(file_path)
+        self.loaded_protocol_path = str(path)
+        self.protocol_name = path.stem
+        self.is_modified = False
+        logger.info(f"Protocol loaded: {self.protocol_name} ({self.loaded_protocol_path})")
+
+    def set_saved(self, file_path: str) -> None:
+        if not file_path:
+            raise ValueError("set_saved requires a non-empty file path")
+        path = Path(file_path)
+        self.loaded_protocol_path = str(path)
+        self.protocol_name = path.stem
+        self.is_modified = False
+        logger.info(f"Protocol saved: {self.protocol_name} ({self.loaded_protocol_path})")
+
+    def reset(self) -> None:
+        self.reset_traits(["protocol_name", "loaded_protocol_path", "is_modified"])
+
+    def mark_modified(self) -> None:
+        if not self.is_modified:
+            self.is_modified = True

--- a/pluggable_protocol_tree/services/protocol_state_tracker.py
+++ b/pluggable_protocol_tree/services/protocol_state_tracker.py
@@ -4,18 +4,53 @@ Owned by ``ProtocolTreePane``. Observers on ``protocol_name`` and
 ``is_modified`` rewrite ``self.dock_pane.name`` so the title reflects
 the loaded file and unsaved-changes state.
 
+Dirty model is incremental against a baseline DataFrame snapshot:
+
+  * ``reseed_baseline(manager)`` — called on save/load/new — copies
+    ``manager.table`` and clears all per-cell + structure diff state.
+  * ``on_cell_changed(path, col_id, manager)`` — O(1) incremental
+    update; adds to or removes from a ``dirty_cells`` set depending on
+    whether the new value matches the baseline.
+  * ``on_structure_changed(manager)`` — O(N) walk that compares the
+    current path set against the baseline; if paths now match
+    (insert+delete or move+undo), it does a full rescan to reset
+    ``dirty_cells`` correctly (since cell_changed didn't see moves).
+
+``is_modified`` is therefore "we have at least one cell that differs
+from baseline OR the structure differs" — reverting a cell to its
+saved value, or undoing an insert/delete, naturally clears it.
+
 The pane wires the ``dock_pane`` reference when the dock pane mounts;
 in headless tests it stays ``None`` and the observers are no-ops.
 """
 
+import math
 from pathlib import Path
 
-from traits.api import Any, Bool, File, HasTraits, Str, observe
+import pandas as pd
+from traits.api import Any, Bool, File, HasTraits, Instance, Str, observe
 
 from logger.logger_service import get_logger
 from pluggable_protocol_tree.consts import PKG_name
 
 logger = get_logger(__name__)
+
+
+def _values_equal(a, b) -> bool:
+    """Cell-value equality that handles list / dict (Python ==) and NaN.
+
+    ``nan == nan`` is False by IEEE rule but for dirty-tracking we want
+    them equal (both "missing"). Lists and dicts compare with normal
+    Python equality, which is what we want for routes/electrodes.
+    """
+    a_is_nan = isinstance(a, float) and math.isnan(a)
+    b_is_nan = isinstance(b, float) and math.isnan(b)
+    if a_is_nan or b_is_nan:
+        return a_is_nan and b_is_nan
+    try:
+        return bool(a == b)
+    except (ValueError, TypeError):
+        return False
 
 
 class PluggableProtocolStateTracker(HasTraits):
@@ -31,6 +66,29 @@ class PluggableProtocolStateTracker(HasTraits):
     # keeps the tracker headlessly testable with a plain stub.
     dock_pane = Any()
 
+    # --- incremental diff state ---
+    baseline_table = Instance(pd.DataFrame, allow_none=True)
+    # frozenset of baseline path tuples; cached so on_structure_changed
+    # doesn't rebuild it on every fire.
+    baseline_paths = Any()
+    # set[(path, col_id)] of cells currently differing from baseline.
+    # In-place mutated by on_cell_changed; len() drives is_modified.
+    dirty_cells = Any()
+    # True when current path set != baseline path set. Incremental cell
+    # updates are skipped while this is True (the path map is invalid);
+    # on_structure_changed clears it via a full rescan once paths
+    # re-align with baseline.
+    structure_dirty = Bool(False)
+
+    def traits_init(self):
+        self.dirty_cells = set()
+        self.baseline_paths = frozenset()
+        # Empty baseline — any add/edit on the empty initial tree will
+        # diverge and mark dirty. Reseed once the user saves/loads.
+        self.baseline_table = pd.DataFrame()
+
+    # --- display name ---
+
     def display_name(self) -> str:
         tag = self.modified_tag if self.is_modified else ""
         return f"{self.pkg_display_name} - {self.protocol_name}{tag}"
@@ -44,14 +102,98 @@ class PluggableProtocolStateTracker(HasTraits):
     def _on_display_relevant_change(self, event):
         self.update_display_name()
 
+    # --- baseline + incremental API ---
+
+    def reseed_baseline(self, manager) -> None:
+        """Snapshot ``manager.table`` as the new baseline and clear
+        all per-cell + structure dirty state. Called from save / load
+        / new.
+        """
+        self.baseline_table = manager.table.copy()
+        self.baseline_paths = frozenset(self.baseline_table.index)
+        self.dirty_cells = set()
+        self.structure_dirty = False
+        self.is_modified = False
+
+    def on_cell_changed(self, path, col_id, manager) -> None:
+        """O(1) incremental: compare the one edited cell against
+        baseline and add/remove from ``dirty_cells`` accordingly.
+
+        Skipped while ``structure_dirty`` is True — the path -> baseline
+        cell map isn't trustworthy until structure re-aligns and we
+        rescan.
+        """
+        if self.structure_dirty:
+            return
+        path = tuple(path)
+        if path not in self.baseline_paths:
+            # Cell exists in current tree but not in baseline — would
+            # mean we got cell_changed without the corresponding
+            # structure update. Mark structure dirty as a safety net.
+            self.structure_dirty = True
+            self._recompute_is_modified()
+            return
+        try:
+            current = manager.table.at[path, col_id]
+            baseline = self.baseline_table.at[path, col_id]
+        except KeyError:
+            return
+        key = (path, col_id)
+        if _values_equal(current, baseline):
+            self.dirty_cells.discard(key)
+        else:
+            self.dirty_cells.add(key)
+        self._recompute_is_modified()
+
+    def on_structure_changed(self, manager) -> None:
+        """O(N) walk: compare current path set to baseline.
+
+        If paths now match baseline, do a full rescan of cell values to
+        rebuild ``dirty_cells`` from scratch (covers moves and bulk
+        writes where cell_changed wasn't fired per cell). If paths
+        differ, just flip ``structure_dirty`` — the rescan deferred
+        until paths re-align.
+        """
+        current_paths = frozenset(p for p, _row in manager._walk())
+        if current_paths == self.baseline_paths:
+            self._rescan_dirty_cells(manager)
+            self.structure_dirty = False
+        else:
+            self.structure_dirty = True
+        self._recompute_is_modified()
+
+    def _rescan_dirty_cells(self, manager) -> None:
+        """Full O(N rows × M cols) compare; only called when paths
+        match baseline (e.g. after move+undo or insert+delete)."""
+        current = manager.table
+        dirty = set()
+        for path in self.baseline_paths:
+            for col_id in self.baseline_table.columns:
+                try:
+                    cur_val = current.at[path, col_id]
+                    base_val = self.baseline_table.at[path, col_id]
+                except KeyError:
+                    continue
+                if not _values_equal(cur_val, base_val):
+                    dirty.add((path, col_id))
+        self.dirty_cells = dirty
+
+    def _recompute_is_modified(self) -> None:
+        self.is_modified = bool(self.dirty_cells) or self.structure_dirty
+
+    # --- file lifecycle (filename + path only; baseline reseed is
+    # done by the caller alongside these so a single manager.table
+    # snapshot serves both record-keeping and diff bookkeeping). ---
+
     def set_loaded(self, file_path: str) -> None:
         if not file_path:
             raise ValueError("set_loaded requires a non-empty file path")
         path = Path(file_path)
         self.loaded_protocol_path = str(path)
         self.protocol_name = path.stem
-        self.is_modified = False
-        logger.info(f"Protocol loaded: {self.protocol_name} ({self.loaded_protocol_path})")
+        logger.info(
+            f"Protocol loaded: {self.protocol_name} ({self.loaded_protocol_path})"
+        )
 
     def set_saved(self, file_path: str) -> None:
         if not file_path:
@@ -59,12 +201,15 @@ class PluggableProtocolStateTracker(HasTraits):
         path = Path(file_path)
         self.loaded_protocol_path = str(path)
         self.protocol_name = path.stem
-        self.is_modified = False
-        logger.info(f"Protocol saved: {self.protocol_name} ({self.loaded_protocol_path})")
+        logger.info(
+            f"Protocol saved: {self.protocol_name} ({self.loaded_protocol_path})"
+        )
 
     def reset(self) -> None:
-        self.reset_traits(["protocol_name", "loaded_protocol_path", "is_modified"])
-
-    def mark_modified(self) -> None:
-        if not self.is_modified:
-            self.is_modified = True
+        """Reset filename / path traits to defaults. Baseline + dirty
+        state are reset separately via ``reseed_baseline`` (which needs
+        the manager handle)."""
+        self.reset_traits(["protocol_name", "loaded_protocol_path"])
+        self.dirty_cells = set()
+        self.structure_dirty = False
+        self.is_modified = False

--- a/pluggable_protocol_tree/tests/test_device_viewer_sync.py
+++ b/pluggable_protocol_tree/tests/test_device_viewer_sync.py
@@ -412,6 +412,53 @@ def test_step_scoped_message_writes_back_to_row(qapp):
     assert ctrl._free_mode_stash is None
 
 
+def test_step_scoped_write_back_fires_manager_rows_changed(qapp):
+    """Regression: DV-driven electrode/route writes go directly to
+    ``row.electrodes`` / ``row.routes``, bypassing both
+    ``QtTreeModel.setData`` and ``ProtocolItemDelegate.setModelData``.
+    The sync controller must fire ``rows_changed`` after a mutation so
+    the protocol state tracker can mark the protocol dirty — without
+    this, editing electrodes/routes via the device viewer leaves the
+    "unsaved changes" indicator off.
+    """
+    from device_viewer.models.messages import GeometryChangedMessage
+    manager = _make_manager()
+    path = manager.add_step(values={
+        "name": "S1", "electrodes": ["e00"], "routes": [],
+    })
+    row = manager.get_row(path)
+
+    ctrl = DeviceViewerSyncController(row_manager=manager)
+    ctrl._on_geometry_qt(
+        GeometryChangedMessage(
+            id_to_channel={"e00": 0, "e01": 1, "e02": 2}
+        ).serialize()
+    )
+
+    fired = []
+    manager.observe(lambda _ev: fired.append(True), "rows_changed")
+
+    # Electrode-only change.
+    ctrl._on_dv_state_qt(_make_dv_msg(
+        channels=[0, 1], step_id=row.uuid,
+    ).serialize())
+    assert row.electrodes == ["e00", "e01"]
+    assert len(fired) == 1
+
+    # Route-only change (same electrodes).
+    ctrl._on_dv_state_qt(_make_dv_msg(
+        channels=[0, 1], routes=[(["e02"], "blue")], step_id=row.uuid,
+    ).serialize())
+    assert row.routes == [["e02"]]
+    assert len(fired) == 2
+
+    # No-op replay: same payload again must NOT re-fire.
+    ctrl._on_dv_state_qt(_make_dv_msg(
+        channels=[0, 1], routes=[(["e02"], "blue")], step_id=row.uuid,
+    ).serialize())
+    assert len(fired) == 2
+
+
 def test_step_scoped_message_with_unknown_step_id_is_noop(qapp):
     """If the DV's step_id doesn't match any row in our tree (e.g. the
     legacy grid is still publishing), don't crash and don't mutate."""

--- a/pluggable_protocol_tree/tests/test_device_viewer_sync.py
+++ b/pluggable_protocol_tree/tests/test_device_viewer_sync.py
@@ -412,14 +412,15 @@ def test_step_scoped_message_writes_back_to_row(qapp):
     assert ctrl._free_mode_stash is None
 
 
-def test_step_scoped_write_back_fires_manager_rows_changed(qapp):
+def test_step_scoped_write_back_fires_manager_cell_changed(qapp):
     """Regression: DV-driven electrode/route writes go directly to
     ``row.electrodes`` / ``row.routes``, bypassing both
     ``QtTreeModel.setData`` and ``ProtocolItemDelegate.setModelData``.
-    The sync controller must fire ``rows_changed`` after a mutation so
-    the protocol state tracker can mark the protocol dirty — without
-    this, editing electrodes/routes via the device viewer leaves the
-    "unsaved changes" indicator off.
+    The sync controller must fire ``cell_changed`` (with path + col_id)
+    after each mutation so the protocol state tracker can update its
+    incremental dirty bookkeeping — without this, editing electrodes/
+    routes via the device viewer leaves the "unsaved changes" indicator
+    off.
     """
     from device_viewer.models.messages import GeometryChangedMessage
     manager = _make_manager()
@@ -436,21 +437,24 @@ def test_step_scoped_write_back_fires_manager_rows_changed(qapp):
     )
 
     fired = []
-    manager.observe(lambda _ev: fired.append(True), "rows_changed")
+    manager.observe(lambda ev: fired.append(ev.new), "cell_changed")
 
     # Electrode-only change.
     ctrl._on_dv_state_qt(_make_dv_msg(
         channels=[0, 1], step_id=row.uuid,
     ).serialize())
     assert row.electrodes == ["e00", "e01"]
-    assert len(fired) == 1
+    assert fired == [{"path": path, "col_id": "electrodes"}]
 
     # Route-only change (same electrodes).
     ctrl._on_dv_state_qt(_make_dv_msg(
         channels=[0, 1], routes=[(["e02"], "blue")], step_id=row.uuid,
     ).serialize())
     assert row.routes == [["e02"]]
-    assert len(fired) == 2
+    assert fired == [
+        {"path": path, "col_id": "electrodes"},
+        {"path": path, "col_id": "routes"},
+    ]
 
     # No-op replay: same payload again must NOT re-fire.
     ctrl._on_dv_state_qt(_make_dv_msg(

--- a/pluggable_protocol_tree/tests/test_menus.py
+++ b/pluggable_protocol_tree/tests/test_menus.py
@@ -1,0 +1,51 @@
+"""Tests for the &Protocol menu factories.
+
+Verifies the SMenu/DockPaneAction wiring without standing up the full
+Pyface task framework.
+"""
+
+from pyface.tasks.action.api import DockPaneAction, SMenu
+
+from pluggable_protocol_tree.consts import PKG
+from pluggable_protocol_tree.menus import (
+    load_dialog_factory,
+    new_protocol_factory,
+    protocol_menu_factory,
+    save_as_dialog_factory,
+    save_dialog_factory,
+)
+
+
+_DOCK_PANE_ID = f"{PKG}.dock_pane"
+
+
+def test_protocol_menu_factory_returns_smenu_with_four_items():
+    menu = protocol_menu_factory()
+    assert isinstance(menu, SMenu)
+    assert menu.name == "&Protocol"
+    items = list(menu.items)
+    assert len(items) == 4
+    assert all(isinstance(item, DockPaneAction) for item in items)
+
+
+def test_each_action_targets_pluggable_dock_pane():
+    for factory in (new_protocol_factory, load_dialog_factory,
+                    save_dialog_factory, save_as_dialog_factory):
+        action = factory()
+        assert action.dock_pane_id == _DOCK_PANE_ID
+
+
+def test_action_method_and_name_pairs():
+    expected = {
+        "new_protocol": "&Create New",
+        "load_protocol_dialog": "&Load",
+        "save_protocol_dialog": "&Save",
+        "save_as_protocol_dialog": "Save &as",
+    }
+    for action in protocol_menu_factory().items:
+        assert action.name == expected[action.method]
+
+
+def test_action_ids_are_pkg_namespaced():
+    for action in protocol_menu_factory().items:
+        assert action.id.startswith(f"{PKG}.")

--- a/pluggable_protocol_tree/tests/test_protocol_state_tracker.py
+++ b/pluggable_protocol_tree/tests/test_protocol_state_tracker.py
@@ -1,12 +1,17 @@
 """Unit tests for PluggableProtocolStateTracker.
 
 No Qt or DockPane required — the tracker accepts a stub object with a
-writable ``name`` attribute for title-rewrite tests.
+writable ``name`` attribute for title-rewrite tests, and a real
+``RowManager`` for the incremental-diff path (RowManager itself is
+HasTraits-only).
 """
 
 import pytest
 
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
 from pluggable_protocol_tree.consts import PKG_name
+from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.services.protocol_state_tracker import (
     PluggableProtocolStateTracker,
 )
@@ -17,6 +22,12 @@ class _NameStub:
     def __init__(self):
         self.name = ""
 
+
+def _make_manager():
+    return RowManager(columns=[make_type_column(), make_name_column()])
+
+
+# --- defaults / display name ----------------------------------------
 
 def test_defaults():
     t = PluggableProtocolStateTracker()
@@ -35,21 +46,45 @@ def test_display_name_clean_dirty_and_untitled():
     assert t.display_name() == f"{PKG_name} - my_assay [modified]"
 
 
-def test_set_loaded_sets_name_path_clears_dirty():
+def test_no_dock_pane_is_safe():
+    """Tracker should be usable headlessly without a dock_pane."""
     t = PluggableProtocolStateTracker()
+    t.protocol_name = "demo"      # no crash
+    t.is_modified = True          # no crash
+    assert t.display_name() == f"{PKG_name} - demo [modified]"
+
+
+def test_dock_pane_name_rewritten_on_name_change():
+    stub = _NameStub()
+    t = PluggableProtocolStateTracker(dock_pane=stub)
+    assert stub.name == f"{PKG_name} - untitled"
+    t.protocol_name = "demo"
+    assert stub.name == f"{PKG_name} - demo"
+
+
+def test_dock_pane_name_rewritten_on_dirty_change():
+    stub = _NameStub()
+    t = PluggableProtocolStateTracker(dock_pane=stub)
+    t.protocol_name = "demo"
     t.is_modified = True
+    assert stub.name == f"{PKG_name} - demo [modified]"
+    t.is_modified = False
+    assert stub.name == f"{PKG_name} - demo"
+
+
+# --- file lifecycle (filename only; dirty is separate) --------------
+
+def test_set_loaded_sets_name_and_path():
+    t = PluggableProtocolStateTracker()
     t.set_loaded("/tmp/some/path/my_assay.json")
     assert t.protocol_name == "my_assay"
     assert "my_assay.json" in t.loaded_protocol_path
-    assert t.is_modified is False
 
 
-def test_set_saved_sets_name_path_clears_dirty():
+def test_set_saved_sets_name_and_path():
     t = PluggableProtocolStateTracker()
-    t.is_modified = True
     t.set_saved("/tmp/x/another.json")
     assert t.protocol_name == "another"
-    assert t.is_modified is False
 
 
 def test_set_loaded_rejects_empty_path():
@@ -68,40 +103,135 @@ def test_reset_returns_defaults():
     assert t.is_modified is False
 
 
-def test_mark_modified_idempotent():
+# --- incremental diff against baseline -------------------------------
+
+def test_reseed_clears_dirty_state():
+    mgr = _make_manager()
+    mgr.add_step(values={"name": "a"})
     t = PluggableProtocolStateTracker()
-    events = []
-    t.observe(lambda e: events.append(e), "is_modified")
-    t.mark_modified()
-    t.mark_modified()
-    t.mark_modified()
-    assert len(events) == 1
+    # Simulate prior structural mutation - tracker would mark dirty.
+    t.on_structure_changed(mgr)
     assert t.is_modified is True
 
-
-def test_dock_pane_name_rewritten_on_name_change():
-    stub = _NameStub()
-    t = PluggableProtocolStateTracker(dock_pane=stub)
-    # Initial assignment fires the observer.
-    assert stub.name == f"{PKG_name} - untitled"
-
-    t.protocol_name = "demo"
-    assert stub.name == f"{PKG_name} - demo"
+    t.reseed_baseline(mgr)
+    assert t.is_modified is False
+    assert len(t.dirty_cells) == 0
+    assert t.structure_dirty is False
 
 
-def test_dock_pane_name_rewritten_on_dirty_change():
-    stub = _NameStub()
-    t = PluggableProtocolStateTracker(dock_pane=stub)
-    t.protocol_name = "demo"
-    t.is_modified = True
-    assert stub.name == f"{PKG_name} - demo [modified]"
-    t.is_modified = False
-    assert stub.name == f"{PKG_name} - demo"
-
-
-def test_no_dock_pane_is_safe():
-    """Tracker should be usable headlessly without a dock_pane."""
+def test_cell_edit_marks_dirty_when_diff_from_baseline():
+    mgr = _make_manager()
+    path = mgr.add_step(values={"name": "before"})
     t = PluggableProtocolStateTracker()
-    t.protocol_name = "demo"      # no crash
-    t.is_modified = True          # no crash
-    assert t.display_name() == f"{PKG_name} - demo [modified]"
+    t.reseed_baseline(mgr)
+
+    row = mgr.get_row(path)
+    row.name = "after"
+    t.on_cell_changed(path, "name", mgr)
+
+    assert t.is_modified is True
+    assert (path, "name") in t.dirty_cells
+
+
+def test_cell_revert_clears_dirty():
+    """Editing back to the baseline value removes the cell from
+    dirty_cells and clears is_modified when nothing else differs."""
+    mgr = _make_manager()
+    path = mgr.add_step(values={"name": "before"})
+    t = PluggableProtocolStateTracker()
+    t.reseed_baseline(mgr)
+
+    row = mgr.get_row(path)
+    row.name = "after"
+    t.on_cell_changed(path, "name", mgr)
+    assert t.is_modified is True
+
+    row.name = "before"     # revert
+    t.on_cell_changed(path, "name", mgr)
+    assert t.is_modified is False
+    assert (path, "name") not in t.dirty_cells
+
+
+def test_two_diffs_then_revert_one_still_dirty():
+    """dirty_cells is a set: removing one entry doesn't clear the
+    other. Mixed revert keeps is_modified True until both revert."""
+    mgr = _make_manager()
+    p1 = mgr.add_step(values={"name": "A"})
+    p2 = mgr.add_step(values={"name": "B"})
+    t = PluggableProtocolStateTracker()
+    t.reseed_baseline(mgr)
+
+    mgr.get_row(p1).name = "A2"
+    t.on_cell_changed(p1, "name", mgr)
+    mgr.get_row(p2).name = "B2"
+    t.on_cell_changed(p2, "name", mgr)
+    assert t.is_modified is True
+    assert len(t.dirty_cells) == 2
+
+    mgr.get_row(p1).name = "A"      # revert one
+    t.on_cell_changed(p1, "name", mgr)
+    assert t.is_modified is True
+    assert len(t.dirty_cells) == 1
+
+
+def test_insert_then_delete_clears_dirty():
+    """Add a step then remove it -> path set matches baseline ->
+    rescan finds no diffs -> dirty clears."""
+    mgr = _make_manager()
+    mgr.add_step(values={"name": "kept"})
+    t = PluggableProtocolStateTracker()
+    t.reseed_baseline(mgr)
+
+    new_path = mgr.add_step(values={"name": "transient"})
+    t.on_structure_changed(mgr)
+    assert t.is_modified is True
+    assert t.structure_dirty is True
+
+    mgr.remove([new_path])
+    t.on_structure_changed(mgr)
+    assert t.is_modified is False
+    assert t.structure_dirty is False
+
+
+def test_move_then_undo_clears_dirty():
+    """Reorder two steps then reorder back -> path set always matches
+    baseline (count unchanged), but the rescan on rows_changed detects
+    that values at each path match baseline again."""
+    mgr = _make_manager()
+    p1 = mgr.add_step(values={"name": "A"})    # A at (0,)
+    mgr.add_step(values={"name": "B"})         # B at (1,)
+    t = PluggableProtocolStateTracker()
+    t.reseed_baseline(mgr)
+
+    # Move A from (0,) to the end. After: B at (0,), A at (1,).
+    mgr.move([p1], target_parent_path=(), target_index=2)
+    t.on_structure_changed(mgr)
+    assert t.is_modified is True   # contents at (0,)/(1,) swapped
+
+    # Now move what is at (1,) (the A row again) back to position 0.
+    # After: A at (0,), B at (1,) — baseline order restored.
+    mgr.move([(1,)], target_parent_path=(), target_index=0)
+    t.on_structure_changed(mgr)
+    assert mgr.get_row((0,)).name == "A"
+    assert mgr.get_row((1,)).name == "B"
+    assert t.is_modified is False
+
+
+def test_structure_change_skips_cell_increment():
+    """While structure_dirty is True the per-cell increment is a
+    no-op (path -> baseline map isn't valid)."""
+    mgr = _make_manager()
+    p1 = mgr.add_step(values={"name": "A"})
+    t = PluggableProtocolStateTracker()
+    t.reseed_baseline(mgr)
+
+    # Cause a structure-mismatch.
+    p2 = mgr.add_step(values={"name": "B"})
+    t.on_structure_changed(mgr)
+    assert t.structure_dirty is True
+
+    # Edit a cell while structure-dirty — dirty_cells stays unchanged.
+    mgr.get_row(p1).name = "edited"
+    t.on_cell_changed(p1, "name", mgr)
+    assert len(t.dirty_cells) == 0
+    assert t.is_modified is True   # held by structure_dirty

--- a/pluggable_protocol_tree/tests/test_protocol_state_tracker.py
+++ b/pluggable_protocol_tree/tests/test_protocol_state_tracker.py
@@ -1,0 +1,107 @@
+"""Unit tests for PluggableProtocolStateTracker.
+
+No Qt or DockPane required — the tracker accepts a stub object with a
+writable ``name`` attribute for title-rewrite tests.
+"""
+
+import pytest
+
+from pluggable_protocol_tree.consts import PKG_name
+from pluggable_protocol_tree.services.protocol_state_tracker import (
+    PluggableProtocolStateTracker,
+)
+
+
+class _NameStub:
+    """Stand-in for a DockPane — only ``name`` matters for these tests."""
+    def __init__(self):
+        self.name = ""
+
+
+def test_defaults():
+    t = PluggableProtocolStateTracker()
+    assert t.protocol_name == "untitled"
+    assert t.loaded_protocol_path == ""
+    assert t.is_modified is False
+    assert t.modified_tag == " [modified]"
+
+
+def test_display_name_clean_dirty_and_untitled():
+    t = PluggableProtocolStateTracker()
+    assert t.display_name() == f"{PKG_name} - untitled"
+    t.protocol_name = "my_assay"
+    assert t.display_name() == f"{PKG_name} - my_assay"
+    t.is_modified = True
+    assert t.display_name() == f"{PKG_name} - my_assay [modified]"
+
+
+def test_set_loaded_sets_name_path_clears_dirty():
+    t = PluggableProtocolStateTracker()
+    t.is_modified = True
+    t.set_loaded("/tmp/some/path/my_assay.json")
+    assert t.protocol_name == "my_assay"
+    assert "my_assay.json" in t.loaded_protocol_path
+    assert t.is_modified is False
+
+
+def test_set_saved_sets_name_path_clears_dirty():
+    t = PluggableProtocolStateTracker()
+    t.is_modified = True
+    t.set_saved("/tmp/x/another.json")
+    assert t.protocol_name == "another"
+    assert t.is_modified is False
+
+
+def test_set_loaded_rejects_empty_path():
+    t = PluggableProtocolStateTracker()
+    with pytest.raises(ValueError):
+        t.set_loaded("")
+
+
+def test_reset_returns_defaults():
+    t = PluggableProtocolStateTracker()
+    t.set_loaded("/tmp/x/foo.json")
+    t.is_modified = True
+    t.reset()
+    assert t.protocol_name == "untitled"
+    assert t.loaded_protocol_path == ""
+    assert t.is_modified is False
+
+
+def test_mark_modified_idempotent():
+    t = PluggableProtocolStateTracker()
+    events = []
+    t.observe(lambda e: events.append(e), "is_modified")
+    t.mark_modified()
+    t.mark_modified()
+    t.mark_modified()
+    assert len(events) == 1
+    assert t.is_modified is True
+
+
+def test_dock_pane_name_rewritten_on_name_change():
+    stub = _NameStub()
+    t = PluggableProtocolStateTracker(dock_pane=stub)
+    # Initial assignment fires the observer.
+    assert stub.name == f"{PKG_name} - untitled"
+
+    t.protocol_name = "demo"
+    assert stub.name == f"{PKG_name} - demo"
+
+
+def test_dock_pane_name_rewritten_on_dirty_change():
+    stub = _NameStub()
+    t = PluggableProtocolStateTracker(dock_pane=stub)
+    t.protocol_name = "demo"
+    t.is_modified = True
+    assert stub.name == f"{PKG_name} - demo [modified]"
+    t.is_modified = False
+    assert stub.name == f"{PKG_name} - demo"
+
+
+def test_no_dock_pane_is_safe():
+    """Tracker should be usable headlessly without a dock_pane."""
+    t = PluggableProtocolStateTracker()
+    t.protocol_name = "demo"      # no crash
+    t.is_modified = True          # no crash
+    assert t.display_name() == f"{PKG_name} - demo [modified]"

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
@@ -38,6 +38,34 @@ def test_mutation_marks_dirty(qapp):
     assert pane.protocol_state_tracker.is_modified is True
 
 
+def test_user_cell_edit_marks_dirty(qapp):
+    """Regression: editing a cell value through the UI (the path the
+    QTreeView delegate uses on commit) must fire the dirty flag. The
+    column handler's default ``on_interact`` writes directly to the row
+    trait, bypassing ``RowManager.set_value``, so the manager-level
+    ``rows_changed`` event must be re-fired from inside ``setData``.
+    """
+    from pyface.qt.QtCore import Qt
+
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "before"})
+    # Clear the dirty flag so we measure only the cell-edit's effect.
+    pane.protocol_state_tracker.is_modified = False
+
+    qt_model = pane.widget.tree.model()
+    # Find the "name" column index dynamically — its position depends
+    # on how the pane was constructed.
+    name_col = next(
+        i for i, c in enumerate(pane.manager.columns)
+        if c.model.col_id == "name"
+    )
+    index = qt_model.index(0, name_col)
+    assert qt_model.setData(index, "after", Qt.EditRole) is True
+
+    assert pane.protocol_state_tracker.is_modified is True
+    assert pane.manager.root.children[0].name == "after"
+
+
 def test_save_as_clears_dirty_and_sets_path(qapp, tmp_path):
     pane = _build_pane(qapp)
     pane.manager.add_step()

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
@@ -40,18 +40,16 @@ def test_mutation_marks_dirty(qapp):
 
 def test_user_cell_edit_via_setData_marks_dirty(qapp):
     """Regression: edits committed via ``QtTreeModel.setData`` (the path
-    Qt uses for CheckStateRole toggles) must fire the dirty flag.
-
-    The column handler's default ``on_interact`` writes the trait
-    directly via ``model.set_value``, bypassing ``RowManager.set_value``,
-    so the manager-level ``rows_changed`` event must be re-fired from
-    inside ``setData`` for the protocol state tracker to see the edit.
+    Qt uses for CheckStateRole toggles) must fire ``cell_changed`` so
+    the tracker can update its incremental dirty bookkeeping.
     """
     from pyface.qt.QtCore import Qt
 
     pane = _build_pane(qapp)
-    pane.manager.add_step(values={"name": "before"})
-    pane.protocol_state_tracker.is_modified = False
+    path = pane.manager.add_step(values={"name": "before"})
+    # Seed baseline at "before" so the next edit is what marks dirty.
+    pane.protocol_state_tracker.reseed_baseline(pane.manager)
+    assert pane.protocol_state_tracker.is_modified is False
 
     qt_model = pane.widget.tree.model()
     name_col = next(
@@ -62,24 +60,21 @@ def test_user_cell_edit_via_setData_marks_dirty(qapp):
     assert qt_model.setData(index, "after", Qt.EditRole) is True
 
     assert pane.protocol_state_tracker.is_modified is True
+    assert (path, "name") in pane.protocol_state_tracker.dirty_cells
     assert pane.manager.root.children[0].name == "after"
 
 
 def test_user_cell_edit_via_delegate_marks_dirty(qapp):
-    """Regression: edits committed via the QTreeView delegate (the real
-    path for spinbox / line-edit cells — what every user actually hits)
-    must fire the dirty flag.
-
-    ``ProtocolItemDelegate.setModelData`` calls ``handler.on_interact``
-    and emits ``dataChanged`` directly, bypassing ``QtTreeModel.setData``
-    entirely. Without firing ``rows_changed`` from inside the delegate,
-    the protocol state tracker never sees spinbox/text-edit commits.
+    """Regression: edits committed via the QTreeView delegate (spinbox
+    / line-edit cells — what every user actually hits) must fire
+    ``cell_changed`` so the tracker increments dirty_cells in O(1).
     """
     from pyface.qt.QtWidgets import QLineEdit
 
     pane = _build_pane(qapp)
-    pane.manager.add_step(values={"name": "before-delegate"})
-    pane.protocol_state_tracker.is_modified = False
+    path = pane.manager.add_step(values={"name": "before-delegate"})
+    pane.protocol_state_tracker.reseed_baseline(pane.manager)
+    assert pane.protocol_state_tracker.is_modified is False
 
     qt_model = pane.widget.tree.model()
     name_col = next(
@@ -96,6 +91,33 @@ def test_user_cell_edit_via_delegate_marks_dirty(qapp):
 
     assert pane.manager.root.children[0].name == "after-delegate"
     assert pane.protocol_state_tracker.is_modified is True
+    assert (path, "name") in pane.protocol_state_tracker.dirty_cells
+
+
+def test_cell_edit_then_revert_clears_dirty_via_pane(qapp):
+    """End-to-end revert test: edit a cell via the delegate, then
+    edit it back to the baseline value. is_modified must clear."""
+    from pyface.qt.QtWidgets import QLineEdit
+
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "saved"})
+    pane.protocol_state_tracker.reseed_baseline(pane.manager)
+
+    qt_model = pane.widget.tree.model()
+    name_col = next(
+        i for i, c in enumerate(pane.manager.columns)
+        if c.model.col_id == "name"
+    )
+    index = qt_model.index(0, name_col)
+
+    editor = QLineEdit()
+    editor.setText("edited")
+    pane.widget.delegate.setModelData(editor, qt_model, index)
+    assert pane.protocol_state_tracker.is_modified is True
+
+    editor.setText("saved")
+    pane.widget.delegate.setModelData(editor, qt_model, index)
+    assert pane.protocol_state_tracker.is_modified is False
 
 
 def test_save_as_clears_dirty_and_sets_path(qapp, tmp_path):

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
@@ -1,0 +1,232 @@
+"""Integration tests for the PPT-10.3 file-menu plumbing on
+``ProtocolTreePane`` — dirty bookkeeping, save/load wrappers, guard
+prompts, and the application_exiting veto.
+
+These use the ``qapp`` fixture so the pane can construct its real Qt
+widgets. File IO and confirm dialogs are patched.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from microdrop_application.dialogs.pyface_wrapper import NO, YES
+
+
+def _build_pane(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+
+    return ProtocolTreePane([make_type_column(), make_name_column()])
+
+
+# --- dirty bookkeeping ---------------------------------------------------
+
+def test_starts_clean_with_untitled_name(qapp):
+    pane = _build_pane(qapp)
+    t = pane.protocol_state_tracker
+    assert t.is_modified is False
+    assert t.protocol_name == "untitled"
+    assert t.loaded_protocol_path == ""
+
+
+def test_mutation_marks_dirty(qapp):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()
+    assert pane.protocol_state_tracker.is_modified is True
+
+
+def test_save_as_clears_dirty_and_sets_path(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()
+    assert pane.protocol_state_tracker.is_modified is True
+
+    target = tmp_path / "out.json"
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        QFD.getSaveFileName.return_value = (str(target), "Protocol JSON (*.json)")
+        pane.save_as_protocol_dialog()
+
+    assert target.exists()
+    assert pane.protocol_state_tracker.is_modified is False
+    assert pane.protocol_state_tracker.protocol_name == "out"
+    assert pane.protocol_state_tracker.loaded_protocol_path == str(target)
+
+
+def test_save_uses_known_path_without_dialog(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    target = tmp_path / "first.json"
+    pane.protocol_state_tracker.set_saved(str(target))
+    pane.manager.add_step()                    # dirty again
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        pane.save_protocol_dialog()
+        QFD.getSaveFileName.assert_not_called()
+
+    assert target.exists()
+    assert pane.protocol_state_tracker.is_modified is False
+
+
+def test_save_without_known_path_falls_back_to_dialog(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()
+    target = tmp_path / "fallback.json"
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        QFD.getSaveFileName.return_value = (str(target), "Protocol JSON (*.json)")
+        pane.save_protocol_dialog()
+        QFD.getSaveFileName.assert_called_once()
+
+    assert target.exists()
+    assert pane.protocol_state_tracker.loaded_protocol_path == str(target)
+
+
+# --- load + guards -------------------------------------------------------
+
+def _write_minimal_protocol(path):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.models.row_manager import RowManager
+
+    rm = RowManager(columns=[make_type_column(), make_name_column()])
+    rm.add_step(values={"name": "from-disk"})
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(rm.to_json(), f)
+
+
+def test_load_clears_dirty_and_sets_path(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    fixture = tmp_path / "in.json"
+    _write_minimal_protocol(fixture)
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        QFD.getOpenFileName.return_value = (str(fixture), "Protocol JSON (*.json)")
+        pane.load_protocol_dialog()
+
+    assert pane.protocol_state_tracker.is_modified is False
+    assert pane.protocol_state_tracker.protocol_name == "in"
+    assert pane.protocol_state_tracker.loaded_protocol_path == str(fixture)
+    assert len(pane.manager.root.children) == 1
+
+
+def test_load_aborts_on_user_no_when_dirty(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()                    # mark dirty
+
+    fixture = tmp_path / "in.json"
+    _write_minimal_protocol(fixture)
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD, patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=NO,
+    ):
+        pane.load_protocol_dialog()
+        QFD.getOpenFileName.assert_not_called()
+
+    assert pane.protocol_state_tracker.is_modified is True
+    # Manager untouched — still has the single step we added.
+    assert len(pane.manager.root.children) == 1
+    assert pane.manager.root.children[0].name != "from-disk"
+
+
+def test_load_proceeds_on_user_yes_when_dirty(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "before-load"})
+    assert pane.protocol_state_tracker.is_modified is True
+
+    fixture = tmp_path / "in.json"
+    _write_minimal_protocol(fixture)
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD, patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=YES,
+    ):
+        QFD.getOpenFileName.return_value = (str(fixture), "Protocol JSON (*.json)")
+        pane.load_protocol_dialog()
+
+    assert pane.protocol_state_tracker.protocol_name == "in"
+    assert pane.protocol_state_tracker.is_modified is False
+    assert pane.manager.root.children[0].name == "from-disk"
+
+
+# --- new protocol --------------------------------------------------------
+
+def test_new_protocol_resets_manager_and_tracker(qapp, tmp_path):
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "before-new"})
+    pane.protocol_state_tracker.set_saved(str(tmp_path / "x.json"))
+    pane.manager.add_step()                   # dirty again
+
+    pane.new_protocol()                       # clean path — no confirm needed
+
+    assert len(pane.manager.root.children) == 0
+    t = pane.protocol_state_tracker
+    assert t.protocol_name == "untitled"
+    assert t.loaded_protocol_path == ""
+    assert t.is_modified is False
+
+
+def test_new_protocol_aborts_on_user_no_when_dirty(qapp):
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "keepme"})    # dirty
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=NO,
+    ):
+        pane.new_protocol()
+
+    assert len(pane.manager.root.children) == 1
+    assert pane.manager.root.children[0].name == "keepme"
+    assert pane.protocol_state_tracker.is_modified is True
+
+
+# --- application_exiting veto -------------------------------------------
+
+class _VetoableEvent:
+    def __init__(self):
+        self.veto = False
+
+
+def test_application_exiting_does_nothing_when_clean(qapp):
+    pane = _build_pane(qapp)
+    ev = _VetoableEvent()
+    pane._on_application_exiting(ev)
+    assert ev.veto is False
+
+
+def test_application_exiting_vetoes_on_dirty_no(qapp):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()                  # dirty
+    ev = _VetoableEvent()
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=NO,
+    ):
+        pane._on_application_exiting(ev)
+    assert ev.veto is True
+
+
+def test_application_exiting_proceeds_on_dirty_yes(qapp):
+    pane = _build_pane(qapp)
+    pane.manager.add_step()                  # dirty
+    ev = _VetoableEvent()
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=YES,
+    ):
+        pane._on_application_exiting(ev)
+    assert ev.veto is False

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
@@ -38,23 +38,22 @@ def test_mutation_marks_dirty(qapp):
     assert pane.protocol_state_tracker.is_modified is True
 
 
-def test_user_cell_edit_marks_dirty(qapp):
-    """Regression: editing a cell value through the UI (the path the
-    QTreeView delegate uses on commit) must fire the dirty flag. The
-    column handler's default ``on_interact`` writes directly to the row
-    trait, bypassing ``RowManager.set_value``, so the manager-level
-    ``rows_changed`` event must be re-fired from inside ``setData``.
+def test_user_cell_edit_via_setData_marks_dirty(qapp):
+    """Regression: edits committed via ``QtTreeModel.setData`` (the path
+    Qt uses for CheckStateRole toggles) must fire the dirty flag.
+
+    The column handler's default ``on_interact`` writes the trait
+    directly via ``model.set_value``, bypassing ``RowManager.set_value``,
+    so the manager-level ``rows_changed`` event must be re-fired from
+    inside ``setData`` for the protocol state tracker to see the edit.
     """
     from pyface.qt.QtCore import Qt
 
     pane = _build_pane(qapp)
     pane.manager.add_step(values={"name": "before"})
-    # Clear the dirty flag so we measure only the cell-edit's effect.
     pane.protocol_state_tracker.is_modified = False
 
     qt_model = pane.widget.tree.model()
-    # Find the "name" column index dynamically — its position depends
-    # on how the pane was constructed.
     name_col = next(
         i for i, c in enumerate(pane.manager.columns)
         if c.model.col_id == "name"
@@ -64,6 +63,39 @@ def test_user_cell_edit_marks_dirty(qapp):
 
     assert pane.protocol_state_tracker.is_modified is True
     assert pane.manager.root.children[0].name == "after"
+
+
+def test_user_cell_edit_via_delegate_marks_dirty(qapp):
+    """Regression: edits committed via the QTreeView delegate (the real
+    path for spinbox / line-edit cells — what every user actually hits)
+    must fire the dirty flag.
+
+    ``ProtocolItemDelegate.setModelData`` calls ``handler.on_interact``
+    and emits ``dataChanged`` directly, bypassing ``QtTreeModel.setData``
+    entirely. Without firing ``rows_changed`` from inside the delegate,
+    the protocol state tracker never sees spinbox/text-edit commits.
+    """
+    from pyface.qt.QtWidgets import QLineEdit
+
+    pane = _build_pane(qapp)
+    pane.manager.add_step(values={"name": "before-delegate"})
+    pane.protocol_state_tracker.is_modified = False
+
+    qt_model = pane.widget.tree.model()
+    name_col = next(
+        i for i, c in enumerate(pane.manager.columns)
+        if c.model.col_id == "name"
+    )
+    index = qt_model.index(0, name_col)
+
+    # Build a real editor populated with the new value, then drive the
+    # delegate's commit path the way QStyledItemDelegate would.
+    editor = QLineEdit()
+    editor.setText("after-delegate")
+    pane.widget.delegate.setModelData(editor, qt_model, index)
+
+    assert pane.manager.root.children[0].name == "after-delegate"
+    assert pane.protocol_state_tracker.is_modified is True
 
 
 def test_save_as_clears_dirty_and_sets_path(qapp, tmp_path):
@@ -198,7 +230,12 @@ def test_new_protocol_resets_manager_and_tracker(qapp, tmp_path):
     pane.protocol_state_tracker.set_saved(str(tmp_path / "x.json"))
     pane.manager.add_step()                   # dirty again
 
-    pane.new_protocol()                       # clean path — no confirm needed
+    # Dirty -> the guard prompts; mock to YES so new_protocol proceeds.
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm",
+        return_value=YES,
+    ):
+        pane.new_protocol()
 
     assert len(pane.manager.root.children) == 0
     t = pane.protocol_state_tracker

--- a/pluggable_protocol_tree/tests/test_qt_model_reactive_wiring.py
+++ b/pluggable_protocol_tree/tests/test_qt_model_reactive_wiring.py
@@ -241,6 +241,51 @@ def test_event_dependency_no_crash_with_zero_rows():
 # Regression — model with no derived columns
 # -----------------------------------------------------------------------------
 
+def test_cell_changed_event_emits_focused_dataChanged():
+    """Regression: read-only summary columns (electrodes, routes) don't
+    declare ``depends_on_row_traits``; their only redraw signal on a
+    direct trait write (e.g. from DeviceViewerSyncController) comes
+    from MvcTreeModel observing ``manager.cell_changed`` and emitting
+    a focused dataChanged for the affected (path, col_id)."""
+    cols = [make_type_column(), make_id_column(), make_name_column()]
+    manager = RowManager(columns=cols)
+    manager.add_step(values={"name": "row-0"})
+    manager.add_step(values={"name": "row-1"})
+
+    qm = MvcTreeModel(manager)
+    name_col = [c.model.col_id for c in manager.columns].index("name")
+
+    received: list = []
+    qm.dataChanged.connect(
+        lambda top, bottom, *_: received.append((top.row(), top.column())),
+    )
+
+    # Simulate a direct trait write + cell_changed (the DV sync path).
+    manager.root.children[1].name = "row-1-renamed"
+    manager.cell_changed = {"path": (1,), "col_id": "name"}
+
+    assert (1, name_col) in received
+    assert (0, name_col) not in received
+
+
+def test_cell_changed_with_bad_payload_is_noop():
+    """Bad / missing payload keys must not crash the observer."""
+    cols = [make_type_column(), make_name_column()]
+    manager = RowManager(columns=cols)
+    manager.add_step()
+    qm = MvcTreeModel(manager)
+
+    received: list = []
+    qm.dataChanged.connect(
+        lambda top, bottom, *_: received.append((top.row(), top.column())),
+    )
+    manager.cell_changed = "not a dict"          # ignored
+    manager.cell_changed = {"path": (99,)}       # bad path, no col_id
+    manager.cell_changed = {"col_id": "name"}    # no path
+
+    assert received == []
+
+
 def test_no_derived_columns_no_extra_signals():
     cols = [make_type_column(), make_id_column(), make_name_column()]
     manager = RowManager(columns=cols)

--- a/pluggable_protocol_tree/views/delegate.py
+++ b/pluggable_protocol_tree/views/delegate.py
@@ -31,10 +31,11 @@ class ProtocolItemDelegate(QStyledItemDelegate):
         value = col.view.get_editor_data(editor)
         if col.handler.on_interact(node, col.model, value):
             model.dataChanged.emit(index, index)
-            # on_interact writes the trait directly via model.set_value;
-            # the manager's rows_changed event would never fire on user
-            # edits otherwise. Fire it here so dirty-state observers
-            # (e.g. the protocol state tracker) match the documented
-            # rows_changed contract: "Fires on structure or value
-            # changes."
-            self._manager.rows_changed = True
+            # on_interact writes the trait directly, bypassing the
+            # manager's set_value path. Fire cell_changed with the
+            # (path, col_id) so the protocol state tracker can update
+            # its incremental dirty bookkeeping in O(1).
+            self._manager.cell_changed = {
+                "path": tuple(node.path),
+                "col_id": col.model.col_id,
+            }

--- a/pluggable_protocol_tree/views/delegate.py
+++ b/pluggable_protocol_tree/views/delegate.py
@@ -31,3 +31,10 @@ class ProtocolItemDelegate(QStyledItemDelegate):
         value = col.view.get_editor_data(editor)
         if col.handler.on_interact(node, col.model, value):
             model.dataChanged.emit(index, index)
+            # on_interact writes the trait directly via model.set_value;
+            # the manager's rows_changed event would never fire on user
+            # edits otherwise. Fire it here so dirty-state observers
+            # (e.g. the protocol state tracker) match the documented
+            # rows_changed contract: "Fires on structure or value
+            # changes."
+            self._manager.rows_changed = True

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -63,3 +63,8 @@ class PluggableProtocolDockPane(TraitsDockPane):
 
     def save_as_protocol_dialog(self):
         self._pane().save_as_protocol_dialog()
+
+    def setup_new_experiment(self):
+        # Reuses the same handler the experiment-bar button drives so
+        # the menu and the toolbutton stay consistent.
+        self._pane()._on_new_experiment()

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -36,7 +36,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
         manager = RowManager(columns=list(self.columns))
         sync = DeviceViewerSyncController(row_manager=manager)
 
-        return ProtocolTreePane(
+        pane = ProtocolTreePane(
             manager,
             application=app,
             experiment_manager=experiment_manager,
@@ -44,3 +44,22 @@ class PluggableProtocolDockPane(TraitsDockPane):
             device_viewer_sync=sync,
             parent=parent,
         )
+        pane.protocol_state_tracker.dock_pane = self
+        return pane
+
+    # --- &Protocol menu action delegates ----------------------------
+
+    def _pane(self):
+        return self.control.widget()
+
+    def new_protocol(self):
+        self._pane().new_protocol()
+
+    def load_protocol_dialog(self):
+        self._pane().load_protocol_dialog()
+
+    def save_protocol_dialog(self):
+        self._pane().save_protocol_dialog()
+
+    def save_as_protocol_dialog(self):
+        self._pane().save_as_protocol_dialog()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from pathlib import Path
 
 from pyface.qt.QtCore import Qt, QModelIndex, QTimer, Signal
 from pyface.qt.QtGui import QFont
@@ -24,7 +25,9 @@ from pyface.qt.QtWidgets import (
     QFileDialog, QToolButton, QVBoxLayout, QWidget,
 )
 
-from microdrop_application.dialogs.pyface_wrapper import error as error_dialog
+from microdrop_application.dialogs.pyface_wrapper import (
+    NO, confirm, error as error_dialog,
+)
 from microdrop_style.button_styles import ICON_FONT_FAMILY
 
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
@@ -33,7 +36,11 @@ from device_viewer.consts import PROTOCOL_RUNNING
 from pluggable_protocol_tree.consts import (
     ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
 )
+from pluggable_protocol_tree.models.row import GroupRow
 from pluggable_protocol_tree.services.phase_math import iter_phases
+from pluggable_protocol_tree.services.protocol_state_tracker import (
+    PluggableProtocolStateTracker,
+)
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
@@ -96,6 +103,9 @@ class ProtocolTreePane(QWidget):
         if self.device_viewer_sync is not None:
             self.device_viewer_sync.attach(self.widget)
 
+        self.protocol_state_tracker = PluggableProtocolStateTracker()
+        self.manager.observe(self._on_manager_rows_changed, "rows_changed")
+
         self._build_status_bar()
         self._build_navigation_bar()
         self._build_experiment_bar()
@@ -135,6 +145,9 @@ class ProtocolTreePane(QWidget):
         if self.application is not None:
             self.application.observe(
                 self._on_experiment_changed, "experiment_changed",
+            )
+            self.application.observe(
+                self._on_application_exiting, "application_exiting",
             )
             try:
                 cur = self.application.current_experiment_directory
@@ -656,30 +669,38 @@ class ProtocolTreePane(QWidget):
     # --- save / load -----------------------------------------------
 
     def save_to_dialog(self, parent=None):
-        """Open a file dialog and persist the manager's JSON state."""
+        """Open a file dialog and persist the manager's JSON state.
+
+        Returns the saved path on success, ``None`` if the user cancels
+        or the write fails.
+        """
         path, _ = QFileDialog.getSaveFileName(
             parent or self, "Save Protocol", "", "Protocol JSON (*.json)",
         )
         if not path:
-            return
+            return None
         try:
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(self.manager.to_json(), f, indent=2)
         except Exception as e:
             error_dialog(parent=parent or self,
                          title="Save error", message=str(e))
+            return None
+        return path
 
     def load_from_dialog(self, columns_factory, parent=None):
         """Open a file dialog and replace the manager's state from JSON.
 
         ``columns_factory`` rebuilds the column list (consumed by
         ``set_state_from_json``); the dock pane and demo window each
-        own a different source of truth for it."""
+        own a different source of truth for it. Returns the loaded path
+        on success, ``None`` otherwise.
+        """
         path, _ = QFileDialog.getOpenFileName(
             parent or self, "Load Protocol", "", "Protocol JSON (*.json)",
         )
         if not path:
-            return
+            return None
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
@@ -687,6 +708,8 @@ class ProtocolTreePane(QWidget):
         except Exception as e:
             error_dialog(parent=parent or self,
                          title="Load error", message=str(e))
+            return None
+        return path
 
     def closeEvent(self, event):
         """Detach Traits observers before the underlying QWidget is
@@ -701,12 +724,131 @@ class ProtocolTreePane(QWidget):
                 )
             except Exception as e:
                 logger.warning(f"failed to detach experiment_changed observer: {e}")
+            try:
+                self.application.observe(
+                    self._on_application_exiting,
+                    "application_exiting",
+                    remove=True,
+                )
+            except Exception as e:
+                logger.warning(f"failed to detach application_exiting observer: {e}")
+        try:
+            self.manager.observe(
+                self._on_manager_rows_changed, "rows_changed", remove=True,
+            )
+        except Exception as e:
+            logger.warning(f"failed to detach rows_changed observer: {e}")
         if self.device_viewer_sync is not None:
             try:
                 self.device_viewer_sync.detach()
             except Exception as e:
                 logger.warning(f"failed to detach device_viewer_sync: {e}")
         super().closeEvent(event)
+
+    # --- file menu actions ------------------------------------------
+
+    def _on_manager_rows_changed(self, event):
+        """Any structure or value mutation flips the dirty flag.
+
+        Load / Save / New helpers explicitly reset the tracker after the
+        manager finishes mutating, so this observer can be unconditional.
+        """
+        self.protocol_state_tracker.mark_modified()
+
+    def _confirm_proceed_or_abort(self) -> bool:
+        """Returns True if the action should proceed.
+
+        Shows a confirm dialog when the protocol is dirty, or when the
+        loaded file no longer exists on disk. Returns False if the user
+        picks NO.
+        """
+        tracker = self.protocol_state_tracker
+        if tracker.is_modified:
+            logger.warning("Attempting to overwrite unsaved protocol.")
+            user_choice = confirm(
+                self,
+                "Current protocol has unsaved changes.\n"
+                "Proceed without saving?",
+                title="Unsaved Protocol Changes",
+                cancel=False,
+            )
+            if user_choice == NO:
+                logger.info("Action cancelled due to unsaved changes.")
+                return False
+        elif (tracker.loaded_protocol_path
+              and not Path(tracker.loaded_protocol_path).exists()):
+            logger.warning("Loaded protocol file no longer exists on disk.")
+            user_choice = confirm(
+                self,
+                "Current protocol file has been deleted.\n"
+                "Proceed without saving?",
+                title="Protocol File Not Found",
+                cancel=False,
+            )
+            if user_choice == NO:
+                logger.info("Action cancelled due to missing protocol file.")
+                return False
+        return True
+
+    def new_protocol(self):
+        if not self._confirm_proceed_or_abort():
+            return
+        self.manager.root = GroupRow(name="Root")
+        self.manager.protocol_metadata = {}
+        self.manager.selection = []
+        self.manager.rows_changed = True
+        self.protocol_state_tracker.reset()
+
+    def save_protocol_dialog(self):
+        known_path = self.protocol_state_tracker.loaded_protocol_path
+        if not known_path:
+            self.save_as_protocol_dialog()
+            return
+        try:
+            with open(known_path, "w", encoding="utf-8") as f:
+                json.dump(self.manager.to_json(), f, indent=2)
+        except Exception as e:
+            error_dialog(parent=self, title="Save error", message=str(e))
+            return
+        self.protocol_state_tracker.set_saved(known_path)
+
+    def save_as_protocol_dialog(self):
+        path = self.save_to_dialog(parent=self)
+        if path:
+            self.protocol_state_tracker.set_saved(path)
+
+    def load_protocol_dialog(self, columns_factory=None):
+        if not self._confirm_proceed_or_abort():
+            return
+        factory = (columns_factory
+                   if columns_factory is not None
+                   else (lambda: list(self.manager.columns)))
+        path = self.load_from_dialog(factory, parent=self)
+        if path:
+            self.protocol_state_tracker.set_loaded(path)
+
+    def _on_application_exiting(self, event):
+        """Veto application exit when the protocol is dirty and the user
+        elects to keep it open.
+
+        ``event`` is a Pyface Vetoable event — setting ``event.veto = True``
+        cancels the exit. Falls back to a non-fatal log if veto plumbing
+        isn't available.
+        """
+        if not self.protocol_state_tracker.is_modified:
+            return
+        user_choice = confirm(
+            self,
+            "Current protocol has unsaved changes.\n"
+            "Exit without saving?",
+            title="Unsaved Protocol Changes",
+            cancel=False,
+        )
+        if user_choice == NO:
+            try:
+                event.veto = True
+            except Exception as e:
+                logger.warning(f"could not veto application exit: {e}")
 
     # --- experiment-bar handlers ------------------------------------
 

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -470,7 +470,7 @@ class ProtocolTreePane(QWidget):
         self._on_protocol_terminated()
 
     def _on_protocol_terminated(self):
-        logger.info("Protocol terminated → free mode")
+        logger.info("Protocol terminated --> free mode")
         self.clear_highlights()
         self._set_idle_button_state()
         self._tick_timer.stop()
@@ -571,11 +571,11 @@ class ProtocolTreePane(QWidget):
             return
         cur = self._current_step_in(steps)
         if cur is None:
-            logger.info(f"Nav: previous (no current) → [{_dotted_path(steps[0])}]")
+            logger.info(f"Nav: previous (no current) --> [{_dotted_path(steps[0])}]")
             self._select_step(steps[0])
             return
         if cur > 0:
-            logger.info(f"Nav: previous step → [{_dotted_path(steps[cur - 1])}]")
+            logger.info(f"Nav: previous step --> [{_dotted_path(steps[cur - 1])}]")
             self._select_step(steps[cur - 1])
 
     def navigate_to_next_step(self):
@@ -584,11 +584,11 @@ class ProtocolTreePane(QWidget):
             return
         cur = self._current_step_in(steps)
         if cur is None:
-            logger.info(f"Nav: next (no current) → [{_dotted_path(steps[0])}]")
+            logger.info(f"Nav: next (no current) --> [{_dotted_path(steps[0])}]")
             self._select_step(steps[0])
             return
         if cur < len(steps) - 1:
-            logger.info(f"Nav: next step → [{_dotted_path(steps[cur + 1])}]")
+            logger.info(f"Nav: next step --> [{_dotted_path(steps[cur + 1])}]")
             self._select_step(steps[cur + 1])
             return
         logger.info(f"Nav: next at end — duplicating [{_dotted_path(steps[cur])}]")

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -146,9 +146,14 @@ class ProtocolTreePane(QWidget):
             self.application.observe(
                 self._on_experiment_changed, "experiment_changed",
             )
-            self.application.observe(
-                self._on_application_exiting, "application_exiting",
-            )
+            try:
+                self.application.observe(
+                    self._on_application_exiting, "application_exiting",
+                )
+            except ValueError as e:
+                # Bare HasTraits test stubs may not declare the trait;
+                # production Envisage apps always do.
+                logger.debug(f"application_exiting observer skipped: {e}")
             try:
                 cur = self.application.current_experiment_directory
                 if cur is not None:

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -292,7 +292,7 @@ class ProtocolTreePane(QWidget):
         self._status_step_label.setText(
             f"Step {self._step_index} / {self._step_total}"
         )
-        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name!r}")
+        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name}")
         self.status_bar.lbl_next_step.setText(
             f"Next Step: {self._next_step_name(row)}"
         )

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -292,7 +292,7 @@ class ProtocolTreePane(QWidget):
         self._status_step_label.setText(
             f"Step {self._step_index} / {self._step_total}"
         )
-        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name}")
+        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name!r}")
         self.status_bar.lbl_next_step.setText(
             f"Next Step: {self._next_step_name(row)}"
         )

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -104,7 +104,13 @@ class ProtocolTreePane(QWidget):
             self.device_viewer_sync.attach(self.widget)
 
         self.protocol_state_tracker = PluggableProtocolStateTracker()
+        # Structural mutations (add/remove/move/paste/new) re-check the
+        # baseline path set and rescan if paths re-aligned (insert+
+        # delete, move+undo).
         self.manager.observe(self._on_manager_rows_changed, "rows_changed")
+        # Cell edits go through cell_changed (carries path + col_id)
+        # so the tracker can update its diff in O(1).
+        self.manager.observe(self._on_manager_cell_changed, "cell_changed")
 
         self._build_status_bar()
         self._build_navigation_bar()
@@ -743,6 +749,12 @@ class ProtocolTreePane(QWidget):
             )
         except Exception as e:
             logger.warning(f"failed to detach rows_changed observer: {e}")
+        try:
+            self.manager.observe(
+                self._on_manager_cell_changed, "cell_changed", remove=True,
+            )
+        except Exception as e:
+            logger.warning(f"failed to detach cell_changed observer: {e}")
         if self.device_viewer_sync is not None:
             try:
                 self.device_viewer_sync.detach()
@@ -753,12 +765,21 @@ class ProtocolTreePane(QWidget):
     # --- file menu actions ------------------------------------------
 
     def _on_manager_rows_changed(self, event):
-        """Any structure or value mutation flips the dirty flag.
+        """Structural mutation — re-check the baseline path set."""
+        self.protocol_state_tracker.on_structure_changed(self.manager)
 
-        Load / Save / New helpers explicitly reset the tracker after the
-        manager finishes mutating, so this observer can be unconditional.
-        """
-        self.protocol_state_tracker.mark_modified()
+    def _on_manager_cell_changed(self, event):
+        """Cell value edit — incremental dirty update for the one cell."""
+        payload = event.new
+        if not isinstance(payload, dict):
+            return
+        path = payload.get("path")
+        col_id = payload.get("col_id")
+        if path is None or col_id is None:
+            return
+        self.protocol_state_tracker.on_cell_changed(
+            path, col_id, self.manager,
+        )
 
     def _confirm_proceed_or_abort(self) -> bool:
         """Returns True if the action should proceed.
@@ -803,6 +824,7 @@ class ProtocolTreePane(QWidget):
         self.manager.selection = []
         self.manager.rows_changed = True
         self.protocol_state_tracker.reset()
+        self.protocol_state_tracker.reseed_baseline(self.manager)
 
     def save_protocol_dialog(self):
         known_path = self.protocol_state_tracker.loaded_protocol_path
@@ -816,11 +838,13 @@ class ProtocolTreePane(QWidget):
             error_dialog(parent=self, title="Save error", message=str(e))
             return
         self.protocol_state_tracker.set_saved(known_path)
+        self.protocol_state_tracker.reseed_baseline(self.manager)
 
     def save_as_protocol_dialog(self):
         path = self.save_to_dialog(parent=self)
         if path:
             self.protocol_state_tracker.set_saved(path)
+            self.protocol_state_tracker.reseed_baseline(self.manager)
 
     def load_protocol_dialog(self, columns_factory=None):
         if not self._confirm_proceed_or_abort():
@@ -831,6 +855,7 @@ class ProtocolTreePane(QWidget):
         path = self.load_from_dialog(factory, parent=self)
         if path:
             self.protocol_state_tracker.set_loaded(path)
+            self.protocol_state_tracker.reseed_baseline(self.manager)
 
     def _on_application_exiting(self, event):
         """Veto application exit when the protocol is dirty and the user

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -123,12 +123,14 @@ class MvcTreeModel(QAbstractItemModel):
             if col.handler.on_interact(node, col.model, value):
                 self.dataChanged.emit(index, index, [role])
                 # on_interact writes directly to the row trait, bypassing
-                # RowManager.set_value, so the manager's rows_changed
-                # event would never fire on user cell edits. Fire it
-                # here so dirty-state observers (e.g. the protocol state
-                # tracker) match the documented semantics: "Fires on
-                # structure or value changes."
-                self._manager.rows_changed = True
+                # RowManager.set_value, so the manager would not see
+                # this edit. Fire cell_changed with (path, col_id) so
+                # the protocol state tracker can update its incremental
+                # dirty bookkeeping in O(1).
+                self._manager.cell_changed = {
+                    "path": tuple(node.path),
+                    "col_id": col.model.col_id,
+                }
                 return True
         return False
 

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -122,6 +122,13 @@ class MvcTreeModel(QAbstractItemModel):
                 value = value == Qt.Checked or value == 2 or value is True
             if col.handler.on_interact(node, col.model, value):
                 self.dataChanged.emit(index, index, [role])
+                # on_interact writes directly to the row trait, bypassing
+                # RowManager.set_value, so the manager's rows_changed
+                # event would never fire on user cell edits. Fire it
+                # here so dirty-state observers (e.g. the protocol state
+                # tracker) match the documented semantics: "Fires on
+                # structure or value changes."
+                self._manager.rows_changed = True
                 return True
         return False
 

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -50,6 +50,11 @@ class MvcTreeModel(QAbstractItemModel):
 
         # Rebroadcast manager changes as layoutChanged
         row_manager.observe(self._on_rows_changed, "rows_changed")
+        # Cell value edits get a focused dataChanged for the affected
+        # (path, col_id) — read-only summary columns (electrodes,
+        # routes) don't declare depends_on_row_traits, so this is the
+        # only redraw signal they receive on DV-driven write-backs.
+        row_manager.observe(self._on_cell_changed, "cell_changed")
 
         self._wire_event_observers()
         self._wire_row_observers()
@@ -158,6 +163,37 @@ class MvcTreeModel(QAbstractItemModel):
         # per-row observers so newcomers participate and detached rows
         # stop emitting against a stale column index.
         self._wire_row_observers()
+
+    def _on_cell_changed(self, event):
+        """Focused dataChanged for a single (path, col_id) edit.
+
+        Fires for delegate / setData edits (where dataChanged was
+        already emitted at the call site — this is a redundant but
+        cheap no-op) AND for direct trait writes from
+        DeviceViewerSyncController (where no other refresh signal
+        reaches the model).
+        """
+        payload = event.new
+        if not isinstance(payload, dict):
+            return
+        path = payload.get("path")
+        col_id = payload.get("col_id")
+        if path is None or col_id is None:
+            return
+        try:
+            row = self._manager.get_row(tuple(path))
+        except (IndexError, AttributeError):
+            return
+        col_idx = next(
+            (i for i, c in enumerate(self._manager.columns)
+             if c.model.col_id == col_id),
+            None,
+        )
+        if col_idx is None:
+            return
+        idx = self._index_for_cell(row, col_idx)
+        if idx.isValid():
+            self.dataChanged.emit(idx, idx)
 
     # ------------ reactive wiring for derived columns ------------
 


### PR DESCRIPTION
## Summary

Resolves #416. Brings the pluggable protocol tree to feature parity with the legacy `protocol_grid` `&Protocol` menu (New / Load / Save / Save As) + dirty-state title + unsaved-changes guard, plus a new application-exit veto.

- `PluggableProtocolStateTracker` (HasTraits) tracks `protocol_name`, `loaded_protocol_path`, `is_modified`; observes its own traits to rewrite the dock-pane title (`Pluggable Protocol Tree - <name>[ [modified]]`).
- `ProtocolTreePane` observes `RowManager.rows_changed` (single mutation point) to mark dirty. Load/Save/New helpers reset the flag post-mutation so the observer can stay unconditional.
- Four new dock-pane methods (`new_protocol`, `load_protocol_dialog`, `save_protocol_dialog`, `save_as_protocol_dialog`) delegate to the pane.
- `menus.py` exports `protocol_menu_factory()` (top-level `&Protocol` in MenuBar, after File).
- App-exit guard: `application_exiting` observer prompts on dirty and vetoes when the user picks NO.
- Save/load helpers (`save_to_dialog`/`load_from_dialog`) now return the path on success so the new wrappers reuse them without duplicating IO.

Design doc: `docs/superpowers/specs/2026-05-12-issue-416-pluggable-protocol-file-menu-design.md`.

## Test plan

- [x] `pytest pluggable_protocol_tree/tests/test_protocol_state_tracker.py` — 10 unit tests pass (no Qt).
- [x] `pytest pluggable_protocol_tree/tests/test_menus.py` — 4 unit tests pass (no Qt).
- [x] `pytest pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py` — 13 qapp-level integration tests pass.
- [x] `pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py` together — all 56 pass (no regression).
- [x] Plugin imports + contributes `protocol_menu_factory` via `SchemaAddition`.
- [ ] **Manual smoke (to run before merge):** `python examples/run_device_viewer_pluggable.py` → `&Protocol` menu appears with 4 entries → edit step → title shows `[modified]` → Save As → title clears → Load with unsaved → confirm dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)