### PR TITLE
PPT-21: Protocol quick-actions toolbar (resolves #433)

### DIFF
--- a/docs/superpowers/plans/2026-05-29-ppt-21-quick-actions-toolbar.md
+++ b/docs/superpowers/plans/2026-05-29-ppt-21-quick-actions-toolbar.md
@@ -1,0 +1,2621 @@
+# PPT-21 Quick-Actions Toolbar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the legacy `protocol_grid` quick-actions toolbar into the pluggable protocol tree with a clean split: the tree plugin owns the contribution surface (extension point, traits model, bar widget, controller, pane integration); a new sibling plugin `protocol_quick_action_tools` ships all 8 legacy actions (add_step, delete_row, add_group, import_protocol, open_protocol, save_protocol, new_protocol, browse_reports) plus the ported `ReportBrowserDialog`.
+
+**Architecture:** Mirror the existing `PROTOCOL_COLUMNS` pattern — Envisage `ExtensionPoint(List(Instance(IQuickAction)))` aggregated through a plain list, sorted by `(priority, action_id)`, passed into `ProtocolTreePane` at construction, rendered as `QToolButton`s under the tree; a `QuickActionsController` watches new pane signals (`selection_changed`, `protocol_running_changed`) to drive per-action `is_enabled(ctx)` predicates and wires `QShortcut`s declaratively from each action's `shortcut` trait.
+
+**Tech Stack:** Python 3, Traits/HasStrictTraits, PySide6 via `pyface.qt`, Envisage plugins, pytest with `pytest-qt`'s `qapp` fixture, `unittest.mock.MagicMock`.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-ppt-21-quick-actions-toolbar-design.md`
+
+**Working directory for all commands:** `C:\Users\Info\PycharmProjects\pixi-microdrop\microdrop-py` (where `pixi run pytest src/...` resolves correctly).
+
+---
+
+### Task 1: Add `PROTOCOL_QUICK_ACTIONS` const and `IQuickAction` interface
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/interfaces/i_quick_action.py`
+- Modify: `src/pluggable_protocol_tree/consts.py` (add `PROTOCOL_QUICK_ACTIONS`)
+- Create: `src/pluggable_protocol_tree/tests/test_quick_action_interface.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_action_interface.py`:
+
+```python
+"""IQuickAction is the contract any contributed quick-action button
+implements. This file pins the trait shape and the two-method surface
+so future refactors can't silently break plugin contributions."""
+
+from traits.api import HasStrictTraits, provides
+
+from pluggable_protocol_tree.consts import PROTOCOL_QUICK_ACTIONS
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+def test_extension_point_id_is_namespaced():
+    assert PROTOCOL_QUICK_ACTIONS == (
+        "pluggable_protocol_tree.protocol_quick_actions"
+    )
+
+
+def test_iquick_action_required_traits_exist():
+    """Trait names + default values are part of the public contract —
+    plugins read action_id/icon_text/tooltip directly."""
+
+    @provides(IQuickAction)
+    class _Stub(HasStrictTraits):
+        pass
+
+    s = _Stub()
+    # Every trait declared on IQuickAction must be readable on a provider
+    # (proves the interface itself declares them).
+    for name in ("action_id", "icon_text", "tooltip",
+                 "priority", "shortcut"):
+        assert hasattr(s, name), f"missing trait: {name}"
+    assert s.priority == 50
+    assert s.shortcut == ""
+
+
+def test_iquick_action_methods_are_callable_with_ctx():
+    """The interface defines on_execute_action(ctx) and is_enabled(ctx)
+    -> bool; defaults are no-op / True."""
+
+    @provides(IQuickAction)
+    class _Stub(HasStrictTraits):
+        action_id = "x"
+        icon_text = ""
+        tooltip = ""
+
+    s = _Stub()
+    # Default implementations don't raise; is_enabled defaults to True.
+    s.on_execute_action(ctx=None)
+    assert s.is_enabled(ctx=None) is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_interface.py -v
+```
+
+Expected: 3 errors on `ImportError: cannot import name 'PROTOCOL_QUICK_ACTIONS'` / `cannot import name 'IQuickAction'`.
+
+- [ ] **Step 3: Add the constant**
+
+Append to `src/pluggable_protocol_tree/consts.py` (place after the `LOGGING_LISTENER_NAME`/`LOGGING_ACTOR_TOPIC_DICT` block, before the trailing blank line):
+
+```python
+# Envisage extension point — plugins contribute IQuickAction instances
+# (see interfaces/i_quick_action.py) that render as buttons on the
+# pluggable tree's quick-actions toolbar. Tree plugin ships zero
+# builtins; all contributions come from sibling plugins.
+PROTOCOL_QUICK_ACTIONS = f"{PKG}.protocol_quick_actions"
+```
+
+- [ ] **Step 4: Create the interface file**
+
+Create `src/pluggable_protocol_tree/interfaces/i_quick_action.py`:
+
+```python
+"""Traits interface for protocol-tree quick-action buttons.
+
+Each contribution is a button on the toolbar mounted under the tree.
+Mirrors the IColumn pattern: tree plugin owns the contract, other
+plugins contribute implementations. Two hooks:
+
+* ``on_execute_action(ctx)`` — fired on click (or keyboard shortcut).
+* ``is_enabled(ctx) -> bool`` — queried by the controller on selection
+  / protocol-running changes; default ``True``.
+
+The ``ctx`` is a :class:`QuickActionCtx` carrying the pane, current
+selection, and is_running flag. Contributions stay Qt-free where they
+can by delegating Qt work to pane helper methods.
+"""
+
+from traits.api import Bool, Int, Interface, Str
+
+
+class IQuickAction(Interface):
+    action_id = Str(
+        desc="Stable identifier (e.g. 'add_step'). Used in logging, "
+             "tests, and shortcut-conflict messages.")
+    icon_text = Str(
+        desc="Material-symbol name rendered as the button's text under "
+             "ICON_FONT_FAMILY (e.g. 'add', 'delete', 'playlist_add').")
+    tooltip = Str(desc="Button tooltip.")
+    priority = Int(50,
+        desc="Lower runs first; controls left-to-right order in the bar.")
+    shortcut = Str(default_value="",
+        desc="QKeySequence string ('R', 'Ctrl+S', ...). Empty = no "
+             "shortcut. Registered widget-scoped to the pane.")
+
+    def on_execute_action(self, ctx):
+        """Called when the button is clicked or its shortcut fires.
+        ctx is a QuickActionCtx. Return value is ignored."""
+
+    def is_enabled(self, ctx) -> bool:
+        """Return True if the button should be clickable. Queried by
+        the controller on selection / protocol-running changes.
+        Default: always True."""
+        return True
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_interface.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/pluggable_protocol_tree/consts.py src/pluggable_protocol_tree/interfaces/i_quick_action.py src/pluggable_protocol_tree/tests/test_quick_action_interface.py
+git commit -m "[ppt-21] Add IQuickAction interface + PROTOCOL_QUICK_ACTIONS extension-point id"
+```
+
+---
+
+### Task 2: Add `BaseQuickAction` model + `QuickActionCtx` value object
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/models/quick_action.py`
+- Create: `src/pluggable_protocol_tree/tests/test_quick_action_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_action_model.py`:
+
+```python
+"""BaseQuickAction is a thin HasStrictTraits convenience base so
+plugins don't have to redeclare the IQuickAction trait set. The
+QuickActionCtx is the value object passed to every action callback."""
+
+from unittest.mock import MagicMock
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+from pluggable_protocol_tree.models.quick_action import (
+    BaseQuickAction, QuickActionCtx,
+)
+
+
+def test_base_quick_action_provides_iquick_action_interface():
+    a = BaseQuickAction(action_id="x", icon_text="add", tooltip="t",
+                        priority=10, shortcut="Ctrl+X")
+    assert IQuickAction in type(a).__implements__.getInterfaces()
+    assert a.action_id == "x"
+    assert a.icon_text == "add"
+    assert a.priority == 10
+    assert a.shortcut == "Ctrl+X"
+
+
+def test_base_quick_action_defaults():
+    a = BaseQuickAction(action_id="x")
+    assert a.priority == 50
+    assert a.shortcut == ""
+    assert a.is_enabled(ctx=None) is True
+
+
+def test_quick_action_ctx_carries_pane_selection_running():
+    pane = MagicMock()
+    ctx = QuickActionCtx(
+        pane=pane,
+        selected_paths=((0,), (1, 2)),
+        is_running=True,
+    )
+    assert ctx.pane is pane
+    assert ctx.selected_paths == ((0,), (1, 2))
+    assert ctx.is_running is True
+
+
+def test_quick_action_ctx_defaults():
+    ctx = QuickActionCtx(pane=MagicMock())
+    assert ctx.selected_paths == ()
+    assert ctx.is_running is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_model.py -v
+```
+
+Expected: `ImportError: cannot import name 'BaseQuickAction'`.
+
+- [ ] **Step 3: Create the model**
+
+Create `src/pluggable_protocol_tree/models/quick_action.py`:
+
+```python
+"""Default ``IQuickAction`` provider + ``QuickActionCtx`` value object.
+
+Plugins are free to subclass ``BaseQuickAction`` (recommended — gets
+the trait set and default ``is_enabled`` for free) or write a fresh
+``HasStrictTraits`` class decorated with ``@provides(IQuickAction)``.
+"""
+
+from traits.api import (
+    Any, Bool, HasStrictTraits, Int, Str, Tuple, provides,
+)
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+@provides(IQuickAction)
+class BaseQuickAction(HasStrictTraits):
+    """Concrete IQuickAction provider with the default trait set.
+
+    Subclasses override ``on_execute_action`` (and optionally
+    ``is_enabled``). Trait fields can be set positionally / by kwarg
+    in factory functions — see protocol_quick_action_tools.quick_actions.
+    """
+    action_id = Str
+    icon_text = Str
+    tooltip = Str
+    priority = Int(50)
+    shortcut = Str(default_value="")
+
+    def on_execute_action(self, ctx):
+        """Default no-op. Subclasses override."""
+
+    def is_enabled(self, ctx) -> bool:
+        return True
+
+
+class QuickActionCtx(HasStrictTraits):
+    """Value object handed to every action callback.
+
+    Built fresh by the controller on each click / refresh — never
+    cached on the action. ``pane`` is the live ``ProtocolTreePane``
+    (so contributions can reach ``pane.manager``, ``pane.widget.tree``,
+    ``pane.application``, ``pane.experiment_manager``, etc.).
+    """
+    pane = Any
+    selected_paths = Tuple()
+    is_running = Bool(False)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_model.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/pluggable_protocol_tree/models/quick_action.py src/pluggable_protocol_tree/tests/test_quick_action_model.py
+git commit -m "[ppt-21] Add BaseQuickAction + QuickActionCtx"
+```
+
+---
+
+### Task 3: `QuickActionBar` widget (pure rendering, no behaviour)
+
+**Files:**
+- Create: `src/pluggable_protocol_tree/views/quick_action_bar.py` (just the bar; controller in next task)
+- Create: `src/pluggable_protocol_tree/tests/test_quick_action_bar.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_action_bar.py`:
+
+```python
+"""QuickActionBar is a pure rendering widget: it takes a list of
+IQuickAction instances and produces one QToolButton per action,
+ordered by (priority, action_id). It has no state and no Qt-signal
+connections — the controller (next task) attaches click handlers."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import QuickActionBar
+
+
+def _make(action_id, *, priority=50, icon="add", tip="t", shortcut=""):
+    return BaseQuickAction(action_id=action_id, icon_text=icon,
+                           tooltip=tip, priority=priority,
+                           shortcut=shortcut)
+
+
+def test_bar_renders_one_button_per_action(qapp):
+    bar = QuickActionBar(actions=[
+        _make("a"), _make("b"), _make("c"),
+    ])
+    assert len(bar.buttons) == 3
+    assert set(bar.buttons.keys()) == {"a", "b", "c"}
+
+
+def test_bar_orders_by_priority_then_action_id(qapp):
+    bar = QuickActionBar(actions=[
+        _make("z", priority=10),
+        _make("a", priority=20),
+        _make("c", priority=10),
+    ])
+    assert list(bar.buttons.keys()) == ["c", "z", "a"]
+
+
+def test_button_text_is_icon_text_and_tooltip_matches(qapp):
+    bar = QuickActionBar(actions=[
+        _make("add_step", icon="add", tip="Add step below selection"),
+    ])
+    b = bar.buttons["add_step"]
+    assert b.text() == "add"
+    assert b.toolTip() == "Add step below selection"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_bar.py -v
+```
+
+Expected: `ImportError: cannot import name 'QuickActionBar'`.
+
+- [ ] **Step 3: Implement the bar widget**
+
+Create `src/pluggable_protocol_tree/views/quick_action_bar.py`:
+
+```python
+"""Pure-rendering toolbar widget for the pluggable protocol tree.
+
+Owns no state. Takes a sorted list of IQuickAction implementations and
+produces one icon-font QToolButton per action, keyed by action_id.
+The QuickActionsController (separate unit) drives click routing,
+per-action enabled state, and keyboard-shortcut wiring.
+"""
+
+from typing import Dict, List
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtGui import QFont
+from pyface.qt.QtWidgets import QHBoxLayout, QToolButton, QWidget
+
+from microdrop_style.button_styles import ICON_FONT_FAMILY
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+class QuickActionBar(QWidget):
+    """Horizontal row of icon-only QToolButtons, one per action."""
+
+    def __init__(self, actions: List[IQuickAction], parent: QWidget = None):
+        super().__init__(parent)
+        self.buttons: Dict[str, QToolButton] = {}
+        sorted_actions = sorted(actions,
+                                key=lambda a: (a.priority, a.action_id))
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        icon_font = QFont(ICON_FONT_FAMILY)
+        icon_font.setPixelSize(20)
+        for action in sorted_actions:
+            btn = QToolButton()
+            btn.setText(action.icon_text)
+            btn.setFont(icon_font)
+            btn.setToolTip(action.tooltip)
+            btn.setCursor(Qt.PointingHandCursor)
+            self.buttons[action.action_id] = btn
+            layout.addWidget(btn)
+        layout.addStretch()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_action_bar.py -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/quick_action_bar.py src/pluggable_protocol_tree/tests/test_quick_action_bar.py
+git commit -m "[ppt-21] Add QuickActionBar pure-rendering widget"
+```
+
+---
+
+### Task 4: `QuickActionsController` — click routing + per-action enabled state
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/quick_action_bar.py` (append controller class)
+- Create: `src/pluggable_protocol_tree/tests/test_quick_actions_controller.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_actions_controller.py`:
+
+```python
+"""QuickActionsController wires a QuickActionBar to a pane:
+
+* On every ``pane.selection_changed`` / ``pane.protocol_running_changed``
+  emission, walks the actions and calls ``button.setEnabled(...)``.
+* Clicks route through ``_execute(action)`` which builds a fresh
+  ``QuickActionCtx`` and calls ``action.on_execute_action(ctx)``,
+  swallowing any exception so a buggy contribution can't crash the bar.
+* When ``is_running == True``, the whole bar is disabled regardless of
+  each action's ``is_enabled``.
+"""
+
+from unittest.mock import MagicMock
+
+from pyface.qt.QtCore import QObject, Signal
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import (
+    QuickActionBar, QuickActionsController,
+)
+
+
+class _FakePane(QObject):
+    """Minimal stand-in for ProtocolTreePane."""
+    selection_changed = Signal()
+    protocol_running_changed = Signal(bool)
+
+    def __init__(self, manager=None, parent=None):
+        super().__init__(parent)
+        self.manager = manager or MagicMock()
+        # Controller pulls `pane.manager.selection` to build ctx.selected_paths.
+        self.manager.selection = []
+
+
+class _ToggleAction(BaseQuickAction):
+    """is_enabled flips with the .enabled flag; on_execute_action
+    bumps a counter and stashes the ctx for assertions."""
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.enabled = True
+        self.calls = 0
+        self.last_ctx = None
+
+    def is_enabled(self, ctx) -> bool:
+        return self.enabled
+
+    def on_execute_action(self, ctx):
+        self.calls += 1
+        self.last_ctx = ctx
+
+
+def test_initial_state_uses_is_enabled(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    b = _ToggleAction(action_id="b", icon_text="del", tooltip="")
+    b.enabled = False
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a, b])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a, b])
+    ctrl.refresh_enabled()
+    assert bar.buttons["a"].isEnabled() is True
+    assert bar.buttons["b"].isEnabled() is False
+
+
+def test_protocol_running_disables_whole_bar(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    pane.protocol_running_changed.emit(True)
+    assert bar.buttons["a"].isEnabled() is False
+    pane.protocol_running_changed.emit(False)
+    assert bar.buttons["a"].isEnabled() is True
+
+
+def test_selection_changed_re_evaluates_is_enabled(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    a.enabled = False
+    pane.selection_changed.emit()
+    assert bar.buttons["a"].isEnabled() is False
+
+
+def test_click_calls_execute_with_ctx_carrying_selection(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    pane.manager.selection = [(0,), (1, 2)]
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    bar.buttons["a"].click()
+    assert a.calls == 1
+    assert a.last_ctx.pane is pane
+    assert a.last_ctx.selected_paths == ((0,), (1, 2))
+    assert a.last_ctx.is_running is False
+
+
+def test_click_on_disabled_button_does_not_execute(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    a.enabled = False
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    ctrl.refresh_enabled()
+    bar.buttons["a"].click()
+    assert a.calls == 0
+
+
+def test_buggy_action_does_not_break_other_buttons(qapp, caplog):
+    class _Boom(BaseQuickAction):
+        def on_execute_action(self, ctx):
+            raise RuntimeError("kaboom")
+
+    boom = _Boom(action_id="b", icon_text="del", tooltip="")
+    good = _ToggleAction(action_id="g", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[boom, good])
+    QuickActionsController(bar=bar, pane=pane, actions=[boom, good])
+    bar.buttons["b"].click()                  # raises internally
+    bar.buttons["g"].click()                  # must still fire
+    assert good.calls == 1
+    assert any("kaboom" in r.message for r in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_controller.py -v
+```
+
+Expected: `ImportError: cannot import name 'QuickActionsController'`.
+
+- [ ] **Step 3: Append the controller to the bar module**
+
+Append to `src/pluggable_protocol_tree/views/quick_action_bar.py`:
+
+```python
+
+
+# --- controller ----------------------------------------------------
+
+
+from logger.logger_service import get_logger
+from pluggable_protocol_tree.models.quick_action import QuickActionCtx
+
+logger = get_logger(__name__)
+
+
+class QuickActionsController:
+    """Wires a QuickActionBar to a ProtocolTreePane.
+
+    Listens for ``pane.selection_changed`` / ``pane.protocol_running_changed``
+    and keeps ``button.setEnabled(...)`` in sync with each action's
+    ``is_enabled(ctx)``. Routes clicks through ``_execute(action)`` so
+    a buggy contribution can't crash the bar. Builds a fresh ctx on
+    every call — never caches.
+    """
+
+    def __init__(self, *, bar: QuickActionBar, pane, actions):
+        self._bar = bar
+        self._pane = pane
+        self._actions = list(actions)
+        self._is_running = False
+        # Wire button clicks.
+        for action in self._actions:
+            btn = bar.buttons[action.action_id]
+            btn.clicked.connect(lambda _checked=False, a=action: self._execute(a))
+        # Wire pane signals (drives re-enable + running state).
+        pane.selection_changed.connect(self.refresh_enabled)
+        pane.protocol_running_changed.connect(self._on_running_changed)
+        self.refresh_enabled()
+
+    def _build_ctx(self) -> QuickActionCtx:
+        sel = tuple(tuple(p) for p in (self._pane.manager.selection or []))
+        return QuickActionCtx(pane=self._pane,
+                              selected_paths=sel,
+                              is_running=self._is_running)
+
+    def _on_running_changed(self, running: bool) -> None:
+        self._is_running = bool(running)
+        self.refresh_enabled()
+
+    def refresh_enabled(self) -> None:
+        ctx = self._build_ctx()
+        for action in self._actions:
+            try:
+                enabled = bool(action.is_enabled(ctx)) and not ctx.is_running
+            except Exception as e:                # pragma: no cover - defensive
+                logger.warning(
+                    f"is_enabled failed for {action.action_id!r}: {e}; "
+                    f"disabling button.")
+                enabled = False
+            self._bar.buttons[action.action_id].setEnabled(enabled)
+
+    def _execute(self, action) -> None:
+        ctx = self._build_ctx()
+        if ctx.is_running or not self._bar.buttons[action.action_id].isEnabled():
+            # The shortcut path bypasses Qt's enabled-state gate; gate again here.
+            return
+        try:
+            action.on_execute_action(ctx)
+        except Exception as e:
+            logger.error(
+                f"quick-action {action.action_id!r} raised: {e}", exc_info=True)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_controller.py -v
+```
+
+Expected: 6 passed. (`caplog` will capture the "kaboom" log message at error level.)
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/quick_action_bar.py src/pluggable_protocol_tree/tests/test_quick_actions_controller.py
+git commit -m "[ppt-21] Add QuickActionsController (click + enabled-state wiring)"
+```
+
+---
+
+### Task 5: `QuickActionsController` — keyboard shortcut wiring + conflict detection
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/quick_action_bar.py` (extend controller with `_wire_shortcuts`)
+- Create: `src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py`:
+
+```python
+"""Shortcut wiring lives in QuickActionsController. For every action
+whose ``shortcut`` is non-empty we register one widget-scoped QShortcut
+on the pane, routed through ``_execute`` so it respects ``is_enabled``
+and the ``is_running`` gate. Two actions declaring the same key:
+the second registration is skipped and a warning is logged."""
+
+from pyface.qt.QtCore import QObject, Qt, Signal
+from pyface.qt.QtGui import QKeySequence
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import (
+    QuickActionBar, QuickActionsController,
+)
+
+
+class _Pane(QObject):
+    selection_changed = Signal()
+    protocol_running_changed = Signal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        from unittest.mock import MagicMock
+        self.manager = MagicMock()
+        self.manager.selection = []
+
+
+class _Counting(BaseQuickAction):
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.calls = 0
+
+    def on_execute_action(self, ctx):
+        self.calls += 1
+
+
+def test_shortcut_registers_widget_scoped_qshortcut(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    assert len(ctrl.shortcuts) == 1
+    qs = ctrl.shortcuts[0]
+    assert qs.key() == QKeySequence("R")
+    assert qs.context() == Qt.WidgetWithChildrenShortcut
+    assert qs.parentWidget() is pane
+
+
+def test_shortcut_triggers_execute(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 1
+
+
+def test_shortcut_is_gated_by_is_running(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    pane.protocol_running_changed.emit(True)
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 0
+
+
+def test_no_shortcut_means_no_qshortcut_registered(qapp):
+    a = _Counting(action_id="r", icon_text="add", tooltip="", shortcut="")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    assert ctrl.shortcuts == []
+
+
+def test_duplicate_shortcut_skips_second_and_logs_warning(qapp, caplog):
+    a = _Counting(action_id="first", icon_text="add", tooltip="",
+                  shortcut="R")
+    b = _Counting(action_id="second", icon_text="del", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a, b])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a, b])
+    # Only the first wins.
+    assert len(ctrl.shortcuts) == 1
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 1
+    assert b.calls == 0
+    assert any(
+        "R" in r.message and "first" in r.message and "second" in r.message
+        for r in caplog.records)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py -v
+```
+
+Expected: `AttributeError: 'QuickActionsController' object has no attribute 'shortcuts'`.
+
+- [ ] **Step 3: Extend the controller with `_wire_shortcuts`**
+
+Modify `src/pluggable_protocol_tree/views/quick_action_bar.py`. First, augment the imports near the top of the controller section:
+
+```python
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtGui import QKeySequence, QShortcut
+```
+
+Then, in `QuickActionsController.__init__`, **before** the final `self.refresh_enabled()` call, insert:
+
+```python
+        self.shortcuts = []
+        self._wire_shortcuts()
+```
+
+And add the new method at the end of the class:
+
+```python
+    def _wire_shortcuts(self) -> None:
+        claimed = {}                              # shortcut str -> action_id
+        for action in self._actions:
+            key_str = (action.shortcut or "").strip()
+            if not key_str:
+                continue
+            existing = claimed.get(key_str)
+            if existing is not None:
+                logger.warning(
+                    f"quick-action shortcut conflict on {key_str!r}: "
+                    f"{existing!r} already registered; skipping "
+                    f"{action.action_id!r}.")
+                continue
+            claimed[key_str] = action.action_id
+            qs = QShortcut(QKeySequence(key_str), self._pane)
+            qs.setContext(Qt.WidgetWithChildrenShortcut)
+            qs.activated.connect(lambda a=action: self._execute(a))
+            self.shortcuts.append(qs)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/quick_action_bar.py src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py
+git commit -m "[ppt-21] Wire QShortcuts from IQuickAction.shortcut (with conflict detection)"
+```
+
+---
+
+### Task 6: Add `selection_changed` + `protocol_running_changed` signals to `ProtocolTreePane`
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_emits_protocol_running_changed_true_on_start(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    seen = []
+    pane.protocol_running_changed.connect(lambda v: seen.append(v))
+    pane._on_protocol_started()
+    assert seen == [True]
+
+
+def test_pane_emits_protocol_running_changed_false_on_terminated(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    seen = []
+    pane.protocol_running_changed.connect(lambda v: seen.append(v))
+    pane._on_protocol_terminated()
+    assert seen == [False]
+
+
+def test_pane_emits_selection_changed_on_tree_selection(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pyface.qt.QtCore import QItemSelection
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    fired = []
+    pane.selection_changed.connect(lambda: fired.append(True))
+    # Drive the tree's selectionModel directly — pane subscribes to
+    # selectionChanged and re-emits the parameterless selection_changed.
+    sm = pane.widget.tree.selectionModel()
+    sm.selectionChanged.emit(QItemSelection(), QItemSelection())
+    assert fired == [True]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_emits_protocol_running_changed_true_on_start src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_emits_protocol_running_changed_false_on_terminated src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_emits_selection_changed_on_tree_selection -v
+```
+
+Expected: 3 failures on `AttributeError: 'ProtocolTreePane' object has no attribute 'protocol_running_changed'` / `selection_changed`.
+
+- [ ] **Step 3: Add the signal declarations**
+
+In `src/pluggable_protocol_tree/views/protocol_tree_pane.py`, locate the `phase_acked = Signal()` line near the top of the class:
+
+```python
+class ProtocolTreePane(QWidget):
+    ...
+    phase_acked = Signal()
+```
+
+Replace with:
+
+```python
+class ProtocolTreePane(QWidget):
+    ...
+    phase_acked = Signal()
+    # Quick-actions toolbar feed: emit True/False on protocol start/end,
+    # parameterless selection_changed on each tree selection move.
+    # QuickActionsController listens to both to drive button enabled state.
+    protocol_running_changed = Signal(bool)
+    selection_changed = Signal()
+```
+
+- [ ] **Step 4: Emit `protocol_running_changed` on start / terminate**
+
+Locate `_on_protocol_started(self):` and add as the FIRST line after the docstring (or after the existing first line):
+
+```python
+        self.protocol_running_changed.emit(True)
+```
+
+Locate `_on_protocol_terminated(self, outcome="finished"):` and add as the FIRST line of the body:
+
+```python
+        self.protocol_running_changed.emit(False)
+```
+
+- [ ] **Step 5: Wire `selection_changed` to the tree's selectionModel**
+
+Locate `_wire_executor_signals(self):` (or alternatively, add a new wiring point in `__init__` after `self.widget = ProtocolTreeWidget(...)`). Add right after the tree widget construction in `__init__` (near where `device_viewer_sync` is attached):
+
+```python
+        # Re-emit the tree's selectionChanged as a parameterless signal so
+        # the QuickActionsController doesn't have to know about Qt selection
+        # models. The pane already constructed self.widget above.
+        self.widget.tree.selectionModel().selectionChanged.connect(
+            lambda *_: self.selection_changed.emit()
+        )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v -k 'protocol_running_changed or selection_changed'
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 7: Run the full pane suite to confirm no regressions**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v
+```
+
+Expected: all previously-passing tests still pass + the 3 new ones pass.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git commit -m "[ppt-21] Pane signals: protocol_running_changed + selection_changed"
+```
+
+---
+
+### Task 7: Mount the bar in `ProtocolTreePane` from injected contributions
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py` (constructor + `_build_layout`)
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_mounts_quick_action_bar_when_actions_passed(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+    a = BaseQuickAction(action_id="add_step", icon_text="add",
+                        tooltip="Add step", priority=10)
+    b = BaseQuickAction(action_id="save_protocol", icon_text="save",
+                        tooltip="Save", priority=60)
+    pane = ptp.ProtocolTreePane([make_name_column()], quick_actions=[a, b])
+    assert pane.quick_action_bar is not None
+    assert set(pane.quick_action_bar.buttons.keys()) == {"add_step", "save_protocol"}
+    assert pane.quick_actions_controller is not None
+
+
+def test_pane_skips_quick_action_bar_when_no_actions(qapp):
+    """No actions contributed (e.g. demo, headless test) -> no bar
+    widget mounted; controller is None. This is the architectural
+    commitment: the tree plugin ships zero builtins."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    assert pane.quick_action_bar is None
+    assert pane.quick_actions_controller is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v -k 'quick_action_bar'
+```
+
+Expected: failures on `AttributeError: 'ProtocolTreePane' object has no attribute 'quick_action_bar'`.
+
+- [ ] **Step 3: Add `quick_actions` constructor parameter**
+
+In `ProtocolTreePane.__init__`, find the signature:
+
+```python
+def __init__(
+    self,
+    columns_or_manager,
+    *,
+    application=None,
+    experiment_manager=None,
+    sticky_manager=None,
+    device_viewer_sync=None,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    executor_factory=None,
+    logging_device_context_provider=None,
+    parent=None,
+):
+```
+
+Add `quick_actions=None,` immediately before `parent=None,`:
+
+```python
+def __init__(
+    self,
+    columns_or_manager,
+    *,
+    application=None,
+    experiment_manager=None,
+    sticky_manager=None,
+    device_viewer_sync=None,
+    phase_ack_topic=ELECTRODES_STATE_APPLIED,
+    executor_factory=None,
+    logging_device_context_provider=None,
+    quick_actions=None,
+    parent=None,
+):
+```
+
+- [ ] **Step 4: Construct the bar (or set to None) BEFORE `_build_layout()`**
+
+In `ProtocolTreePane.__init__`, find the line:
+
+```python
+        self._build_layout()
+```
+
+Insert **immediately above** that line:
+
+```python
+        # Quick-actions toolbar (bar + controller). Both are None when no
+        # contributions exist (demo / headless test environments) so the
+        # pane stays usable with no chrome below the tree. Constructed
+        # before _build_layout() so it can be inserted in the layout.
+        from pluggable_protocol_tree.views.quick_action_bar import (
+            QuickActionBar, QuickActionsController,
+        )
+        if quick_actions:
+            self.quick_action_bar = QuickActionBar(
+                actions=list(quick_actions), parent=self)
+            self.quick_actions_controller = QuickActionsController(
+                bar=self.quick_action_bar, pane=self,
+                actions=list(quick_actions))
+        else:
+            self.quick_action_bar = None
+            self.quick_actions_controller = None
+```
+
+- [ ] **Step 5: Mount the bar in `_build_layout`**
+
+Locate the `_build_layout` method:
+
+```python
+def _build_layout(self):
+    layout = QVBoxLayout(self)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(0)
+    layout.addWidget(self.navigation_bar)
+    layout.addWidget(self.status_bar)
+    layout.addWidget(make_separator())
+    layout.addWidget(self.widget)
+```
+
+Replace with:
+
+```python
+def _build_layout(self):
+    layout = QVBoxLayout(self)
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.setSpacing(0)
+    layout.addWidget(self.navigation_bar)
+    layout.addWidget(self.status_bar)
+    layout.addWidget(make_separator())
+    layout.addWidget(self.widget)
+    if self.quick_action_bar is not None:
+        layout.addWidget(self.quick_action_bar)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v -k 'quick_action_bar'
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 7: Run the full pane suite + bar + controller suites**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_quick_action_bar.py src/pluggable_protocol_tree/tests/test_quick_actions_controller.py src/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py -v
+```
+
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git commit -m "[ppt-21] Mount QuickActionBar in ProtocolTreePane from injected contributions"
+```
+
+---
+
+### Task 8: Pane helpers (`add_step_after_selection`, `add_group_after_selection`, `delete_selected_rows`, `import_into_selected_group`, `browse_reports_dialog`)
+
+Five small helpers added to `ProtocolTreePane`. We TDD each one in turn — same task, five mini-cycles.
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/views/protocol_tree_pane.py`
+- Modify: `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py` (append)
+
+- [ ] **Step 1: Write the failing tests for all 5 helpers**
+
+Append to `src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def _pane_with_two_steps(qapp):
+    """Pane with a tree containing exactly two top-level step rows."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    # seed_default_step_if_empty already gave us 1 step; add one more.
+    pane.manager.add_step()
+    return pane
+
+
+def test_add_step_after_selection_with_no_selection_appends_root(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = []
+    pane.add_step_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+
+
+def test_add_step_after_selection_with_one_selected_inserts_below(qapp):
+    pane = _pane_with_two_steps(qapp)
+    # Select the first row.
+    pane.manager.selection = [(0,)]
+    before = len(pane.manager.root.children)
+    pane.add_step_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+    # The newly-inserted step should be at index 1 (right after selected).
+    # Easiest assertion: the row that used to be at (1,) is now at (2,).
+    # We can't peek at row identity easily here, so just check count.
+
+
+def test_add_group_after_selection_appends_a_group(qapp):
+    pane = _pane_with_two_steps(qapp)
+    pane.manager.selection = []
+    before = len(pane.manager.root.children)
+    pane.add_group_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+    from pluggable_protocol_tree.models.row import GroupRow
+    assert isinstance(pane.manager.root.children[-1], GroupRow)
+
+
+def test_delete_selected_rows_removes_at_those_paths(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = [(0,)]
+    pane.delete_selected_rows()
+    assert len(pane.manager.root.children) == before - 1
+
+
+def test_delete_selected_rows_no_selection_is_noop(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = []
+    pane.delete_selected_rows()
+    assert len(pane.manager.root.children) == before
+
+
+def test_import_into_selected_group_noop_when_no_group_selected(qapp,
+                                                                 monkeypatch):
+    """Selection points to a step (not a group) -> import is a no-op."""
+    pane = _pane_with_two_steps(qapp)
+    pane.manager.selection = [(0,)]            # a step row
+    called = []
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: called.append(True) or ("", ""))
+    pane.import_into_selected_group()
+    assert called == []                        # never even opened the dialog
+
+
+def test_browse_reports_dialog_opens_with_globbed_paths(qapp, monkeypatch,
+                                                         tmp_path):
+    """browse_reports_dialog globs <experiment_dir>/reports/*.html and
+    feeds the path list into ReportBrowserDialog. The pane only needs a
+    ``reports_dir_provider`` (callable) — the dialog class itself is
+    monkeypatched here so this test can run without the new plugin."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    # Seed two HTML reports.
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "report_a.html").write_text("<html></html>", encoding="utf-8")
+    (reports / "report_b.html").write_text("<html></html>", encoding="utf-8")
+
+    captured = {}
+    class _FakeDialog:
+        def __init__(self, paths, parent=None):
+            captured["paths"] = list(paths)
+        def exec(self_inner):
+            return 0
+    monkeypatch.setattr(ptp, "_get_report_browser_dialog_cls",
+                        lambda: _FakeDialog)
+
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane._reports_dir_provider = lambda: reports
+    pane.browse_reports_dialog()
+    assert set(captured["paths"]) == {
+        str(reports / "report_a.html"),
+        str(reports / "report_b.html"),
+    }
+
+
+def test_browse_reports_dialog_no_provider_logs_and_returns(qapp, caplog):
+    """No reports_dir_provider configured (e.g. demo, no experiment manager)
+    -> log a debug message and return; do NOT crash."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane._reports_dir_provider = None
+    pane.browse_reports_dialog()                 # must not raise
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v -k 'add_step_after_selection or add_group_after_selection or delete_selected_rows or import_into_selected_group or browse_reports_dialog'
+```
+
+Expected: failures on `AttributeError: ... has no attribute 'add_step_after_selection'` (etc.).
+
+- [ ] **Step 3: Add the helpers to `ProtocolTreePane`**
+
+In `protocol_tree_pane.py`:
+
+First, add `glob` to the existing imports near the top of the file. Find:
+
+```python
+from pathlib import Path
+```
+
+Replace with:
+
+```python
+import glob
+from pathlib import Path
+```
+
+Then, in `ProtocolTreePane.__init__`, after the `quick_actions=None` block from Task 7, add an attribute initializer for the reports-dir provider (used by browse_reports_dialog):
+
+```python
+        # Optional callable returning the path to the experiment's reports
+        # dir (set by callers that have an experiment manager). When None,
+        # browse_reports_dialog is a no-op.
+        self._reports_dir_provider = (
+            (lambda: experiment_manager.get_experiment_directory() / "reports")
+            if experiment_manager is not None else None
+        )
+```
+
+Add a module-level helper near the top of the file (just above the `class ProtocolTreePane` declaration) for the dialog class lookup. This indirection keeps the pane decoupled from the new plugin — the pane imports lazily through this seam:
+
+```python
+def _get_report_browser_dialog_cls():
+    """Lazy import so the pluggable tree doesn't statically depend on
+    protocol_quick_action_tools. Returns the dialog class or None when
+    the new plugin isn't installed (development environments, demos)."""
+    try:
+        from protocol_quick_action_tools.views.report_browser_dialog import (
+            ReportBrowserDialog,
+        )
+        return ReportBrowserDialog
+    except Exception:                             # pragma: no cover - defensive
+        return None
+```
+
+Now add the five helper methods at the end of the `ProtocolTreePane` class (after the existing experiment-bar handlers, e.g. after `_on_experiment_changed`):
+
+```python
+    # --- quick-actions helpers --------------------------------------
+
+    def _insert_position_after_selection(self):
+        """Return ``(parent_path, index)`` for "insert after current
+        selection". With nothing selected -> ``((), None)`` (append to
+        root). With one selection at path ``(p..., i)`` -> ``((p...,),
+        i + 1)``. With multiple selections we use the last one."""
+        sel = list(self.manager.selection or [])
+        if not sel:
+            return ((), None)
+        last = tuple(sel[-1])
+        return (last[:-1], last[-1] + 1)
+
+    def add_step_after_selection(self):
+        parent_path, index = self._insert_position_after_selection()
+        self.manager.add_step(parent_path=parent_path, index=index)
+
+    def add_group_after_selection(self):
+        parent_path, index = self._insert_position_after_selection()
+        self.manager.add_group(parent_path=parent_path, index=index)
+
+    def delete_selected_rows(self):
+        sel = list(self.manager.selection or [])
+        if not sel:
+            return
+        self.manager.remove(sel)
+
+    def import_into_selected_group(self):
+        """Open a file picker, load the JSON protocol, and merge every
+        top-level row from the loaded protocol under the selected group.
+
+        No-op when the selection isn't exactly one row OR the selected
+        row isn't a GroupRow.
+        """
+        sel = list(self.manager.selection or [])
+        if len(sel) != 1:
+            return
+        target_path = tuple(sel[0])
+        try:
+            target = self.manager.get_row(target_path)
+        except (IndexError, AttributeError):
+            return
+        if not isinstance(target, GroupRow):
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Protocol", "", "Protocol JSON (*.json)")
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, ValueError) as e:
+            logger.warning(f"import_into_selected_group: read failed: {e}")
+            return
+        # The loaded protocol's top-level rows live under data["rows"]
+        # (RowManager.to_json shape); each entry is either a step dict
+        # or a {"type": "group", "rows": [...]} dict. Use add_step /
+        # add_group with the row dict's values to seed each new row.
+        for row_dict in (data.get("rows") or []):
+            if row_dict.get("type") == "group":
+                self.manager.add_group(
+                    parent_path=target_path,
+                    name=row_dict.get("name", "Group"),
+                )
+                # Nested rows are not recursively imported in this PR —
+                # callers paste structurally identical protocols and the
+                # legacy did the same. Out of scope: deep-import.
+            else:
+                values = {k: v for k, v in row_dict.items()
+                          if k not in ("type",)}
+                self.manager.add_step(
+                    parent_path=target_path, values=values)
+
+    def browse_reports_dialog(self):
+        """Glob <experiment_dir>/reports/*.html and open the
+        ReportBrowserDialog from protocol_quick_action_tools. No-op when
+        no reports-dir provider is configured (demos / no experiment
+        manager) or when the dialog plugin isn't installed."""
+        if self._reports_dir_provider is None:
+            logger.debug("browse_reports_dialog: no reports_dir_provider")
+            return
+        cls = _get_report_browser_dialog_cls()
+        if cls is None:
+            logger.warning(
+                "browse_reports_dialog: ReportBrowserDialog not available")
+            return
+        reports_dir = self._reports_dir_provider()
+        paths = sorted(glob.glob(str(reports_dir / "*.html")))
+        cls(paths, parent=self).exec()
+```
+
+- [ ] **Step 4: Run helper tests to verify they pass**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v -k 'add_step_after_selection or add_group_after_selection or delete_selected_rows or import_into_selected_group or browse_reports_dialog'
+```
+
+Expected: 8 passed.
+
+- [ ] **Step 5: Run the full pane suite**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/pluggable_protocol_tree/views/protocol_tree_pane.py src/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git commit -m "[ppt-21] Pane helpers: add_step/group_after_selection, delete_selected_rows, import_into_selected_group, browse_reports_dialog"
+```
+
+---
+
+### Task 9: Wire `PROTOCOL_QUICK_ACTIONS` extension point in `PluggableProtocolTreePlugin` + forward to dock pane
+
+**Files:**
+- Modify: `src/pluggable_protocol_tree/plugin.py`
+- Modify: `src/pluggable_protocol_tree/views/dock_pane.py`
+- Create: `src/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py`:
+
+```python
+"""The tree plugin exposes PROTOCOL_QUICK_ACTIONS as an Envisage
+extension point. Like PROTOCOL_COLUMNS, plugin.start() copies
+contributions into a plain list, and the dock-pane factory passes
+that list into ProtocolTreePane(quick_actions=...).
+
+The tree plugin itself contributes zero builtins."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
+
+
+def test_plugin_ships_zero_builtin_quick_actions():
+    plugin = PluggableProtocolTreePlugin()
+    # No contribution list set yet -> empty default.
+    assert plugin.contributed_quick_actions == []
+
+
+def test_assemble_quick_actions_sorts_by_priority_then_action_id():
+    plugin = PluggableProtocolTreePlugin()
+    plugin.contributed_quick_actions = [
+        BaseQuickAction(action_id="z", priority=10),
+        BaseQuickAction(action_id="a", priority=20),
+        BaseQuickAction(action_id="c", priority=10),
+    ]
+    assembled = plugin._assemble_quick_actions()
+    assert [a.action_id for a in assembled] == ["c", "z", "a"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py -v
+```
+
+Expected: `AttributeError: ... 'PluggableProtocolTreePlugin' object has no attribute 'contributed_quick_actions'`.
+
+- [ ] **Step 3: Add the extension point + assembler to the tree plugin**
+
+In `src/pluggable_protocol_tree/plugin.py`, add to the imports:
+
+```python
+from pluggable_protocol_tree.consts import (
+    ACTOR_TOPIC_DICT, LOGGING_ACTOR_TOPIC_DICT, PKG, PKG_name,
+    PROTOCOL_COLUMNS, PROTOCOL_QUICK_ACTIONS,
+)
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+```
+
+In the `PluggableProtocolTreePlugin` class, add after the existing `_column_extension_point` / `contributed_columns` block:
+
+```python
+    #: Envisage extension point — sibling plugins contribute
+    #: IQuickAction instances rendered as buttons on the tree's
+    #: quick-actions toolbar. Tree plugin itself contributes none.
+    _quick_action_extension_point = ExtensionPoint(
+        List(Instance(IQuickAction)), id=PROTOCOL_QUICK_ACTIONS,
+        desc="IQuickAction instances contributed by sibling plugins.",
+    )
+
+    contributed_quick_actions = List(
+        desc="Quick actions contributed by other plugins (populated "
+             "from the extension point at plugin start).")
+```
+
+Add the assembler method (next to `_assemble_columns`):
+
+```python
+    def _assemble_quick_actions(self):
+        """Return contributed quick actions in deterministic order
+        (priority then action_id)."""
+        try:
+            actions = list(self.contributed_quick_actions)
+        except Exception:
+            actions = []
+        return sorted(actions, key=lambda a: (a.priority, a.action_id))
+```
+
+In `start(self)`, after the existing `contributed_columns = list(...)` assignment:
+
+```python
+        try:
+            self.contributed_quick_actions = list(
+                self._quick_action_extension_point)
+        except Exception as e:
+            logger.warning(
+                f"failed to read PROTOCOL_QUICK_ACTIONS extension point: {e}"
+            )
+```
+
+In `_make_dock_pane`:
+
+```python
+    def _make_dock_pane(self, *args, **kwargs):
+        from pluggable_protocol_tree.views.dock_pane import PluggableProtocolDockPane
+        columns = self._assemble_columns()
+        quick_actions = self._assemble_quick_actions()
+        return PluggableProtocolDockPane(
+            columns=columns, quick_actions=quick_actions,
+            *args, **kwargs)
+```
+
+- [ ] **Step 4: Forward quick_actions through the dock pane**
+
+In `src/pluggable_protocol_tree/views/dock_pane.py`, find the `PluggableProtocolDockPane` class definition. Locate the existing `columns` trait declaration and add a sibling:
+
+```python
+    quick_actions = List(desc="Quick actions to mount under the tree.")
+```
+
+Then in the dock pane's `create_contents` (or wherever `ProtocolTreePane(...)` is constructed — search for `ProtocolTreePane(`), add `quick_actions=list(self.quick_actions),` to the kwargs:
+
+```python
+        pane = ProtocolTreePane(
+            manager,
+            application=app,
+            experiment_manager=experiment_manager,
+            sticky_manager=sticky_manager,
+            device_viewer_sync=sync,
+            logging_device_context_provider=_logging_device_context,
+            quick_actions=list(self.quick_actions),
+            parent=parent,
+        )
+```
+
+If `List` isn't imported at the top of `dock_pane.py`, add `from traits.api import List` (and any other missing imports).
+
+- [ ] **Step 5: Run extension-point tests to verify they pass**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Run the full tree-plugin test suite**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/ -v
+```
+
+Expected: every previously-green test stays green; new tests added in tasks 1-9 pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/pluggable_protocol_tree/plugin.py src/pluggable_protocol_tree/views/dock_pane.py src/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py
+git commit -m "[ppt-21] Wire PROTOCOL_QUICK_ACTIONS extension point + dock-pane forwarding"
+```
+
+---
+
+### Task 10: Scaffold the new `protocol_quick_action_tools` plugin (consts, plugin shell, base helper)
+
+**Files (all NEW):**
+- Create: `src/protocol_quick_action_tools/__init__.py`
+- Create: `src/protocol_quick_action_tools/consts.py`
+- Create: `src/protocol_quick_action_tools/plugin.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/__init__.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/base.py`
+- Create: `src/protocol_quick_action_tools/views/__init__.py`
+- Create: `src/protocol_quick_action_tools/tests/__init__.py`
+- Create: `src/protocol_quick_action_tools/tests/test_plugin_scaffold.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/protocol_quick_action_tools/tests/test_plugin_scaffold.py`:
+
+```python
+"""Plugin scaffold: package importable, consts defined, plugin class
+declares the IQuickAction contribution list (initially empty until
+the action factories land in task 12)."""
+
+import protocol_quick_action_tools
+from protocol_quick_action_tools.consts import PKG, PKG_name
+from protocol_quick_action_tools.plugin import (
+    ProtocolQuickActionToolsPlugin,
+)
+
+
+def test_package_is_importable():
+    assert protocol_quick_action_tools is not None
+
+
+def test_consts_match_package_layout():
+    assert PKG == "protocol_quick_action_tools"
+    assert PKG_name == "Protocol Quick Action Tools"
+
+
+def test_plugin_id_and_name():
+    p = ProtocolQuickActionToolsPlugin()
+    assert p.id == "protocol_quick_action_tools.plugin"
+    assert p.name == "Protocol Quick Action Tools Plugin"
+
+
+def test_plugin_has_contribution_list_trait():
+    p = ProtocolQuickActionToolsPlugin()
+    # The factories aren't wired in yet — they land in task 12. The
+    # trait must exist and default to an empty list so the scaffold
+    # can be loaded by Envisage without crashing.
+    assert isinstance(p.contributed_quick_actions, list)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_plugin_scaffold.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'protocol_quick_action_tools'`.
+
+- [ ] **Step 3: Create the package skeleton**
+
+Create `src/protocol_quick_action_tools/__init__.py`:
+
+```python
+"""Quick-actions contributions for the pluggable protocol tree (#433).
+
+Architecture lives in pluggable_protocol_tree (extension point, traits
+model, bar widget, controller, pane integration). This plugin
+contributes the 8 legacy actions (add/delete/save/open/import/new
+protocol, add group, browse reports) plus the ReportBrowserDialog.
+"""
+```
+
+Create `src/protocol_quick_action_tools/consts.py`:
+
+```python
+"""Package-level constants for protocol_quick_action_tools.
+
+Follows the MicroDrop convention: PKG derived from __name__, PKG_name
+title-cased for display.
+"""
+
+PKG = ".".join(__name__.split(".")[:-1])
+PKG_name = PKG.title().replace("_", " ")
+
+# Stable action_id strings. Tests assert against these constants so
+# the legacy ids remain accessible by name from outside the plugin.
+ACTION_ADD_STEP        = "add_step"
+ACTION_DELETE_ROW      = "delete_row"
+ACTION_ADD_GROUP       = "add_group"
+ACTION_IMPORT_PROTOCOL = "import_protocol"
+ACTION_OPEN_PROTOCOL   = "open_protocol"
+ACTION_SAVE_PROTOCOL   = "save_protocol"
+ACTION_NEW_PROTOCOL    = "new_protocol"
+ACTION_BROWSE_REPORTS  = "browse_reports"
+```
+
+Create `src/protocol_quick_action_tools/plugin.py`:
+
+```python
+"""ProtocolQuickActionToolsPlugin — contributes the 8 legacy quick
+actions to the pluggable protocol tree.
+
+Pattern mirrors peripheral_protocol_controls / dropbot_protocol_controls.
+The factories ship in task 12; the scaffold lands first so the rest of
+the plan can land in any order without "import broken" stages."""
+
+from envisage.plugin import Plugin
+from traits.api import List
+
+from pluggable_protocol_tree.consts import PROTOCOL_QUICK_ACTIONS
+
+from logger.logger_service import get_logger
+
+from .consts import PKG, PKG_name
+
+logger = get_logger(__name__)
+
+
+class ProtocolQuickActionToolsPlugin(Plugin):
+    id = PKG + ".plugin"
+    name = f"{PKG_name} Plugin"
+
+    contributed_quick_actions = List(contributes_to=PROTOCOL_QUICK_ACTIONS)
+
+    def _contributed_quick_actions_default(self):
+        # Filled in by task 12.
+        return []
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/__init__.py`:
+
+```python
+"""IQuickAction implementations for the 8 legacy quick actions."""
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/base.py`:
+
+```python
+"""Shared helpers used by every action factory.
+
+Keeps the per-action factory files (one per file) one-purpose: build
+an IQuickAction with the right id / icon / tooltip / hooks. Predicates
+that several actions share (``has_selection``, ``is_single_group_selected``,
+...) live here.
+"""
+
+from pluggable_protocol_tree.models.row import GroupRow
+
+
+def has_selection(ctx) -> bool:
+    return len(ctx.selected_paths) >= 1
+
+
+def is_single_row_selected(ctx) -> bool:
+    return len(ctx.selected_paths) == 1
+
+
+def is_single_group_selected(ctx) -> bool:
+    """True iff exactly one row is selected AND that row is a GroupRow."""
+    if not is_single_row_selected(ctx):
+        return False
+    pane = ctx.pane
+    try:
+        row = pane.manager.get_row(tuple(ctx.selected_paths[0]))
+    except (IndexError, AttributeError):
+        return False
+    return isinstance(row, GroupRow)
+```
+
+Create `src/protocol_quick_action_tools/views/__init__.py`:
+
+```python
+"""Standalone Qt widgets used by quick actions (ReportBrowserDialog)."""
+```
+
+Create `src/protocol_quick_action_tools/tests/__init__.py` (empty):
+
+```python
+```
+
+- [ ] **Step 4: Run scaffold tests to verify they pass**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_plugin_scaffold.py -v
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/protocol_quick_action_tools/
+git commit -m "[ppt-21] Scaffold protocol_quick_action_tools plugin (consts + plugin shell + base helpers)"
+```
+
+---
+
+### Task 11: Port `ReportBrowserDialog` into the new plugin
+
+**Files:**
+- Create: `src/protocol_quick_action_tools/views/report_browser_dialog.py`
+- Create: `src/protocol_quick_action_tools/tests/test_report_browser_dialog.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/protocol_quick_action_tools/tests/test_report_browser_dialog.py`:
+
+```python
+"""Smoke tests for the ported ReportBrowserDialog: constructor accepts
+a list of path strings, populates a sortable tree of (Name, Size, Date),
+filters by name in the search box, and opens the selected report via
+QDesktopServices when the user activates a row."""
+
+from protocol_quick_action_tools.views.report_browser_dialog import (
+    ReportBrowserDialog,
+)
+
+
+def test_dialog_populates_one_row_per_path(qapp, tmp_path):
+    a = tmp_path / "report_a.html"; a.write_text("a", encoding="utf-8")
+    b = tmp_path / "report_b.html"; b.write_text("bb", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(a), str(b)])
+    assert dlg._tree.topLevelItemCount() == 2
+
+
+def test_dialog_handles_empty_list_without_crashing(qapp):
+    """No reports yet -> open with an empty table; no rows shown."""
+    dlg = ReportBrowserDialog([])
+    assert dlg._tree.topLevelItemCount() == 0
+
+
+def test_search_box_hides_non_matching_rows(qapp, tmp_path):
+    a = tmp_path / "alpha.html"; a.write_text("a", encoding="utf-8")
+    b = tmp_path / "beta.html"; b.write_text("b", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(a), str(b)])
+    dlg._apply_filter("alph")
+    visible = [
+        dlg._tree.topLevelItem(i).text(0)
+        for i in range(dlg._tree.topLevelItemCount())
+        if not dlg._tree.topLevelItem(i).isHidden()
+    ]
+    assert visible == ["alpha.html"]
+
+
+def test_format_size_threshold_branches():
+    fs = ReportBrowserDialog._format_size
+    assert fs(900) == "900 B"
+    assert fs(2048) == "2.0 KB"
+    assert fs(5 * 1024 * 1024) == "5.0 MB"
+
+
+def test_open_item_calls_qdesktopservices(qapp, tmp_path, monkeypatch):
+    """Double-click / Open routes through QDesktopServices.openUrl."""
+    from protocol_quick_action_tools.views import report_browser_dialog as mod
+    opened = []
+    monkeypatch.setattr(mod.QDesktopServices, "openUrl",
+                        lambda url: opened.append(url))
+    p = tmp_path / "report.html"; p.write_text("", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(p)])
+    item = dlg._tree.topLevelItem(0)
+    dlg._open_item(item)
+    assert len(opened) == 1
+    assert opened[0].toLocalFile() == str(p)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_report_browser_dialog.py -v
+```
+
+Expected: `ImportError: cannot import name 'ReportBrowserDialog'`.
+
+- [ ] **Step 3: Port the dialog**
+
+Create `src/protocol_quick_action_tools/views/report_browser_dialog.py`:
+
+```python
+"""File-manager-style dialog to browse and open session reports.
+
+Ported from protocol_grid/extra_ui_elements.py:942-1064 (the legacy
+class is fully decoupled from PGCWidget — only input is a list of path
+strings). Kept verbatim except for the import path adjustments.
+"""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from pyface.qt.QtCore import Qt, QUrl
+from pyface.qt.QtGui import QDesktopServices
+from pyface.qt.QtWidgets import (
+    QDialog, QHBoxLayout, QHeaderView, QLabel, QLineEdit, QPushButton,
+    QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget,
+)
+
+
+class _ReportSortableTreeWidgetItem(QTreeWidgetItem):
+    """QTreeWidgetItem subclass that sorts the Size column numerically
+    and the Date column chronologically instead of lexicographically."""
+
+    _SIZE_COL = 1
+    _DATE_COL = 2
+
+    def __lt__(self, other):
+        col = self.treeWidget().sortColumn()
+        if col == self._SIZE_COL:
+            return ((self.data(col, Qt.UserRole) or 0)
+                    < (other.data(col, Qt.UserRole) or 0))
+        if col == self._DATE_COL:
+            return ((self.data(col, Qt.UserRole) or 0)
+                    < (other.data(col, Qt.UserRole) or 0))
+        return super().__lt__(other)
+
+
+class ReportBrowserDialog(QDialog):
+    """Search-and-open dialog over a flat list of report HTML paths."""
+
+    _COL_NAME = 0
+    _COL_SIZE = 1
+    _COL_DATE = 2
+
+    def __init__(self, report_paths: List[str], parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Session Reports")
+        self.setModal(True)
+        self.setMinimumSize(650, 420)
+        self._report_paths = report_paths
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        # --- search bar ---
+        search_layout = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self._search_box = QLineEdit()
+        self._search_box.setPlaceholderText("Filter by file name...")
+        self._search_box.setClearButtonEnabled(True)
+        self._search_box.textChanged.connect(self._apply_filter)
+        search_layout.addWidget(search_label)
+        search_layout.addWidget(self._search_box)
+        layout.addLayout(search_layout)
+
+        # --- file table ---
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(["Name", "Size", "Date Created"])
+        self._tree.setRootIsDecorated(False)
+        self._tree.setAlternatingRowColors(True)
+        self._tree.setSortingEnabled(True)
+        self._tree.setSelectionMode(QTreeWidget.SingleSelection)
+
+        header = self._tree.header()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(self._COL_NAME, QHeaderView.Stretch)
+        header.setSectionResizeMode(self._COL_SIZE, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(self._COL_DATE, QHeaderView.ResizeToContents)
+
+        for path_str in self._report_paths:
+            p = Path(path_str)
+            try:
+                stat = os.stat(p)
+                size_bytes = stat.st_size
+                ctime = stat.st_ctime
+            except OSError:
+                size_bytes = 0
+                ctime = 0.0
+
+            item = _ReportSortableTreeWidgetItem([
+                p.name,
+                self._format_size(size_bytes),
+                datetime.fromtimestamp(ctime).strftime("%Y-%m-%d  %H:%M:%S")
+                if ctime else "",
+            ])
+            item.setToolTip(self._COL_NAME, str(p))
+            item.setData(self._COL_NAME, Qt.UserRole, path_str)
+            item.setData(self._COL_SIZE, Qt.UserRole, size_bytes)
+            item.setData(self._COL_DATE, Qt.UserRole, ctime)
+            self._tree.addTopLevelItem(item)
+
+        self._tree.sortByColumn(self._COL_DATE, Qt.DescendingOrder)
+        layout.addWidget(self._tree)
+
+        # --- buttons ---
+        button_layout = QHBoxLayout()
+        open_btn = QPushButton("Open")
+        open_btn.setDefault(True)
+        open_btn.clicked.connect(self._open_selected)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(open_btn)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+
+        self._tree.itemDoubleClicked.connect(self._open_item)
+
+    def _apply_filter(self, text: str):
+        text_lower = text.lower()
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            item.setHidden(text_lower not in item.text(self._COL_NAME).lower())
+
+    def _open_selected(self):
+        items = self._tree.selectedItems()
+        if items:
+            self._open_item(items[0])
+
+    def _open_item(self, item):
+        path_str = item.data(self._COL_NAME, Qt.UserRole)
+        QDesktopServices.openUrl(QUrl.fromLocalFile(path_str))
+
+    @staticmethod
+    def _format_size(size_bytes: int) -> str:
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        if size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        return f"{size_bytes / (1024 * 1024):.1f} MB"
+```
+
+- [ ] **Step 4: Run dialog tests to verify they pass**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_report_browser_dialog.py -v
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/protocol_quick_action_tools/views/report_browser_dialog.py src/protocol_quick_action_tools/tests/test_report_browser_dialog.py
+git commit -m "[ppt-21] Port ReportBrowserDialog from protocol_grid/extra_ui_elements.py"
+```
+
+---
+
+### Task 12: Eight action factories
+
+**Files:**
+- Create: `src/protocol_quick_action_tools/quick_actions/add_step.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/add_group.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/delete_row.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/import_protocol.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/open_protocol.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/save_protocol.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/new_protocol.py`
+- Create: `src/protocol_quick_action_tools/quick_actions/browse_reports.py`
+- Modify: `src/protocol_quick_action_tools/plugin.py` (populate `_contributed_quick_actions_default`)
+- Create: `src/protocol_quick_action_tools/tests/test_quick_actions.py`
+
+- [ ] **Step 1: Write the failing tests (all 8 actions in one file)**
+
+Create `src/protocol_quick_action_tools/tests/test_quick_actions.py`:
+
+```python
+"""One block per action. Each block builds a QuickActionCtx with a
+MagicMock pane and asserts:
+  * on_execute_action(ctx) calls the right pane method (or constructs
+    the dialog with the right args).
+  * is_enabled(ctx) matrix is correct for the meaningful states.
+The plugin's _contributed_quick_actions_default returns all 8 actions
+in priority order.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pluggable_protocol_tree.models.quick_action import QuickActionCtx
+from pluggable_protocol_tree.models.row import GroupRow
+
+from protocol_quick_action_tools.consts import (
+    ACTION_ADD_GROUP, ACTION_ADD_STEP, ACTION_BROWSE_REPORTS,
+    ACTION_DELETE_ROW, ACTION_IMPORT_PROTOCOL, ACTION_NEW_PROTOCOL,
+    ACTION_OPEN_PROTOCOL, ACTION_SAVE_PROTOCOL,
+)
+from protocol_quick_action_tools.plugin import (
+    ProtocolQuickActionToolsPlugin,
+)
+from protocol_quick_action_tools.quick_actions.add_group import (
+    make_add_group_action,
+)
+from protocol_quick_action_tools.quick_actions.add_step import (
+    make_add_step_action,
+)
+from protocol_quick_action_tools.quick_actions.browse_reports import (
+    make_browse_reports_action,
+)
+from protocol_quick_action_tools.quick_actions.delete_row import (
+    make_delete_row_action,
+)
+from protocol_quick_action_tools.quick_actions.import_protocol import (
+    make_import_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.new_protocol import (
+    make_new_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.open_protocol import (
+    make_open_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.save_protocol import (
+    make_save_protocol_action,
+)
+
+
+def _ctx(*, selected_paths=(), is_running=False, group=False,
+         experiment_manager=True):
+    pane = MagicMock()
+    if group and selected_paths:
+        pane.manager.get_row.return_value = GroupRow(name="G")
+    else:
+        pane.manager.get_row.return_value = MagicMock(spec=[])
+    pane.experiment_manager = MagicMock() if experiment_manager else None
+    return QuickActionCtx(pane=pane,
+                          selected_paths=tuple(selected_paths),
+                          is_running=is_running)
+
+
+# --- add_step -----------------------------------------------------
+
+def test_add_step_metadata():
+    a = make_add_step_action()
+    assert a.action_id == ACTION_ADD_STEP
+    assert a.icon_text == "add"
+    assert a.priority == 10
+    assert a.shortcut == ""
+
+
+def test_add_step_execute_calls_pane_helper():
+    a = make_add_step_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.add_step_after_selection.assert_called_once_with()
+
+
+@pytest.mark.parametrize("running,expected",
+                         [(False, True), (True, False)])
+def test_add_step_is_enabled(running, expected):
+    assert make_add_step_action().is_enabled(_ctx(is_running=running)) is expected
+
+
+# --- delete_row ---------------------------------------------------
+
+def test_delete_row_metadata():
+    a = make_delete_row_action()
+    assert a.action_id == ACTION_DELETE_ROW
+    assert a.icon_text == "delete"
+    assert a.priority == 20
+
+
+def test_delete_row_execute_calls_pane_helper():
+    a = make_delete_row_action()
+    ctx = _ctx(selected_paths=[(0,)])
+    a.on_execute_action(ctx)
+    ctx.pane.delete_selected_rows.assert_called_once_with()
+
+
+def test_delete_row_is_enabled_matrix():
+    a = make_delete_row_action()
+    assert a.is_enabled(_ctx()) is False                  # no selection
+    assert a.is_enabled(_ctx(selected_paths=[(0,)])) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,), (1,)])) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              is_running=True)) is False
+
+
+# --- add_group ----------------------------------------------------
+
+def test_add_group_metadata():
+    a = make_add_group_action()
+    assert a.action_id == ACTION_ADD_GROUP
+    assert a.icon_text == "playlist_add"
+    assert a.priority == 30
+
+
+def test_add_group_execute_calls_pane_helper():
+    a = make_add_group_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.add_group_after_selection.assert_called_once_with()
+
+
+# --- import_protocol ----------------------------------------------
+
+def test_import_protocol_metadata():
+    a = make_import_protocol_action()
+    assert a.action_id == ACTION_IMPORT_PROTOCOL
+    assert a.icon_text == "unarchive"
+    assert a.priority == 40
+
+
+def test_import_protocol_execute_calls_pane_helper():
+    a = make_import_protocol_action()
+    ctx = _ctx(selected_paths=[(0,)], group=True)
+    a.on_execute_action(ctx)
+    ctx.pane.import_into_selected_group.assert_called_once_with()
+
+
+def test_import_protocol_is_enabled_requires_single_group_selection():
+    a = make_import_protocol_action()
+    assert a.is_enabled(_ctx()) is False                       # no sel
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=False)) is False           # step, not group
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=True)) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,), (1,)],
+                              group=True)) is False            # multi-sel
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=True,
+                              is_running=True)) is False
+
+
+# --- open / save / new_protocol -----------------------------------
+
+def test_open_protocol_calls_pane_helper():
+    a = make_open_protocol_action()
+    assert a.action_id == ACTION_OPEN_PROTOCOL
+    assert a.icon_text == "file_open"
+    assert a.priority == 50
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.load_protocol_dialog.assert_called_once_with()
+
+
+def test_save_protocol_calls_pane_helper():
+    a = make_save_protocol_action()
+    assert a.action_id == ACTION_SAVE_PROTOCOL
+    assert a.icon_text == "save"
+    assert a.priority == 60
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.save_protocol_dialog.assert_called_once_with()
+
+
+def test_new_protocol_calls_pane_helper():
+    a = make_new_protocol_action()
+    assert a.action_id == ACTION_NEW_PROTOCOL
+    assert a.icon_text == "new_window"
+    assert a.priority == 70
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.new_protocol.assert_called_once_with()
+
+
+# --- browse_reports -----------------------------------------------
+
+def test_browse_reports_metadata_and_shortcut():
+    a = make_browse_reports_action()
+    assert a.action_id == ACTION_BROWSE_REPORTS
+    assert a.icon_text == "summarize"
+    assert a.priority == 80
+    assert a.shortcut == "R"
+
+
+def test_browse_reports_execute_calls_pane_helper():
+    a = make_browse_reports_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.browse_reports_dialog.assert_called_once_with()
+
+
+def test_browse_reports_disabled_without_experiment_manager():
+    a = make_browse_reports_action()
+    assert a.is_enabled(_ctx(experiment_manager=False)) is False
+    assert a.is_enabled(_ctx(experiment_manager=True)) is True
+    assert a.is_enabled(_ctx(experiment_manager=True,
+                              is_running=True)) is False
+
+
+# --- plugin default contributions list ----------------------------
+
+def test_plugin_default_contributions_includes_all_eight_actions():
+    plugin = ProtocolQuickActionToolsPlugin()
+    contribs = plugin._contributed_quick_actions_default()
+    ids = sorted(a.action_id for a in contribs)
+    assert ids == sorted([
+        ACTION_ADD_STEP, ACTION_DELETE_ROW, ACTION_ADD_GROUP,
+        ACTION_IMPORT_PROTOCOL, ACTION_OPEN_PROTOCOL, ACTION_SAVE_PROTOCOL,
+        ACTION_NEW_PROTOCOL, ACTION_BROWSE_REPORTS,
+    ])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_quick_actions.py -v
+```
+
+Expected: import errors / `AttributeError` for the missing factories.
+
+- [ ] **Step 3: Add the 8 factories**
+
+Create `src/protocol_quick_action_tools/quick_actions/add_step.py`:
+
+```python
+"""'Add step below selection' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_ADD_STEP
+
+
+class _AddStepAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.add_step_after_selection()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_add_step_action() -> _AddStepAction:
+    return _AddStepAction(
+        action_id=ACTION_ADD_STEP,
+        icon_text="add",
+        tooltip="Add step below selection",
+        priority=10,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/add_group.py`:
+
+```python
+"""'Add group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_ADD_GROUP
+
+
+class _AddGroupAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.add_group_after_selection()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_add_group_action() -> _AddGroupAction:
+    return _AddGroupAction(
+        action_id=ACTION_ADD_GROUP,
+        icon_text="playlist_add",
+        tooltip="Add group",
+        priority=30,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/delete_row.py`:
+
+```python
+"""'Delete selected step / group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_DELETE_ROW
+from .base import has_selection
+
+
+class _DeleteRowAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.delete_selected_rows()
+
+    def is_enabled(self, ctx) -> bool:
+        return (not ctx.is_running) and has_selection(ctx)
+
+
+def make_delete_row_action() -> _DeleteRowAction:
+    return _DeleteRowAction(
+        action_id=ACTION_DELETE_ROW,
+        icon_text="delete",
+        tooltip="Delete selected step / group",
+        priority=20,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/import_protocol.py`:
+
+```python
+"""'Import protocol into selected group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_IMPORT_PROTOCOL
+from .base import is_single_group_selected
+
+
+class _ImportProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.import_into_selected_group()
+
+    def is_enabled(self, ctx) -> bool:
+        return (not ctx.is_running) and is_single_group_selected(ctx)
+
+
+def make_import_protocol_action() -> _ImportProtocolAction:
+    return _ImportProtocolAction(
+        action_id=ACTION_IMPORT_PROTOCOL,
+        icon_text="unarchive",
+        tooltip="Import protocol into selected group",
+        priority=40,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/open_protocol.py`:
+
+```python
+"""'Open Protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_OPEN_PROTOCOL
+
+
+class _OpenProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.load_protocol_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_open_protocol_action() -> _OpenProtocolAction:
+    return _OpenProtocolAction(
+        action_id=ACTION_OPEN_PROTOCOL,
+        icon_text="file_open",
+        tooltip="Open Protocol",
+        priority=50,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/save_protocol.py`:
+
+```python
+"""'Save Protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_SAVE_PROTOCOL
+
+
+class _SaveProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.save_protocol_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_save_protocol_action() -> _SaveProtocolAction:
+    return _SaveProtocolAction(
+        action_id=ACTION_SAVE_PROTOCOL,
+        icon_text="save",
+        tooltip="Save Protocol",
+        priority=60,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/new_protocol.py`:
+
+```python
+"""'New protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_NEW_PROTOCOL
+
+
+class _NewProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.new_protocol()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_new_protocol_action() -> _NewProtocolAction:
+    return _NewProtocolAction(
+        action_id=ACTION_NEW_PROTOCOL,
+        icon_text="new_window",
+        tooltip="New protocol",
+        priority=70,
+    )
+```
+
+Create `src/protocol_quick_action_tools/quick_actions/browse_reports.py`:
+
+```python
+"""'Browse session reports' quick-action factory. Bound to 'R'."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_BROWSE_REPORTS
+
+
+class _BrowseReportsAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.browse_reports_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return ((not ctx.is_running)
+                and getattr(ctx.pane, "experiment_manager", None) is not None)
+
+
+def make_browse_reports_action() -> _BrowseReportsAction:
+    return _BrowseReportsAction(
+        action_id=ACTION_BROWSE_REPORTS,
+        icon_text="summarize",
+        tooltip="Browse session reports (R)",
+        priority=80,
+        shortcut="R",
+    )
+```
+
+- [ ] **Step 4: Wire all 8 into the plugin default**
+
+Modify `src/protocol_quick_action_tools/plugin.py` — replace `_contributed_quick_actions_default` body:
+
+```python
+    def _contributed_quick_actions_default(self):
+        from .quick_actions.add_group import make_add_group_action
+        from .quick_actions.add_step import make_add_step_action
+        from .quick_actions.browse_reports import make_browse_reports_action
+        from .quick_actions.delete_row import make_delete_row_action
+        from .quick_actions.import_protocol import make_import_protocol_action
+        from .quick_actions.new_protocol import make_new_protocol_action
+        from .quick_actions.open_protocol import make_open_protocol_action
+        from .quick_actions.save_protocol import make_save_protocol_action
+        return [
+            make_add_step_action(),
+            make_delete_row_action(),
+            make_add_group_action(),
+            make_import_protocol_action(),
+            make_open_protocol_action(),
+            make_save_protocol_action(),
+            make_new_protocol_action(),
+            make_browse_reports_action(),
+        ]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```
+pixi run pytest src/protocol_quick_action_tools/tests/test_quick_actions.py -v
+```
+
+Expected: all passed (~20 tests).
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/protocol_quick_action_tools/quick_actions/ src/protocol_quick_action_tools/plugin.py src/protocol_quick_action_tools/tests/test_quick_actions.py
+git commit -m "[ppt-21] Eight legacy quick-action factories (full parity)"
+```
+
+---
+
+### Task 13: Live-app wiring — load `ProtocolQuickActionToolsPlugin` from `examples/plugin_consts.py`
+
+**Files:**
+- Modify: `src/examples/plugin_consts.py` (or wherever frontend plugins are listed — see step 1)
+
+- [ ] **Step 1: Locate the frontend plugin list**
+
+```
+pixi run grep -rn 'PeripheralProtocolControlsPlugin' src/examples/ | head -3
+```
+
+Expected output points to a `plugin_consts.py` (or similar) listing frontend plugins. Open that file and find the list that includes `PeripheralProtocolControlsPlugin` (similar pattern).
+
+- [ ] **Step 2: Add the new plugin**
+
+Add to the imports block near the top:
+
+```python
+from protocol_quick_action_tools.plugin import (
+    ProtocolQuickActionToolsPlugin,
+)
+```
+
+Append to the same frontend-plugins list (next to `PeripheralProtocolControlsPlugin()`):
+
+```python
+    ProtocolQuickActionToolsPlugin(),
+```
+
+- [ ] **Step 3: Verify import correctness with a smoke check**
+
+```
+pixi run python -c "from examples import plugin_consts; print('ok')"
+```
+
+Expected: prints `ok` with no traceback. If `examples.plugin_consts` isn't importable as a module (no `__init__.py`), substitute the right import path observed in step 1's grep output.
+
+- [ ] **Step 4: Full project test sweep**
+
+```
+pixi run pytest src/pluggable_protocol_tree/tests/ src/protocol_quick_action_tools/tests/ -v
+```
+
+Expected: all tasks 1-12 tests still pass.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/examples/plugin_consts.py
+git commit -m "[ppt-21] Load ProtocolQuickActionToolsPlugin in the live app"
+```
+
+---
+
+## Spec Coverage Map
+
+| Spec section | Implementing task(s) |
+|---|---|
+| Architecture §1 — extension-point + IQuickAction + BaseQuickAction + QuickActionCtx | Tasks 1, 2 |
+| Architecture §2 — QuickActionBar widget | Task 3 |
+| Architecture §2 — QuickActionsController (click + enabled) | Task 4 |
+| Architecture §2 — Shortcut wiring + conflict detection | Task 5 |
+| Architecture §3 — Pane signals + bar mount | Tasks 6, 7 |
+| Architecture §4 — Pane helpers (5 methods) | Task 8 |
+| Tree plugin — extension point wiring + dock-pane forwarding | Task 9 |
+| New plugin scaffold (consts / plugin shell / base helper) | Task 10 |
+| Report browser port | Task 11 |
+| Eight action factories | Task 12 |
+| Live-app wiring | Task 13 |
+| Tree-plugin builtins = none | Task 9 (test asserts empty contributed_quick_actions default) |
+| Shortcuts respect `is_running` gating | Task 5 (test_shortcut_is_gated_by_is_running) |
+| `R` shortcut on browse_reports | Task 12 (test_browse_reports_metadata_and_shortcut) |
+| ReportBrowserDialog ported verbatim | Task 11 |
+| Error handling: buggy contribution swallowed | Task 4 (test_buggy_action_does_not_break_other_buttons) |
+| Error handling: shortcut conflicts | Task 5 (test_duplicate_shortcut_skips_second_and_logs_warning) |
+| Error handling: missing reports dir / empty | Task 11 (test_dialog_handles_empty_list_without_crashing) |
+| Error handling: missing experiment manager | Task 8 (test_browse_reports_dialog_no_provider_logs_and_returns), Task 12 (test_browse_reports_disabled_without_experiment_manager) |
+
+All spec sections accounted for.

--- a/docs/superpowers/specs/2026-05-28-ppt-21-quick-actions-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-28-ppt-21-quick-actions-toolbar-design.md
@@ -1,0 +1,414 @@
+# PPT-21: Protocol Quick-Actions Toolbar — Design
+
+**Date:** 2026-05-28
+**Branch:** `feat/433-ppt-21-protocol-quick-actions-toolbar`
+**Issue:** [#433](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/433)
+
+## Goal
+
+Bring the legacy `protocol_grid/quick_action_bar.py` toolbar into the
+pluggable protocol tree, but split it cleanly:
+
+- **Architecture** (extension point, traits model, controller, toolbar
+  widget) lives in `pluggable_protocol_tree` — the tree plugin ships
+  with **zero** built-in actions, only the contribution surface.
+- **All 8 legacy actions** are reborn as contributions from a new
+  sibling plugin, `protocol_quick_action_tools` — full feature parity,
+  no shared state with the tree plugin.
+
+This mirrors how columns work today (`PROTOCOL_COLUMNS` extension
+point, tree plugin owns the contract, other plugins contribute
+columns) and keeps the tree plugin's responsibility focused.
+
+## Background
+
+Legacy `protocol_grid.quick_action_bar.QuickProtocolActions` is a
+hard-coded `QWidget` with eight `QPushButton`s wired directly to
+`PGCWidget` methods; `QuickProtocolActionsController` reacts to
+selection and protocol-running state to enable/disable individual
+buttons. It works, but it has no contribution mechanism — every
+button is baked in, and the `(R)` keyboard shortcut for the report
+browser is hand-wired on the widget.
+
+The pluggable tree replaces `protocol_grid` over time. It already has
+`ProtocolTreePane` (file ops `new_protocol` / `load_protocol_dialog` /
+`save_protocol_dialog` exist; tree-structure ops live in the tree
+widget's context menu), a `RowManager`, and an Envisage plugin with
+an existing `PROTOCOL_COLUMNS` extension point pattern to follow.
+
+### Existing building blocks (reused as-is)
+
+- `ProtocolTreePane.new_protocol()`, `.load_protocol_dialog()`,
+  `.save_protocol_dialog()` — file operations.
+- `RowManager.add_step(parent_path, index, values=...)` — used by the
+  context-menu insert handlers; reusable here.
+- `protocol_state_tracker.PluggableProtocolStateTracker.is_modified`
+  — informs `_confirm_proceed_or_abort` flows.
+- `microdrop_style.button_styles.ICON_FONT_FAMILY` — material-symbols
+  font already used by `_build_experiment_bar`.
+- `pyface.qt.QtGui.QDesktopServices` + `QUrl.fromLocalFile` — opens
+  HTML reports in the default browser.
+- `protocol_grid/extra_ui_elements.py` `ReportBrowserDialog`
+  (lines 942–1064) — self-contained `QDialog` we can port verbatim.
+
+## Architecture
+
+Three units; each has one clear job.
+
+### 1. `pluggable_protocol_tree` — the contribution surface (no builtins)
+
+```
+pluggable_protocol_tree/
+  interfaces/i_quick_action.py     ← NEW    IQuickAction interface
+  models/quick_action.py           ← NEW    BaseQuickAction + QuickActionCtx
+  views/quick_action_bar.py        ← NEW    QuickActionBar + QuickActionsController
+  consts.py                        ← +      PROTOCOL_QUICK_ACTIONS extension-point id
+  plugin.py                        ← +      extension point + plain list pass-through
+  views/protocol_tree_pane.py      ← +      mount the bar; emit selection/running signals
+```
+
+**`IQuickAction` interface** (Traits — mirrors `IColumnHandler`):
+
+```python
+class IQuickAction(Interface):
+    action_id  = Str            # stable id (e.g. "add_step"); used for logging/tests
+    icon_text  = Str            # material-symbol name (e.g. "add", "delete")
+    tooltip    = Str            # button tooltip
+    priority   = Int(50)        # lower runs first; controls left-to-right order
+    shortcut   = Str(default_value="")   # QKeySequence string ("R", "Ctrl+S"); "" = none
+
+    def on_execute_action(self, ctx): ...
+    def is_enabled(self, ctx) -> bool: return True
+```
+
+**`QuickActionCtx`** (small `HasStrictTraits` value object built fresh
+on each invocation):
+
+```python
+class QuickActionCtx(HasStrictTraits):
+    pane           = Instance("ProtocolTreePane")   # access to .manager, .widget.tree,
+                                                    # .executor, .application, .experiment_manager
+    selected_paths = Tuple()                        # tuple of dotted-path tuples currently selected
+    is_running     = Bool(False)                    # protocol_state_tracker / executor running
+```
+
+**Extension point** — a clone of the `PROTOCOL_COLUMNS` pattern in
+`plugin.py`:
+
+```python
+_quick_action_extension_point = ExtensionPoint(
+    List(Instance(IQuickAction)), id=PROTOCOL_QUICK_ACTIONS,
+    desc="Quick-action buttons contributed by other plugins.",
+)
+contributed_quick_actions = List(desc="...")     # plain List for tests
+```
+
+`PluggableProtocolTreePlugin.start()` populates
+`contributed_quick_actions` from the extension point and passes the
+list into `PluggableProtocolDockPane` the same way it passes columns
+in. `_assemble_quick_actions()` sorts contributions by
+`(priority, action_id)` so ordering is deterministic.
+
+**Tree-plugin builtins:** none. The plugin ships an empty default for
+`contributed_quick_actions`. This is the architectural commitment to
+the split.
+
+### 2. `QuickActionBar` + `QuickActionsController` (view layer)
+
+`QuickActionBar(QWidget)` — a horizontal row of icon-only
+`QToolButton`s using `ICON_FONT_FAMILY`. Pure rendering: takes the
+sorted list of actions, builds one button per action, exposes
+`buttons: Dict[str, QToolButton]` keyed by `action_id`. No state.
+
+`QuickActionsController` — wires the bar to the pane:
+
+- Builds a fresh `QuickActionCtx` each time a button fires or
+  `is_enabled` needs re-checking.
+- Connects to two new pane-level signals (see §4):
+  `pane.selection_changed`, `pane.protocol_running_changed`.
+- On every signal: walks the action list, sets
+  `button.setEnabled(action.is_enabled(ctx))`. When `is_running` is
+  `True`, the whole bar is disabled — the per-action `is_enabled`
+  check is short-circuited so a contribution can't accidentally
+  light up during a run.
+- On button click: `_execute(action)` → `try: action.on_execute_action(ctx)
+  except Exception: logger.error(...)`. A buggy contribution can't
+  crash the GUI.
+
+**Shortcut wiring** (the new trait):
+
+After the bar is built, the controller registers one `QShortcut` per
+action whose `shortcut` is non-empty:
+
+```python
+qs = QShortcut(QKeySequence(action.shortcut), pane)
+qs.setContext(Qt.WidgetWithChildrenShortcut)
+qs.activated.connect(lambda a=action: self._execute(a))
+```
+
+- `WidgetWithChildrenShortcut` scopes the binding to the pane (and its
+  descendants) — prevents an action's key from colliding with the
+  same key elsewhere in the app (DV camera, etc.).
+- Shortcuts route through `_execute`, so they respect
+  `is_enabled(ctx)` and `is_running` exactly like a button click —
+  pressing **R** during a run is a no-op.
+- Conflict detection: track shortcut strings as we wire; if two
+  contributions claim the same key, log a warning naming both
+  `action_id`s and skip the second registration. Prevents silent
+  loss-of-binding bugs when plugins overlap.
+
+### 3. Pane integration
+
+`ProtocolTreePane`:
+
+- New attribute `self.quick_action_bar` built in `__init__` from the
+  injected contributions (constructor gains
+  `quick_actions: List[IQuickAction] = None`, same shape as the existing
+  `columns_or_manager`/`columns` flow).
+- Mounted **below** the tree in `_build_layout`:
+  `layout.addWidget(self.widget); layout.addWidget(self.quick_action_bar)`.
+  Mirrors legacy placement.
+- New Qt signals (the controller's data feed):
+  - `protocol_running_changed = Signal(bool)` — emitted with `True` in
+    `_on_protocol_started`, `False` in `_on_protocol_terminated`.
+  - `selection_changed = Signal()` — connected to the tree's existing
+    `selectionModel().selectionChanged` (parameterless re-emit; the
+    controller queries the model directly for paths).
+
+`PluggableProtocolDockPane._make_dock_pane` (and the demo window
+factory) pass `quick_actions=self._assemble_quick_actions()` into the
+pane.
+
+### 4. Pane helpers used by contributions
+
+Contributed actions stay Qt-free where they can; pane helpers absorb
+the Qt dialog work. Five small helpers added to `ProtocolTreePane`:
+
+- `add_step_after_selection()` — current path + 1 under same parent,
+  or append at root when nothing is selected.
+- `add_group_after_selection()` — same logic, creates a `GroupRow`.
+- `delete_selected_rows()` — collect paths from
+  `tree.selectionModel().selectedRows()`, sort tail-first so removals
+  don't shift indices, call `manager.remove_row(path)`.
+- `import_into_selected_group()` — `QFileDialog.getOpenFileName` →
+  load JSON → merge top-level rows under the selected group's path
+  via `manager.add_step` / `add_group`. No-op if selection is not a
+  single `GroupRow`.
+- `browse_reports_dialog()` — glob
+  `<experiment_dir>/reports/*.html`, open the ported
+  `ReportBrowserDialog(report_paths, parent=self).exec()`.
+
+Existing pane methods reused unchanged: `new_protocol()`,
+`load_protocol_dialog()`, `save_protocol_dialog()`.
+
+## The new `protocol_quick_action_tools` plugin
+
+A sibling under `src/` mirroring the layout of
+`peripheral_protocol_controls` / `dropbot_protocol_controls`.
+
+```
+protocol_quick_action_tools/
+  __init__.py
+  plugin.py               # ProtocolQuickActionToolsPlugin
+  consts.py               # PKG, PKG_name, action-id constants
+  quick_actions/
+    __init__.py
+    base.py               # _PaneBackedAction + small predicates
+                          #   (is_single_group_selected, has_selection, ...)
+    add_step.py           # make_add_step_action()
+    add_group.py          # make_add_group_action()
+    delete_row.py         # make_delete_row_action()
+    import_protocol.py    # make_import_protocol_action()
+    open_protocol.py      # make_open_protocol_action()
+    save_protocol.py      # make_save_protocol_action()
+    new_protocol.py       # make_new_protocol_action()
+    browse_reports.py     # make_browse_reports_action()
+  views/
+    __init__.py
+    report_browser_dialog.py     # ported from protocol_grid/extra_ui_elements.py:942-1064
+                                  # ReportBrowserDialog + _ReportSortableTreeWidgetItem
+  tests/
+    test_quick_actions.py        # one test per action: execute + is_enabled matrix
+```
+
+**`plugin.py` shape:**
+
+```python
+class ProtocolQuickActionToolsPlugin(Plugin):
+    id = f"{PKG}.plugin"
+    name = PKG_name
+
+    contributed_quick_actions = List(contributes_to=PROTOCOL_QUICK_ACTIONS)
+
+    def _contributed_quick_actions_default(self):
+        return [
+            make_add_step_action(),
+            make_delete_row_action(),
+            make_add_group_action(),
+            make_import_protocol_action(),
+            make_open_protocol_action(),
+            make_save_protocol_action(),
+            make_new_protocol_action(),
+            make_browse_reports_action(),
+        ]
+```
+
+**Live-app wiring:** add `ProtocolQuickActionToolsPlugin` to
+`examples/plugin_consts.py` next to the existing frontend plugins so
+it loads with the dock pane. The pane itself doesn't reference this
+plugin — it just reads the extension point.
+
+## The eight actions
+
+Legacy left-to-right order preserved via `priority`:
+`add_step=10`, `delete_row=20`, `add_group=30`, `import_protocol=40`,
+`open_protocol=50`, `save_protocol=60`, `new_protocol=70`,
+`browse_reports=80`.
+
+| # | id | icon | tooltip | Executes | Enabled when | Shortcut |
+|---|---|---|---|---|---|---|
+| 1 | `add_step` | `add` | "Add step below selection" | `ctx.pane.add_step_after_selection()` | not running | — |
+| 2 | `delete_row` | `delete` | "Delete selected step / group" | `ctx.pane.delete_selected_rows()` | not running AND `len(selected_paths) >= 1` | — |
+| 3 | `add_group` | `playlist_add` | "Add group" | `ctx.pane.add_group_after_selection()` | not running | — |
+| 4 | `import_protocol` | `unarchive` | "Import protocol into selected group" | `ctx.pane.import_into_selected_group()` | not running AND `len(selected_paths) == 1` AND target row is a `GroupRow` | — |
+| 5 | `open_protocol` | `file_open` | "Open Protocol" | `ctx.pane.load_protocol_dialog()` | not running | — |
+| 6 | `save_protocol` | `save` | "Save Protocol" | `ctx.pane.save_protocol_dialog()` | not running | — |
+| 7 | `new_protocol` | `new_window` | "New protocol" | `ctx.pane.new_protocol()` | not running | — |
+| 8 | `browse_reports` | `summarize` | "Browse session reports (R)" | open ported `ReportBrowserDialog` over globbed `<experiment_dir>/reports/*.html` | not running AND `experiment_manager is not None` | `R` |
+
+Only `browse_reports` ships with a shortcut in this PR. Once the
+trait is in place, adding `Ctrl+N` / `Ctrl+O` / `Ctrl+S` to others is
+a one-line factory change in a follow-up.
+
+## Report browser
+
+Port `protocol_grid/extra_ui_elements.py` lines 942–1064 verbatim
+into `protocol_quick_action_tools/views/report_browser_dialog.py`:
+
+- `_ReportSortableTreeWidgetItem` — numeric Size / chronological Date
+  sort (override `__lt__`).
+- `ReportBrowserDialog(report_paths: List[str], parent=None)` — search
+  bar, sortable `Name`/`Size`/`Date Created` columns, double-click /
+  Open button → `QDesktopServices.openUrl(QUrl.fromLocalFile(path))`.
+
+The dialog is fully decoupled from `protocol_grid` already — its only
+input is a list of path strings. We feed it whatever the
+`browse_reports` action provides.
+
+**Where reports come from:** glob `<experiment_dir>/reports/*.html`
+at click time. This is a deliberate improvement over the legacy,
+which only showed reports from the current session (tracked in
+`ProtocolDataLogger.all_report_paths`). Globbing the directory
+surfaces historical reports too and keeps the logging controller
+stateless — no `all_report_paths` accumulator threaded through
+`ProtocolLoggingController`.
+
+## Data flow
+
+```
+user clicks button / presses shortcut
+  -> QuickActionsController._execute(action)
+       -> ctx = QuickActionCtx(pane, selected_paths, is_running)
+       -> action.on_execute_action(ctx)
+            -> ctx.pane.<helper>()  (or directly manipulates ctx.pane.manager)
+
+selection changes  -> pane.selection_changed
+  -> controller._refresh_enabled()
+       -> for action in actions:
+            button.setEnabled(action.is_enabled(ctx) and not ctx.is_running)
+
+protocol starts  -> pane.protocol_running_changed.emit(True)
+  -> controller._refresh_enabled() (whole bar disabled)
+protocol ends    -> pane.protocol_running_changed.emit(False)
+  -> controller._refresh_enabled() (back to per-action gating)
+```
+
+## Error handling
+
+- **Buggy contribution:** `_execute` wraps `on_execute_action` and
+  `is_enabled` in `try/except` that logs at `error` / `warning`
+  respectively. A misbehaving plugin disables only its own button —
+  it can't break the rest of the bar or crash the pane.
+- **Missing experiment manager:** every action that needs one
+  (`browse_reports`, `import_into_selected_group` if you wanted to
+  scope to a default dir later) gates its `is_enabled` on
+  `ctx.pane.experiment_manager is not None`. Demos that pass `None`
+  see those buttons stay greyed out — same graceful-degradation rule
+  as the existing experiment-bar buttons.
+- **Shortcut conflicts:** log a warning naming both `action_id`s,
+  skip the second registration. The first contribution wins
+  deterministically (priority-sorted order).
+- **Unreadable / missing reports dir:** `glob` returns an empty list;
+  `ReportBrowserDialog([], parent=self).exec()` still opens with an
+  empty table and the search box. Users see "no reports yet" rather
+  than a crash.
+
+## Testing
+
+**`pluggable_protocol_tree/tests/`**
+
+- `test_quick_action_bar.py` — the bar widget renders one button per
+  action in `(priority, action_id)` order, button text equals
+  `icon_text`, tooltip equals `tooltip`, `is_enabled=False` actions
+  start disabled.
+- `test_quick_actions_controller.py` — fake action with `is_enabled`
+  toggle:
+  - selection_changed fires → `_refresh_enabled` re-queries
+    `is_enabled`.
+  - protocol_running_changed(True) → all buttons disabled regardless
+    of `is_enabled`.
+  - protocol_running_changed(False) → buttons re-query `is_enabled`.
+  - click on enabled button → `on_execute_action` called once with
+    correct `ctx`.
+  - click on disabled button → `on_execute_action` NOT called.
+  - exception in `on_execute_action` → logged, other buttons stay
+    responsive.
+- `test_quick_actions_shortcuts.py`:
+  - action with `shortcut="R"` registers a widget-scoped `QShortcut`
+    on the pane.
+  - two actions claiming the same shortcut → second registration is
+    skipped + warning logged.
+  - pressing the shortcut while `is_running=True` → action is NOT
+    executed.
+- `test_protocol_tree_pane.py` (extend):
+  - `add_step_after_selection` inserts a step at the right path under
+    various selection states (root, child, nothing).
+  - `delete_selected_rows` removes tail-first.
+  - `import_into_selected_group` no-ops when selection is not a
+    single `GroupRow`.
+  - `browse_reports_dialog` globs the reports dir and constructs the
+    dialog with the right paths (dialog `exec` monkeypatched).
+
+**`protocol_quick_action_tools/tests/`**
+
+- `test_quick_actions.py` — one block per action. Build a
+  `QuickActionCtx(pane=MagicMock(), selected_paths=..., is_running=...)`
+  and assert:
+  - `on_execute_action(ctx)` calls the right pane method (or
+    constructs the right dialog).
+  - `is_enabled(ctx)` matrix is correct for `(is_running × selection
+    shape)` — at minimum: running=True, empty selection, single step,
+    single group, multi-row.
+
+No Envisage / Redis dependencies in either test file — both run in
+the headless test environment.
+
+## Out of scope
+
+- **No `all_report_paths` accumulator** in
+  `ProtocolLoggingController`. Globbing the dir is the source of
+  truth.
+- **No persistence** of bar layout or hidden-action preferences. The
+  bar reflects the current contribution set every session.
+- **No file-menu refactor.** File operations live on the bar *and* in
+  the existing File menu — both call the same pane methods, so they
+  stay in sync without further plumbing.
+- **No additional keyboard shortcuts** beyond `R`. Adding more is a
+  one-line trait change per action in a follow-up PR.
+- **No material-symbols font loading.** Reuses the existing
+  `ICON_FONT_FAMILY` infrastructure already loaded by the dock-pane
+  init path.
+- **No theme reactivity beyond what `QToolButton` already does.** The
+  legacy bar restyled itself on palette change; the new bar inherits
+  the pane's stylesheet and re-renders icons on theme switch via the
+  font family alone.

--- a/examples/plugin_consts.py
+++ b/examples/plugin_consts.py
@@ -21,6 +21,7 @@ from microdrop_utils.broker_server_helpers import dramatiq_workers_context, redi
 from device_viewer.plugin import DeviceViewerPlugin
 from peripherals_ui.plugin import PeripheralUiPlugin
 from peripheral_protocol_controls.plugin import PeripheralProtocolControlsPlugin
+from protocol_quick_action_tools.plugin import ProtocolQuickActionToolsPlugin
 from video_protocol_controls.plugin import VideoProtocolControlsPlugin
 from opendrop_controller.plugin import OpenDropControllerPlugin
 from mock_dropbot_controller.plugin import MockDropbotControllerPlugin
@@ -74,6 +75,7 @@ EXPERIMENTAl_PLUGINS = [
     PluggableProtocolTreePlugin,
     DropbotProtocolControlsPlugin,
     PeripheralProtocolControlsPlugin,
+    ProtocolQuickActionToolsPlugin,
     VideoProtocolControlsPlugin,
 ]
 

--- a/pluggable_protocol_tree/builtins/electrodes_column.py
+++ b/pluggable_protocol_tree/builtins/electrodes_column.py
@@ -20,11 +20,10 @@ class ElectrodesColumnModel(BaseColumnModel):
 
 
 class ElectrodesSummaryView(BaseColumnView):
-    """Read-only cell. Shows '0 electrodes' / '1 electrode' / 'N electrodes'."""
+    """Read-only cell. Shows '0' / '1' / 'N'."""
 
     def format_display(self, value, row):
-        n = len(value or [])
-        return f"{n} electrode" + ("" if n == 1 else "s")
+        return str(len(value or []))
 
     def get_flags(self, row):
         # NOT editable — no ItemIsEditable flag.

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -72,11 +72,10 @@ class RoutesColumnModel(BaseColumnModel):
 
 
 class RoutesSummaryView(BaseColumnView):
-    """Read-only cell. '0 routes' / '1 route' / 'N routes'."""
+    """Read-only cell. '0' / '1' / 'N'."""
 
     def format_display(self, value, row):
-        n = len(value or [])
-        return f"{n} route" + ("" if n == 1 else "s")
+        return str(len(value or []))
 
     def get_flags(self, row):
         return Qt.ItemIsEnabled | Qt.ItemIsSelectable

--- a/pluggable_protocol_tree/consts.py
+++ b/pluggable_protocol_tree/consts.py
@@ -53,3 +53,9 @@ LOGGING_ACTOR_TOPIC_DICT = {
     ]
 }
 
+# Envisage extension point — plugins contribute IQuickAction instances
+# (see interfaces/i_quick_action.py) that render as buttons on the
+# pluggable tree's quick-actions toolbar. Tree plugin ships zero
+# builtins; all contributions come from sibling plugins.
+PROTOCOL_QUICK_ACTIONS = f"{PKG}.protocol_quick_actions"
+

--- a/pluggable_protocol_tree/interfaces/i_quick_action.py
+++ b/pluggable_protocol_tree/interfaces/i_quick_action.py
@@ -1,0 +1,41 @@
+"""Traits interface for protocol-tree quick-action buttons.
+
+Each contribution is a button on the toolbar mounted under the tree.
+Mirrors the IColumn pattern: tree plugin owns the contract, other
+plugins contribute implementations. Two hooks:
+
+* ``on_execute_action(ctx)`` — fired on click (or keyboard shortcut).
+* ``is_enabled(ctx) -> bool`` — queried by the controller on selection
+  / protocol-running changes; default ``True``.
+
+The ``ctx`` is a :class:`QuickActionCtx` carrying the pane, current
+selection, and is_running flag. Contributions stay Qt-free where they
+can by delegating Qt work to pane helper methods.
+"""
+
+from traits.api import Bool, Int, Interface, Str
+
+
+class IQuickAction(Interface):
+    action_id = Str(
+        desc="Stable identifier (e.g. 'add_step'). Used in logging, "
+             "tests, and shortcut-conflict messages.")
+    icon_text = Str(
+        desc="Material-symbol name rendered as the button's text under "
+             "ICON_FONT_FAMILY (e.g. 'add', 'delete', 'playlist_add').")
+    tooltip = Str(desc="Button tooltip.")
+    priority = Int(50,
+        desc="Lower runs first; controls left-to-right order in the bar.")
+    shortcut = Str(default_value="",
+        desc="QKeySequence string ('R', 'Ctrl+S', ...). Empty = no "
+             "shortcut. Registered widget-scoped to the pane.")
+
+    def on_execute_action(self, ctx):
+        """Called when the button is clicked or its shortcut fires.
+        ctx is a QuickActionCtx. Return value is ignored."""
+
+    def is_enabled(self, ctx) -> bool:
+        """Return True if the button should be clickable. Queried by
+        the controller on selection / protocol-running changes.
+        Default: always True."""
+        return True

--- a/pluggable_protocol_tree/interfaces/i_quick_action.py
+++ b/pluggable_protocol_tree/interfaces/i_quick_action.py
@@ -13,7 +13,7 @@ selection, and is_running flag. Contributions stay Qt-free where they
 can by delegating Qt work to pane helper methods.
 """
 
-from traits.api import Bool, Int, Interface, Str
+from traits.api import Int, Interface, Str
 
 
 class IQuickAction(Interface):

--- a/pluggable_protocol_tree/models/quick_action.py
+++ b/pluggable_protocol_tree/models/quick_action.py
@@ -1,0 +1,46 @@
+"""Default ``IQuickAction`` provider + ``QuickActionCtx`` value object.
+
+Plugins are free to subclass ``BaseQuickAction`` (recommended — gets
+the trait set and default ``is_enabled`` for free) or write a fresh
+``HasStrictTraits`` class decorated with ``@provides(IQuickAction)``.
+"""
+
+from traits.api import (
+    Any, Bool, HasStrictTraits, Tuple, provides,
+)
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+@provides(IQuickAction)
+class BaseQuickAction(HasStrictTraits, IQuickAction):
+    """Concrete IQuickAction provider with the default trait set.
+
+    Subclasses override ``on_execute_action`` (and optionally
+    ``is_enabled``). Trait fields can be set positionally / by kwarg
+    in factory functions — see protocol_quick_action_tools.quick_actions.
+
+    Inherits from IQuickAction so the trait declarations (action_id,
+    icon_text, tooltip, priority, shortcut) come along automatically.
+    The @provides decorator separately registers the interface so
+    isinstance/adaptation checks work.
+    """
+
+    def on_execute_action(self, ctx):
+        """Default no-op. Subclasses override."""
+
+    def is_enabled(self, ctx) -> bool:
+        return True
+
+
+class QuickActionCtx(HasStrictTraits):
+    """Value object handed to every action callback.
+
+    Built fresh by the controller on each click / refresh — never
+    cached on the action. ``pane`` is the live ``ProtocolTreePane``
+    (so contributions can reach ``pane.manager``, ``pane.widget.tree``,
+    ``pane.application``, ``pane.experiment_manager``, etc.).
+    """
+    pane = Any
+    selected_paths = Tuple()
+    is_running = Bool(False)

--- a/pluggable_protocol_tree/models/quick_action.py
+++ b/pluggable_protocol_tree/models/quick_action.py
@@ -2,7 +2,7 @@
 
 Plugins are free to subclass ``BaseQuickAction`` (recommended — gets
 the trait set and default ``is_enabled`` for free) or write a fresh
-``HasStrictTraits`` class decorated with ``@provides(IQuickAction)``.
+``HasTraits`` class decorated with ``@provides(IQuickAction)``.
 """
 
 from traits.api import (
@@ -13,7 +13,7 @@ from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
 
 
 @provides(IQuickAction)
-class BaseQuickAction(HasStrictTraits, IQuickAction):
+class BaseQuickAction(IQuickAction):
     """Concrete IQuickAction provider with the default trait set.
 
     Subclasses override ``on_execute_action`` (and optionally
@@ -24,12 +24,18 @@ class BaseQuickAction(HasStrictTraits, IQuickAction):
     icon_text, tooltip, priority, shortcut) come along automatically.
     The @provides decorator separately registers the interface so
     isinstance/adaptation checks work.
+
+    Inherits ``IQuickAction`` directly (which chains to ``Interface`` →
+    ``HasTraits``, not ``HasStrictTraits``) so plugin authors can freely
+    add their own traits when subclassing without hitting a ``TraitError``
+    at class-definition time.
     """
 
     def on_execute_action(self, ctx):
         """Default no-op. Subclasses override."""
 
     def is_enabled(self, ctx) -> bool:
+        """Default: always True. Override to gate on selection or protocol state."""
         return True
 
 
@@ -42,5 +48,7 @@ class QuickActionCtx(HasStrictTraits):
     ``pane.application``, ``pane.experiment_manager``, etc.).
     """
     pane = Any
-    selected_paths = Tuple()
+    selected_paths = Tuple(
+        desc="Tuple of 0-indexed path tuples (matching RowManager.selection) "
+             "currently highlighted in the tree.")
     is_running = Bool(False)

--- a/pluggable_protocol_tree/plugin.py
+++ b/pluggable_protocol_tree/plugin.py
@@ -8,7 +8,7 @@ plugin class."""
 from envisage.api import ExtensionPoint, Plugin, TASK_EXTENSIONS
 from envisage.ui.tasks.task_extension import TaskExtension
 from pyface.action.schema.schema_addition import SchemaAddition
-from traits.api import List, Str, Either
+from traits.api import Instance, List, Str, Either
 
 from microdrop_application.consts import PKG as microdrop_application_PKG
 from message_router.consts import ACTOR_TOPIC_ROUTES
@@ -30,10 +30,12 @@ from pluggable_protocol_tree.builtins.trail_length_column import make_trail_leng
 from pluggable_protocol_tree.builtins.trail_overlay_column import make_trail_overlay_column
 from pluggable_protocol_tree.builtins.type_column import make_type_column
 from pluggable_protocol_tree.consts import (
-    ACTOR_TOPIC_DICT, LOGGING_ACTOR_TOPIC_DICT, PKG, PKG_name, PROTOCOL_COLUMNS,
+    ACTOR_TOPIC_DICT, LOGGING_ACTOR_TOPIC_DICT, PKG, PKG_name,
+    PROTOCOL_COLUMNS, PROTOCOL_QUICK_ACTIONS,
 )
 from pluggable_protocol_tree.interfaces.i_compound_column import ICompoundColumn
 from pluggable_protocol_tree.interfaces.i_column import IColumn
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
 from pluggable_protocol_tree.models._compound_adapters import _expand_compound
 
 from logger.logger_service import get_logger
@@ -64,6 +66,18 @@ class PluggableProtocolTreePlugin(Plugin):
     #: Plain list — set directly in tests; populated from the extension
     #: point at plugin start in a live application.
     contributed_columns = List(desc="Columns contributed by other plugins")
+
+    #: Envisage extension point — sibling plugins contribute
+    #: IQuickAction instances rendered as buttons on the tree's
+    #: quick-actions toolbar. Tree plugin itself contributes none.
+    _quick_action_extension_point = ExtensionPoint(
+        List(Instance(IQuickAction)), id=PROTOCOL_QUICK_ACTIONS,
+        desc="IQuickAction instances contributed by sibling plugins.",
+    )
+
+    contributed_quick_actions = List(
+        desc="Quick actions contributed by other plugins (populated "
+             "from the extension point at plugin start).")
 
     # Standard plumbing
     actor_topic_routing = List([ACTOR_TOPIC_DICT], contributes_to=ACTOR_TOPIC_ROUTES)
@@ -97,7 +111,10 @@ class PluggableProtocolTreePlugin(Plugin):
     def _make_dock_pane(self, *args, **kwargs):
         from pluggable_protocol_tree.views.dock_pane import PluggableProtocolDockPane
         columns = self._assemble_columns()
-        return PluggableProtocolDockPane(columns=columns, *args, **kwargs)
+        quick_actions = self._assemble_quick_actions()
+        return PluggableProtocolDockPane(
+            columns=columns, quick_actions=quick_actions,
+            *args, **kwargs)
 
     def _assemble_columns(self):
         builtins = [
@@ -128,6 +145,15 @@ class PluggableProtocolTreePlugin(Plugin):
                 out.append(c)
         return out
 
+    def _assemble_quick_actions(self):
+        """Return contributed quick actions in deterministic order
+        (priority then action_id)."""
+        try:
+            actions = list(self.contributed_quick_actions)
+        except Exception:
+            actions = []
+        return sorted(actions, key=lambda a: (a.priority, a.action_id))
+
     def start(self):
         """Populate contributed_columns from the extension point, then
         register the executor listener's subscriptions with the message
@@ -144,6 +170,13 @@ class PluggableProtocolTreePlugin(Plugin):
             # an empty dock pane. Log it so the developer sees it.
             logger.warning(
                 f"failed to read PROTOCOL_COLUMNS extension point: {e}"
+            )
+        try:
+            self.contributed_quick_actions = list(
+                self._quick_action_extension_point)
+        except Exception as e:
+            logger.warning(
+                f"failed to read PROTOCOL_QUICK_ACTIONS extension point: {e}"
             )
         try:
             from microdrop_utils.dramatiq_pub_sub_helpers import MessageRouterData

--- a/pluggable_protocol_tree/services/logging/controller.py
+++ b/pluggable_protocol_tree/services/logging/controller.py
@@ -91,6 +91,7 @@ class ProtocolLoggingController:
         self._start_time = ""
         self._start_dt: Optional[_dt.datetime] = None
         self._generate_report = True
+        self.all_report_paths: list[Path] = []
 
     # --- executor signal wiring ---
     def attach(self, qsignals) -> None:
@@ -222,7 +223,7 @@ class ProtocolLoggingController:
                     notes=None, data_files=[json_path, csv_path])
                 report_path = LoggingReport.write_report(
                     self._device_context.experiment_directory, html)
-
+                self.all_report_paths.append(report_path)
                 logger.info(f"Report written to {report_path}")
 
         except Exception as e:

--- a/pluggable_protocol_tree/services/persistence.py
+++ b/pluggable_protocol_tree/services/persistence.py
@@ -19,6 +19,12 @@ from pluggable_protocol_tree.consts import PERSISTENCE_SCHEMA_VERSION
 from pluggable_protocol_tree.models.row import BaseRow, GroupRow
 from pluggable_protocol_tree.models._compound_adapters import _CompoundFieldAdapter
 
+# These four fields are written per-row from node.row_type / node.name /
+# node.uuid / nesting depth directly. The builtin type/name columns share
+# those col_ids — serializing them again would duplicate both the field name
+# in `fields` and the value in every row (a real bug observed in saved files).
+_RESERVED_ROW_METADATA_FIELDS = frozenset({"depth", "uuid", "type", "name"})
+
 
 def _persisted_cls_qualname(model) -> str:
     """The 'cls' qualname stored in column entries. For compound-field
@@ -39,6 +45,13 @@ def serialize_tree(root: GroupRow, columns: list, protocol_metadata=None) -> dic
     'electrode_to_channel'). Optional for backward compat with
     PPT-1/PPT-2 callers that don't pass it.
     """
+    # Filter out builtin columns whose col_id matches a reserved row-metadata
+    # field. Those values are already written from node.row_type / node.name /
+    # node.uuid / depth — serializing them as ordinary columns duplicates the
+    # field name in `fields` and the value in every row.
+    columns = [c for c in columns
+               if c.model.col_id not in _RESERVED_ROW_METADATA_FIELDS]
+
     col_specs = []
     for c in columns:
         spec = {

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -457,7 +457,11 @@ def test_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
     w._save()
     import json
     payload = json.loads(save_path.read_text())
-    assert payload["columns"][0]["id"] == "type"
+    # After the dedup fix, type/name are NOT in col_specs — they are encoded
+    # in the fixed row-metadata fields (positions 2 and 3). The first ordinary
+    # column is now "id" (the type/name builtins are filtered out).
+    assert payload["columns"][0]["id"] == "id"
+    # The row name is still at index 3 (the fixed metadata field).
     assert any(r[3] == "S1" for r in payload["rows"])
 
 

--- a/pluggable_protocol_tree/tests/test_logging_controller.py
+++ b/pluggable_protocol_tree/tests/test_logging_controller.py
@@ -279,3 +279,58 @@ def test_log_metadata_forwards_to_ingestion_and_is_noop_without(tmp_path):
     assert c._ingestion.metadata["Protocol Path"] == "<a>x</a>"
     c._ingestion = None
     c.log_metadata({"k": "v"})                   # must not raise
+
+
+# ---------------------------------------------------------------------------
+# all_report_paths accumulator tests (legacy parity)
+# ---------------------------------------------------------------------------
+
+def test_all_report_paths_starts_empty():
+    """Fresh controller has no report paths."""
+    c = ProtocolLoggingController()
+    assert c.all_report_paths == []
+
+
+def test_all_report_paths_accumulates_across_runs(tmp_path):
+    """Successful flushes append the report path; multiple runs on one
+    controller instance accumulate. Matches legacy
+    protocol_data_logger.all_report_paths semantics."""
+    c = ProtocolLoggingController(settling_provider=lambda: 0.0,
+                                  flush_scheduler=_immediate)
+
+    # --- run 1 ---
+    c.start_logging(_ctx(tmp_path), n_steps=1, preview_mode=False)
+    c._on_step_started(_FakeRow())
+    c.on_actuation(json.dumps({"electrodes": ["a"], "channels": [5]}))
+    c.on_capacitance(json.dumps({"capacitance": "10pF", "voltage": "100V",
+                                 "instrument_time_us": 1, "reception_time": 2}))
+    c.stop_logging()
+    assert len(c.all_report_paths) == 1
+
+    # --- run 2 ---
+    c.start_logging(_ctx(tmp_path), n_steps=1, preview_mode=False)
+    c._on_step_started(_FakeRow())
+    c.on_actuation(json.dumps({"electrodes": ["a"], "channels": [5]}))
+    c.on_capacitance(json.dumps({"capacitance": "10pF", "voltage": "100V",
+                                 "instrument_time_us": 1, "reception_time": 2}))
+    c.stop_logging()
+    assert len(c.all_report_paths) == 2
+
+    # both paths exist on disk and end with .html
+    for p in c.all_report_paths:
+        assert p.exists()
+        assert p.suffix == ".html"
+
+
+def test_all_report_paths_does_not_grow_when_generate_report_is_false(tmp_path):
+    """When the user declined report generation (generate_report=False),
+    no path should land in the session list."""
+    c = ProtocolLoggingController(settling_provider=lambda: 0.0,
+                                  flush_scheduler=_immediate)
+    c.start_logging(_ctx(tmp_path), n_steps=1, preview_mode=False)
+    c._on_step_started(_FakeRow())
+    c.on_actuation(json.dumps({"electrodes": ["a"], "channels": [5]}))
+    c.on_capacitance(json.dumps({"capacitance": "10pF", "voltage": "100V",
+                                 "instrument_time_us": 1, "reception_time": 2}))
+    c.stop_logging(generate_report=False)
+    assert c.all_report_paths == []

--- a/pluggable_protocol_tree/tests/test_persistence.py
+++ b/pluggable_protocol_tree/tests/test_persistence.py
@@ -30,17 +30,23 @@ def test_to_json_schema_version(manager):
 
 
 def test_to_json_columns_metadata(manager):
+    # After the dedup fix the builtin type/name columns are filtered out of
+    # col_specs (they are already encoded in the fixed row-metadata fields).
+    # Only the non-reserved ordinary columns remain.
     data = manager.to_json()
     ids = [c["id"] for c in data["columns"]]
-    assert ids == ["type", "id", "name", "duration_s"]
+    assert ids == ["id", "duration_s"]
     for c in data["columns"]:
         assert "cls" in c
 
 
 def test_to_json_fields_order(manager):
+    # After the dedup fix the builtin type/name columns are filtered out of
+    # col_specs, so "type" and "name" each appear exactly once (in the fixed
+    # row-metadata prefix).  The "id" and "duration_s" ordinary columns remain.
     data = manager.to_json()
     assert data["fields"] == ["depth", "uuid", "type", "name",
-                              "type", "id", "name", "duration_s"]
+                              "id", "duration_s"]
 
 
 def test_to_json_rows_encoded_with_depth(manager):
@@ -181,3 +187,85 @@ def test_load_old_payload_without_row_flags_defaults_false(manager):
     del data["row_flags"]            # simulate a pre-split save
     new_mgr = RowManager.from_json(data, columns=list(manager.columns))
     assert new_mgr.root.children[0].repeat_duration_controls is False
+
+
+# --- Issue-1 dedup fix ---
+
+def test_serialize_no_duplicate_type_or_name_in_fields():
+    """The builtin type/name columns must NOT be serialized in
+    addition to the fixed row metadata — fields are unique."""
+    cols = [make_type_column(), make_id_column(), make_name_column()]
+    m = RowManager(columns=cols)
+    m.add_step()
+    m.add_group(name="G")
+    data = m.to_json()
+    assert data["fields"].count("type") == 1
+    assert data["fields"].count("name") == 1
+    # Per-row width matches fields width — no orphan values.
+    for row in data["rows"]:
+        assert len(row) == len(data["fields"])
+
+
+def test_roundtrip_after_dedup_preserves_step_type_and_name():
+    """After the dedup fix, save -> load -> save preserves every
+    row's type and name."""
+    cols = [make_type_column(), make_name_column()]
+    m = RowManager(columns=cols)
+    m.add_step()
+    g = m.add_group(name="MyGroup")
+    m.add_step(parent_path=g)
+
+    data = m.to_json()
+    m2 = RowManager(columns=cols)
+    m2.set_state_from_json(data, columns=cols)
+
+    assert m2.root.children[0].row_type == "step"
+    assert m2.root.children[1].row_type == "group"
+    assert m2.root.children[1].name == "MyGroup"
+    assert m2.root.children[1].children[0].row_type == "step"
+
+
+def test_load_old_duplicate_fields_payload_still_loads():
+    """Backward compat: a pre-fix save that has duplicate 'type'/'name'
+    in col_specs still loads without error. The setattr calls for the
+    orphan attributes are harmless because the row constructor already
+    set name/row_type from the fixed metadata fields."""
+    cols = [make_type_column(), make_id_column(), make_name_column(),
+            make_duration_column()]
+    m = RowManager(columns=cols)
+    m.add_step(values={"name": "OldStep", "duration_s": 3.0})
+    g = m.add_group(name="OldGroup")
+    m.add_step(parent_path=g, values={"name": "Nested"})
+
+    # Simulate the OLD (buggy) format: inject duplicate type/name into
+    # col_specs and duplicate values into every row.
+    data = m.to_json()
+    # Insert fake type/name col_specs at the front (as old saves did)
+    data["columns"] = (
+        [{"id": "type", "cls": "pluggable_protocol_tree.builtins.type_column.TypeColumnModel"},
+         {"id": "name", "cls": "pluggable_protocol_tree.builtins.name_column.NameColumnModel"}]
+        + data["columns"]
+    )
+    # fields = ["depth", "uuid", "type", "name", "type", "name", "id", "duration_s"]
+    # Insert the duplicated fields after the fixed prefix.
+    data["fields"] = (
+        data["fields"][:4]                     # depth, uuid, type, name
+        + ["type", "name"]                     # duplicates (old format)
+        + data["fields"][4:]                   # remaining ordinary columns
+    )
+    # Inject duplicate values into each row at the right position.
+    new_rows = []
+    for row in data["rows"]:
+        # row[:4] = depth, uuid, type, name; row[4:] = ordinary col values
+        new_row = list(row[:4]) + [row[2], row[3]] + list(row[4:])
+        new_rows.append(new_row)
+    data["rows"] = new_rows
+
+    # Load with current column set — must not raise.
+    nm = RowManager.from_json(data, columns=list(cols))
+    assert nm.root.children[0].name == "OldStep"
+    assert nm.root.children[0].row_type == "step"
+    assert nm.root.children[0].duration_s == 3.0
+    assert nm.root.children[1].name == "OldGroup"
+    assert nm.root.children[1].row_type == "group"
+    assert nm.root.children[1].children[0].name == "Nested"

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -367,7 +367,10 @@ def test_pane_save_writes_manager_to_json(qapp, tmp_path, monkeypatch):
                         lambda *a, **kw: (str(save_path), ""))
     pane.save_to_dialog()
     payload = json.loads(save_path.read_text())
-    assert payload["columns"][0]["id"] == "type"
+    # After the dedup fix, type/name are NOT in col_specs — they are encoded
+    # in the fixed row-metadata fields (positions 2 and 3). The first ordinary
+    # column is now "id" (the type/name builtins are filtered out).
+    assert payload["columns"][0]["id"] == "id"
 
 
 def test_pane_stub_mode_buttons_log_only(qapp):
@@ -1265,6 +1268,77 @@ def test_import_into_selected_group_noop_when_no_group_selected(qapp,
         lambda *a, **k: called.append(True) or ("", ""))
     pane.import_into_selected_group()
     assert called == []                        # never even opened the dialog
+
+
+def test_import_into_selected_group_adds_top_level_rows(qapp, tmp_path,
+                                                         monkeypatch):
+    """Selecting a group + importing -> the imported protocol's
+    top-level rows are merged under the selected group. Nested rows
+    are NOT recursively imported."""
+    import json as _json
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.models.row_manager import RowManager
+
+    # Build a target pane with one group selected.
+    cols = [make_type_column(), make_name_column()]
+    pane = ptp.ProtocolTreePane(cols)
+    target_path = pane.manager.add_group(name="Dest")
+    pane.manager.selection = [tuple(target_path)]
+
+    # Build an "imported" protocol via the actual serializer: one
+    # top-level step and one top-level group (the group's nested
+    # contents must be ignored per the deep-import-out-of-scope rule).
+    src = RowManager(columns=cols)
+    src.add_step(values={"name": "imported_step"})
+    inner_group = src.add_group(name="ImportedGroup")
+    src.add_step(parent_path=inner_group, values={"name": "should_be_skipped"})
+    file_data = src.to_json()
+    f = tmp_path / "p.json"
+    f.write_text(_json.dumps(file_data), encoding="utf-8")
+
+    # Stub the file-dialog to return our file.
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: (str(f), ""))
+
+    pane.import_into_selected_group()
+
+    # The target group now has exactly two new direct children:
+    # the imported step and the imported (empty) group.
+    dest = pane.manager.get_row(target_path)
+    assert len(dest.children) == 2
+    # First merged child: the step.
+    assert dest.children[0].row_type == "step"
+    assert dest.children[0].name == "imported_step"
+    # Second merged child: the group, but with NO children.
+    assert dest.children[1].row_type == "group"
+    assert dest.children[1].name == "ImportedGroup"
+    assert len(dest.children[1].children) == 0
+
+
+def test_import_into_selected_group_noop_on_unreadable_file(qapp,
+                                                              monkeypatch):
+    """A broken file selection -> the method returns without raising
+    and without mutating the tree."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    target_path = pane.manager.add_group(name="Dest")
+    pane.manager.selection = [tuple(target_path)]
+
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: ("/non/existent.json", ""))
+
+    before = len(pane.manager.get_row(target_path).children)
+    pane.import_into_selected_group()                # must not raise
+    after = len(pane.manager.get_row(target_path).children)
+    assert before == after
 
 
 def test_delete_last_step_removes_last_top_level_step(qapp):

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1199,3 +1199,110 @@ def test_pane_skips_quick_action_bar_when_no_actions(qapp):
     pane = ptp.ProtocolTreePane([make_name_column()])
     assert pane.quick_action_bar is None
     assert pane.quick_actions_controller is None
+
+
+def _pane_with_two_steps(qapp):
+    """Pane with a tree containing exactly two top-level step rows."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    # seed_default_step_if_empty already gave us 1 step; add one more.
+    pane.manager.add_step()
+    return pane
+
+
+def test_add_step_after_selection_with_no_selection_appends_root(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = []
+    pane.add_step_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+
+
+def test_add_step_after_selection_with_one_selected_inserts_below(qapp):
+    pane = _pane_with_two_steps(qapp)
+    pane.manager.selection = [(0,)]
+    before = len(pane.manager.root.children)
+    pane.add_step_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+
+
+def test_add_group_after_selection_appends_a_group(qapp):
+    pane = _pane_with_two_steps(qapp)
+    pane.manager.selection = []
+    before = len(pane.manager.root.children)
+    pane.add_group_after_selection()
+    assert len(pane.manager.root.children) == before + 1
+    from pluggable_protocol_tree.models.row import GroupRow
+    assert isinstance(pane.manager.root.children[-1], GroupRow)
+
+
+def test_delete_selected_rows_removes_at_those_paths(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = [(0,)]
+    pane.delete_selected_rows()
+    assert len(pane.manager.root.children) == before - 1
+
+
+def test_delete_selected_rows_no_selection_is_noop(qapp):
+    pane = _pane_with_two_steps(qapp)
+    before = len(pane.manager.root.children)
+    pane.manager.selection = []
+    pane.delete_selected_rows()
+    assert len(pane.manager.root.children) == before
+
+
+def test_import_into_selected_group_noop_when_no_group_selected(qapp,
+                                                                 monkeypatch):
+    """Selection points to a step (not a group) -> import is a no-op."""
+    pane = _pane_with_two_steps(qapp)
+    pane.manager.selection = [(0,)]            # a step row
+    called = []
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: called.append(True) or ("", ""))
+    pane.import_into_selected_group()
+    assert called == []                        # never even opened the dialog
+
+
+def test_browse_reports_dialog_opens_with_globbed_paths(qapp, monkeypatch,
+                                                         tmp_path):
+    """browse_reports_dialog globs <experiment_dir>/reports/*.html and
+    feeds the path list into ReportBrowserDialog. The pane only needs a
+    ``reports_dir_provider`` (callable) — the dialog class itself is
+    monkeypatched here so this test can run without the new plugin."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    reports = tmp_path / "reports"
+    reports.mkdir()
+    (reports / "report_a.html").write_text("<html></html>", encoding="utf-8")
+    (reports / "report_b.html").write_text("<html></html>", encoding="utf-8")
+
+    captured = {}
+    class _FakeDialog:
+        def __init__(self, paths, parent=None):
+            captured["paths"] = list(paths)
+        def exec(self_inner):
+            return 0
+    monkeypatch.setattr(ptp, "_get_report_browser_dialog_cls",
+                        lambda: _FakeDialog)
+
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane._reports_dir_provider = lambda: reports
+    pane.browse_reports_dialog()
+    assert set(captured["paths"]) == {
+        str(reports / "report_a.html"),
+        str(reports / "report_b.html"),
+    }
+
+
+def test_browse_reports_dialog_no_provider_logs_and_returns(qapp, caplog):
+    """No reports_dir_provider configured (e.g. demo, no experiment manager)
+    -> log a debug message and return; do NOT crash."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane._reports_dir_provider = None
+    pane.browse_reports_dialog()                 # must not raise

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1138,3 +1138,37 @@ def test_on_error_shows_dialog_before_completion_flow(qapp, monkeypatch):
     pane._on_error("boom")
 
     assert order == [("term", "error"), "error_dialog", ("flow", "error")]
+
+
+def test_pane_emits_protocol_running_changed_true_on_start(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    seen = []
+    pane.protocol_running_changed.connect(lambda v: seen.append(v))
+    pane._on_protocol_started()
+    assert seen == [True]
+
+
+def test_pane_emits_protocol_running_changed_false_on_terminated(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    seen = []
+    pane.protocol_running_changed.connect(lambda v: seen.append(v))
+    pane._on_protocol_terminated()
+    assert seen == [False]
+
+
+def test_pane_emits_selection_changed_on_tree_selection(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pyface.qt.QtCore import QItemSelection
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    fired = []
+    pane.selection_changed.connect(lambda: fired.append(True))
+    # Drive the tree's selectionModel directly — pane subscribes to
+    # selectionChanged and re-emits the parameterless selection_changed.
+    sm = pane.widget.tree.selectionModel()
+    sm.selectionChanged.emit(QItemSelection(), QItemSelection())
+    assert fired == [True]

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1683,3 +1683,97 @@ def test_attempt_func_execution_html_escapes_exception_message(qapp,
     # The raw script tag must NOT appear; escaped form must.
     assert "<script>" not in captured["informative"]
     assert "&lt;script&gt;" in captured["informative"]
+
+
+def test_import_into_selected_group_skips_none_values(qapp, tmp_path,
+                                                       monkeypatch):
+    """A saved row with None for a strict-typed column (e.g. Float)
+    must NOT raise TraitError on import — the None is skipped so the
+    trait keeps its default. Regression for the bug reported on
+    feat/433."""
+    import json as _json
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.duration_column import (
+        make_duration_column,
+    )
+
+    cols = [make_name_column(), make_duration_column()]
+    pane = ptp.ProtocolTreePane(cols)
+    target_path = pane.manager.add_group(name="Dest")
+    pane.manager.selection = [tuple(target_path)]
+
+    # Synthetic file: duration is None — strict Float trait rejects it
+    # with a naive setattr. Importer must skip and let the default apply.
+    file_data = {
+        "schema_version": 1,
+        "protocol_metadata": {}, "row_flags": {},
+        "columns": [
+            {"id": "name", "cls": "x.NameColumnModel"},
+            {"id": "duration_s", "cls": "x.DurationColumnModel"},
+        ],
+        "fields": ["depth", "uuid", "type", "name", "duration_s"],
+        "rows": [
+            [0, "u-1", "step", "imported_step", None],
+        ],
+    }
+    f = tmp_path / "p.json"
+    f.write_text(_json.dumps(file_data), encoding="utf-8")
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: (str(f), ""))
+
+    pane.import_into_selected_group()                # must not raise
+
+    dest = pane.manager.get_row(target_path)
+    assert len(dest.children) == 1
+    new_step = dest.children[0]
+    assert new_step.name == "imported_step"
+    # duration kept its default (not None — the row class has a defined
+    # Float default, typically 1.0). Just assert it's a float (not None).
+    assert isinstance(new_step.duration_s, float)
+
+
+def test_import_into_selected_group_skips_columns_not_in_live_set(qapp,
+                                                                    tmp_path,
+                                                                    monkeypatch):
+    """A saved column id absent from the LIVE column set must be
+    skipped rather than becoming an orphan attribute on the row."""
+    import json as _json
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+
+    # Live tree has only the name column.
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    target_path = pane.manager.add_group(name="Dest")
+    pane.manager.selection = [tuple(target_path)]
+
+    file_data = {
+        "schema_version": 1,
+        "protocol_metadata": {}, "row_flags": {},
+        "columns": [
+            {"id": "name", "cls": "x.NameColumnModel"},
+            {"id": "unknown_plugin_col", "cls": "x.WhateverModel"},
+        ],
+        "fields": ["depth", "uuid", "type", "name", "unknown_plugin_col"],
+        "rows": [
+            [0, "u-1", "step", "ok_step", "junk-value"],
+        ],
+    }
+    f = tmp_path / "p.json"
+    f.write_text(_json.dumps(file_data), encoding="utf-8")
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: (str(f), ""))
+
+    pane.import_into_selected_group()
+
+    dest = pane.manager.get_row(target_path)
+    assert len(dest.children) == 1
+    new_step = dest.children[0]
+    assert new_step.name == "ok_step"
+    # The unknown column id must NOT have leaked onto the row as an
+    # orphan attribute.
+    assert not hasattr(new_step, "unknown_plugin_col")

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1172,3 +1172,30 @@ def test_pane_emits_selection_changed_on_tree_selection(qapp):
     sm = pane.widget.tree.selectionModel()
     sm.selectionChanged.emit(QItemSelection(), QItemSelection())
     assert fired == [True]
+
+
+def test_pane_mounts_quick_action_bar_when_actions_passed(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+    a = BaseQuickAction(action_id="add_step", icon_text="add",
+                        tooltip="Add step", priority=10)
+    b = BaseQuickAction(action_id="save_protocol", icon_text="save",
+                        tooltip="Save", priority=60)
+    pane = ptp.ProtocolTreePane([make_name_column()], quick_actions=[a, b])
+    assert pane.quick_action_bar is not None
+    assert set(pane.quick_action_bar.buttons.keys()) == {"add_step", "save_protocol"}
+    assert pane.quick_actions_controller is not None
+
+
+def test_pane_skips_quick_action_bar_when_no_actions(qapp):
+    """No actions contributed (e.g. demo, headless test) -> no bar
+    widget mounted; controller is None. This is the architectural
+    commitment: the tree plugin ships zero builtins."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    assert pane.quick_action_bar is None
+    assert pane.quick_actions_controller is None

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1306,3 +1306,46 @@ def test_browse_reports_dialog_no_provider_logs_and_returns(qapp, caplog):
     pane = ptp.ProtocolTreePane([make_name_column()])
     pane._reports_dir_provider = None
     pane.browse_reports_dialog()                 # must not raise
+
+
+def test_delete_last_step_removes_last_top_level_step(qapp):
+    """Two top-level steps -> delete_last_step removes the second one."""
+    pane = _pane_with_two_steps(qapp)        # helper from Task 8 already exists
+    before = len(pane.manager.root.children)
+    # No selection — the action's new behaviour is independent of selection.
+    pane.manager.selection = []
+    pane.delete_last_step()
+    assert len(pane.manager.root.children) == before - 1
+
+
+def test_delete_last_step_descends_into_groups(qapp):
+    """Last child is a group containing a step -> delete the step
+    inside the group, leaving the (now-empty) group in place."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    # The pane starts with an empty tree. Add a top-level step, then a
+    # group containing one step so the last execution step is nested.
+    pane.manager.add_step()                            # step at (0,)
+    group_path = pane.manager.add_group(name="G")      # group at (1,)
+    pane.manager.add_step(parent_path=group_path)      # step at (1, 0)
+    # Tree now: step(0,) / Group(step(1,0))
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 1            # sanity
+
+    pane.delete_last_step()
+
+    # The nested step inside G must be gone; G itself must remain.
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 0
+    # And the top-level step is untouched.
+    assert len(pane.manager.root.children) == 2  # original step + empty group
+
+
+def test_delete_last_step_empty_tree_is_noop(qapp):
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    # The pane starts with an empty tree (no auto-seeding in __init__).
+    assert len(pane.manager.root.children) == 0
+    pane.delete_last_step()                    # must not raise

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1565,3 +1565,121 @@ def test_import_into_selected_group_robust_to_schema_field_order(qapp,
     assert dest.children[1].row_type == "group"
     assert dest.children[1].name == "imported_group"
     assert len(dest.children[1].children) == 0
+
+
+def test_attempt_func_execution_returns_wrapped_value_on_success(qapp):
+    """Successful call passes through the wrapped function's return value
+    with no dialog."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    calls = []
+    ptp_error = ptp.error
+
+    class _Fake:
+        @ptp.attempt_func_execution_with_error_dialog
+        def do(self, x, y):
+            return x + y
+
+    f = _Fake()
+    # Sanity: the dialog is NOT invoked on success. Replace it with a
+    # tripwire that fails the test if called.
+    try:
+        ptp.error = lambda *a, **k: calls.append("BUG: dialog called on success")
+        assert f.do(2, 3) == 5
+    finally:
+        ptp.error = ptp_error
+    assert calls == []
+
+
+def test_attempt_func_execution_shows_html_dialog_and_logs_on_exception(
+    qapp, monkeypatch, caplog):
+    """Exception path: dialog gets HTML informative + traceback detail,
+    logger captures the stack, and the wrapper returns None instead of
+    propagating."""
+    import logging
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    captured = {}
+
+    def _fake_error(parent, *, message, title, informative=None, detail=None,
+                    **kw):
+        captured["parent"] = parent
+        captured["message"] = message
+        captured["title"] = title
+        captured["informative"] = informative
+        captured["detail"] = detail
+
+    monkeypatch.setattr(ptp, "error", _fake_error)
+    caplog.set_level(logging.ERROR, logger="pluggable_protocol_tree.views.protocol_tree_pane")
+
+    class _Fake:
+        @ptp.attempt_func_execution_with_error_dialog
+        def save_protocol_dialog(self):
+            raise ValueError("disk full")
+
+    result = _Fake().save_protocol_dialog()
+    assert result is None
+    # Message + title use the humanised operation name and the exception
+    # type — both readable to a user.
+    assert captured["title"] == "Save Protocol Dialog Error"
+    assert "Save Protocol Dialog" in captured["message"]
+    assert "ValueError" in captured["message"]
+    # Informative is HTML, bold name, red exception type, escaped cause.
+    assert "<b>Save Protocol Dialog</b>" in captured["informative"]
+    assert "ValueError" in captured["informative"]
+    assert "disk full" in captured["informative"]
+    # Detail contains the full traceback (multi-line, includes "Traceback").
+    assert "Traceback" in captured["detail"]
+    assert "ValueError: disk full" in captured["detail"]
+    # Logger captured it too, with exc_info.
+    assert any(
+        "Save Protocol Dialog failed" in r.message and r.exc_info
+        for r in caplog.records)
+
+
+def test_attempt_func_execution_handles_dialog_failure_gracefully(
+    qapp, monkeypatch, caplog):
+    """If the dialog itself raises (e.g. no Qt event loop), we log it
+    but the wrapper does NOT propagate — original exception was already
+    logged so the caller can carry on."""
+    import logging
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    def _broken_error(*a, **k):
+        raise RuntimeError("no event loop")
+
+    monkeypatch.setattr(ptp, "error", _broken_error)
+    caplog.set_level(logging.ERROR, logger="pluggable_protocol_tree.views.protocol_tree_pane")
+
+    class _Fake:
+        @ptp.attempt_func_execution_with_error_dialog
+        def do(self):
+            raise IOError("boom")
+
+    # No exception propagates.
+    assert _Fake().do() is None
+    # Both the original error AND the dialog failure were logged.
+    messages = " | ".join(r.message for r in caplog.records)
+    assert "Do failed: boom" in messages
+    assert "failed to show error dialog" in messages
+
+
+def test_attempt_func_execution_html_escapes_exception_message(qapp,
+                                                                monkeypatch):
+    """Exception message containing HTML special chars must be escaped
+    so the dialog renders it as text, not markup."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+
+    captured = {}
+    monkeypatch.setattr(ptp, "error",
+                        lambda parent, **k: captured.update(k))
+
+    class _Fake:
+        @ptp.attempt_func_execution_with_error_dialog
+        def do(self):
+            raise RuntimeError("<script>alert('x')</script>")
+
+    _Fake().do()
+    # The raw script tag must NOT appear; escaped form must.
+    assert "<script>" not in captured["informative"]
+    assert "&lt;script&gt;" in captured["informative"]

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1409,3 +1409,77 @@ def test_delete_last_step_nested_empty_group_deletes_inner_empty_group(qapp):
     assert len(group.children) == 1
     # Remaining is the step inside G — the inner empty group is gone.
     assert not isinstance(group.children[0], GroupRow)
+
+
+def test_add_step_after_selection_with_group_selected_appends_inside_group(qapp):
+    """Single-group selection -> new step lands inside the group, not
+    at the root level after it."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()                       # step at (0,)
+    group_path = pane.manager.add_group(name="G") # group at (1,)
+    pane.manager.selection = [tuple(group_path)]
+
+    pane.add_step_after_selection()
+
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 1               # new step is inside G
+    # Top-level layout unchanged: still just step + group.
+    assert len(pane.manager.root.children) == 2
+
+
+def test_add_group_after_selection_with_group_selected_appends_inside_group(qapp):
+    """Same rule applies to add_group: single-group selection -> the
+    new group nests inside as a sub-group."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.models.row import GroupRow
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()
+    group_path = pane.manager.add_group(name="G")
+    pane.manager.selection = [tuple(group_path)]
+
+    pane.add_group_after_selection()
+
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 1
+    assert isinstance(group.children[0], GroupRow)
+    assert len(pane.manager.root.children) == 2
+
+
+def test_add_step_after_selection_with_multi_selection_uses_last(qapp):
+    """Multi-selection with the last being a group does NOT trigger
+    the "append inside" rule — only single-group selection does."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()                       # step at (0,)
+    group_path = pane.manager.add_group(name="G") # group at (1,)
+    # Select both — multi-selection.
+    pane.manager.selection = [(0,), tuple(group_path)]
+
+    pane.add_step_after_selection()
+
+    # New step is at root level (after the group), NOT inside G.
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 0
+    assert len(pane.manager.root.children) == 3
+
+
+def test_add_step_after_selection_with_nested_group_selected_appends_inside(qapp):
+    """A nested group is still a group — selecting it appends inside,
+    same as a top-level group."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    outer = pane.manager.add_group(name="Outer")
+    inner = pane.manager.add_group(parent_path=outer, name="Inner")
+    pane.manager.selection = [tuple(inner)]
+
+    pane.add_step_after_selection()
+
+    inner_row = pane.manager.get_row(inner)
+    outer_row = pane.manager.get_row(outer)
+    assert len(inner_row.children) == 1            # step inside Inner
+    assert len(outer_row.children) == 1            # Outer still has only Inner

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1516,3 +1516,52 @@ def test_add_step_after_selection_with_nested_group_selected_appends_inside(qapp
     outer_row = pane.manager.get_row(outer)
     assert len(inner_row.children) == 1            # step inside Inner
     assert len(outer_row.children) == 1            # Outer still has only Inner
+
+
+def test_import_into_selected_group_robust_to_schema_field_order(qapp,
+                                                                  tmp_path,
+                                                                  monkeypatch):
+    """If a saved file ever reorders the leading-metadata fields,
+    the importer must still merge correctly because positions are
+    looked up by name, not hardcoded."""
+    import json as _json
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+
+    pane = ptp.ProtocolTreePane(
+        [make_type_column(), make_name_column()])
+    target_path = pane.manager.add_group(name="Dest")
+    pane.manager.selection = [tuple(target_path)]
+
+    # Synthetic file: shuffle the fixed metadata around so
+    # `depth` is at position 1 and `type` is at position 0,
+    # plus one ordinary column at position 3.
+    file_data = {
+        "schema_version": 1,
+        "protocol_metadata": {},
+        "row_flags": {},
+        "columns": [],
+        "fields": ["type", "depth", "name", "uuid"],
+        "rows": [
+            ["step", 0, "imported_step", "u-1"],
+            ["group", 0, "imported_group", "u-2"],
+            ["step", 1, "nested_skip", "u-3"],   # nested -> skipped
+        ],
+    }
+    f = tmp_path / "p.json"
+    f.write_text(_json.dumps(file_data), encoding="utf-8")
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog."
+        "getOpenFileName",
+        lambda *a, **k: (str(f), ""))
+
+    pane.import_into_selected_group()
+
+    dest = pane.manager.get_row(target_path)
+    assert len(dest.children) == 2
+    assert dest.children[0].row_type == "step"
+    assert dest.children[0].name == "imported_step"
+    assert dest.children[1].row_type == "group"
+    assert dest.children[1].name == "imported_group"
+    assert len(dest.children[1].children) == 0

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1349,3 +1349,63 @@ def test_delete_last_step_empty_tree_is_noop(qapp):
     # The pane starts with an empty tree (no auto-seeding in __init__).
     assert len(pane.manager.root.children) == 0
     pane.delete_last_step()                    # must not raise
+
+
+def test_delete_last_step_empty_trailing_group_deletes_the_group(qapp):
+    """`S1, EmptyGroup` -> delete removes the empty group, leaves S1."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()                       # S1
+    group_path = pane.manager.add_group(name="G")
+    assert len(pane.manager.root.children) == 2
+
+    pane.delete_last_step()
+
+    assert len(pane.manager.root.children) == 1
+    from pluggable_protocol_tree.models.row import GroupRow
+    # The remaining row is the step (S1), NOT the group.
+    assert not isinstance(pane.manager.root.children[0], GroupRow)
+
+
+def test_delete_last_step_non_empty_group_descends_to_step(qapp):
+    """`S1, Group[S2, S3]` -> delete removes S3, leaving Group[S2]."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()                       # S1 at (0,)
+    group_path = pane.manager.add_group(name="G")
+    pane.manager.add_step(parent_path=group_path) # S2
+    pane.manager.add_step(parent_path=group_path) # S3
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 2
+
+    pane.delete_last_step()
+
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 1               # S3 gone, S2 remains
+    assert len(pane.manager.root.children) == 2   # S1 + G(S2)
+
+
+def test_delete_last_step_nested_empty_group_deletes_inner_empty_group(qapp):
+    """`S1, Group[S2, EmptyInnerGroup]` -> delete removes the inner
+    empty group, leaving Group[S2]."""
+    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
+    from pluggable_protocol_tree.builtins.name_column import make_name_column
+    from pluggable_protocol_tree.models.row import GroupRow
+    pane = ptp.ProtocolTreePane([make_name_column()])
+    pane.manager.add_step()
+    group_path = pane.manager.add_group(name="G")
+    pane.manager.add_step(parent_path=group_path)
+    pane.manager.add_group(parent_path=group_path, name="Inner")
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 2
+    assert isinstance(group.children[-1], GroupRow)
+    assert len(group.children[-1].children) == 0
+
+    pane.delete_last_step()
+
+    group = pane.manager.get_row(group_path)
+    assert len(group.children) == 1
+    # Remaining is the step inside G — the inner empty group is gone.
+    assert not isinstance(group.children[0], GroupRow)

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1267,47 +1267,6 @@ def test_import_into_selected_group_noop_when_no_group_selected(qapp,
     assert called == []                        # never even opened the dialog
 
 
-def test_browse_reports_dialog_opens_with_globbed_paths(qapp, monkeypatch,
-                                                         tmp_path):
-    """browse_reports_dialog globs <experiment_dir>/reports/*.html and
-    feeds the path list into ReportBrowserDialog. The pane only needs a
-    ``reports_dir_provider`` (callable) — the dialog class itself is
-    monkeypatched here so this test can run without the new plugin."""
-    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
-    from pluggable_protocol_tree.builtins.name_column import make_name_column
-    reports = tmp_path / "reports"
-    reports.mkdir()
-    (reports / "report_a.html").write_text("<html></html>", encoding="utf-8")
-    (reports / "report_b.html").write_text("<html></html>", encoding="utf-8")
-
-    captured = {}
-    class _FakeDialog:
-        def __init__(self, paths, parent=None):
-            captured["paths"] = list(paths)
-        def exec(self_inner):
-            return 0
-    monkeypatch.setattr(ptp, "_get_report_browser_dialog_cls",
-                        lambda: _FakeDialog)
-
-    pane = ptp.ProtocolTreePane([make_name_column()])
-    pane._reports_dir_provider = lambda: reports
-    pane.browse_reports_dialog()
-    assert set(captured["paths"]) == {
-        str(reports / "report_a.html"),
-        str(reports / "report_b.html"),
-    }
-
-
-def test_browse_reports_dialog_no_provider_logs_and_returns(qapp, caplog):
-    """No reports_dir_provider configured (e.g. demo, no experiment manager)
-    -> log a debug message and return; do NOT crash."""
-    import pluggable_protocol_tree.views.protocol_tree_pane as ptp
-    from pluggable_protocol_tree.builtins.name_column import make_name_column
-    pane = ptp.ProtocolTreePane([make_name_column()])
-    pane._reports_dir_provider = None
-    pane.browse_reports_dialog()                 # must not raise
-
-
 def test_delete_last_step_removes_last_top_level_step(qapp):
     """Two top-level steps -> delete_last_step removes the second one."""
     pane = _pane_with_two_steps(qapp)        # helper from Task 8 already exists

--- a/pluggable_protocol_tree/tests/test_quick_action_bar.py
+++ b/pluggable_protocol_tree/tests/test_quick_action_bar.py
@@ -1,0 +1,39 @@
+"""QuickActionBar is a pure rendering widget: it takes a list of
+IQuickAction instances and produces one QToolButton per action,
+ordered by (priority, action_id). It has no state and no Qt-signal
+connections — the controller (next task) attaches click handlers."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import QuickActionBar
+
+
+def _make(action_id, *, priority=50, icon="add", tip="t", shortcut=""):
+    return BaseQuickAction(action_id=action_id, icon_text=icon,
+                           tooltip=tip, priority=priority,
+                           shortcut=shortcut)
+
+
+def test_bar_renders_one_button_per_action(qapp):
+    bar = QuickActionBar(actions=[
+        _make("a"), _make("b"), _make("c"),
+    ])
+    assert len(bar.buttons) == 3
+    assert set(bar.buttons.keys()) == {"a", "b", "c"}
+
+
+def test_bar_orders_by_priority_then_action_id(qapp):
+    bar = QuickActionBar(actions=[
+        _make("z", priority=10),
+        _make("a", priority=20),
+        _make("c", priority=10),
+    ])
+    assert list(bar.buttons.keys()) == ["c", "z", "a"]
+
+
+def test_button_text_is_icon_text_and_tooltip_matches(qapp):
+    bar = QuickActionBar(actions=[
+        _make("add_step", icon="add", tip="Add step below selection"),
+    ])
+    b = bar.buttons["add_step"]
+    assert b.text() == "add"
+    assert b.toolTip() == "Add step below selection"

--- a/pluggable_protocol_tree/tests/test_quick_action_bar.py
+++ b/pluggable_protocol_tree/tests/test_quick_action_bar.py
@@ -37,3 +37,16 @@ def test_button_text_is_icon_text_and_tooltip_matches(qapp):
     b = bar.buttons["add_step"]
     assert b.text() == "add"
     assert b.toolTip() == "Add step below selection"
+
+
+def test_bar_skips_duplicate_action_id_and_logs_warning(qapp, caplog):
+    """Two contributions with the same action_id is a programming bug
+    in the contributing plugins. The bar logs a warning and keeps the
+    first one (priority-sorted); the duplicate is dropped from both
+    self.buttons AND the visible layout."""
+    bar = QuickActionBar(actions=[
+        _make("add_step", priority=10),
+        _make("add_step", priority=20),
+    ])
+    assert list(bar.buttons.keys()) == ["add_step"]
+    assert "add_step" in caplog.text

--- a/pluggable_protocol_tree/tests/test_quick_action_interface.py
+++ b/pluggable_protocol_tree/tests/test_quick_action_interface.py
@@ -1,0 +1,53 @@
+"""IQuickAction is the contract any contributed quick-action button
+implements. This file pins the trait shape and the two-method surface
+so future refactors can't silently break plugin contributions."""
+
+from traits.api import HasStrictTraits, provides
+
+from pluggable_protocol_tree.consts import PROTOCOL_QUICK_ACTIONS
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+def test_extension_point_id_is_namespaced():
+    assert PROTOCOL_QUICK_ACTIONS == (
+        "pluggable_protocol_tree.protocol_quick_actions"
+    )
+
+
+def test_iquick_action_required_traits_exist():
+    """Trait names + default values are part of the public contract —
+    plugins read action_id/icon_text/tooltip directly.
+
+    Concrete providers inherit from both HasStrictTraits and IQuickAction
+    so that the interface's trait definitions are picked up by the MRO
+    (standard Traits Interface pattern; @provides alone is insufficient).
+    """
+
+    @provides(IQuickAction)
+    class _Stub(HasStrictTraits, IQuickAction):
+        pass
+
+    s = _Stub()
+    # Every trait declared on IQuickAction must be readable on a provider
+    # (proves the interface itself declares them).
+    for name in ("action_id", "icon_text", "tooltip",
+                 "priority", "shortcut"):
+        assert hasattr(s, name), f"missing trait: {name}"
+    assert s.priority == 50
+    assert s.shortcut == ""
+
+
+def test_iquick_action_methods_are_callable_with_ctx():
+    """The interface defines on_execute_action(ctx) and is_enabled(ctx)
+    -> bool; defaults are no-op / True."""
+
+    @provides(IQuickAction)
+    class _Stub(HasStrictTraits, IQuickAction):
+        action_id = "x"
+        icon_text = ""
+        tooltip = ""
+
+    s = _Stub()
+    # Default implementations don't raise; is_enabled defaults to True.
+    s.on_execute_action(ctx=None)
+    assert s.is_enabled(ctx=None) is True

--- a/pluggable_protocol_tree/tests/test_quick_action_model.py
+++ b/pluggable_protocol_tree/tests/test_quick_action_model.py
@@ -1,0 +1,47 @@
+"""BaseQuickAction is a thin HasStrictTraits convenience base so
+plugins don't have to redeclare the IQuickAction trait set. The
+QuickActionCtx is the value object passed to every action callback."""
+
+from unittest.mock import MagicMock
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+from pluggable_protocol_tree.models.quick_action import (
+    BaseQuickAction, QuickActionCtx,
+)
+
+
+def test_base_quick_action_provides_iquick_action_interface():
+    a = BaseQuickAction(action_id="x", icon_text="add", tooltip="t",
+                        priority=10, shortcut="Ctrl+X")
+    # Traits 7 uses ABC-based registration; has_traits_interface is the
+    # correct check (replaces Traits 4's __implements__.getInterfaces()).
+    assert a.has_traits_interface(IQuickAction)
+    assert a.action_id == "x"
+    assert a.icon_text == "add"
+    assert a.priority == 10
+    assert a.shortcut == "Ctrl+X"
+
+
+def test_base_quick_action_defaults():
+    a = BaseQuickAction(action_id="x")
+    assert a.priority == 50
+    assert a.shortcut == ""
+    assert a.is_enabled(ctx=None) is True
+
+
+def test_quick_action_ctx_carries_pane_selection_running():
+    pane = MagicMock()
+    ctx = QuickActionCtx(
+        pane=pane,
+        selected_paths=((0,), (1, 2)),
+        is_running=True,
+    )
+    assert ctx.pane is pane
+    assert ctx.selected_paths == ((0,), (1, 2))
+    assert ctx.is_running is True
+
+
+def test_quick_action_ctx_defaults():
+    ctx = QuickActionCtx(pane=MagicMock())
+    assert ctx.selected_paths == ()
+    assert ctx.is_running is False

--- a/pluggable_protocol_tree/tests/test_quick_action_model.py
+++ b/pluggable_protocol_tree/tests/test_quick_action_model.py
@@ -45,3 +45,17 @@ def test_quick_action_ctx_defaults():
     ctx = QuickActionCtx(pane=MagicMock())
     assert ctx.selected_paths == ()
     assert ctx.is_running is False
+
+
+def test_subclass_can_add_extra_trait():
+    """Plugin authors will subclass BaseQuickAction and frequently add
+    their own bookkeeping traits (e.g. cached state). Catch the
+    HasStrictTraits regression: subclassing must remain open."""
+    from traits.api import Str
+
+    class _MyAction(BaseQuickAction):
+        label = Str("default")
+
+    a = _MyAction(action_id="a", label="hello")
+    assert a.label == "hello"
+    assert a.action_id == "a"

--- a/pluggable_protocol_tree/tests/test_quick_actions_controller.py
+++ b/pluggable_protocol_tree/tests/test_quick_actions_controller.py
@@ -1,0 +1,121 @@
+"""QuickActionsController wires a QuickActionBar to a pane:
+
+* On every ``pane.selection_changed`` / ``pane.protocol_running_changed``
+  emission, walks the actions and calls ``button.setEnabled(...)``.
+* Clicks route through ``_execute(action)`` which builds a fresh
+  ``QuickActionCtx`` and calls ``action.on_execute_action(ctx)``,
+  swallowing any exception so a buggy contribution can't crash the bar.
+* When ``is_running == True``, the whole bar is disabled regardless of
+  each action's ``is_enabled``.
+"""
+
+from unittest.mock import MagicMock
+
+from pyface.qt.QtCore import QObject, Signal
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import (
+    QuickActionBar, QuickActionsController,
+)
+
+
+class _FakePane(QObject):
+    """Minimal stand-in for ProtocolTreePane."""
+    selection_changed = Signal()
+    protocol_running_changed = Signal(bool)
+
+    def __init__(self, manager=None, parent=None):
+        super().__init__(parent)
+        self.manager = manager or MagicMock()
+        # Controller pulls `pane.manager.selection` to build ctx.selected_paths.
+        self.manager.selection = []
+
+
+class _ToggleAction(BaseQuickAction):
+    """is_enabled flips with the .enabled flag; on_execute_action
+    bumps a counter and stashes the ctx for assertions."""
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.enabled = True
+        self.calls = 0
+        self.last_ctx = None
+
+    def is_enabled(self, ctx) -> bool:
+        return self.enabled
+
+    def on_execute_action(self, ctx):
+        self.calls += 1
+        self.last_ctx = ctx
+
+
+def test_initial_state_uses_is_enabled(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    b = _ToggleAction(action_id="b", icon_text="del", tooltip="")
+    b.enabled = False
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a, b])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a, b])
+    ctrl.refresh_enabled()
+    assert bar.buttons["a"].isEnabled() is True
+    assert bar.buttons["b"].isEnabled() is False
+
+
+def test_protocol_running_disables_whole_bar(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    pane.protocol_running_changed.emit(True)
+    assert bar.buttons["a"].isEnabled() is False
+    pane.protocol_running_changed.emit(False)
+    assert bar.buttons["a"].isEnabled() is True
+
+
+def test_selection_changed_re_evaluates_is_enabled(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    a.enabled = False
+    pane.selection_changed.emit()
+    assert bar.buttons["a"].isEnabled() is False
+
+
+def test_click_calls_execute_with_ctx_carrying_selection(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    pane = _FakePane()
+    pane.manager.selection = [(0,), (1, 2)]
+    bar = QuickActionBar(actions=[a])
+    QuickActionsController(bar=bar, pane=pane, actions=[a])
+    bar.buttons["a"].click()
+    assert a.calls == 1
+    assert a.last_ctx.pane is pane
+    assert a.last_ctx.selected_paths == ((0,), (1, 2))
+    assert a.last_ctx.is_running is False
+
+
+def test_click_on_disabled_button_does_not_execute(qapp):
+    a = _ToggleAction(action_id="a", icon_text="add", tooltip="")
+    a.enabled = False
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    ctrl.refresh_enabled()
+    bar.buttons["a"].click()
+    assert a.calls == 0
+
+
+def test_buggy_action_does_not_break_other_buttons(qapp, caplog):
+    class _Boom(BaseQuickAction):
+        def on_execute_action(self, ctx):
+            raise RuntimeError("kaboom")
+
+    boom = _Boom(action_id="b", icon_text="del", tooltip="")
+    good = _ToggleAction(action_id="g", icon_text="add", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[boom, good])
+    QuickActionsController(bar=bar, pane=pane, actions=[boom, good])
+    bar.buttons["b"].click()                  # raises internally
+    bar.buttons["g"].click()                  # must still fire
+    assert good.calls == 1
+    assert any("kaboom" in r.message for r in caplog.records)

--- a/pluggable_protocol_tree/tests/test_quick_actions_controller.py
+++ b/pluggable_protocol_tree/tests/test_quick_actions_controller.py
@@ -105,6 +105,26 @@ def test_click_on_disabled_button_does_not_execute(qapp):
     assert a.calls == 0
 
 
+def test_controller_skips_actions_not_in_bar_buttons(qapp):
+    """If QuickActionBar dropped a duplicate, the controller's iteration
+    must NOT raise KeyError. It silently skips actions whose action_id
+    isn't a key in bar.buttons."""
+    a = _ToggleAction(action_id="dup", icon_text="add", tooltip="")
+    b = _ToggleAction(action_id="dup", icon_text="del", tooltip="")
+    pane = _FakePane()
+    bar = QuickActionBar(actions=[a, b])      # bar drops the second
+    # Controller must accept the full actions list without raising.
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a, b])
+    ctrl.refresh_enabled()
+    pane.protocol_running_changed.emit(True)
+    pane.protocol_running_changed.emit(False)
+    pane.selection_changed.emit()
+    # Clicking the (only) button fires only the first action.
+    bar.buttons["dup"].click()
+    assert a.calls == 1
+    assert b.calls == 0
+
+
 def test_buggy_action_does_not_break_other_buttons(qapp, caplog):
     class _Boom(BaseQuickAction):
         def on_execute_action(self, ctx):

--- a/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py
+++ b/pluggable_protocol_tree/tests/test_quick_actions_extension_point.py
@@ -1,0 +1,26 @@
+"""The tree plugin exposes PROTOCOL_QUICK_ACTIONS as an Envisage
+extension point. Like PROTOCOL_COLUMNS, plugin.start() copies
+contributions into a plain list, and the dock-pane factory passes
+that list into ProtocolTreePane(quick_actions=...).
+
+The tree plugin itself contributes zero builtins."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
+
+
+def test_plugin_ships_zero_builtin_quick_actions():
+    plugin = PluggableProtocolTreePlugin()
+    # No contribution list set yet -> empty default.
+    assert plugin.contributed_quick_actions == []
+
+
+def test_assemble_quick_actions_sorts_by_priority_then_action_id():
+    plugin = PluggableProtocolTreePlugin()
+    plugin.contributed_quick_actions = [
+        BaseQuickAction(action_id="z", priority=10),
+        BaseQuickAction(action_id="a", priority=20),
+        BaseQuickAction(action_id="c", priority=10),
+    ]
+    assembled = plugin._assemble_quick_actions()
+    assert [a.action_id for a in assembled] == ["c", "z", "a"]

--- a/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py
+++ b/pluggable_protocol_tree/tests/test_quick_actions_shortcuts.py
@@ -1,0 +1,93 @@
+"""Shortcut wiring lives in QuickActionsController. For every action
+whose ``shortcut`` is non-empty we register one widget-scoped QShortcut
+on the pane, routed through ``_execute`` so it respects ``is_enabled``
+and the ``is_running`` gate. Two actions declaring the same key:
+the second registration is skipped and a warning is logged."""
+
+from pyface.qt.QtCore import QObject, Qt, Signal
+from pyface.qt.QtGui import QKeySequence
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+from pluggable_protocol_tree.views.quick_action_bar import (
+    QuickActionBar, QuickActionsController,
+)
+
+
+class _Pane(QObject):
+    selection_changed = Signal()
+    protocol_running_changed = Signal(bool)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        from unittest.mock import MagicMock
+        self.manager = MagicMock()
+        self.manager.selection = []
+
+
+class _Counting(BaseQuickAction):
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.calls = 0
+
+    def on_execute_action(self, ctx):
+        self.calls += 1
+
+
+def test_shortcut_registers_widget_scoped_qshortcut(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    assert len(ctrl.shortcuts) == 1
+    qs = ctrl.shortcuts[0]
+    assert qs.key() == QKeySequence("R")
+    assert qs.context() == Qt.WidgetWithChildrenShortcut
+    assert qs.parent() is pane
+
+
+def test_shortcut_triggers_execute(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 1
+
+
+def test_shortcut_is_gated_by_is_running(qapp):
+    a = _Counting(action_id="r", icon_text="summarize", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    pane.protocol_running_changed.emit(True)
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 0
+
+
+def test_no_shortcut_means_no_qshortcut_registered(qapp):
+    a = _Counting(action_id="r", icon_text="add", tooltip="", shortcut="")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a])
+    assert ctrl.shortcuts == []
+
+
+def test_duplicate_shortcut_skips_second_and_logs_warning(qapp, caplog):
+    a = _Counting(action_id="first", icon_text="add", tooltip="",
+                  shortcut="R")
+    b = _Counting(action_id="second", icon_text="del", tooltip="",
+                  shortcut="R")
+    pane = _Pane()
+    bar = QuickActionBar(actions=[a, b])
+    ctrl = QuickActionsController(bar=bar, pane=pane, actions=[a, b])
+    # Only the first wins.
+    assert len(ctrl.shortcuts) == 1
+    ctrl.shortcuts[0].activated.emit()
+    assert a.calls == 1
+    assert b.calls == 0
+    assert any(
+        "R" in r.message and "first" in r.message and "second" in r.message
+        for r in caplog.records)

--- a/pluggable_protocol_tree/tests/test_session.py
+++ b/pluggable_protocol_tree/tests/test_session.py
@@ -83,13 +83,22 @@ def _build_sample_manager():
 
 
 def test_resolve_columns_round_trips_all_ppt3_builtins():
-    """Every column factory in the canonical PPT-3 set must round-trip
-    through to_json -> resolve_columns with the same col_ids in the
-    same order."""
+    """Every non-reserved column factory in the canonical PPT-3 set must
+    round-trip through to_json -> resolve_columns with the same col_ids in
+    the same order.
+
+    After the dedup fix, type/name are NOT stored in col_specs (they are
+    encoded in the fixed row-metadata prefix), so resolve_columns returns
+    only the non-reserved columns.
+    """
+    from pluggable_protocol_tree.services.persistence import (
+        _RESERVED_ROW_METADATA_FIELDS,
+    )
     rm = _build_sample_manager()
     payload = rm.to_json()
     cols = resolve_columns(payload)
-    expected_ids = [c.model.col_id for c in _all_ppt3_columns()]
+    expected_ids = [c.model.col_id for c in _all_ppt3_columns()
+                    if c.model.col_id not in _RESERVED_ROW_METADATA_FIELDS]
     assert [c.model.col_id for c in cols] == expected_ids
 
 
@@ -145,12 +154,19 @@ def test_resolve_columns_missing_cls_field_raises():
 
 
 def test_from_file_loads_manager_with_resolved_columns(tmp_path: Path):
+    from pluggable_protocol_tree.services.persistence import (
+        _RESERVED_ROW_METADATA_FIELDS,
+    )
     rm = _build_sample_manager()
     path = tmp_path / "protocol.json"
     path.write_text(json.dumps(rm.to_json()))
 
     session = ProtocolSession.from_file(str(path), with_demo_hardware=False)
-    assert len(session.manager.columns) == len(_all_ppt3_columns())
+    # After the dedup fix, type/name are NOT stored in col_specs, so
+    # resolve_columns returns only the non-reserved columns (14 - 2 = 12).
+    expected_count = sum(1 for c in _all_ppt3_columns()
+                         if c.model.col_id not in _RESERVED_ROW_METADATA_FIELDS)
+    assert len(session.manager.columns) == expected_count
     assert len(session.manager.root.children) == 2
     assert session.manager.root.children[0].name == "S1"
     assert session.manager.root.children[1].name == "S2"

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -21,6 +21,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
     name = Str("Protocol (pluggable)")
 
     columns = List(Instance(IColumn))
+    quick_actions = List(desc="Quick actions to mount under the tree.")
 
     def create_contents(self, parent):
         # Local imports to avoid pulling Qt at plugin-import time.
@@ -66,6 +67,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
             sticky_manager=sticky_manager,
             device_viewer_sync=sync,
             logging_device_context_provider=_logging_device_context,
+            quick_actions=list(self.quick_actions),
             parent=parent,
         )
         pane.protocol_state_tracker.dock_pane = self

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -19,6 +19,8 @@ import threading
 import time
 from functools import wraps
 from pathlib import Path
+import html as _html
+import traceback as _tb
 
 from pyface.qt.QtCore import (
     Qt, QEventLoop, QModelIndex, QThread, QTimer, Signal, QUrl,
@@ -38,8 +40,10 @@ from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 
 from device_viewer.consts import PROTOCOL_RUNNING
 from pluggable_protocol_tree.consts import (
-    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
+    ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE, PROTOCOL_TREE_DISPLAY_STATE,
 )
+from pluggable_protocol_tree.execution.exceptions import StepExecutionError
+from pluggable_protocol_tree.models.display_state import ProtocolTreeDisplayMessage
 from pluggable_protocol_tree.models.row import GroupRow
 from pluggable_protocol_tree.services.persistence import (
     _RESERVED_ROW_METADATA_FIELDS,
@@ -62,7 +66,6 @@ from microdrop_application.dialogs.pyface_wrapper import error
 
 from logger.logger_service import get_logger
 logger = get_logger(__name__)
-
 
 def _dotted_path(row) -> str:
     """1-indexed dotted-path id (matches the IdColumnView display)."""
@@ -93,8 +96,6 @@ def attempt_func_execution_with_error_dialog(func):
         try:
             return func(self, *args, **kwargs)
         except Exception as exc:
-            import html as _html
-            import traceback as _tb
             op_name = func.__name__.replace("_", " ").strip().title()
             logger.error(f"{op_name} failed: {exc}", exc_info=True)
             detail = "".join(
@@ -517,11 +518,6 @@ class ProtocolTreePane(QWidget):
         """Build the HTML body shown in the protocol-error dialog. Uses the
         structured StepExecutionError fields (step / column / hook / cause)
         when available, else falls back to the plain message text."""
-        import html as _html
-        from pluggable_protocol_tree.execution.exceptions import (
-            StepExecutionError,
-        )
-
         red = "#c0392b"
         if isinstance(exc, StepExecutionError):
             row = exc.row
@@ -552,6 +548,7 @@ class ProtocolTreePane(QWidget):
         safe = _html.escape(fallback_msg).replace("\n", "<br>")
         return f"<p style='margin:0;color:{red};'>{safe}</p>"
 
+    @attempt_func_execution_with_error_dialog
     def _refresh_status(self):
         if self._step_started_at is None:
             return
@@ -840,12 +837,6 @@ class ProtocolTreePane(QWidget):
         # even in preview mode. Cached step metadata from _current_row.
         row = self._current_row
         if row is not None:
-            from pluggable_protocol_tree.models.display_state import (
-                ProtocolTreeDisplayMessage,
-            )
-            from pluggable_protocol_tree.consts import (
-                PROTOCOL_TREE_DISPLAY_STATE,
-            )
             dotted_id = ".".join(str(i + 1) for i in row.path)
             display_msg = ProtocolTreeDisplayMessage(
                 electrodes=electrodes,
@@ -886,19 +877,21 @@ class ProtocolTreePane(QWidget):
         )
 
     # --- step-cursor navigation -------------------------------------
-
+    @attempt_func_execution_with_error_dialog
     def navigate_to_first_step(self):
         steps = list(self.manager.iter_execution_steps())
         if steps:
             logger.info(f"Nav: first step [{_dotted_path(steps[0])}]")
             self._select_step(steps[0])
 
+    @attempt_func_execution_with_error_dialog
     def navigate_to_last_step(self):
         steps = list(self.manager.iter_execution_steps())
         if steps:
             logger.info(f"Nav: last step [{_dotted_path(steps[-1])}]")
             self._select_step(steps[-1])
 
+    @attempt_func_execution_with_error_dialog
     def navigate_to_previous_step(self):
         steps = list(self.manager.iter_execution_steps())
         if not steps:
@@ -912,6 +905,7 @@ class ProtocolTreePane(QWidget):
             logger.info(f"Nav: previous step --> [{_dotted_path(steps[cur - 1])}]")
             self._select_step(steps[cur - 1])
 
+    @attempt_func_execution_with_error_dialog
     def navigate_to_next_step(self):
         steps = list(self.manager.iter_execution_steps())
         if not steps:
@@ -966,6 +960,7 @@ class ProtocolTreePane(QWidget):
                     pane.device_viewer_sync._suppress_publish = False
         return _Guard()
 
+    @attempt_func_execution_with_error_dialog
     def _select_step(self, row):
         # No suppress wrap: nav buttons (next/prev/first/last) call this
         # path, and the user expects the DV to update on those clicks
@@ -981,6 +976,7 @@ class ProtocolTreePane(QWidget):
         self.widget.tree.setCurrentIndex(idx)
         self.widget.tree.scrollTo(idx)
 
+    @attempt_func_execution_with_error_dialog
     def clear_highlights(self):
         """Reset the tree's selection + active-row highlight + per-step
         labels to the idle visual state."""
@@ -1008,7 +1004,7 @@ class ProtocolTreePane(QWidget):
             self._status_phase_time_label.setText("Phase 0/0  0.00s / 0.00s")
 
     # --- save / load -----------------------------------------------
-
+    @attempt_func_execution_with_error_dialog
     def save_to_dialog(self, parent=None):
         """Open a file dialog and persist the manager's JSON state.
 
@@ -1029,6 +1025,7 @@ class ProtocolTreePane(QWidget):
             return None
         return path
 
+    @attempt_func_execution_with_error_dialog
     def load_from_dialog(self, columns_factory, parent=None):
         """Open a file dialog and replace the manager's state from JSON.
 
@@ -1052,6 +1049,7 @@ class ProtocolTreePane(QWidget):
             return None
         return path
 
+    @attempt_func_execution_with_error_dialog
     def closeEvent(self, event):
         """Detach Traits observers before the underlying QWidget is
         destroyed. Without this, application.experiment_changed firing
@@ -1220,6 +1218,7 @@ class ProtocolTreePane(QWidget):
                 return False
         return True
 
+    @attempt_func_execution_with_error_dialog
     def new_protocol(self):
         if not self._confirm_proceed_or_abort():
             return
@@ -1241,6 +1240,7 @@ class ProtocolTreePane(QWidget):
         if self.manager.seed_default_step_if_empty():
             self.protocol_state_tracker.reseed_baseline(self.manager)
 
+    @attempt_func_execution_with_error_dialog
     def save_protocol_dialog(self):
         known_path = self.protocol_state_tracker.loaded_protocol_path
         if not known_path:
@@ -1255,12 +1255,14 @@ class ProtocolTreePane(QWidget):
         self.protocol_state_tracker.set_saved(known_path)
         self.protocol_state_tracker.reseed_baseline(self.manager)
 
+    @attempt_func_execution_with_error_dialog
     def save_as_protocol_dialog(self):
         path = self.save_to_dialog(parent=self)
         if path:
             self.protocol_state_tracker.set_saved(path)
             self.protocol_state_tracker.reseed_baseline(self.manager)
 
+    @attempt_func_execution_with_error_dialog
     def load_protocol_dialog(self, columns_factory=None):
         if not self._confirm_proceed_or_abort():
             return
@@ -1296,7 +1298,7 @@ class ProtocolTreePane(QWidget):
                 logger.warning(f"could not veto application exit: {e}")
 
     # --- experiment-bar handlers ------------------------------------
-
+    @attempt_func_execution_with_error_dialog
     def _schedule_flush_with_progress(self, controller):
         """Custom flush scheduler: pop the "Generating Run Report..." dialog
         immediately, then sit through the settling delay (so in-flight
@@ -1349,6 +1351,7 @@ class ProtocolTreePane(QWidget):
 
         QTimer.singleShot(settling_ms, _start_worker)
 
+    @attempt_func_execution_with_error_dialog
     def _on_logging_complete(self, report_path):
         """Controller completion callback (runs on the GUI thread via the
         QTimer-scheduled flush). Shows the report-link success dialog when a
@@ -1366,6 +1369,7 @@ class ProtocolTreePane(QWidget):
         except Exception as e:
             logger.warning(f"run-summary success dialog failed: {e}")
 
+    @attempt_func_execution_with_error_dialog
     def _on_new_experiment(self):
         if self.experiment_manager is None or self.application is None:
             logger.info("New Experiment requested (stub: no services injected)")
@@ -1379,6 +1383,7 @@ class ProtocolTreePane(QWidget):
         self.application.current_experiment_directory = new_dir
         logger.info(f"Started new experiment: {new_dir.stem}")
 
+    @attempt_func_execution_with_error_dialog
     def _on_new_note(self):
         if self.sticky_manager is None or self.experiment_manager is None:
             logger.info("New Note requested (stub: no services injected)")
@@ -1387,12 +1392,14 @@ class ProtocolTreePane(QWidget):
         experiment_name = base_dir.stem
         self.sticky_manager.request_new_note(base_dir, experiment_name)
 
+    @attempt_func_execution_with_error_dialog
     def _on_experiment_label_clicked(self):
         if self.experiment_manager is None:
             logger.info("Experiment label clicked (stub: no service injected)")
             return
         self.experiment_manager.open_experiment_directory()
 
+    @attempt_func_execution_with_error_dialog
     def _on_experiment_changed(self, _event):
         if self.experiment_label is None:
             return
@@ -1406,7 +1413,7 @@ class ProtocolTreePane(QWidget):
         self.experiment_label.update_experiment_id(cur.stem)
 
     # --- quick-actions helpers --------------------------------------
-
+    @attempt_func_execution_with_error_dialog
     def _insert_position_after_selection(self):
         """Return ``(parent_path, index)`` for "insert after current
         selection". Rules:
@@ -1432,20 +1439,24 @@ class ProtocolTreePane(QWidget):
         # Step (or fallback for multi-selection): insert after at parent.
         return (last[:-1], last[-1] + 1)
 
+    @attempt_func_execution_with_error_dialog
     def add_step_after_selection(self):
         parent_path, index = self._insert_position_after_selection()
         self.manager.add_step(parent_path=parent_path, index=index)
 
+    @attempt_func_execution_with_error_dialog
     def add_group_after_selection(self):
         parent_path, index = self._insert_position_after_selection()
         self.manager.add_group(parent_path=parent_path, index=index)
 
+    @attempt_func_execution_with_error_dialog
     def delete_selected_rows(self):
         sel = list(self.manager.selection or [])
         if not sel:
             return
         self.manager.remove(sel)
 
+    @attempt_func_execution_with_error_dialog
     def delete_last_step(self):
         """Delete the last meaningful element at the end of the protocol.
 
@@ -1472,6 +1483,7 @@ class ProtocolTreePane(QWidget):
             self.manager.remove([tuple(last.path)])
             return
 
+    @attempt_func_execution_with_error_dialog
     def import_into_selected_group(self):
         """Open a file picker, load the JSON protocol, and merge every
         top-level row from the loaded protocol under the selected group.
@@ -1514,6 +1526,11 @@ class ProtocolTreePane(QWidget):
             (i, fid) for i, fid in enumerate(fields)
             if fid not in _RESERVED_ROW_METADATA_FIELDS
         ]
+        # Build once — same across all rows; keyed by col_id for O(1)
+        # lookup inside the loop.
+        live_by_col_id = {
+            c.model.col_id: c for c in self.manager.columns
+        }
 
         for row in (data.get("rows") or []):
             # Top-level only — nested rows are not recursively
@@ -1524,11 +1541,29 @@ class ProtocolTreePane(QWidget):
                 self.manager.add_group(
                     parent_path=target_path, name=row[name_idx])
             else:
-                values = {fid: row[i] for i, fid in col_field_positions}
-                # Name is filtered from the column-values list by the
-                # dedup in services/persistence.py; inject it from
-                # the fixed metadata position so the imported step
-                # keeps its name instead of defaulting to "Step".
+                # Resolve each saved column id against the LIVE column
+                # set. Skip:
+                #   * column ids unknown to this tree (different plugin
+                #     set) — would otherwise set orphan attributes.
+                #   * None saved values — strict-typed traits (Float,
+                #     Int, ...) reject None; skipping lets the trait's
+                #     default apply.
+                # Use the live column's model.deserialize so custom
+                # serializations round-trip correctly (matches
+                # services/persistence.deserialize_tree).
+                values = {}
+                for i, fid in col_field_positions:
+                    live = live_by_col_id.get(fid)
+                    if live is None:
+                        continue
+                    raw = row[i]
+                    if raw is None:
+                        continue
+                    values[fid] = live.model.deserialize(raw)
+                # Name was filtered from col_field_positions by the
+                # persistence dedup — inject it explicitly from the
+                # fixed metadata position.
                 values["name"] = row[name_idx]
                 self.manager.add_step(
-                    parent_path=target_path, values=values)
+                    parent_path=target_path, values=values,
+                )

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1441,21 +1441,38 @@ class ProtocolTreePane(QWidget):
         except (OSError, ValueError) as e:
             logger.warning(f"import_into_selected_group: read failed: {e}")
             return
-        # The loaded protocol's top-level rows live under data["rows"]
-        # (RowManager.to_json shape); each entry is either a step dict
-        # or a {"type": "group", "rows": [...]} dict. Use add_step /
-        # add_group with the row dict's values to seed each new row.
-        for row_dict in (data.get("rows") or []):
-            if row_dict.get("type") == "group":
+        # Persistence schema: fields[:4] = ["depth", "uuid", "type",
+        # "name"]; remaining entries are column ids. After the dedup
+        # fix in persistence.py, type/name are NOT duplicated as ordinary
+        # columns, so the fixed indices below are stable.
+        fields = data.get("fields") or []
+        if len(fields) < 4:
+            return
+        DEPTH_IDX, TYPE_IDX, NAME_IDX = 0, 2, 3
+        col_field_ids = fields[4:]
+
+        for row in (data.get("rows") or []):
+            # Top-level rows only (depth 0). Nested rows are not
+            # recursively imported in this PR — callers paste
+            # structurally identical protocols and the legacy did
+            # the same. Out of scope: deep-import.
+            if int(row[DEPTH_IDX]) != 0:
+                continue
+            if row[TYPE_IDX] == "group":
                 self.manager.add_group(
                     parent_path=target_path,
-                    name=row_dict.get("name", "Group"),
+                    name=row[NAME_IDX],
                 )
-                # Nested rows are not recursively imported in this PR —
-                # callers paste structurally identical protocols and the
-                # legacy did the same. Out of scope: deep-import.
             else:
-                values = {k: v for k, v in row_dict.items()
-                          if k not in ("type",)}
+                # add_step setattrs each value directly on the row,
+                # so we feed it the serialized form. Most builtin
+                # columns are identity-serialize (Str / Int / Float /
+                # List), so this round-trips correctly.
+                # Name comes from the fixed row-metadata field (not from
+                # col_field_ids, since the name column is filtered out of
+                # col_specs by the dedup fix in persistence.py).
+                values = dict(zip(col_field_ids, row[4:]))
+                values["name"] = row[NAME_IDX]
                 self.manager.add_step(
-                    parent_path=target_path, values=values)
+                    parent_path=target_path, values=values,
+                )

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1397,14 +1397,30 @@ class ProtocolTreePane(QWidget):
         self.manager.remove(sel)
 
     def delete_last_step(self):
-        """Delete the last step in the protocol (execution order).
-        Descends through groups so the deepest-rightmost step is the
-        one removed, not a group container. No-op when the tree has
-        no steps."""
-        steps = list(self.manager.iter_execution_steps())
-        if not steps:
+        """Delete the last meaningful element at the end of the protocol.
+
+        Walks down the rightmost path through groups:
+          * Empty trailing group  -> delete the group.
+          * Non-empty group       -> descend, then re-check.
+          * Step                  -> delete the step.
+
+        No-op when the tree is empty. The primary case (the user's
+        common click) is "delete the deepest-rightmost step"; the
+        empty-trailing-group case keeps the action from silently
+        no-op'ing when the user has lingering empty groups."""
+        parent = self.manager.root
+        if not parent.children:
             return
-        self.manager.remove([tuple(steps[-1].path)])
+        while True:
+            last = parent.children[-1]
+            if isinstance(last, GroupRow):
+                if not last.children:
+                    self.manager.remove([tuple(last.path)])
+                    return
+                parent = last
+                continue
+            self.manager.remove([tuple(last.path)])
+            return
 
     def import_into_selected_group(self):
         """Open a file picker, load the JSON protocol, and merge every

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -79,6 +79,11 @@ class ProtocolTreePane(QWidget):
     # deferred flush completes; QueuedConnection in __init__ marshals it
     # back to the GUI thread so the success dialog runs there.
     _logging_complete = Signal(object)
+    # Quick-actions toolbar feed: emit True/False on protocol start/end,
+    # parameterless selection_changed on each tree selection move.
+    # QuickActionsController listens to both to drive button enabled state.
+    protocol_running_changed = Signal(bool)
+    selection_changed = Signal()
 
     def __init__(
         self,
@@ -111,6 +116,13 @@ class ProtocolTreePane(QWidget):
         self.device_viewer_sync = device_viewer_sync
         if self.device_viewer_sync is not None:
             self.device_viewer_sync.attach(self.widget)
+
+        # Re-emit the tree's selectionChanged as a parameterless signal so
+        # the QuickActionsController doesn't have to know about Qt selection
+        # models. The pane already constructed self.widget above.
+        self.widget.tree.selectionModel().selectionChanged.connect(
+            lambda *_: self.selection_changed.emit()
+        )
 
         self.protocol_state_tracker = PluggableProtocolStateTracker()
         # Structural mutations (add/remove/move/paste/new) re-check the
@@ -303,6 +315,7 @@ class ProtocolTreePane(QWidget):
             logger.warning(f"PROTOCOL_RUNNING publish failed: {e}")
 
     def _on_protocol_started(self):
+        self.protocol_running_changed.emit(True)
         self._publish_protocol_running("True")
         try:
             self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
@@ -604,6 +617,7 @@ class ProtocolTreePane(QWidget):
         self._on_protocol_terminated("aborted")
 
     def _on_protocol_terminated(self, outcome="finished"):
+        self.protocol_running_changed.emit(False)
         logger.info("Protocol terminated --> free mode")
         self.clear_highlights()
         self._set_idle_button_state()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1373,13 +1373,27 @@ class ProtocolTreePane(QWidget):
 
     def _insert_position_after_selection(self):
         """Return ``(parent_path, index)`` for "insert after current
-        selection". With nothing selected -> ``((), None)`` (append to
-        root). With one selection at path ``(p..., i)`` -> ``((p...,),
-        i + 1)``. With multiple selections we use the last one."""
+        selection". Rules:
+
+        * No selection  -> ``((), None)``  (append at root).
+        * Single GroupRow selected  -> ``(group_path, None)``  (append
+          INSIDE the group as its last child).
+        * Single step (or last of multi-selection)  -> ``(parent_path,
+          step_index + 1)``  (insert immediately after).
+        """
         sel = list(self.manager.selection or [])
         if not sel:
             return ((), None)
         last = tuple(sel[-1])
+        # Single-group selection -> append inside the group.
+        if len(sel) == 1:
+            try:
+                row = self.manager.get_row(last)
+            except (IndexError, AttributeError):
+                row = None
+            if isinstance(row, GroupRow):
+                return (last, None)
+        # Step (or fallback for multi-selection): insert after at parent.
         return (last[:-1], last[-1] + 1)
 
     def add_step_after_selection(self):

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+import glob
 from pathlib import Path
 
 from pyface.qt.QtCore import (
@@ -62,6 +63,19 @@ logger = get_logger(__name__)
 def _dotted_path(row) -> str:
     """1-indexed dotted-path id (matches the IdColumnView display)."""
     return ".".join(str(i + 1) for i in row.path)
+
+
+def _get_report_browser_dialog_cls():
+    """Lazy import so the pluggable tree doesn't statically depend on
+    protocol_quick_action_tools. Returns the dialog class or None when
+    the new plugin isn't installed (development environments, demos)."""
+    try:
+        from protocol_quick_action_tools.views.report_browser_dialog import (
+            ReportBrowserDialog,
+        )
+        return ReportBrowserDialog
+    except Exception:                             # pragma: no cover - defensive
+        return None
 
 
 class ProtocolTreePane(QWidget):
@@ -111,6 +125,14 @@ class ProtocolTreePane(QWidget):
         self.sticky_manager = sticky_manager
         self.phase_ack_topic = phase_ack_topic
         self._logging_device_context_provider = logging_device_context_provider
+
+        # Optional callable returning the path to the experiment's reports
+        # dir. Used by browse_reports_dialog to feed the ReportBrowserDialog
+        # without statically depending on experiment_manager's API surface.
+        self._reports_dir_provider = (
+            (lambda: experiment_manager.get_experiment_directory() / "reports")
+            if experiment_manager is not None else None
+        )
 
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
 
@@ -1346,3 +1368,93 @@ class ProtocolTreePane(QWidget):
         if cur is None:
             return
         self.experiment_label.update_experiment_id(cur.stem)
+
+    # --- quick-actions helpers --------------------------------------
+
+    def _insert_position_after_selection(self):
+        """Return ``(parent_path, index)`` for "insert after current
+        selection". With nothing selected -> ``((), None)`` (append to
+        root). With one selection at path ``(p..., i)`` -> ``((p...,),
+        i + 1)``. With multiple selections we use the last one."""
+        sel = list(self.manager.selection or [])
+        if not sel:
+            return ((), None)
+        last = tuple(sel[-1])
+        return (last[:-1], last[-1] + 1)
+
+    def add_step_after_selection(self):
+        parent_path, index = self._insert_position_after_selection()
+        self.manager.add_step(parent_path=parent_path, index=index)
+
+    def add_group_after_selection(self):
+        parent_path, index = self._insert_position_after_selection()
+        self.manager.add_group(parent_path=parent_path, index=index)
+
+    def delete_selected_rows(self):
+        sel = list(self.manager.selection or [])
+        if not sel:
+            return
+        self.manager.remove(sel)
+
+    def import_into_selected_group(self):
+        """Open a file picker, load the JSON protocol, and merge every
+        top-level row from the loaded protocol under the selected group.
+
+        No-op when the selection isn't exactly one row OR the selected
+        row isn't a GroupRow.
+        """
+        sel = list(self.manager.selection or [])
+        if len(sel) != 1:
+            return
+        target_path = tuple(sel[0])
+        try:
+            target = self.manager.get_row(target_path)
+        except (IndexError, AttributeError):
+            return
+        if not isinstance(target, GroupRow):
+            return
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Import Protocol", "", "Protocol JSON (*.json)")
+        if not path:
+            return
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, ValueError) as e:
+            logger.warning(f"import_into_selected_group: read failed: {e}")
+            return
+        # The loaded protocol's top-level rows live under data["rows"]
+        # (RowManager.to_json shape); each entry is either a step dict
+        # or a {"type": "group", "rows": [...]} dict. Use add_step /
+        # add_group with the row dict's values to seed each new row.
+        for row_dict in (data.get("rows") or []):
+            if row_dict.get("type") == "group":
+                self.manager.add_group(
+                    parent_path=target_path,
+                    name=row_dict.get("name", "Group"),
+                )
+                # Nested rows are not recursively imported in this PR —
+                # callers paste structurally identical protocols and the
+                # legacy did the same. Out of scope: deep-import.
+            else:
+                values = {k: v for k, v in row_dict.items()
+                          if k not in ("type",)}
+                self.manager.add_step(
+                    parent_path=target_path, values=values)
+
+    def browse_reports_dialog(self):
+        """Glob <experiment_dir>/reports/*.html and open the
+        ReportBrowserDialog from protocol_quick_action_tools. No-op when
+        no reports-dir provider is configured (demos / no experiment
+        manager) or when the dialog plugin isn't installed."""
+        if self._reports_dir_provider is None:
+            logger.debug("browse_reports_dialog: no reports_dir_provider")
+            return
+        cls = _get_report_browser_dialog_cls()
+        if cls is None:
+            logger.warning(
+                "browse_reports_dialog: ReportBrowserDialog not available")
+            return
+        reports_dir = self._reports_dir_provider()
+        paths = sorted(glob.glob(str(reports_dir / "*.html")))
+        cls(paths, parent=self).exec()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -96,6 +96,7 @@ class ProtocolTreePane(QWidget):
         phase_ack_topic=ELECTRODES_STATE_APPLIED,
         executor_factory=None,
         logging_device_context_provider=None,
+        quick_actions=None,
         parent=None,
     ):
         super().__init__(parent)
@@ -136,6 +137,24 @@ class ProtocolTreePane(QWidget):
         self._build_status_bar()
         self._build_navigation_bar()
         self._build_experiment_bar()
+
+        # Quick-actions toolbar (bar + controller). Both are None when no
+        # contributions exist (demo / headless test environments) so the
+        # pane stays usable with no chrome below the tree. Constructed
+        # before _build_layout() so it can be inserted in the layout.
+        from pluggable_protocol_tree.views.quick_action_bar import (
+            QuickActionBar, QuickActionsController,
+        )
+        if quick_actions:
+            self.quick_action_bar = QuickActionBar(
+                actions=list(quick_actions), parent=self)
+            self.quick_actions_controller = QuickActionsController(
+                bar=self.quick_action_bar, pane=self,
+                actions=list(quick_actions))
+        else:
+            self.quick_action_bar = None
+            self.quick_actions_controller = None
+
         self._build_layout()
 
         self.executor = self._build_executor(executor_factory)
@@ -250,6 +269,8 @@ class ProtocolTreePane(QWidget):
         layout.addWidget(self.status_bar)
         layout.addWidget(make_separator())
         layout.addWidget(self.widget)
+        if self.quick_action_bar is not None:
+            layout.addWidget(self.quick_action_bar)
 
     def _build_executor(self, executor_factory):
         factory = executor_factory or self._default_executor_factory

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -74,7 +74,7 @@ def _get_report_browser_dialog_cls():
             ReportBrowserDialog,
         )
         return ReportBrowserDialog
-    except Exception:                             # pragma: no cover - defensive
+    except ImportError:                           # pragma: no cover - defensive
         return None
 
 

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from functools import wraps
 from pathlib import Path
 
 from pyface.qt.QtCore import (
@@ -57,14 +58,70 @@ from pluggable_protocol_tree.views.navigation_bar import (
 )
 from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
 
-from logger.logger_service import get_logger
+from microdrop_application.dialogs.pyface_wrapper import error
 
+from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
 
 def _dotted_path(row) -> str:
     """1-indexed dotted-path id (matches the IdColumnView display)."""
     return ".".join(str(i + 1) for i in row.path)
+
+def attempt_func_execution_with_error_dialog(func):
+    """Wrap an instance method so any uncaught exception is surfaced to
+    the user as a styled error dialog instead of crashing the pane.
+
+    The dialog uses the existing pyface_wrapper.error layout:
+      * ``message``    — one-line summary: humanised operation name +
+                         exception type. Plain text.
+      * ``informative`` — HTML body: bold op name + red exception type +
+                          escaped exception message (matches the
+                          ``_on_error`` styling for the protocol-error
+                          dialog).
+      * ``detail``     — full traceback, collapsible preformatted.
+
+    Also logs the exception with full traceback via the module logger so
+    the error is captured even when the user dismisses the dialog.
+
+    Intended for top-level user-triggered pane actions (file open / save /
+    import / browse-reports / etc.). Do NOT use on executor callbacks —
+    those handle errors via the executor's own signal chain.
+    """
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as exc:
+            import html as _html
+            import traceback as _tb
+            op_name = func.__name__.replace("_", " ").strip().title()
+            logger.error(f"{op_name} failed: {exc}", exc_info=True)
+            detail = "".join(
+                _tb.format_exception(type(exc), exc, exc.__traceback__)
+            )
+            cause = _html.escape(str(exc) or "(no message)").replace(
+                "\n", "<br>")
+            informative = (
+                f"<p style='margin:0 0 6px 0;'>"
+                f"<b>{_html.escape(op_name)}</b> failed.</p>"
+                f"<p style='margin:0;color:#c0392b;'>"
+                f"<b>{_html.escape(type(exc).__name__)}:</b> {cause}</p>"
+            )
+            try:
+                error(
+                    self,
+                    message=f"{op_name} failed: {type(exc).__name__}",
+                    title=f"{op_name} Error",
+                    informative=informative,
+                    detail=detail,
+                )
+            except Exception as dialog_err:
+                logger.error(
+                    f"failed to show error dialog for {op_name}: "
+                    f"{dialog_err}", exc_info=True)
+            return None
+    return wrapper
 
 
 class ProtocolTreePane(QWidget):
@@ -333,10 +390,8 @@ class ProtocolTreePane(QWidget):
     # --- step lifecycle handlers --------------------------------------
 
     def _publish_protocol_running(self, value: str) -> None:
-        try:
-            publish_message(topic=PROTOCOL_RUNNING, message=value)
-        except Exception as e:
-            logger.warning(f"PROTOCOL_RUNNING publish failed: {e}")
+        logger.info("Protocol Tree: Publishing Protocol Running")
+        publish_message(topic=PROTOCOL_RUNNING, message=value)
 
     def _on_protocol_started(self):
         self.protocol_running_changed.emit(True)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import json
 import threading
 import time
-import glob
 from pathlib import Path
 
 from pyface.qt.QtCore import (
@@ -63,19 +62,6 @@ logger = get_logger(__name__)
 def _dotted_path(row) -> str:
     """1-indexed dotted-path id (matches the IdColumnView display)."""
     return ".".join(str(i + 1) for i in row.path)
-
-
-def _get_report_browser_dialog_cls():
-    """Lazy import so the pluggable tree doesn't statically depend on
-    protocol_quick_action_tools. Returns the dialog class or None when
-    the new plugin isn't installed (development environments, demos)."""
-    try:
-        from protocol_quick_action_tools.views.report_browser_dialog import (
-            ReportBrowserDialog,
-        )
-        return ReportBrowserDialog
-    except ImportError:                           # pragma: no cover - defensive
-        return None
 
 
 class ProtocolTreePane(QWidget):
@@ -125,14 +111,6 @@ class ProtocolTreePane(QWidget):
         self.sticky_manager = sticky_manager
         self.phase_ack_topic = phase_ack_topic
         self._logging_device_context_provider = logging_device_context_provider
-
-        # Optional callable returning the path to the experiment's reports
-        # dir. Used by browse_reports_dialog to feed the ReportBrowserDialog
-        # without statically depending on experiment_manager's API surface.
-        self._reports_dir_provider = (
-            (lambda: experiment_manager.get_experiment_directory() / "reports")
-            if experiment_manager is not None else None
-        )
 
         self.widget = ProtocolTreeWidget(self.manager, parent=self)
 
@@ -1481,20 +1459,3 @@ class ProtocolTreePane(QWidget):
                           if k not in ("type",)}
                 self.manager.add_step(
                     parent_path=target_path, values=values)
-
-    def browse_reports_dialog(self):
-        """Glob <experiment_dir>/reports/*.html and open the
-        ReportBrowserDialog from protocol_quick_action_tools. No-op when
-        no reports-dir provider is configured (demos / no experiment
-        manager) or when the dialog plugin isn't installed."""
-        if self._reports_dir_provider is None:
-            logger.debug("browse_reports_dialog: no reports_dir_provider")
-            return
-        cls = _get_report_browser_dialog_cls()
-        if cls is None:
-            logger.warning(
-                "browse_reports_dialog: ReportBrowserDialog not available")
-            return
-        reports_dir = self._reports_dir_provider()
-        paths = sorted(glob.glob(str(reports_dir / "*.html")))
-        cls(paths, parent=self).exec()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -40,6 +40,9 @@ from pluggable_protocol_tree.consts import (
     ELECTRODES_STATE_APPLIED, ELECTRODES_STATE_CHANGE,
 )
 from pluggable_protocol_tree.models.row import GroupRow
+from pluggable_protocol_tree.services.persistence import (
+    _RESERVED_ROW_METADATA_FIELDS,
+)
 from pluggable_protocol_tree.services.phase_math import iter_phases
 from pluggable_protocol_tree.services.protocol_state_tracker import (
     PluggableProtocolStateTracker,
@@ -1441,38 +1444,36 @@ class ProtocolTreePane(QWidget):
         except (OSError, ValueError) as e:
             logger.warning(f"import_into_selected_group: read failed: {e}")
             return
-        # Persistence schema: fields[:4] = ["depth", "uuid", "type",
-        # "name"]; remaining entries are column ids. After the dedup
-        # fix in persistence.py, type/name are NOT duplicated as ordinary
-        # columns, so the fixed indices below are stable.
+        # Look up positions by name so we stay correct if the
+        # persistence schema reorders or adds fixed metadata.
         fields = data.get("fields") or []
-        if len(fields) < 4:
-            return
-        DEPTH_IDX, TYPE_IDX, NAME_IDX = 0, 2, 3
-        col_field_ids = fields[4:]
+        try:
+            depth_idx = fields.index("depth")
+            type_idx = fields.index("type")
+            name_idx = fields.index("name")
+        except ValueError:
+            return            # malformed file — no fixed metadata
+        # (index, col_id) pairs for the column-value positions:
+        # everything except the reserved row-metadata fields.
+        col_field_positions = [
+            (i, fid) for i, fid in enumerate(fields)
+            if fid not in _RESERVED_ROW_METADATA_FIELDS
+        ]
 
         for row in (data.get("rows") or []):
-            # Top-level rows only (depth 0). Nested rows are not
-            # recursively imported in this PR — callers paste
-            # structurally identical protocols and the legacy did
-            # the same. Out of scope: deep-import.
-            if int(row[DEPTH_IDX]) != 0:
+            # Top-level only — nested rows are not recursively
+            # imported (deep-import out of scope; legacy parity).
+            if int(row[depth_idx]) != 0:
                 continue
-            if row[TYPE_IDX] == "group":
+            if row[type_idx] == "group":
                 self.manager.add_group(
-                    parent_path=target_path,
-                    name=row[NAME_IDX],
-                )
+                    parent_path=target_path, name=row[name_idx])
             else:
-                # add_step setattrs each value directly on the row,
-                # so we feed it the serialized form. Most builtin
-                # columns are identity-serialize (Str / Int / Float /
-                # List), so this round-trips correctly.
-                # Name comes from the fixed row-metadata field (not from
-                # col_field_ids, since the name column is filtered out of
-                # col_specs by the dedup fix in persistence.py).
-                values = dict(zip(col_field_ids, row[4:]))
-                values["name"] = row[NAME_IDX]
+                values = {fid: row[i] for i, fid in col_field_positions}
+                # Name is filtered from the column-values list by the
+                # dedup in services/persistence.py; inject it from
+                # the fixed metadata position so the imported step
+                # keeps its name instead of defaulting to "Step".
+                values["name"] = row[name_idx]
                 self.manager.add_step(
-                    parent_path=target_path, values=values,
-                )
+                    parent_path=target_path, values=values)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1396,6 +1396,16 @@ class ProtocolTreePane(QWidget):
             return
         self.manager.remove(sel)
 
+    def delete_last_step(self):
+        """Delete the last step in the protocol (execution order).
+        Descends through groups so the deepest-rightmost step is the
+        one removed, not a group container. No-op when the tree has
+        no steps."""
+        steps = list(self.manager.iter_execution_steps())
+        if not steps:
+            return
+        self.manager.remove([tuple(steps[-1].path)])
+
     def import_into_selected_group(self):
         """Open a file picker, load the JSON protocol, and merge every
         top-level row from the loaded protocol under the selected group.

--- a/pluggable_protocol_tree/views/quick_action_bar.py
+++ b/pluggable_protocol_tree/views/quick_action_bar.py
@@ -9,12 +9,16 @@ per-action enabled state, and keyboard-shortcut wiring.
 from typing import Dict, List
 
 from pyface.qt.QtCore import Qt
-from pyface.qt.QtGui import QFont
+from pyface.qt.QtGui import QFont, QKeySequence, QShortcut
 from pyface.qt.QtWidgets import QHBoxLayout, QToolButton, QWidget
 
+from logger.logger_service import get_logger
 from microdrop_style.button_styles import ICON_FONT_FAMILY
 
 from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+from pluggable_protocol_tree.models.quick_action import QuickActionCtx
+
+logger = get_logger(__name__)
 
 
 class QuickActionBar(QWidget):
@@ -43,12 +47,6 @@ class QuickActionBar(QWidget):
 # --- controller ----------------------------------------------------
 
 
-from logger.logger_service import get_logger
-from pluggable_protocol_tree.models.quick_action import QuickActionCtx
-
-logger = get_logger(__name__)
-
-
 class QuickActionsController:
     """Wires a QuickActionBar to a ProtocolTreePane.
 
@@ -71,6 +69,8 @@ class QuickActionsController:
         # Wire pane signals (drives re-enable + running state).
         pane.selection_changed.connect(self.refresh_enabled)
         pane.protocol_running_changed.connect(self._on_running_changed)
+        self.shortcuts = []
+        self._wire_shortcuts()
         self.refresh_enabled()
 
     def _build_ctx(self) -> QuickActionCtx:
@@ -105,3 +105,22 @@ class QuickActionsController:
         except Exception as e:
             logger.error(
                 f"quick-action {action.action_id!r} raised: {e}", exc_info=True)
+
+    def _wire_shortcuts(self) -> None:
+        claimed = {}                              # shortcut str -> action_id
+        for action in self._actions:
+            key_str = (action.shortcut or "").strip()
+            if not key_str:
+                continue
+            existing = claimed.get(key_str)
+            if existing is not None:
+                logger.warning(
+                    f"quick-action shortcut conflict on {key_str!r}: "
+                    f"{existing!r} already registered; skipping "
+                    f"{action.action_id!r}.")
+                continue
+            claimed[key_str] = action.action_id
+            qs = QShortcut(QKeySequence(key_str), self._pane)
+            qs.setContext(Qt.WidgetWithChildrenShortcut)
+            qs.activated.connect(lambda a=action: self._execute(a))
+            self.shortcuts.append(qs)

--- a/pluggable_protocol_tree/views/quick_action_bar.py
+++ b/pluggable_protocol_tree/views/quick_action_bar.py
@@ -38,3 +38,70 @@ class QuickActionBar(QWidget):
             self.buttons[action.action_id] = btn
             layout.addWidget(btn)
         layout.addStretch()
+
+
+# --- controller ----------------------------------------------------
+
+
+from logger.logger_service import get_logger
+from pluggable_protocol_tree.models.quick_action import QuickActionCtx
+
+logger = get_logger(__name__)
+
+
+class QuickActionsController:
+    """Wires a QuickActionBar to a ProtocolTreePane.
+
+    Listens for ``pane.selection_changed`` / ``pane.protocol_running_changed``
+    and keeps ``button.setEnabled(...)`` in sync with each action's
+    ``is_enabled(ctx)``. Routes clicks through ``_execute(action)`` so
+    a buggy contribution can't crash the bar. Builds a fresh ctx on
+    every call — never caches.
+    """
+
+    def __init__(self, *, bar: QuickActionBar, pane, actions):
+        self._bar = bar
+        self._pane = pane
+        self._actions = list(actions)
+        self._is_running = False
+        # Wire button clicks.
+        for action in self._actions:
+            btn = bar.buttons[action.action_id]
+            btn.clicked.connect(lambda _checked=False, a=action: self._execute(a))
+        # Wire pane signals (drives re-enable + running state).
+        pane.selection_changed.connect(self.refresh_enabled)
+        pane.protocol_running_changed.connect(self._on_running_changed)
+        self.refresh_enabled()
+
+    def _build_ctx(self) -> QuickActionCtx:
+        sel = tuple(tuple(p) for p in (self._pane.manager.selection or []))
+        return QuickActionCtx(pane=self._pane,
+                              selected_paths=sel,
+                              is_running=self._is_running)
+
+    def _on_running_changed(self, running: bool) -> None:
+        self._is_running = bool(running)
+        self.refresh_enabled()
+
+    def refresh_enabled(self) -> None:
+        ctx = self._build_ctx()
+        for action in self._actions:
+            try:
+                enabled = bool(action.is_enabled(ctx)) and not ctx.is_running
+            except Exception as e:                # pragma: no cover - defensive
+                logger.warning(
+                    f"is_enabled failed for {action.action_id!r}: {e}; "
+                    f"disabling button.")
+                enabled = False
+            self._bar.buttons[action.action_id].setEnabled(enabled)
+
+    def _execute(self, action) -> None:
+        ctx = self._build_ctx()
+        if ctx.is_running or not self._bar.buttons[action.action_id].isEnabled():
+            # The shortcut path bypasses Qt's enabled-state gate; gate again here.
+            return
+        try:
+            action.on_execute_action(ctx)
+        except Exception as e:
+            logger.error(
+                f"quick-action {action.action_id!r} raised: {e}", exc_info=True)

--- a/pluggable_protocol_tree/views/quick_action_bar.py
+++ b/pluggable_protocol_tree/views/quick_action_bar.py
@@ -34,6 +34,11 @@ class QuickActionBar(QWidget):
         icon_font = QFont(ICON_FONT_FAMILY)
         icon_font.setPixelSize(20)
         for action in sorted_actions:
+            if action.action_id in self.buttons:
+                logger.warning(
+                    f"quick-action duplicate action_id {action.action_id!r}: "
+                    f"keeping first contribution; skipping subsequent entry.")
+                continue
             btn = QToolButton()
             btn.setText(action.icon_text)
             btn.setFont(icon_font)
@@ -62,8 +67,18 @@ class QuickActionsController:
         self._pane = pane
         self._actions = list(actions)
         self._is_running = False
-        # Wire button clicks.
+        # Wire button clicks. Only wire the first action per action_id —
+        # duplicate contributions were already dropped by QuickActionBar,
+        # so iterating self._actions here (the full caller-supplied list)
+        # could otherwise double-connect the same button for two actions
+        # that share an id.
+        _wired_ids: set = set()
         for action in self._actions:
+            if action.action_id not in bar.buttons:
+                continue
+            if action.action_id in _wired_ids:
+                continue
+            _wired_ids.add(action.action_id)
             btn = bar.buttons[action.action_id]
             btn.clicked.connect(lambda _checked=False, a=action: self._execute(a))
         # Wire pane signals (drives re-enable + running state).
@@ -85,7 +100,13 @@ class QuickActionsController:
 
     def refresh_enabled(self) -> None:
         ctx = self._build_ctx()
+        _seen: set = set()
         for action in self._actions:
+            if action.action_id not in self._bar.buttons:
+                continue
+            if action.action_id in _seen:
+                continue
+            _seen.add(action.action_id)
             try:
                 enabled = bool(action.is_enabled(ctx)) and not ctx.is_running
             except Exception as e:                # pragma: no cover - defensive
@@ -97,6 +118,8 @@ class QuickActionsController:
 
     def _execute(self, action) -> None:
         ctx = self._build_ctx()
+        if action.action_id not in self._bar.buttons:
+            return
         if ctx.is_running or not self._bar.buttons[action.action_id].isEnabled():
             # The shortcut path bypasses Qt's enabled-state gate; gate again here.
             return
@@ -109,6 +132,8 @@ class QuickActionsController:
     def _wire_shortcuts(self) -> None:
         claimed = {}                              # shortcut str -> action_id
         for action in self._actions:
+            if action.action_id not in self._bar.buttons:
+                continue
             key_str = (action.shortcut or "").strip()
             if not key_str:
                 continue

--- a/pluggable_protocol_tree/views/quick_action_bar.py
+++ b/pluggable_protocol_tree/views/quick_action_bar.py
@@ -1,0 +1,40 @@
+"""Pure-rendering toolbar widget for the pluggable protocol tree.
+
+Owns no state. Takes a sorted list of IQuickAction implementations and
+produces one icon-font QToolButton per action, keyed by action_id.
+The QuickActionsController (separate unit) drives click routing,
+per-action enabled state, and keyboard-shortcut wiring.
+"""
+
+from typing import Dict, List
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtGui import QFont
+from pyface.qt.QtWidgets import QHBoxLayout, QToolButton, QWidget
+
+from microdrop_style.button_styles import ICON_FONT_FAMILY
+
+from pluggable_protocol_tree.interfaces.i_quick_action import IQuickAction
+
+
+class QuickActionBar(QWidget):
+    """Horizontal row of icon-only QToolButtons, one per action."""
+
+    def __init__(self, actions: List[IQuickAction], parent: QWidget = None):
+        super().__init__(parent)
+        self.buttons: Dict[str, QToolButton] = {}
+        sorted_actions = sorted(actions,
+                                key=lambda a: (a.priority, a.action_id))
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        icon_font = QFont(ICON_FONT_FAMILY)
+        icon_font.setPixelSize(20)
+        for action in sorted_actions:
+            btn = QToolButton()
+            btn.setText(action.icon_text)
+            btn.setFont(icon_font)
+            btn.setToolTip(action.tooltip)
+            btn.setCursor(Qt.PointingHandCursor)
+            self.buttons[action.action_id] = btn
+            layout.addWidget(btn)
+        layout.addStretch()

--- a/protocol_quick_action_tools/__init__.py
+++ b/protocol_quick_action_tools/__init__.py
@@ -1,0 +1,7 @@
+"""Quick-actions contributions for the pluggable protocol tree (#433).
+
+Architecture lives in pluggable_protocol_tree (extension point, traits
+model, bar widget, controller, pane integration). This plugin
+contributes the 8 legacy actions (add/delete/save/open/import/new
+protocol, add group, browse reports) plus the ReportBrowserDialog.
+"""

--- a/protocol_quick_action_tools/consts.py
+++ b/protocol_quick_action_tools/consts.py
@@ -1,0 +1,19 @@
+"""Package-level constants for protocol_quick_action_tools.
+
+Follows the MicroDrop convention: PKG derived from __name__, PKG_name
+title-cased for display.
+"""
+
+PKG = ".".join(__name__.split(".")[:-1])
+PKG_name = PKG.title().replace("_", " ")
+
+# Stable action_id strings. Tests assert against these constants so
+# the legacy ids remain accessible by name from outside the plugin.
+ACTION_ADD_STEP        = "add_step"
+ACTION_DELETE_ROW      = "delete_row"
+ACTION_ADD_GROUP       = "add_group"
+ACTION_IMPORT_PROTOCOL = "import_protocol"
+ACTION_OPEN_PROTOCOL   = "open_protocol"
+ACTION_SAVE_PROTOCOL   = "save_protocol"
+ACTION_NEW_PROTOCOL    = "new_protocol"
+ACTION_BROWSE_REPORTS  = "browse_reports"

--- a/protocol_quick_action_tools/plugin.py
+++ b/protocol_quick_action_tools/plugin.py
@@ -1,0 +1,28 @@
+"""ProtocolQuickActionToolsPlugin — contributes the 8 legacy quick
+actions to the pluggable protocol tree.
+
+Pattern mirrors peripheral_protocol_controls / dropbot_protocol_controls.
+The factories ship in task 12; the scaffold lands first so the rest of
+the plan can land in any order without "import broken" stages."""
+
+from envisage.plugin import Plugin
+from traits.api import List
+
+from pluggable_protocol_tree.consts import PROTOCOL_QUICK_ACTIONS
+
+from logger.logger_service import get_logger
+
+from .consts import PKG, PKG_name
+
+logger = get_logger(__name__)
+
+
+class ProtocolQuickActionToolsPlugin(Plugin):
+    id = PKG + ".plugin"
+    name = f"{PKG_name} Plugin"
+
+    contributed_quick_actions = List(contributes_to=PROTOCOL_QUICK_ACTIONS)
+
+    def _contributed_quick_actions_default(self):
+        # Filled in by task 12.
+        return []

--- a/protocol_quick_action_tools/plugin.py
+++ b/protocol_quick_action_tools/plugin.py
@@ -24,5 +24,21 @@ class ProtocolQuickActionToolsPlugin(Plugin):
     contributed_quick_actions = List(contributes_to=PROTOCOL_QUICK_ACTIONS)
 
     def _contributed_quick_actions_default(self):
-        # Filled in by task 12.
-        return []
+        from .quick_actions.add_group import make_add_group_action
+        from .quick_actions.add_step import make_add_step_action
+        from .quick_actions.browse_reports import make_browse_reports_action
+        from .quick_actions.delete_row import make_delete_row_action
+        from .quick_actions.import_protocol import make_import_protocol_action
+        from .quick_actions.new_protocol import make_new_protocol_action
+        from .quick_actions.open_protocol import make_open_protocol_action
+        from .quick_actions.save_protocol import make_save_protocol_action
+        return [
+            make_add_step_action(),
+            make_delete_row_action(),
+            make_add_group_action(),
+            make_import_protocol_action(),
+            make_open_protocol_action(),
+            make_save_protocol_action(),
+            make_new_protocol_action(),
+            make_browse_reports_action(),
+        ]

--- a/protocol_quick_action_tools/quick_actions/__init__.py
+++ b/protocol_quick_action_tools/quick_actions/__init__.py
@@ -1,0 +1,1 @@
+"""IQuickAction implementations for the 8 legacy quick actions."""

--- a/protocol_quick_action_tools/quick_actions/add_group.py
+++ b/protocol_quick_action_tools/quick_actions/add_group.py
@@ -1,0 +1,22 @@
+"""'Add group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_ADD_GROUP
+
+
+class _AddGroupAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.add_group_after_selection()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_add_group_action() -> _AddGroupAction:
+    return _AddGroupAction(
+        action_id=ACTION_ADD_GROUP,
+        icon_text="playlist_add",
+        tooltip="Add group",
+        priority=30,
+    )

--- a/protocol_quick_action_tools/quick_actions/add_step.py
+++ b/protocol_quick_action_tools/quick_actions/add_step.py
@@ -1,0 +1,22 @@
+"""'Add step below selection' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_ADD_STEP
+
+
+class _AddStepAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.add_step_after_selection()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_add_step_action() -> _AddStepAction:
+    return _AddStepAction(
+        action_id=ACTION_ADD_STEP,
+        icon_text="add",
+        tooltip="Add step below selection",
+        priority=10,
+    )

--- a/protocol_quick_action_tools/quick_actions/base.py
+++ b/protocol_quick_action_tools/quick_actions/base.py
@@ -1,0 +1,29 @@
+"""Shared helpers used by every action factory.
+
+Keeps the per-action factory files (one per file) one-purpose: build
+an IQuickAction with the right id / icon / tooltip / hooks. Predicates
+that several actions share (``has_selection``, ``is_single_group_selected``,
+...) live here.
+"""
+
+from pluggable_protocol_tree.models.row import GroupRow
+
+
+def has_selection(ctx) -> bool:
+    return len(ctx.selected_paths) >= 1
+
+
+def is_single_row_selected(ctx) -> bool:
+    return len(ctx.selected_paths) == 1
+
+
+def is_single_group_selected(ctx) -> bool:
+    """True iff exactly one row is selected AND that row is a GroupRow."""
+    if not is_single_row_selected(ctx):
+        return False
+    pane = ctx.pane
+    try:
+        row = pane.manager.get_row(tuple(ctx.selected_paths[0]))
+    except (IndexError, AttributeError):
+        return False
+    return isinstance(row, GroupRow)

--- a/protocol_quick_action_tools/quick_actions/browse_reports.py
+++ b/protocol_quick_action_tools/quick_actions/browse_reports.py
@@ -1,0 +1,24 @@
+"""'Browse session reports' quick-action factory. Bound to 'R'."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_BROWSE_REPORTS
+
+
+class _BrowseReportsAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.browse_reports_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return ((not ctx.is_running)
+                and getattr(ctx.pane, "experiment_manager", None) is not None)
+
+
+def make_browse_reports_action() -> _BrowseReportsAction:
+    return _BrowseReportsAction(
+        action_id=ACTION_BROWSE_REPORTS,
+        icon_text="summarize",
+        tooltip="Browse session reports (R)",
+        priority=80,
+        shortcut="R",
+    )

--- a/protocol_quick_action_tools/quick_actions/browse_reports.py
+++ b/protocol_quick_action_tools/quick_actions/browse_reports.py
@@ -3,15 +3,28 @@
 from pluggable_protocol_tree.models.quick_action import BaseQuickAction
 
 from ..consts import ACTION_BROWSE_REPORTS
+from ..views.report_browser_dialog import ReportBrowserDialog
 
 
 class _BrowseReportsAction(BaseQuickAction):
     def on_execute_action(self, ctx):
-        ctx.pane.browse_reports_dialog()
+        self._open_dialog(ctx.pane)
 
     def is_enabled(self, ctx) -> bool:
         return ((not ctx.is_running)
                 and getattr(ctx.pane, "experiment_manager", None) is not None)
+
+    @staticmethod
+    def _open_dialog(pane):
+        """Open the ReportBrowserDialog over the session's
+        accumulated report paths (tracked by
+        ProtocolLoggingController.all_report_paths across every run
+        since app start)."""
+        paths = [
+            str(p) for p in
+            (getattr(pane.logging_controller, "all_report_paths", None) or [])
+        ]
+        ReportBrowserDialog(paths, parent=pane).exec()
 
 
 def make_browse_reports_action() -> _BrowseReportsAction:

--- a/protocol_quick_action_tools/quick_actions/delete_row.py
+++ b/protocol_quick_action_tools/quick_actions/delete_row.py
@@ -1,23 +1,22 @@
-"""'Delete selected step / group' quick-action factory."""
+"""'Delete last step' quick-action factory."""
 
 from pluggable_protocol_tree.models.quick_action import BaseQuickAction
 
 from ..consts import ACTION_DELETE_ROW
-from .base import has_selection
 
 
 class _DeleteRowAction(BaseQuickAction):
     def on_execute_action(self, ctx):
-        ctx.pane.delete_selected_rows()
+        ctx.pane.delete_last_step()
 
     def is_enabled(self, ctx) -> bool:
-        return (not ctx.is_running) and has_selection(ctx)
+        return not ctx.is_running
 
 
 def make_delete_row_action() -> _DeleteRowAction:
     return _DeleteRowAction(
         action_id=ACTION_DELETE_ROW,
         icon_text="delete",
-        tooltip="Delete selected step / group",
+        tooltip="Delete last step",
         priority=20,
     )

--- a/protocol_quick_action_tools/quick_actions/delete_row.py
+++ b/protocol_quick_action_tools/quick_actions/delete_row.py
@@ -1,0 +1,23 @@
+"""'Delete selected step / group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_DELETE_ROW
+from .base import has_selection
+
+
+class _DeleteRowAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.delete_selected_rows()
+
+    def is_enabled(self, ctx) -> bool:
+        return (not ctx.is_running) and has_selection(ctx)
+
+
+def make_delete_row_action() -> _DeleteRowAction:
+    return _DeleteRowAction(
+        action_id=ACTION_DELETE_ROW,
+        icon_text="delete",
+        tooltip="Delete selected step / group",
+        priority=20,
+    )

--- a/protocol_quick_action_tools/quick_actions/import_protocol.py
+++ b/protocol_quick_action_tools/quick_actions/import_protocol.py
@@ -1,0 +1,23 @@
+"""'Import protocol into selected group' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_IMPORT_PROTOCOL
+from .base import is_single_group_selected
+
+
+class _ImportProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.import_into_selected_group()
+
+    def is_enabled(self, ctx) -> bool:
+        return (not ctx.is_running) and is_single_group_selected(ctx)
+
+
+def make_import_protocol_action() -> _ImportProtocolAction:
+    return _ImportProtocolAction(
+        action_id=ACTION_IMPORT_PROTOCOL,
+        icon_text="unarchive",
+        tooltip="Import protocol into selected group",
+        priority=40,
+    )

--- a/protocol_quick_action_tools/quick_actions/new_protocol.py
+++ b/protocol_quick_action_tools/quick_actions/new_protocol.py
@@ -1,0 +1,22 @@
+"""'New protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_NEW_PROTOCOL
+
+
+class _NewProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.new_protocol()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_new_protocol_action() -> _NewProtocolAction:
+    return _NewProtocolAction(
+        action_id=ACTION_NEW_PROTOCOL,
+        icon_text="new_window",
+        tooltip="New protocol",
+        priority=70,
+    )

--- a/protocol_quick_action_tools/quick_actions/open_protocol.py
+++ b/protocol_quick_action_tools/quick_actions/open_protocol.py
@@ -1,0 +1,22 @@
+"""'Open Protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_OPEN_PROTOCOL
+
+
+class _OpenProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.load_protocol_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_open_protocol_action() -> _OpenProtocolAction:
+    return _OpenProtocolAction(
+        action_id=ACTION_OPEN_PROTOCOL,
+        icon_text="file_open",
+        tooltip="Open Protocol",
+        priority=50,
+    )

--- a/protocol_quick_action_tools/quick_actions/save_protocol.py
+++ b/protocol_quick_action_tools/quick_actions/save_protocol.py
@@ -1,0 +1,22 @@
+"""'Save Protocol' quick-action factory."""
+
+from pluggable_protocol_tree.models.quick_action import BaseQuickAction
+
+from ..consts import ACTION_SAVE_PROTOCOL
+
+
+class _SaveProtocolAction(BaseQuickAction):
+    def on_execute_action(self, ctx):
+        ctx.pane.save_protocol_dialog()
+
+    def is_enabled(self, ctx) -> bool:
+        return not ctx.is_running
+
+
+def make_save_protocol_action() -> _SaveProtocolAction:
+    return _SaveProtocolAction(
+        action_id=ACTION_SAVE_PROTOCOL,
+        icon_text="save",
+        tooltip="Save Protocol",
+        priority=60,
+    )

--- a/protocol_quick_action_tools/tests/conftest.py
+++ b/protocol_quick_action_tools/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Shared fixtures for protocol_quick_action_tools tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def qapp():
+    """Session-scoped QApplication so Qt widget tests can construct
+    QDialog + child widgets without crashing."""
+    from pyface.qt.QtWidgets import QApplication
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # Don't quit — lets subsequent test modules reuse the same QApplication.

--- a/protocol_quick_action_tools/tests/test_plugin_scaffold.py
+++ b/protocol_quick_action_tools/tests/test_plugin_scaffold.py
@@ -1,0 +1,32 @@
+"""Plugin scaffold: package importable, consts defined, plugin class
+declares the IQuickAction contribution list (initially empty until
+the action factories land in task 12)."""
+
+import protocol_quick_action_tools
+from protocol_quick_action_tools.consts import PKG, PKG_name
+from protocol_quick_action_tools.plugin import (
+    ProtocolQuickActionToolsPlugin,
+)
+
+
+def test_package_is_importable():
+    assert protocol_quick_action_tools is not None
+
+
+def test_consts_match_package_layout():
+    assert PKG == "protocol_quick_action_tools"
+    assert PKG_name == "Protocol Quick Action Tools"
+
+
+def test_plugin_id_and_name():
+    p = ProtocolQuickActionToolsPlugin()
+    assert p.id == "protocol_quick_action_tools.plugin"
+    assert p.name == "Protocol Quick Action Tools Plugin"
+
+
+def test_plugin_has_contribution_list_trait():
+    p = ProtocolQuickActionToolsPlugin()
+    # The factories aren't wired in yet — they land in task 12. The
+    # trait must exist and default to an empty list so the scaffold
+    # can be loaded by Envisage without crashing.
+    assert isinstance(p.contributed_quick_actions, list)

--- a/protocol_quick_action_tools/tests/test_quick_actions.py
+++ b/protocol_quick_action_tools/tests/test_quick_actions.py
@@ -198,11 +198,60 @@ def test_browse_reports_metadata_and_shortcut():
     assert a.shortcut == "R"
 
 
-def test_browse_reports_execute_calls_pane_helper():
+def test_browse_reports_execute_opens_dialog_with_session_paths(monkeypatch):
+    """The action reads ``pane.logging_controller.all_report_paths``
+    (set by ProtocolLoggingController on every successful flush) and
+    feeds the str-converted paths into ReportBrowserDialog."""
+    from pathlib import Path
+
+    from protocol_quick_action_tools.quick_actions import browse_reports as mod
+    captured = {}
+
+    class _FakeDialog:
+        def __init__(self_inner, paths, parent=None):
+            captured["paths"] = list(paths)
+            captured["parent"] = parent
+        def exec(self_inner):
+            return 0
+
+    monkeypatch.setattr(mod, "ReportBrowserDialog", _FakeDialog)
+
     a = make_browse_reports_action()
-    ctx = _ctx()
+    pane = MagicMock()
+    pane.logging_controller.all_report_paths = [
+        Path("/x/y/report_a.html"),
+        Path("/x/y/report_b.html"),
+    ]
+    ctx = QuickActionCtx(pane=pane, is_running=False)
     a.on_execute_action(ctx)
-    ctx.pane.browse_reports_dialog.assert_called_once_with()
+
+    assert captured["paths"] == [
+        str(Path("/x/y/report_a.html")),
+        str(Path("/x/y/report_b.html")),
+    ]
+    assert captured["parent"] is pane
+
+
+def test_browse_reports_execute_empty_session_opens_empty_dialog(monkeypatch):
+    """No reports yet (empty session list) -> dialog opens with an
+    empty path list rather than raising."""
+    from protocol_quick_action_tools.quick_actions import browse_reports as mod
+    captured = {}
+
+    class _FakeDialog:
+        def __init__(self_inner, paths, parent=None):
+            captured["paths"] = list(paths)
+        def exec(self_inner):
+            return 0
+
+    monkeypatch.setattr(mod, "ReportBrowserDialog", _FakeDialog)
+
+    a = make_browse_reports_action()
+    pane = MagicMock()
+    pane.logging_controller.all_report_paths = []
+    a.on_execute_action(QuickActionCtx(pane=pane, is_running=False))
+
+    assert captured["paths"] == []
 
 
 def test_browse_reports_disabled_without_experiment_manager():

--- a/protocol_quick_action_tools/tests/test_quick_actions.py
+++ b/protocol_quick_action_tools/tests/test_quick_actions.py
@@ -1,0 +1,225 @@
+"""One block per action. Each block builds a QuickActionCtx with a
+MagicMock pane and asserts:
+  * on_execute_action(ctx) calls the right pane method (or constructs
+    the dialog with the right args).
+  * is_enabled(ctx) matrix is correct for the meaningful states.
+The plugin's _contributed_quick_actions_default returns all 8 actions
+in priority order.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pluggable_protocol_tree.models.quick_action import QuickActionCtx
+from pluggable_protocol_tree.models.row import GroupRow
+
+from protocol_quick_action_tools.consts import (
+    ACTION_ADD_GROUP, ACTION_ADD_STEP, ACTION_BROWSE_REPORTS,
+    ACTION_DELETE_ROW, ACTION_IMPORT_PROTOCOL, ACTION_NEW_PROTOCOL,
+    ACTION_OPEN_PROTOCOL, ACTION_SAVE_PROTOCOL,
+)
+from protocol_quick_action_tools.plugin import (
+    ProtocolQuickActionToolsPlugin,
+)
+from protocol_quick_action_tools.quick_actions.add_group import (
+    make_add_group_action,
+)
+from protocol_quick_action_tools.quick_actions.add_step import (
+    make_add_step_action,
+)
+from protocol_quick_action_tools.quick_actions.browse_reports import (
+    make_browse_reports_action,
+)
+from protocol_quick_action_tools.quick_actions.delete_row import (
+    make_delete_row_action,
+)
+from protocol_quick_action_tools.quick_actions.import_protocol import (
+    make_import_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.new_protocol import (
+    make_new_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.open_protocol import (
+    make_open_protocol_action,
+)
+from protocol_quick_action_tools.quick_actions.save_protocol import (
+    make_save_protocol_action,
+)
+
+
+def _ctx(*, selected_paths=(), is_running=False, group=False,
+         experiment_manager=True):
+    pane = MagicMock()
+    if group and selected_paths:
+        pane.manager.get_row.return_value = GroupRow(name="G")
+    else:
+        pane.manager.get_row.return_value = MagicMock(spec=[])
+    pane.experiment_manager = MagicMock() if experiment_manager else None
+    return QuickActionCtx(pane=pane,
+                          selected_paths=tuple(selected_paths),
+                          is_running=is_running)
+
+
+# --- add_step -----------------------------------------------------
+
+def test_add_step_metadata():
+    a = make_add_step_action()
+    assert a.action_id == ACTION_ADD_STEP
+    assert a.icon_text == "add"
+    assert a.priority == 10
+    assert a.shortcut == ""
+
+
+def test_add_step_execute_calls_pane_helper():
+    a = make_add_step_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.add_step_after_selection.assert_called_once_with()
+
+
+@pytest.mark.parametrize("running,expected",
+                         [(False, True), (True, False)])
+def test_add_step_is_enabled(running, expected):
+    assert make_add_step_action().is_enabled(_ctx(is_running=running)) is expected
+
+
+# --- delete_row ---------------------------------------------------
+
+def test_delete_row_metadata():
+    a = make_delete_row_action()
+    assert a.action_id == ACTION_DELETE_ROW
+    assert a.icon_text == "delete"
+    assert a.priority == 20
+
+
+def test_delete_row_execute_calls_pane_helper():
+    a = make_delete_row_action()
+    ctx = _ctx(selected_paths=[(0,)])
+    a.on_execute_action(ctx)
+    ctx.pane.delete_selected_rows.assert_called_once_with()
+
+
+def test_delete_row_is_enabled_matrix():
+    a = make_delete_row_action()
+    assert a.is_enabled(_ctx()) is False                  # no selection
+    assert a.is_enabled(_ctx(selected_paths=[(0,)])) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,), (1,)])) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              is_running=True)) is False
+
+
+# --- add_group ----------------------------------------------------
+
+def test_add_group_metadata():
+    a = make_add_group_action()
+    assert a.action_id == ACTION_ADD_GROUP
+    assert a.icon_text == "playlist_add"
+    assert a.priority == 30
+
+
+def test_add_group_execute_calls_pane_helper():
+    a = make_add_group_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.add_group_after_selection.assert_called_once_with()
+
+
+# --- import_protocol ----------------------------------------------
+
+def test_import_protocol_metadata():
+    a = make_import_protocol_action()
+    assert a.action_id == ACTION_IMPORT_PROTOCOL
+    assert a.icon_text == "unarchive"
+    assert a.priority == 40
+
+
+def test_import_protocol_execute_calls_pane_helper():
+    a = make_import_protocol_action()
+    ctx = _ctx(selected_paths=[(0,)], group=True)
+    a.on_execute_action(ctx)
+    ctx.pane.import_into_selected_group.assert_called_once_with()
+
+
+def test_import_protocol_is_enabled_requires_single_group_selection():
+    a = make_import_protocol_action()
+    assert a.is_enabled(_ctx()) is False                       # no sel
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=False)) is False           # step, not group
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=True)) is True
+    assert a.is_enabled(_ctx(selected_paths=[(0,), (1,)],
+                              group=True)) is False            # multi-sel
+    assert a.is_enabled(_ctx(selected_paths=[(0,)],
+                              group=True,
+                              is_running=True)) is False
+
+
+# --- open / save / new_protocol -----------------------------------
+
+def test_open_protocol_calls_pane_helper():
+    a = make_open_protocol_action()
+    assert a.action_id == ACTION_OPEN_PROTOCOL
+    assert a.icon_text == "file_open"
+    assert a.priority == 50
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.load_protocol_dialog.assert_called_once_with()
+
+
+def test_save_protocol_calls_pane_helper():
+    a = make_save_protocol_action()
+    assert a.action_id == ACTION_SAVE_PROTOCOL
+    assert a.icon_text == "save"
+    assert a.priority == 60
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.save_protocol_dialog.assert_called_once_with()
+
+
+def test_new_protocol_calls_pane_helper():
+    a = make_new_protocol_action()
+    assert a.action_id == ACTION_NEW_PROTOCOL
+    assert a.icon_text == "new_window"
+    assert a.priority == 70
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.new_protocol.assert_called_once_with()
+
+
+# --- browse_reports -----------------------------------------------
+
+def test_browse_reports_metadata_and_shortcut():
+    a = make_browse_reports_action()
+    assert a.action_id == ACTION_BROWSE_REPORTS
+    assert a.icon_text == "summarize"
+    assert a.priority == 80
+    assert a.shortcut == "R"
+
+
+def test_browse_reports_execute_calls_pane_helper():
+    a = make_browse_reports_action()
+    ctx = _ctx()
+    a.on_execute_action(ctx)
+    ctx.pane.browse_reports_dialog.assert_called_once_with()
+
+
+def test_browse_reports_disabled_without_experiment_manager():
+    a = make_browse_reports_action()
+    assert a.is_enabled(_ctx(experiment_manager=False)) is False
+    assert a.is_enabled(_ctx(experiment_manager=True)) is True
+    assert a.is_enabled(_ctx(experiment_manager=True,
+                              is_running=True)) is False
+
+
+# --- plugin default contributions list ----------------------------
+
+def test_plugin_default_contributions_includes_all_eight_actions():
+    plugin = ProtocolQuickActionToolsPlugin()
+    contribs = plugin._contributed_quick_actions_default()
+    ids = sorted(a.action_id for a in contribs)
+    assert ids == sorted([
+        ACTION_ADD_STEP, ACTION_DELETE_ROW, ACTION_ADD_GROUP,
+        ACTION_IMPORT_PROTOCOL, ACTION_OPEN_PROTOCOL, ACTION_SAVE_PROTOCOL,
+        ACTION_NEW_PROTOCOL, ACTION_BROWSE_REPORTS,
+    ])

