### PR TITLE
feat(run-script): add --plugins arg to select frontend/backend/services layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,41 @@ The command to create the environment is:
 
 And remember to startup the redis server. There is a start_redis_server.py python script for thisnin examples. Or one can just ruin ``redis-server`` on a terminal.
 
+## **Running the Application**
+
+Redis must be running before launching (see above).
+
+The combined launcher `examples/run_device_viewer_pluggable.py` can load any
+combination of plugin layers via `--plugins`, so a single script covers the
+full app, frontend-only, or backend-only runs:
+
+```bash
+# Full app — frontend + backend (the default)
+python examples/run_device_viewer_pluggable.py
+
+# Frontend (GUI) only — needs Redis + a backend running separately
+python examples/run_device_viewer_pluggable.py --plugins frontend
+
+# Backend only — persistent headless process, connects to an existing Redis
+python examples/run_device_viewer_pluggable.py --plugins backend
+
+# Any combination, with a device selection
+python examples/run_device_viewer_pluggable.py --plugins backend services --device mock
+```
+
+`--plugins` accepts one or more space-separated values from `frontend`,
+`backend`, and `services`, defaulting to `frontend backend`. Notes:
+
+- **Services** (e.g. SSH controls) are trust-bound to the GUI host, so they
+  load automatically with `frontend`, or on explicit `services` request.
+- Selecting `frontend` runs the GUI application; a backend-only selection runs
+  the persistent headless backend application.
+- The **frontend host owns the Redis server**; a backend-only run instead
+  connects to an already-running Redis (use this for a remote backend host).
+
+`--device` selects the hardware target (`dropbot`, `opendrop`, or `mock`;
+default `dropbot`) and pulls in the matching device-specific plugins.
+
 # **Remote Microdrop Instructions**
 
 ## **1. SERVER-SIDE (via SSH)**

--- a/examples/run_device_viewer_pluggable.py
+++ b/examples/run_device_viewer_pluggable.py
@@ -12,7 +12,8 @@ from microdrop_utils.app_setup_helpers import microdrop_runner_setup
 microdrop_runner_setup()
 
 from examples.plugin_consts import REQUIRED_PLUGINS, FRONTEND_PLUGINS, BACKEND_PLUGINS, DROPBOT_BACKEND_PLUGINS, \
-    DROPBOT_FRONTEND_PLUGINS, OPENDROP_FRONTEND_PLUGINS, OPENDROP_BACKEND_PLUGINS, DEFAULT_APPLICATION, SERVER_CONTEXT, \
+    DROPBOT_FRONTEND_PLUGINS, OPENDROP_FRONTEND_PLUGINS, OPENDROP_BACKEND_PLUGINS, FRONTEND_APPLICATION, \
+    BACKEND_APPLICATION, SERVER_CONTEXT, \
     REQUIRED_CONTEXT, MOCK_DROPBOT_BACKEND_PLUGINS, MOCK_DROPBOT_FRONTEND_PLUGINS, SERVICE_PLUGINS
 
 from logger.logger_service import get_logger
@@ -81,7 +82,7 @@ def main(plugins, contexts, application, persist):
 if __name__ == "__main__":
     import argparse
 
-    parser = argparse.ArgumentParser(description="Run the frontend device viewer plugins.")
+    parser = argparse.ArgumentParser(description="Run the device viewer plugins.")
 
     parser.add_argument(
         "--device",
@@ -91,21 +92,57 @@ if __name__ == "__main__":
         help="Specify the device to use: 'dropbot' or 'opendrop'"
     )
 
-    plugins = REQUIRED_PLUGINS + FRONTEND_PLUGINS + SERVICE_PLUGINS + BACKEND_PLUGINS
+    parser.add_argument(
+        "--plugins",
+        nargs="+",
+        choices=["frontend", "backend", "services"],
+        default=["frontend", "backend"],
+        help="Which plugin layers to load (space-separated). 'frontend' also pulls in "
+             "the colocated service plugins. Default: frontend backend.",
+    )
 
     args = parser.parse_args()
+    selected = set(args.plugins)
 
