### PR TITLE
feat(device-viewer): persist sidebar calibration data across restarts

### DIFF
--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -124,6 +124,23 @@ class DeviceViewMainModel(HasTraits):
             # Corrupt preference value -- fall back to the default (0).
             pass
 
+    def load_calibration_data_from_preferences(self):
+        """Restore the last measured calibration capacitances so the sidebar
+        starts at the previous session's values. Data-only, mirroring the
+        camera reference-rect persistence -- no preferences-pane view."""
+        for key, trait_name in (
+            ("calibration.liquid_capacitance_over_area", "liquid_capacitance_over_area"),
+            ("calibration.filler_capacitance_over_area", "filler_capacitance_over_area"),
+        ):
+            raw = self.preferences.preferences.get(key, "")
+            if not raw:
+                continue
+            try:
+                setattr(self.calibration, trait_name, float(raw))
+            except (TypeError, ValueError):
+                # Corrupt preference value -- keep the default (None).
+                pass
+
     # ------------------ Initialization --------------------
     def traits_init(self):
         """Initialize the model with default traits."""
@@ -313,6 +330,21 @@ class DeviceViewMainModel(HasTraits):
     def _device_perspective_changed(self, event=None):
         self.preferences.preferences.set(
             "device_view.rotation_deg", str(self.device_rotation_deg)
+        )
+
+    @observe("calibration:liquid_capacitance_over_area, calibration:filler_capacitance_over_area")
+    def _calibration_data_changed(self, event=None):
+        """Persist the calibration capacitances so they survive a restart
+        (loaded back via load_calibration_data_from_preferences)."""
+        liquid = self.calibration.liquid_capacitance_over_area
+        filler = self.calibration.filler_capacitance_over_area
+        self.preferences.preferences.set(
+            "calibration.liquid_capacitance_over_area",
+            "" if liquid is None else str(liquid),
+        )
+        self.preferences.preferences.set(
+            "calibration.filler_capacitance_over_area",
+            "" if filler is None else str(filler),
         )
 
     @observe("protocol_running")

--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -128,18 +128,19 @@ class DeviceViewMainModel(HasTraits):
         """Restore the last measured calibration capacitances so the sidebar
         starts at the previous session's values. Data-only, mirroring the
         camera reference-rect persistence -- no preferences-pane view."""
-        for key, trait_name in (
-            ("calibration.liquid_capacitance_over_area", "liquid_capacitance_over_area"),
-            ("calibration.filler_capacitance_over_area", "filler_capacitance_over_area"),
-        ):
-            raw = self.preferences.preferences.get(key, "")
-            if not raw:
-                continue
-            try:
-                setattr(self.calibration, trait_name, float(raw))
-            except (TypeError, ValueError):
-                # Corrupt preference value -- keep the default (None).
-                pass
+        l_cap_pref = str(self.preferences.preferences.get("calibration.liquid_capacitance_over_area"))
+        f_cap_pref = str(self.preferences.preferences.get("calibration.filler_capacitance_over_area"))
+
+        try:
+            self.calibration.liquid_capacitance_over_area = float(l_cap_pref)
+            self.calibration.filler_capacitance_over_area = float(f_cap_pref)
+
+            logger.info(f"Loaded calibration data from preferences:\n"
+                        f"filler cap = {self.calibration.filler_capacitance_over_area}pF / mm^2;\n"
+                        f"liquid cap = {self.calibration.liquid_capacitance_over_area}pF / mm^2")
+
+        except (TypeError, ValueError):
+            logger.warning(f"Failed to load calibration data from preferences: since values were not floats: liquid cap preference = {l_cap_pref}, filler capacitance preference = {f_cap_pref}")
 
     # ------------------ Initialization --------------------
     def traits_init(self):
@@ -336,16 +337,9 @@ class DeviceViewMainModel(HasTraits):
     def _calibration_data_changed(self, event=None):
         """Persist the calibration capacitances so they survive a restart
         (loaded back via load_calibration_data_from_preferences)."""
-        liquid = self.calibration.liquid_capacitance_over_area
-        filler = self.calibration.filler_capacitance_over_area
-        self.preferences.preferences.set(
-            "calibration.liquid_capacitance_over_area",
-            "" if liquid is None else str(liquid),
-        )
-        self.preferences.preferences.set(
-            "calibration.filler_capacitance_over_area",
-            "" if filler is None else str(filler),
-        )
+        self.preferences.preferences.set(f"calibration.{event.name}", str(event.new))
+
+        logger.info(f"Preferences: {event.name} changed to {event.new}")
 
     @observe("protocol_running")
     def _protocol_running_changed(self, event=None):

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -210,6 +210,9 @@ class DeviceViewerDockPane(TraitsDockPane):
         ############## load preferred / default device-view rotation ###################
         self.model.load_device_perspective_from_preferences()
 
+        ############## load last-session calibration data ##############################
+        self.model.load_calibration_data_from_preferences()
+
         ################################################################################################
         # ----------- Setup device view widget ----------------- #
         ################################################################################################


### PR DESCRIPTION
## Summary

Persist the device-viewer sidebar **calibration data** so that when the user closes and reopens the app, the calibration capacitances start at the values from the previous session — exactly like the camera perspective / reference rect already do.

## Changes

Mirrors the existing camera reference-rect persistence pattern in `DeviceViewMainModel`:

- **`models/main_model.py`**
  - `_calibration_data_changed` observer — writes `liquid_capacitance_over_area` and `filler_capacitance_over_area` into the preferences node (`calibration.*` keys) whenever they change.
  - `load_calibration_data_from_preferences()` — restores them on startup.
- **`views/device_view_dock_pane.py`** — calls `load_calibration_data_from_preferences()` during dock-pane setup, alongside the existing camera-perspective and device-rotation loads.

## Notes

- **Data-only, no preferences-pane view** — like the camera reference rect, these are stored as raw `calibration.*` preference keys (not declared `PreferencesHelper` traits) and do **not** appear in the Preferences dialog. Just model definition + load wiring, per request.
- **`last_capacitance` is intentionally not persisted** — it's a live, transient dropbot reading, not a calibration setting.
- Corrupt/empty stored values fall back to the default (`None`), matching the defensive handling on the rotation/camera loads.

## Testing

No automated test added — this matches the existing convention for the camera-perspective and device-rotation persistence methods, which are untested because they go through the global apptools preferences node. (Per repo workflow, tests are run in the pixi env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