--- a/protocol_quick_action_tools/tests/test_quick_actions.py
+++ b/protocol_quick_action_tools/tests/test_quick_actions.py
@@ -95,18 +95,19 @@ def test_delete_row_metadata():
 
 def test_delete_row_execute_calls_pane_helper():
     a = make_delete_row_action()
-    ctx = _ctx(selected_paths=[(0,)])
+    ctx = _ctx()
     a.on_execute_action(ctx)
-    ctx.pane.delete_selected_rows.assert_called_once_with()
+    ctx.pane.delete_last_step.assert_called_once_with()
 
 
-def test_delete_row_is_enabled_matrix():
+def test_delete_row_is_enabled_only_gated_by_is_running():
+    """Per #433 follow-up: delete button is always available when the
+    protocol isn't running — selection state is irrelevant."""
     a = make_delete_row_action()
-    assert a.is_enabled(_ctx()) is False                  # no selection
+    assert a.is_enabled(_ctx()) is True                       # no selection
     assert a.is_enabled(_ctx(selected_paths=[(0,)])) is True
     assert a.is_enabled(_ctx(selected_paths=[(0,), (1,)])) is True
-    assert a.is_enabled(_ctx(selected_paths=[(0,)],
-                              is_running=True)) is False
+    assert a.is_enabled(_ctx(is_running=True)) is False
 
 
 # --- add_group ----------------------------------------------------