-    if args.device == "dropbot":
-        plugins += DROPBOT_FRONTEND_PLUGINS + DROPBOT_BACKEND_PLUGINS
-    elif args.device == "opendrop":
-        plugins += OPENDROP_FRONTEND_PLUGINS + OPENDROP_BACKEND_PLUGINS
+    plugins = list(REQUIRED_PLUGINS)
 
-    elif args.device == "mock":
-        plugins += MOCK_DROPBOT_FRONTEND_PLUGINS + MOCK_DROPBOT_BACKEND_PLUGINS + DROPBOT_FRONTEND_PLUGINS
+    if "frontend" in selected:
+        plugins += FRONTEND_PLUGINS
+        if args.device == "dropbot":
+            plugins += DROPBOT_FRONTEND_PLUGINS
+        elif args.device == "opendrop":
+            plugins += OPENDROP_FRONTEND_PLUGINS
+        elif args.device == "mock":
+            plugins += MOCK_DROPBOT_FRONTEND_PLUGINS + DROPBOT_FRONTEND_PLUGINS
+
+    # Service plugins are host-bound by trust and must colocate with the GUI,
+    # so they load alongside the frontend as well as on explicit request.
+    if "frontend" in selected or "services" in selected:
+        plugins += SERVICE_PLUGINS
+
+    if "backend" in selected:
+        plugins += BACKEND_PLUGINS
+        if args.device == "dropbot":
+            plugins += DROPBOT_BACKEND_PLUGINS
+        elif args.device == "opendrop":
+            plugins += OPENDROP_BACKEND_PLUGINS
+        elif args.device == "mock":
+            plugins += MOCK_DROPBOT_BACKEND_PLUGINS
+
+    # De-duplicate while preserving load order (matters for service priority).
+    plugins = list(dict.fromkeys(plugins))
+
+    # A GUI process when the frontend is loaded; otherwise a persistent
+    # headless backend process.
+    has_frontend = "frontend" in selected
+
+    # The frontend host owns the Redis server; a backend-only process is
+    # assumed to be remote and connects to an already-running Redis.
+    contexts = (SERVER_CONTEXT + REQUIRED_CONTEXT) if has_frontend else REQUIRED_CONTEXT
 
     main(
         plugins=plugins,
-        contexts=SERVER_CONTEXT + REQUIRED_CONTEXT,
-        application=DEFAULT_APPLICATION,
-        persist=False # UI so no
-         )
+        contexts=contexts,
+        application=FRONTEND_APPLICATION if has_frontend else BACKEND_APPLICATION,
+        persist=not has_frontend,
+    )


### PR DESCRIPTION
## Summary

The combined launcher (`examples/run_device_viewer_pluggable.py`) now accepts a `--plugins` argument so the terminal can pick which plugin layers to load, instead of needing the separate frontend/backend run scripts.

```bash
# default — frontend + backend (unchanged behavior)
python examples/run_device_viewer_pluggable.py

# frontend only
python examples/run_device_viewer_pluggable.py --plugins frontend

# backend only (persistent headless backend, connects to existing Redis)
python examples/run_device_viewer_pluggable.py --plugins backend

# combinations + device selection
python examples/run_device_viewer_pluggable.py --plugins backend services --device mock
```

`--plugins` is `nargs="+"` with choices `frontend` / `backend` / `services`, defaulting to `frontend backend`.

## Behavior derived from the selection

- **Services** load with the frontend (trust-bound to the GUI host, per the `plugin_consts.py` category comment) or on explicit `services` request.
- **Application / persistence** — a frontend selection runs the GUI app (`FRONTEND_APPLICATION`, non-persistent); a backend-only selection runs the persistent headless `BACKEND_APPLICATION`.
- **Redis** — the frontend host owns the Redis server (`SERVER_CONTEXT`); a backend-only process uses only `REQUIRED_CONTEXT` and connects to an already-running Redis, matching the standalone `_backend.py` script for remote-host use.
- Plugins are de-duplicated while preserving load order, since Envisage service priority depends on it.

The default invocation reproduces the previous full-app plugin set, application, and context exactly.

## Docs

Adds a "Running the Application" section to the README documenting the `--plugins` and `--device` flags and the behavior notes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
