### PR TITLE
feat(protocol-tree): persist column visibility across restarts

### DIFF
--- a/pluggable_protocol_tree/services/column_visibility_store.py
+++ b/pluggable_protocol_tree/services/column_visibility_store.py
@@ -1,0 +1,71 @@
+"""Persist the user's protocol-tree column visibility across app restarts.
+
+The protocol-tree header right-click menu
+(``ProtocolTreeWidget._on_header_context_menu``) lets the user toggle which
+columns are shown. Without persistence those choices reset on every launch.
+We store a small JSON map ``{col_name: visible}`` under the per-user app
+config directory (``ETSConfig.application_home`` — the same root the rest of
+the app uses) so the same columns reappear next time.
+
+Keyed by ``col_name`` (the stable display identity from the column model),
+not by column index: indices shift whenever the column set changes, names
+don't. A column missing from the saved map falls back to its
+``hidden_by_default`` flag, so newly added columns still honour their own
+default rather than being forced visible.
+
+All filesystem access is best-effort: a missing/unreadable/unwritable
+settings file degrades to "no persisted preference" and is logged, never
+raised — column visibility must never crash the tree.
+"""
+
+import json
+from pathlib import Path
+
+from traits.etsconfig.api import ETSConfig
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+_SETTINGS_FILENAME = "protocol_tree_column_visibility.json"
+
+
+def _settings_path() -> Path:
+    return Path(ETSConfig.application_home) / _SETTINGS_FILENAME
+
+
+def load_column_visibility() -> dict[str, bool]:
+    """Return the persisted ``{col_name: visible}`` map.
+
+    Returns an empty dict when no settings file exists yet or it cannot be
+    read/parsed — callers treat an absent entry as "use the column default".
+    """
+    path = _settings_path()
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError) as exc:
+        logger.warning(f"Could not read column visibility settings {path}: {exc}")
+        return {}
+
+    if not isinstance(data, dict):
+        logger.warning(f"Ignoring malformed column visibility settings {path}")
+        return {}
+    return {str(name): bool(visible) for name, visible in data.items()}
+
+
+def save_column_visibility(visibility: dict[str, bool]) -> None:
+    """Persist the ``{col_name: visible}`` map, creating the config dir if needed."""
+    path = _settings_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(
+                {str(name): bool(visible) for name, visible in visibility.items()},
+                f,
+                indent=2,
+            )
+    except OSError as exc:
+        logger.warning(f"Could not write column visibility settings {path}: {exc}")

--- a/pluggable_protocol_tree/tests/test_column_visibility_persistence.py
+++ b/pluggable_protocol_tree/tests/test_column_visibility_persistence.py
@@ -1,0 +1,92 @@
+"""Tests for persisting protocol-tree column visibility across restarts.
+
+Covers the standalone store (save/load round-trip, graceful degradation)
+and the ProtocolTreeWidget wiring (restore on construction, persist on
+toggle, fall back to hidden_by_default for columns with no saved entry).
+"""
+
+import pytest
+
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.trail_length_column import (
+    make_trail_length_column,
+)
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.services import column_visibility_store as store
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+@pytest.fixture
+def config_home(tmp_path, monkeypatch):
+    """Redirect the store's per-user config dir at a temp path."""
+    monkeypatch.setattr(store.ETSConfig, "application_home", str(tmp_path))
+    return tmp_path
+
+
+def _index_of(manager, col_name):
+    for i, col in enumerate(manager.columns):
+        if col.model.col_name == col_name:
+            return i
+    raise AssertionError(f"column {col_name!r} not found")
+
+
+# --- store ---------------------------------------------------------------
+
+def test_load_returns_empty_when_no_file(config_home):
+    assert store.load_column_visibility() == {}
+
+
+def test_save_load_round_trip(config_home):
+    store.save_column_visibility({"Name": False, "Trail Len": True})
+    assert store.load_column_visibility() == {"Name": False, "Trail Len": True}
+
+
+def test_load_ignores_malformed_file(config_home):
+    store._settings_path().write_text("not json", encoding="utf-8")
+    assert store.load_column_visibility() == {}
+
+
+def test_load_ignores_non_dict_json(config_home):
+    store._settings_path().write_text("[1, 2, 3]", encoding="utf-8")
+    assert store.load_column_visibility() == {}
+
+
+# --- widget wiring -------------------------------------------------------
+
+def test_widget_uses_defaults_when_no_saved_state(qapp, config_home):
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager)
+
+    name_i = _index_of(manager, make_name_column().model.col_name)
+    trail_i = _index_of(manager, make_trail_length_column().model.col_name)
+
+    assert widget.tree.isColumnHidden(name_i) is False
+    assert widget.tree.isColumnHidden(trail_i) is True  # hidden_by_default
+
+
+def test_widget_restores_persisted_visibility(qapp, config_home):
+    name_col = make_name_column().model.col_name
+    trail_col = make_trail_length_column().model.col_name
+    # Opposite of the defaults: hide Name, show the hidden-by-default Trail.
+    store.save_column_visibility({name_col: False, trail_col: True})
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager)
+
+    assert widget.tree.isColumnHidden(_index_of(manager, name_col)) is True
+    assert widget.tree.isColumnHidden(_index_of(manager, trail_col)) is False
+
+
+def test_toggle_persists_full_visibility_map(qapp, config_home):
+    name_col = make_name_column().model.col_name
+    trail_col = make_trail_length_column().model.col_name
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager)
+
+    # Reveal the hidden-by-default column, then persist as the menu does.
+    widget.tree.setColumnHidden(_index_of(manager, trail_col), False)
+    widget._persist_column_visibility()
+
+    saved = store.load_column_visibility()
+    assert saved == {name_col: True, trail_col: True}

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -9,6 +9,9 @@ from pyface.qt.QtGui import QKeySequence, QShortcut
 from pyface.qt.QtWidgets import QWidget, QVBoxLayout, QTreeView, QMenu, QAbstractItemView
 
 from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.services.column_visibility_store import (
+    load_column_visibility, save_column_visibility,
+)
 from pluggable_protocol_tree.views.delegate import ProtocolItemDelegate
 from pluggable_protocol_tree.views.qt_tree_model import MvcTreeModel
 