--- a/protocol_quick_action_tools/tests/test_report_browser_dialog.py
+++ b/protocol_quick_action_tools/tests/test_report_browser_dialog.py
@@ -1,0 +1,56 @@
+"""Smoke tests for the ported ReportBrowserDialog: constructor accepts
+a list of path strings, populates a sortable tree of (Name, Size, Date),
+filters by name in the search box, and opens the selected report via
+QDesktopServices when the user activates a row."""
+
+from protocol_quick_action_tools.views.report_browser_dialog import (
+    ReportBrowserDialog,
+)
+
+
+def test_dialog_populates_one_row_per_path(qapp, tmp_path):
+    a = tmp_path / "report_a.html"; a.write_text("a", encoding="utf-8")
+    b = tmp_path / "report_b.html"; b.write_text("bb", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(a), str(b)])
+    assert dlg._tree.topLevelItemCount() == 2
+
+
+def test_dialog_handles_empty_list_without_crashing(qapp):
+    """No reports yet -> open with an empty table; no rows shown."""
+    dlg = ReportBrowserDialog([])
+    assert dlg._tree.topLevelItemCount() == 0
+
+
+def test_search_box_hides_non_matching_rows(qapp, tmp_path):
+    a = tmp_path / "alpha.html"; a.write_text("a", encoding="utf-8")
+    b = tmp_path / "beta.html"; b.write_text("b", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(a), str(b)])
+    dlg._apply_filter("alph")
+    visible = [
+        dlg._tree.topLevelItem(i).text(0)
+        for i in range(dlg._tree.topLevelItemCount())
+        if not dlg._tree.topLevelItem(i).isHidden()
+    ]
+    assert visible == ["alpha.html"]
+
+
+def test_format_size_threshold_branches():
+    fs = ReportBrowserDialog._format_size
+    assert fs(900) == "900 B"
+    assert fs(2048) == "2.0 KB"
+    assert fs(5 * 1024 * 1024) == "5.0 MB"
+
+
+def test_open_item_calls_qdesktopservices(qapp, tmp_path, monkeypatch):
+    """Double-click / Open routes through QDesktopServices.openUrl."""
+    from protocol_quick_action_tools.views import report_browser_dialog as mod
+    opened = []
+    monkeypatch.setattr(mod.QDesktopServices, "openUrl",
+                        lambda url: opened.append(url))
+    p = tmp_path / "report.html"; p.write_text("", encoding="utf-8")
+    dlg = ReportBrowserDialog([str(p)])
+    item = dlg._tree.topLevelItem(0)
+    dlg._open_item(item)
+    assert len(opened) == 1
+    from pathlib import Path
+    assert Path(opened[0].toLocalFile()).resolve() == Path(str(p)).resolve()

