### PR TITLE
Add DropBot reboot command

### DIFF
--- a/dropbot_controller/consts.py
+++ b/dropbot_controller/consts.py
@@ -34,6 +34,7 @@ RETRY_CONNECTION = "dropbot/requests/retry_connection"
 HALT = "dropbot/requests/halt"
 SET_VOLTAGE = "dropbot/requests/set_voltage"
 SET_FREQUENCY = "dropbot/requests/set_frequency"
+REBOOT = "dropbot/requests/reboot"
 
 # Protocol-driven setpoint topics (separate from UI SET_VOLTAGE/SET_FREQUENCY
 # so the realtime-mode gate and prefs-persistence side effects don't apply).

--- a/dropbot_controller/dropbot_controller_base.py
+++ b/dropbot_controller/dropbot_controller_base.py
@@ -338,6 +338,9 @@ class DropbotControllerBase(HasTraits):
 
         publish_message(topic=ELECTRODES_STATE_CHANGE, message=app_globals.get("last_channels_requested", []))
 
+    def on_reboot_request(self, message):
+        logger.critical("Attempting to reboot dropbot microcontroller...")
+        self.proxy.reboot()
     ########################################################################################################
 
 

--- a/dropbot_controller/interfaces/i_dropbot_controller_base.py
+++ b/dropbot_controller/interfaces/i_dropbot_controller_base.py
@@ -54,4 +54,9 @@ class IDropbotControllerBase(IDramatiqControllerBase):
         """
         handle halt requests.
         """
+
+    def on_reboot_request(self, message):
+        """
+        Reboot the dropbot microcontroller. This disconnects the device while it resets.
+        """
     ####################################################################################

--- a/dropbot_tools_menu/menus.py
+++ b/dropbot_tools_menu/menus.py
@@ -1,20 +1,22 @@
-from dropbot.hardware_test import ALL_TESTS
 from pyface.tasks.action.api import SMenu
 from traits.api import Property, Directory
+from traits.api import Int, Any
 
 from logger.logger_service import get_logger
-from microdrop_utils.dramatiq_traits_helpers import DramatiqMessagePublishAction
-
 logger = get_logger(__name__)
 
+from dropbot.hardware_test import ALL_TESTS
+
+from microdrop_utils.dramatiq_traits_helpers import DramatiqMessagePublishAction
 from microdrop_utils.status_bar_utils import set_status_bar_message
 
 from dropbot_controller.consts import RUN_ALL_TESTS, TEST_SHORTS, TEST_VOLTAGE, TEST_CHANNELS, \
-    TEST_ON_BOARD_FEEDBACK_CALIBRATION, START_DEVICE_MONITORING
+    TEST_ON_BOARD_FEEDBACK_CALIBRATION, START_DEVICE_MONITORING, REBOOT
 
-from traits.api import Int, Any
 
 from .self_test_dialogs import ShowSelfTestIntroDialogAction, DropbotDisconnectedDialogAction
+
+from microdrop_application.dialogs.pyface_wrapper import warning, OK
 
 
 class RunTests(DramatiqMessagePublishAction):
@@ -82,7 +84,25 @@ def dropbot_tools_menu_factory(plugin=None):
     # create an action to restart dropbot search
     dropbot_search = DramatiqMessagePublishAction(name="&Search for Dropbot Connection", topic=START_DEVICE_MONITORING)
 
+    # create an action to reboot dropbot
+
+    class DropbotRebootAction(DramatiqMessagePublishAction):
+        name = "&Reboot Dropbot"
+        topic = REBOOT
+
+        def pre_perform(self):
+            logger.info("Request user confirmation to reboot Dropbot")
+
+            user_choice = warning(None,
+                                  "Rebooting the <b>DropBot</b> will <b>Disconnect</b> the microcontroller and the "
+                                  "DropBot may become <b>Unresponsive</b>. Do you still want to proceed?",
+                                  title="Dropbot Reboot Warning",)
+
+            return user_choice == OK
+
+    dropbot_reboot = DropbotRebootAction()
+
     # return an SMenu object compiling each object made and put into Dropbot menu under Tools menu.
-    return SMenu(items=[run_all_tests, test_options_menu, dropbot_search], id="dropbot_tools", name="Drop&bot")
+    return SMenu(items=[run_all_tests, test_options_menu, dropbot_search, dropbot_reboot], id="dropbot_tools", name="Drop&bot")
 
 

--- a/microdrop_utils/dramatiq_traits_helpers.py
+++ b/microdrop_utils/dramatiq_traits_helpers.py
@@ -3,10 +3,36 @@ from traits.trait_types import Str, Any
 
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
 
 class DramatiqMessagePublishAction(TaskWindowAction):
     topic = Str(desc="topic this action connects to")
     message = Any(desc="message to publish")
 
     def perform(self, event=None):
-        publish_message(topic=self.topic, message=self.message)
+        pre_routine_result = self.pre_perform()
+
+        if pre_routine_result:
+            publish_message(topic=self.topic, message=self.message)
+
+        else:
+            logger.warning(f"Pre perform failed: Action to publish {self.message} to topic {self.topic} not executed")
+            return
+
+        self.post_perform()
+
+    ## Additional hooks for routines done pre/post perform
+
+    def pre_perform(self) -> bool:
+        """
+        Add routine to perform fter performing the action. Return True to proceed to perform
+        """
+        return True
+
+    def post_perform(self):
+        """
+        Add routine to perform before performing the action.
+        """
+        pass


### PR DESCRIPTION
## Summary

Adds a **Reboot Dropbot** command that resets the DropBot microcontroller from the Tools → Dropbot menu.

- New `REBOOT` request topic (`dropbot/requests/reboot`) and an `on_reboot_request` backend handler that calls `proxy.reboot()`. The interface (`IDropbotControllerBase`) declares the matching method. The existing `dropbot/requests/#` subscription in `ACTOR_TOPIC_DICT` already routes the topic, so no subscription change was needed.
- `DramatiqMessagePublishAction` gains `pre_perform`/`post_perform` hooks so a subclass can gate or extend publishing.
- New `DropbotRebootAction` uses `pre_perform` to show a confirmation warning explaining the device will disconnect and may become unresponsive during the reset, and only publishes `REBOOT` if the user accepts.

## Test plan

- [ ] Tools → Dropbot → Reboot Dropbot shows the warning dialog
- [ ] Cancelling does not publish / reboot
- [ ] Confirming reboots the connected DropBot

🤖 Generated with [Claude Code](https://claude.com/claude-code)
