### PR TITLE
Mock dropbot status: independently collapsible sections

### DIFF
--- a/mock_dropbot_status/model.py
+++ b/mock_dropbot_status/model.py
@@ -46,5 +46,13 @@ class MockDropbotStatusModel(BaseStatusModel):
 
     actuated_channels_text = Str("None")
 
+    # Per-section expand/collapse toggles for the mock controls panel. Each
+    # drives a `visible_when` on its section's content group so the sections
+    # collapse independently (any combination can be open at once).
+    show_status = Bool(True, desc="Expand the Status section")
+    show_readings = Bool(True, desc="Expand the Readings section")
+    show_capacitance_sim = Bool(True, desc="Expand the Capacitance Simulation section")
+    show_event_sim = Bool(True, desc="Expand the Event Simulation section")
+
     def _update_chip_display(self, inserted: bool) -> None:
         self.chip_status_text = "Present" if inserted else "Absent"

--- a/mock_dropbot_status/view.py
+++ b/mock_dropbot_status/view.py
@@ -1,59 +1,91 @@
 from traitsui.api import View, Item, UItem, HGroup, VGroup, Group, Spring, EnumEditor
 from manual_controls.MVC import ToggleEditorFactory
 
-
+# Each section is an independently collapsible panel: a header checkbox
+# (the `show_*` model trait) toggles the `visible_when` on its content
+# group, so any combination of sections can be expanded at once.
 mock_controls = VGroup(
     VGroup(
-        Item("connection_status_text", style="readonly", label="Connection"),
-        Item("chip_status_text", style="readonly", label="Chip"),
-        Item("actuated_channels_text", style="readonly", label="Actuated"),
-        UItem(
-            "realtime_mode",
-            style="custom",
-            editor=ToggleEditorFactory(),
-            enabled_when="connected",
+        Item("show_status", label="Status"),
+        VGroup(
+            Item("connection_status_text", style="readonly", label="Connection"),
+            Item("chip_status_text", style="readonly", label="Chip"),
+            Item("actuated_channels_text", style="readonly", label="Actuated"),
+            UItem(
+                "realtime_mode",
+                style="custom",
+                editor=ToggleEditorFactory(),
+                enabled_when="connected",
+            ),
+            visible_when="show_status",
         ),
-        label="Status",
+        show_border=True,
+        springy=True,
+    ),
+    VGroup(
+        Item("show_readings", label="Readings"),
+        VGroup(
+            Item("capacitance_display", style="readonly", label="Capacitance"),
+            Item("voltage_display", style="readonly", label="Voltage"),
+            Item("frequency_display_text", style="readonly", label="Frequency"),
+            visible_when="show_readings",
+        ),
         show_border=True,
     ),
     VGroup(
-        Item("capacitance_display", style="readonly", label="Capacitance"),
-        Item("voltage_display", style="readonly", label="Voltage"),
-        Item("frequency_display_text", style="readonly", label="Frequency"),
-        label="Readings",
+        Item("show_capacitance_sim", label="Capacitance Simulation"),
+        VGroup(
+            Item("base_capacitance_pf", label="Base (pF)"),
+            Item("capacitance_delta_pf", label="Delta/electrode (pF)"),
+            Item("capacitance_noise_pf", label="Noise (pF)"),
+            Item("stream_interval_ms", label="Interval (ms)"),
+            Item("stream_active", style="readonly", label="Streaming"),
+            visible_when="show_capacitance_sim",
+        ),
         show_border=True,
+        springy=True,
+
     ),
     VGroup(
-        Item("base_capacitance_pf", label="Base (pF)"),
-        Item("capacitance_delta_pf", label="Delta/electrode (pF)"),
-        Item("capacitance_noise_pf", label="Noise (pF)"),
-        Item("stream_interval_ms", label="Interval (ms)"),
-        Item("stream_active", style="readonly", label="Streaming"),
-        label="Capacitance Simulation",
+        Item("show_event_sim", label="Event Simulation"),
+        VGroup(
+            HGroup(
+                UItem("simulate_connect_button"),
+                UItem("simulate_disconnect_button"),
+            ),
+            UItem("simulate_chip_toggle"),
+            HGroup(
+                Item("shorts_channels_text", label="Channels"),
+                UItem("simulate_shorts_button"),
+            ),
+            HGroup(
+                Item("halt_error_type", label="Error Type",
+                     editor=EnumEditor(values=["output-current-exceeded", "chip-load-saturated"])),
+                UItem("simulate_halt_button"),
+            ),
+            visible_when="show_event_sim",
+        ),
         show_border=True,
+        springy=True,
     ),
-    VGroup(
-        HGroup(
-            UItem("simulate_connect_button"),
-            UItem("simulate_disconnect_button"),
-        ),
-        UItem("simulate_chip_toggle"),
-        HGroup(
-            Item("shorts_channels_text", label="Channels"),
-            UItem("simulate_shorts_button"),
-        ),
-        HGroup(
-            Item("halt_error_type", label="Error Type",
-                 editor=EnumEditor(values=["output-current-exceeded", "chip-load-saturated"])),
-            UItem("simulate_halt_button"),
-        ),
-        label="Event Simulation",
-        show_border=True,
-    ),
+    springy=True,
+    scrollable=True,
 )
 
 MockDropbotView = View(
     mock_controls,
-    resizable=True,
-    width=350,
 )
+
+if __name__ == "__main__":
+    from mock_dropbot_status.model import MockDropbotStatusModel
+    from mock_dropbot_status.controller import MockDropbotDockPaneController
+
+    model = MockDropbotStatusModel()
+    view = MockDropbotView
+    controller = MockDropbotDockPaneController(model)
+    view.handler = controller
+
+    model.configure_traits(view=view)
+
+
+

--- a/template_status_and_controls/base_model.py
+++ b/template_status_and_controls/base_model.py
@@ -97,8 +97,11 @@ class BaseStatusModel(HasTraits):
         return self.DISCONNECTED_COLOR
 
     def traits_init(self):
-        # push initial app globals based on model values
-        self._realtime_mode_updated()
+        # push initial app globals based on model values if server is connected
+        try:
+            self._realtime_mode_updated()
+        except:
+            pass
 
     # ------------------------------------------------------------------ #
     # Observers


### PR DESCRIPTION
## Summary
Make each section of the **MockDropbot status panel** collapse independently — any combination of sections can be open at once (replacing the earlier single-open accordion behaviour).

## Changes
- **`mock_dropbot_status/model.py`** — add `show_status`, `show_readings`, `show_capacitance_sim`, `show_event_sim` `Bool` toggles (default expanded).
- **`mock_dropbot_status/view.py`** — each section is a bordered group with a checkbox header that drives a `visible_when` on its content group, so sections toggle independently; sections are `springy` + `scrollable` so the panel resizes cleanly.
- **`template_status_and_controls/base_model.py`** — guard the initial `_realtime_mode_updated()` push so the panel still builds when the message server (Redis) isn't connected.

## Notes
- The `base_model.py` guard currently uses a bare `except: pass`. Happy to narrow it to the specific connection exception if preferred, so unrelated errors aren't silently swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)