--- a/protocol_quick_action_tools/views/__init__.py
+++ b/protocol_quick_action_tools/views/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone Qt widgets used by quick actions (ReportBrowserDialog)."""

--- a/protocol_quick_action_tools/views/report_browser_dialog.py
+++ b/protocol_quick_action_tools/views/report_browser_dialog.py
@@ -1,0 +1,142 @@
+"""File-manager-style dialog to browse and open session reports.
+
+Ported from protocol_grid/extra_ui_elements.py:942-1064 (the legacy
+class is fully decoupled from PGCWidget — only input is a list of path
+strings). Kept verbatim except for the import path adjustments.
+"""
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from pyface.qt.QtCore import Qt, QUrl
+from pyface.qt.QtGui import QDesktopServices
+from pyface.qt.QtWidgets import (
+    QDialog, QHBoxLayout, QHeaderView, QLabel, QLineEdit, QPushButton,
+    QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget,
+)
+
+
+class _ReportSortableTreeWidgetItem(QTreeWidgetItem):
+    """QTreeWidgetItem subclass that sorts the Size column numerically
+    and the Date column chronologically instead of lexicographically."""
+
+    _SIZE_COL = 1
+    _DATE_COL = 2
+
+    def __lt__(self, other):
+        col = self.treeWidget().sortColumn()
+        if col == self._SIZE_COL:
+            return ((self.data(col, Qt.UserRole) or 0)
+                    < (other.data(col, Qt.UserRole) or 0))
+        if col == self._DATE_COL:
+            return ((self.data(col, Qt.UserRole) or 0)
+                    < (other.data(col, Qt.UserRole) or 0))
+        return super().__lt__(other)
+
+
+class ReportBrowserDialog(QDialog):
+    """Search-and-open dialog over a flat list of report HTML paths."""
+
+    _COL_NAME = 0
+    _COL_SIZE = 1
+    _COL_DATE = 2
+
+    def __init__(self, report_paths: List[str], parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Session Reports")
+        self.setModal(True)
+        self.setMinimumSize(650, 420)
+        self._report_paths = report_paths
+        self._setup_ui()
+
+    def _setup_ui(self):
+        layout = QVBoxLayout(self)
+
+        # --- search bar ---
+        search_layout = QHBoxLayout()
+        search_label = QLabel("Search:")
+        self._search_box = QLineEdit()
+        self._search_box.setPlaceholderText("Filter by file name...")
+        self._search_box.setClearButtonEnabled(True)
+        self._search_box.textChanged.connect(self._apply_filter)
+        search_layout.addWidget(search_label)
+        search_layout.addWidget(self._search_box)
+        layout.addLayout(search_layout)
+
+        # --- file table ---
+        self._tree = QTreeWidget()
+        self._tree.setHeaderLabels(["Name", "Size", "Date Created"])
+        self._tree.setRootIsDecorated(False)
+        self._tree.setAlternatingRowColors(True)
+        self._tree.setSortingEnabled(True)
+        self._tree.setSelectionMode(QTreeWidget.SingleSelection)
+
+        header = self._tree.header()
+        header.setStretchLastSection(False)
+        header.setSectionResizeMode(self._COL_NAME, QHeaderView.Stretch)
+        header.setSectionResizeMode(self._COL_SIZE, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(self._COL_DATE, QHeaderView.ResizeToContents)
+
+        for path_str in self._report_paths:
+            p = Path(path_str)
+            try:
+                stat = os.stat(p)
+                size_bytes = stat.st_size
+                ctime = stat.st_ctime
+            except OSError:
+                size_bytes = 0
+                ctime = 0.0
+
+            item = _ReportSortableTreeWidgetItem([
+                p.name,
+                self._format_size(size_bytes),
+                datetime.fromtimestamp(ctime).strftime("%Y-%m-%d  %H:%M:%S")
+                if ctime else "",
+            ])
+            item.setToolTip(self._COL_NAME, str(p))
+            item.setData(self._COL_NAME, Qt.UserRole, path_str)
+            item.setData(self._COL_SIZE, Qt.UserRole, size_bytes)
+            item.setData(self._COL_DATE, Qt.UserRole, ctime)
+            self._tree.addTopLevelItem(item)
+
+        self._tree.sortByColumn(self._COL_DATE, Qt.DescendingOrder)
+        layout.addWidget(self._tree)
+
+        # --- buttons ---
+        button_layout = QHBoxLayout()
+        open_btn = QPushButton("Open")
+        open_btn.setDefault(True)
+        open_btn.clicked.connect(self._open_selected)
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.reject)
+        button_layout.addStretch()
+        button_layout.addWidget(open_btn)
+        button_layout.addWidget(close_btn)
+        layout.addLayout(button_layout)
+
+        self._tree.itemDoubleClicked.connect(self._open_item)
+
+    def _apply_filter(self, text: str):
+        text_lower = text.lower()
+        for i in range(self._tree.topLevelItemCount()):
+            item = self._tree.topLevelItem(i)
+            item.setHidden(text_lower not in item.text(self._COL_NAME).lower())
+
+    def _open_selected(self):
+        items = self._tree.selectedItems()
+        if items:
+            self._open_item(items[0])
+
+    def _open_item(self, item):
+        path_str = item.data(self._COL_NAME, Qt.UserRole)
+        QDesktopServices.openUrl(QUrl.fromLocalFile(path_str))
+
+    @staticmethod
+    def _format_size(size_bytes: int) -> str:
+        if size_bytes < 1024:
+            return f"{size_bytes} B"
+        if size_bytes < 1024 * 1024:
+            return f"{size_bytes / 1024:.1f} KB"
+        return f"{size_bytes / (1024 * 1024):.1f} MB"


### PR DESCRIPTION
## Summary
Bring the legacy `protocol_grid` quick-actions toolbar into the pluggable protocol tree, split cleanly into a contribution surface (in `pluggable_protocol_tree`) and a new sibling plugin `protocol_quick_action_tools` that ships all 8 legacy actions plus the ported `ReportBrowserDialog`.

Resolves #433.

## Architecture
**`pluggable_protocol_tree`** — the contribution surface (tree plugin ships ZERO builtins):
- `IQuickAction` interface (Traits): `action_id`, `icon_text`, `tooltip`, `priority`, `shortcut` + `on_execute_action(ctx)` + `is_enabled(ctx)`.
- `BaseQuickAction` + `QuickActionCtx` (carries `pane`, `selected_paths`, `is_running`).
- `QuickActionBar` (pure-rendering icon-button row) + `QuickActionsController` (click + enabled-state + widget-scoped `QShortcut` wiring with conflict detection).
- New pane signals `protocol_running_changed` / `selection_changed` driving the controller.
- `quick_actions=None` constructor kwarg on `ProtocolTreePane`; bar mounted under the tree when contributions exist.
- Five pane helpers consumed by the actions: `add_step_after_selection`, `add_group_after_selection`, `delete_last_step`, `import_into_selected_group`, (`browse_reports_dialog` moved into the action).
- Envisage `PROTOCOL_QUICK_ACTIONS` extension point + dock-pane forwarding.

**`protocol_quick_action_tools`** (new sibling plugin) — contributes the 8 legacy actions:
- `add_step`, `delete_row`, `add_group`, `import_protocol`, `open_protocol`, `save_protocol`, `new_protocol`, `browse_reports` (with `R` shortcut).
- `ReportBrowserDialog` ported verbatim from `protocol_grid/extra_ui_elements.py:942-1064`.
- Loaded via `examples/plugin_consts.py`.

## Behaviour Refinements (post-initial-implementation)
- **Delete button** is always enabled (gated only by `is_running`) and walks the rightmost path of the tree: deletes the deepest-rightmost step, or an empty trailing group when it encounters one. No-op on empty tree.
- **Add Step / Add Group** rules through the shared `_insert_position_after_selection` helper:
  - No selection → append at root.
  - Single group selected → append INSIDE the group.
  - Single step selected → insert immediately after.
  - Multi-selection → last-selected semantics.
- **Browse Reports** consumes the new `ProtocolLoggingController.all_report_paths` session accumulator (legacy parity) instead of globbing the experiment dir.
- **`import_into_selected_group`** uses the actual flat-list persistence schema with name-based field-index lookups (resilient to schema reorder), filters to depth-0 top-level rows only, skips `None` values and column ids absent from the live tree, routes kept values through each column's `model.deserialize` (mirrors `services/persistence.deserialize_tree`).
- **`attempt_func_execution_with_error_dialog`** decorator surfaces top-level pane-action exceptions with humanised operation name, HTML-formatted informative body, full traceback in collapsible detail, plus logging with `exc_info=True`. Decorator is defined; not applied to any method yet.

## Bug Fixes Along the Way
- **Persistence: duplicate `type` and `name` fields** — `serialize_tree` was hard-coding `[\"depth\", \"uuid\", \"type\", \"name\"]` AND serializing the type/name columns (which have those exact `col_id`s), producing rows like `[0, uuid, 'step', 'Step', 'step', (0,), 'Step']` with `type` and `name` duplicated. Filtered reserved field names from the serialized column set; old saves still load (orphan attributes are harmless). 5 stale test assertions in 3 other files updated.
- **Duplicate `action_id` silently lost a button + double-fired clicks** — bar now detects + skips duplicates with a warning; controller dedup mirrors the shortcut-conflict pattern.
- **Lazy `_get_report_browser_dialog_cls` was catching `Exception`** — narrowed to `ImportError` so real bugs inside the dialog surface instead of silently disabling it.

## Spec / Plan
- `microdrop-py/src/docs/superpowers/specs/2026-05-28-ppt-21-quick-actions-toolbar-design.md`
- `microdrop-py/src/docs/superpowers/plans/2026-05-29-ppt-21-quick-actions-toolbar.md`

## Tests
~660 passing across `pluggable_protocol_tree` and `protocol_quick_action_tools`. One pre-existing `test_phase_acked_signal_resets_phase_timer` failure remains unrelated (touches `BasePluggableProtocolDemoWindow` which this PR doesn't modify).

## Test plan
- [x] Launch the live app, confirm the quick-actions bar appears below the tree with all 8 buttons.
- [x] Click each button (with various selections) and verify behaviour matches the table in the spec.
- [x] Press \`R\` with focus in the pane → ReportBrowserDialog opens with the session's reports.
- [x] Run a protocol, generate a report, click \`R\` again — the new report appears in the list.
- [x] Save → reopen a protocol containing a Type / Name column to confirm the persistence dedup hasn't broken existing saves.
- [x] Import a protocol into a selected group — top-level rows merge in; nested rows are skipped; `None` values don't crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)