@@ -74,6 +77,15 @@ class ProtocolTreeWidget(QWidget):
         for i, col in enumerate(self._manager.columns):
             if getattr(col.view, "hidden_by_default", False):
                 self.tree.setColumnHidden(i, True)
+
+        # Restore the user's persisted column visibility, overriding the
+        # hidden_by_default defaults for any column they have toggled before.
+        # Columns absent from the saved map keep the default applied above.
+        saved_visibility = load_column_visibility()
+        for i, col in enumerate(self._manager.columns):
+            visible = saved_visibility.get(col.model.col_name)
+            if visible is not None:
+                self.tree.setColumnHidden(i, not visible)
 
         # PPT-3: header right-click menu to toggle column visibility
         header = self.tree.header()
@@ -174,7 +186,10 @@ class ProtocolTreeWidget(QWidget):
     def _on_header_context_menu(self, pos):
         """Header right-click → menu listing every column with a
         toggleable 'Show' checkmark. Affects only the QTreeView's
-        column visibility — does not touch the underlying row data."""
+        column visibility — does not touch the underlying row data.
+
+        Each toggle persists the full visibility map so the choice
+        survives an app restart (see column_visibility_store)."""
         menu = QMenu()
         for i, col in enumerate(self._manager.columns):
             action = menu.addAction(col.model.col_name)
@@ -183,9 +198,18 @@ class ProtocolTreeWidget(QWidget):
 
             def _toggle(checked, idx=i):
                 self.tree.setColumnHidden(idx, not checked)
+                self._persist_column_visibility()
 
             action.toggled.connect(_toggle)
         menu.exec(self.tree.header().viewport().mapToGlobal(pos))
+
+    def _persist_column_visibility(self):
+        """Save the current {col_name: visible} map for every column."""
+        visibility = {
+            col.model.col_name: not self.tree.isColumnHidden(i)
+            for i, col in enumerate(self._manager.columns)
+        }
+        save_column_visibility(visibility)
 
     def _add_step_at(self, idx):
         parent_path = self._parent_path_for_anchor(idx)


### PR DESCRIPTION
## Summary

Persist the protocol tree's **column visibility** across app restarts. The header right-click menu already toggles which columns are shown, but the choice was transient (Qt runtime state only) — reopening the app reset everything to defaults. Now the user's selection is saved and restored.

## Changes

- **New `pluggable_protocol_tree/services/column_visibility_store.py`** — a small JSON-backed store (`load_column_visibility` / `save_column_visibility`) writing `{col_name: visible}` to `protocol_tree_column_visibility.json` under `ETSConfig.application_home` (the per-user config dir the app already uses).
  - Keyed by `col_name` (stable identity), not column index, so choices survive column reordering/additions.
  - Best-effort and logged — a missing/unreadable/unwritable file degrades to "no saved preference" and never raises, so visibility can't crash the tree.
- **`views/tree_widget.py`** — on construction, apply `hidden_by_default` then overlay the saved map (explicit user choices win); columns with no saved entry keep their default. Every header-menu toggle saves the full map.
- **Tests** — store round-trip + graceful degradation on missing/malformed files, and widget restore-on-construction, default fallback, and persist-on-toggle.

## Design note

This uses a standalone JSON file rather than the Envisage `PreferencesHelper` / `preferences.ini` pattern, because the toggle lives in a plain `QWidget` that's also constructed in demos/tests without an Envisage app context — keeping it self-contained and working everywhere. The toggle is only ever set from the header menu, so not being in the Preferences dialog is not a functional loss.

Migrating this into `ProtocolPreferences` (alongside the other protocol prefs) is tracked as a parity requirement in #420.

## Testing

- New unit tests under `pluggable_protocol_tree/tests/test_column_visibility_persistence.py` (not run here — per repo workflow tests are run in the pixi env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
