### PR TITLE
[PPT] Volume threshold: filler-inclusive math + stale-capacitance fix

### DIFF
--- a/volume_threshold_protocol_controls/demos/__init__.py
+++ b/volume_threshold_protocol_controls/demos/__init__.py
@@ -1,0 +1,8 @@
+"""Demos / manual test apps for the volume-threshold plugin.
+
+run_volume_threshold_test — a broker-free Qt app that runs a real
+ProtocolExecutor over a volume-threshold step and drives a scripted
+capacitance timeline to prove the stale-capacitance flush works (a phase
+must ignore high readings buffered from the previous phase and advance
+only on a genuine crossing).
+"""

--- a/volume_threshold_protocol_controls/demos/run_volume_threshold_test.py
+++ b/volume_threshold_protocol_controls/demos/run_volume_threshold_test.py
@@ -1,0 +1,265 @@
+"""Broker-free Qt app that proves the volume-threshold stale-capacitance fix.
+
+Runs a REAL ProtocolExecutor over a single 3-phase volume-threshold step,
+with no Redis / Dramatiq / hardware (see vt_test_harness). A scripted
+capacitance timeline drives each phase:
+
+  * At the phase boundary the fake hardware seeds a STALE high-capacitance
+    backlog (readings "left over" from the previous phase) into the mailbox
+    *before* the VT handler starts monitoring.
+  * The handler must FLUSH those stale readings (the fix) and then HOLD —
+    not advance — until a genuine crossing arrives.
+  * A fresh "below target" stream holds the phase; at +1.5 s a genuine
+    crossing reading arrives and the phase advances.
+
+If the fix works, every phase holds ~1.5 s and advances on the crossing.
+Without it, a phase would advance almost immediately on the stale backlog.
+The verdict (phase hold durations) drives a PASS/FAIL banner.
+
+Run::
+
+    pixi run python -m volume_threshold_protocol_controls.demos.run_volume_threshold_test
+"""
+
+import sys
+import time
+
+from PySide6.QtCore import QObject, QTimer, Signal
+from PySide6.QtWidgets import QApplication
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.electrodes_column import (
+    make_electrodes_column,
+)
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.routes_column import make_routes_column
+from pluggable_protocol_tree.builtins.trail_length_column import (
+    make_trail_length_column,
+)
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.execution.executor import ProtocolExecutor
+from pluggable_protocol_tree.models.row_manager import RowManager
+from volume_threshold_protocol_controls.protocol_columns.volume_threshold_column import (
+    make_volume_threshold_column,
+)
+
+from . import vt_test_harness as H
+from .vt_test_panel import VTTestPanel
+
+
+# --- scenario knobs -------------------------------------------------------
+VT_PERCENT = 80              # coverage threshold for the step
+DWELL_S = 3.0                # per-phase dwell (the miss deadline)
+CROSS_DELAY_S = 1.5          # when the genuine crossing arrives in a phase
+LOW_PF = 12.0                # fresh "below target" reading
+CROSS_PF = 33.0              # fresh "crossing" reading (>= target)
+STALE_PF = 99.0              # stale leftover reading seeded at each boundary
+STALE_BURST = 4              # how many stale readings to seed per boundary
+INJECT_INTERVAL_MS = 50      # capacitance stream cadence
+
+# Verdict window: a phase should HOLD well past the stale spike (>= MIN_HOLD)
+# and advance on the crossing BEFORE the dwell/dialog (< MAX_HOLD).
+MIN_HOLD_S = 1.0
+MAX_HOLD_S = 2.9
+
+
+class _Sim:
+    """Shared current simulated capacitance (pF). Attribute read/write is
+    atomic under the GIL, so the worker thread (pre_actuate) and the GUI
+    thread (injector) can touch it without a lock."""
+    def __init__(self, value):
+        self.value = float(value)
+
+
+class _Bridge(QObject):
+    """Marshals worker-thread harness callbacks onto the GUI thread."""
+    drained = Signal(int)            # stale readings flushed at a phase start
+    seeded = Signal(int)             # stale readings seeded before a phase
+    reached = Signal(float)          # monotonic time VT's monitor hit the target
+
+
+def _build_protocol() -> RowManager:
+    rm = RowManager(columns=[
+        make_type_column(), make_id_column(), make_name_column(),
+        make_duration_column(), make_electrodes_column(),
+        make_routes_column(), make_trail_length_column(),
+        make_volume_threshold_column(),
+    ])
+    rm.protocol_metadata["electrode_to_channel"] = dict(H.ELECTRODE_TO_CHANNEL)
+    rm.add_step(values={
+        "name": "VT stale-cap test",
+        "duration_s": DWELL_S,
+        "routes": [["e00", "e01", "e02"]],   # 3 single-electrode phases
+        "trail_length": 1,
+        "volume_threshold": VT_PERCENT,
+    })
+    return rm
+
+
+def main() -> int:
+    # --selftest: run the same flow headless (use QT_QPA_PLATFORM=offscreen),
+    # auto-quit on the verdict, and exit 0 (PASS) / 1 (FAIL). Lets the demo
+    # double as a smoke check without anyone watching the window.
+    selftest = "--selftest" in sys.argv
+
+    app = QApplication(sys.argv)
+    panel = VTTestPanel()
+    sim = _Sim(LOW_PF)
+    bridge = _Bridge()
+    target = H.target_pf(VT_PERCENT)
+    result = {"ok": None}
+    _t0 = time.monotonic()
+
+    def L(msg):
+        panel.log(f"[{time.monotonic() - _t0:6.2f}s] {msg}")
+
+    # --- harness callbacks (run on the executor's worker thread) ----------
+    def pre_actuate(channels):
+        """Seed the stale backlog for the phase that's about to start, then
+        drop the stream to 'below target'. Runs before the actuation reaches
+        the VT handler, so these readings are guaranteed stale."""
+        for _ in range(STALE_BURST):
+            H.inject(STALE_PF)
+        sim.value = LOW_PF
+        bridge.seeded.emit(STALE_BURST)
+
+    def on_drained(count):
+        bridge.drained.emit(count)
+
+    harness = H.Harness(on_drained=on_drained, pre_actuate=pre_actuate)
+    harness.setup()
+
+    # Hook the handler's monitor so we learn the EXACT moment a phase reaches
+    # its target (sets phase_advance). This is the true "advance" time — more
+    # accurate than step_finished, which on the terminal phase lags ~2s while
+    # the handler's outer loop does a final wait_for(ELECTRODES_STATE_CHANGE).
+    import volume_threshold_protocol_controls.protocol_columns.volume_threshold_column as _vtmod
+    _orig_monitor = _vtmod.VolumeThresholdHandler._monitor_until_threshold
+
+    def _monitor_logged(ctx, target_cap, deadline):
+        status, last = _orig_monitor(ctx, target_cap, deadline)
+        if status == "reached":
+            bridge.reached.emit(time.monotonic())
+        return status, last
+    _vtmod.VolumeThresholdHandler._monitor_until_threshold = staticmethod(
+        _monitor_logged)
+
+    # --no-flush: simulate the PRE-FIX behavior (don't drop stale readings) to
+    # show the bug reproduce — phases then advance on the buffered spike.
+    if "--no-flush" in sys.argv:
+        _vtmod._drain_stale = lambda ctx, topic: None
+        L("--no-flush: stale-capacitance flush DISABLED (expect FAIL)")
+
+    # --- per-phase timing + verdict state ---------------------------------
+    # phase_starts[i] / reach_times[i] pair by index: phase i+1's start and
+    # the time its monitor crossed the target. Latency = reach - start.
+    phase_starts: list = []
+    reach_times: list = []
+    total_phases = {"n": 0}
+
+    def on_phase_started(idx, total, dwell):
+        phase_starts.append(time.monotonic())
+        total_phases["n"] = total
+        panel.set_phase(idx, total, target)
+        L(f"phase {idx}/{total} started (dwell {dwell:.1f}s, "
+          f"target {target:.2f} pF)")
+
+        def _cross():
+            sim.value = CROSS_PF
+            L(f"   injected genuine crossing {CROSS_PF:.0f} pF "
+              f"(>= target {target:.1f})")
+        QTimer.singleShot(int(CROSS_DELAY_S * 1000), _cross)
+
+    def on_reached(t):
+        idx = len(reach_times)               # 0-based phase this belongs to
+        reach_times.append(t)
+        latency = t - phase_starts[idx] if idx < len(phase_starts) else float("nan")
+        L(f"   -> phase {idx + 1} reached target after {latency:.2f}s")
+
+    def _finish(text_prefix=""):
+        injector.stop()
+        n = min(len(reach_times), len(phase_starts))
+        latencies = [reach_times[i] - phase_starts[i] for i in range(n)]
+        expected = total_phases["n"] or len(phase_starts)
+        missed = expected - len(reach_times)
+        fast = [i + 1 for i, d in enumerate(latencies) if d < MIN_HOLD_S]
+        slow = [i + 1 for i, d in enumerate(latencies) if d > MAX_HOLD_S]
+        ok = expected > 0 and missed == 0 and not fast and not slow
+        if ok:
+            text = (f"all {expected} phases ignored the stale spike and "
+                    f"advanced on the real crossing")
+        elif fast:
+            detail = ", ".join(f"{latencies[i - 1]:.2f}s" for i in fast)
+            text = f"phase(s) {fast} advanced on a STALE reading ({detail})"
+        elif missed:
+            text = f"{missed} phase(s) never reached the target (timed out)"
+        else:
+            text = f"phase(s) {slow} advanced suspiciously late"
+        panel.set_verdict(ok, text_prefix + text)
+        L(f"VERDICT: {'PASS' if ok else 'FAIL'} — latencies="
+          f"{[round(d, 2) for d in latencies]}")
+        harness.teardown()
+        result["ok"] = ok
+        if selftest:
+            print("---- event log ----")
+            print(panel.log_text())
+            print("-------------------")
+            print(f"SELFTEST {'PASS' if ok else 'FAIL'}: {text} "
+                  f"(latencies={[round(d, 2) for d in latencies]})")
+            QTimer.singleShot(50, app.quit)
+
+    def on_protocol_error(msg):
+        injector.stop()
+        L(f"ERROR: {msg}")
+        panel.set_verdict(False, f"executor error: {msg}")
+        harness.teardown()
+
+    # --- capacitance stream (GUI thread) ----------------------------------
+    injector = QTimer()
+    injector.setInterval(INJECT_INTERVAL_MS)
+
+    last_injected = {"pf": None}
+
+    def _tick():
+        pf = sim.value
+        H.inject(pf)
+        panel.set_reading(pf, holding=(pf < target))
+        if pf != last_injected["pf"]:
+            L(f"   stream -> {pf:.0f} pF")
+            last_injected["pf"] = pf
+    injector.timeout.connect(_tick)
+
+    # --- wire signals -----------------------------------------------------
+    ex = ProtocolExecutor(row_manager=_build_protocol())
+    ex.qsignals.phase_started.connect(on_phase_started)
+    ex.qsignals.protocol_finished.connect(lambda: _finish())
+    ex.qsignals.protocol_aborted.connect(lambda: _finish("aborted — "))
+    ex.qsignals.protocol_error.connect(on_protocol_error)
+    bridge.reached.connect(on_reached)
+    bridge.seeded.connect(
+        lambda n: L(f"   (seeded {n} stale {STALE_PF:.0f} pF readings "
+                    f"before phase)"))
+    bridge.drained.connect(
+        lambda n: L(f"   FLUSHED {n} stale reading(s) at phase start"))
+
+    panel.log(f"target for {VT_PERCENT}% coverage of one "
+              f"{H.ELECTRODE_AREA_MM2} mm^2 electrode = {target:.2f} pF")
+    panel.log(f"(liquid {H.LIQUID_PF_PER_MM2}  filler {H.FILLER_PF_PER_MM2} "
+              f"-> full {H.full_cap_over_area():.1f} pF/mm^2)\n")
+    panel.show()
+
+    if selftest:
+        # Watchdog so a hang can't block CI forever.
+        QTimer.singleShot(30_000, app.quit)
+
+    injector.start()
+    QTimer.singleShot(300, lambda: ex.start(preview_mode=False))
+    app.exec()
+    if selftest:
+        return 0 if result["ok"] else 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/volume_threshold_protocol_controls/demos/run_volume_threshold_test.py
+++ b/volume_threshold_protocol_controls/demos/run_volume_threshold_test.py
@@ -19,6 +19,9 @@ The verdict (phase hold durations) drives a PASS/FAIL banner.
 Run::
 
     pixi run python -m volume_threshold_protocol_controls.demos.run_volume_threshold_test
+    ... --selftest      # headless (QT_QPA_PLATFORM=offscreen); exit 0 = PASS
+    ... --no-flush      # simulate the pre-fix bug (stale readings advance)
+    ... --pause-test    # pause mid-phase; verify the column stays inert
 """
 
 import sys
@@ -63,6 +66,15 @@ INJECT_INTERVAL_MS = 50      # capacitance stream cadence
 MIN_HOLD_S = 1.0
 MAX_HOLD_S = 2.9
 
+# --pause-test scenario: pause mid-phase, simulate the operator "manually
+# moving around" by streaming an above-target reading, hold paused PAST the
+# dwell (so a non-pause-aware column would time out and pop the dialog), then
+# resume and cross. A pause-aware column must advance only after resume.
+PAUSE_AT_S = 0.3
+RESUME_AT_S = 4.0          # > DWELL_S, so a non-pause-aware run would time out
+PAUSE_CROSS_S = 4.3
+MANUAL_HIGH_PF = 99.0      # "manual move" reading injected during the pause
+
 
 class _Sim:
     """Shared current simulated capacitance (pF). Attribute read/write is
@@ -102,6 +114,9 @@ def main() -> int:
     # auto-quit on the verdict, and exit 0 (PASS) / 1 (FAIL). Lets the demo
     # double as a smoke check without anyone watching the window.
     selftest = "--selftest" in sys.argv
+    # --pause-test: pause mid-phase and verify the column stays inert (no
+    # advance on the manual reading, no recovery dialog) until resumed.
+    pause_test = "--pause-test" in sys.argv
 
     app = QApplication(sys.argv)
     panel = VTTestPanel()
@@ -151,12 +166,32 @@ def main() -> int:
         _vtmod._drain_stale = lambda ctx, topic: None
         L("--no-flush: stale-capacitance flush DISABLED (expect FAIL)")
 
+    # Spy on the recovery dialog: it must NEVER open during a pause. The spy
+    # records the fact and returns "proceed" so a headless run can't block on a
+    # real modal dialog.
+    dialog_fired = {"v": False}
+    _orig_dialog = _vtmod.show_volume_threshold_recovery_dialog
+
+    def _dialog_spy(*args, **kwargs):
+        dialog_fired["v"] = True
+        L("   !!! recovery dialog opened (unexpected during a pause)")
+        return {"action": "proceed"}
+    _vtmod.show_volume_threshold_recovery_dialog = _dialog_spy
+
     # --- per-phase timing + verdict state ---------------------------------
     # phase_starts[i] / reach_times[i] pair by index: phase i+1's start and
     # the time its monitor crossed the target. Latency = reach - start.
     phase_starts: list = []
     reach_times: list = []
+    resume_times: list = []          # pause-test: when each phase was resumed
     total_phases = {"n": 0}
+
+    def _schedule_cross(delay_s):
+        def _cross():
+            sim.value = CROSS_PF
+            L(f"   injected genuine crossing {CROSS_PF:.0f} pF "
+              f"(>= target {target:.1f})")
+        QTimer.singleShot(int(delay_s * 1000), _cross)
 
     def on_phase_started(idx, total, dwell):
         phase_starts.append(time.monotonic())
@@ -165,11 +200,27 @@ def main() -> int:
         L(f"phase {idx}/{total} started (dwell {dwell:.1f}s, "
           f"target {target:.2f} pF)")
 
-        def _cross():
-            sim.value = CROSS_PF
-            L(f"   injected genuine crossing {CROSS_PF:.0f} pF "
-              f"(>= target {target:.1f})")
-        QTimer.singleShot(int(CROSS_DELAY_S * 1000), _cross)
+        if not pause_test:
+            _schedule_cross(CROSS_DELAY_S)
+            return
+
+        # Pause scenario: pause mid-phase, "manually" stream an above-target
+        # reading, hold paused past the dwell, then resume and cross.
+        def _pause():
+            sim.value = MANUAL_HIGH_PF
+            ex.pause()
+            L(f"   PAUSED — operator 'manually' streaming {MANUAL_HIGH_PF:.0f} "
+              f"pF (>= target; must NOT advance or open the dialog)")
+
+        def _resume():
+            ex.resume()
+            sim.value = LOW_PF
+            resume_times.append(time.monotonic())
+            L("   RESUMED — back to a below-target stream")
+
+        QTimer.singleShot(int(PAUSE_AT_S * 1000), _pause)
+        QTimer.singleShot(int(RESUME_AT_S * 1000), _resume)
+        _schedule_cross(PAUSE_CROSS_S)
 
     def on_reached(t):
         idx = len(reach_times)               # 0-based phase this belongs to
@@ -179,26 +230,52 @@ def main() -> int:
 
     def _finish(text_prefix=""):
         injector.stop()
-        n = min(len(reach_times), len(phase_starts))
-        latencies = [reach_times[i] - phase_starts[i] for i in range(n)]
         expected = total_phases["n"] or len(phase_starts)
         missed = expected - len(reach_times)
-        fast = [i + 1 for i, d in enumerate(latencies) if d < MIN_HOLD_S]
-        slow = [i + 1 for i, d in enumerate(latencies) if d > MAX_HOLD_S]
-        ok = expected > 0 and missed == 0 and not fast and not slow
-        if ok:
-            text = (f"all {expected} phases ignored the stale spike and "
-                    f"advanced on the real crossing")
-        elif fast:
-            detail = ", ".join(f"{latencies[i - 1]:.2f}s" for i in fast)
-            text = f"phase(s) {fast} advanced on a STALE reading ({detail})"
-        elif missed:
-            text = f"{missed} phase(s) never reached the target (timed out)"
+        detail_nums: list = []
+
+        if pause_test:
+            # Pass requires: every phase reached the target only AFTER it was
+            # resumed (so it ignored the manual reading during the pause), and
+            # the recovery dialog never opened.
+            n = min(len(reach_times), len(resume_times))
+            during_pause = [i + 1 for i in range(n)
+                            if reach_times[i] < resume_times[i] - 0.1]
+            ok = (expected > 0 and missed == 0
+                  and not during_pause and not dialog_fired["v"])
+            if ok:
+                text = (f"all {expected} phases stayed inert while paused — no "
+                        f"advance on the manual reading, no recovery dialog")
+            elif dialog_fired["v"]:
+                text = "the recovery dialog opened during a pause"
+            elif during_pause:
+                text = f"phase(s) {during_pause} advanced WHILE paused"
+            else:
+                text = f"{missed} phase(s) never reached the target"
+            detail_nums = [round(reach_times[i] - resume_times[i], 2)
+                           for i in range(n)]
+            metric = "reach-after-resume(s)"
         else:
-            text = f"phase(s) {slow} advanced suspiciously late"
+            n = min(len(reach_times), len(phase_starts))
+            latencies = [reach_times[i] - phase_starts[i] for i in range(n)]
+            fast = [i + 1 for i, d in enumerate(latencies) if d < MIN_HOLD_S]
+            slow = [i + 1 for i, d in enumerate(latencies) if d > MAX_HOLD_S]
+            ok = expected > 0 and missed == 0 and not fast and not slow
+            if ok:
+                text = (f"all {expected} phases ignored the stale spike and "
+                        f"advanced on the real crossing")
+            elif fast:
+                d = ", ".join(f"{latencies[i - 1]:.2f}s" for i in fast)
+                text = f"phase(s) {fast} advanced on a STALE reading ({d})"
+            elif missed:
+                text = f"{missed} phase(s) never reached the target (timed out)"
+            else:
+                text = f"phase(s) {slow} advanced suspiciously late"
+            detail_nums = [round(d, 2) for d in latencies]
+            metric = "latencies(s)"
+
         panel.set_verdict(ok, text_prefix + text)
-        L(f"VERDICT: {'PASS' if ok else 'FAIL'} — latencies="
-          f"{[round(d, 2) for d in latencies]}")
+        L(f"VERDICT: {'PASS' if ok else 'FAIL'} — {metric}={detail_nums}")
         harness.teardown()
         result["ok"] = ok
         if selftest:
@@ -206,7 +283,7 @@ def main() -> int:
             print(panel.log_text())
             print("-------------------")
             print(f"SELFTEST {'PASS' if ok else 'FAIL'}: {text} "
-                  f"(latencies={[round(d, 2) for d in latencies]})")
+                  f"({metric}={detail_nums})")
             QTimer.singleShot(50, app.quit)
 
     def on_protocol_error(msg):

--- a/volume_threshold_protocol_controls/demos/vt_test_harness.py
+++ b/volume_threshold_protocol_controls/demos/vt_test_harness.py
@@ -1,0 +1,153 @@
+"""Broker-free wiring for the volume-threshold test app.
+
+Stands in for everything the volume-threshold handler normally needs from
+the rest of the system, WITHOUT Redis / Dramatiq / hardware:
+
+  * Seeds calibration + channel areas into the two module-level
+    ``app_globals`` the handler reads (the VT column's own, and
+    force_math's — ``current_full_electrode_capacitance_per_unit_area``
+    reads the latter).
+  * Replaces RoutesHandler's electrode-actuation publish with an
+    in-process stand-in that feeds ELECTRODES_STATE_CHANGE to the VT
+    handler's mailbox and immediately acks ELECTRODES_STATE_APPLIED —
+    using ``listener.route_to_active_step``, the documented direct entry
+    point into the running step's mailbox.
+  * Exposes ``inject(pF)`` to push a CAPACITANCE_UPDATED reading the same
+    way, and wraps the handler's ``_drain_stale`` so the app can show how
+    many stale readings each phase boundary dropped.
+
+All monkeypatching is reverted by ``teardown()``.
+"""
+
+import json
+
+import dropbot_protocol_controls.services.force_math as force_math_mod
+import pluggable_protocol_tree.builtins.routes_column as routes_mod
+import volume_threshold_protocol_controls.protocol_columns.volume_threshold_column as vt_mod
+
+from device_viewer.consts import (
+    CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY, LIQUID_CAPACITANCE_KEY,
+)
+from dropbot_controller.consts import CAPACITANCE_UPDATED
+from electrode_controller.consts import ELECTRODES_STATE_CHANGE
+from pluggable_protocol_tree.consts import ELECTRODES_STATE_APPLIED
+from pluggable_protocol_tree.execution.listener import route_to_active_step
+
+
+# --- the simulated device's calibration ----------------------------------
+# liquid - filler = full (liquid-covered) cap/area = 6.4 pF/mm^2.
+LIQUID_PF_PER_MM2 = 7.5
+FILLER_PF_PER_MM2 = 1.1
+ELECTRODE_AREA_MM2 = 4.35
+# Three single-electrode phases (channels 0,1,2), each 4.35 mm^2.
+CHANNEL_AREAS = {"0": ELECTRODE_AREA_MM2, "1": ELECTRODE_AREA_MM2,
+                 "2": ELECTRODE_AREA_MM2}
+ELECTRODE_TO_CHANNEL = {"e00": 0, "e01": 1, "e02": 2}
+
+
+def full_cap_over_area() -> float:
+    """The full (liquid-covered) cap/area the handler will compute."""
+    return LIQUID_PF_PER_MM2 - FILLER_PF_PER_MM2
+
+
+def target_pf(percent: float, actuated_area: float = ELECTRODE_AREA_MM2) -> float:
+    """The per-phase threshold capacitance for ``percent`` coverage of one
+    electrode — same formula as VolumeThresholdHandler._threshold_cap."""
+    return ((percent / 100.0) * full_cap_over_area()
+            + FILLER_PF_PER_MM2) * actuated_area
+
+
+class _FakeElectrodePublisher:
+    """Stands in for electrode_state_change_publisher: feeds the actuation
+    to the VT handler's mailbox and synchronously acks it, so RoutesHandler's
+    ``wait_for(ELECTRODES_STATE_APPLIED)`` returns at once (no hardware).
+
+    ``pre_actuate`` (optional) runs FIRST, on this (RoutesHandler's worker)
+    thread, before the actuation is delivered. The runner uses it to seed a
+    stale-capacitance backlog: anything it injects is guaranteed to be in the
+    mailbox before the VT handler wakes on ELECTRODES_STATE_CHANGE and flushes
+    — a deterministic happens-before, no thread race.
+    """
+
+    def __init__(self, pre_actuate=None):
+        self._pre_actuate = pre_actuate
+
+    def publish(self, actuated_channels, *args, **kwargs):
+        if self._pre_actuate is not None:
+            self._pre_actuate(sorted(actuated_channels))
+        payload = json.dumps({"channels": sorted(actuated_channels)})
+        route_to_active_step(ELECTRODES_STATE_CHANGE, payload)
+        route_to_active_step(ELECTRODES_STATE_APPLIED, "ok")
+
+
+def inject(pf: float) -> None:
+    """Push one CAPACITANCE_UPDATED reading (pF) into the running step's
+    mailbox, exactly as the dropbot stream would."""
+    route_to_active_step(
+        CAPACITANCE_UPDATED, json.dumps({"capacitance": f"{pf} pF"}))
+
+
+class Harness:
+    """Owns the monkeypatches + calibration so the runner can set up once
+    and ``teardown()`` cleanly."""
+
+    def __init__(self, on_drained=None, pre_actuate=None):
+        # on_drained(count:int): called (on the executor's worker thread)
+        # each time a phase boundary drains stale capacitance readings.
+        # pre_actuate(channels): runs on the worker thread just before each
+        # actuation is delivered — used to seed the stale backlog.
+        self._on_drained = on_drained
+        self._pre_actuate = pre_actuate
+        self._saved = {}
+        self.calibration = {
+            LIQUID_CAPACITANCE_KEY: LIQUID_PF_PER_MM2,
+            FILLER_CAPACITANCE_KEY: FILLER_PF_PER_MM2,
+            CHANNEL_AREAS_KEY: dict(CHANNEL_AREAS),
+        }
+
+    def setup(self):
+        # 1. Seed calibration into both readers (same dict).
+        self._saved["force_globals"] = force_math_mod.app_globals
+        self._saved["vt_globals"] = vt_mod.app_globals
+        force_math_mod.app_globals = self.calibration
+        vt_mod.app_globals = self.calibration
+
+        # 2. Stub the hardware-facing publishes in RoutesHandler.
+        self._saved["publish_message"] = routes_mod.publish_message
+        self._saved["electrode_pub"] = routes_mod.electrode_state_change_publisher
+        routes_mod.publish_message = lambda **kwargs: None  # display: no-op
+        routes_mod.electrode_state_change_publisher = _FakeElectrodePublisher(
+            pre_actuate=self._pre_actuate)
+
+        # 3. Wrap the real _drain_stale so we can report how many stale
+        #    readings each phase dropped — while still exercising the fix.
+        self._saved["drain"] = vt_mod._drain_stale
+        real_drain = vt_mod._drain_stale
+
+        def _instrumented_drain(ctx, topic):
+            dropped = _mailbox_size(ctx, topic)
+            real_drain(ctx, topic)          # the actual fix under test
+            if dropped and self._on_drained is not None:
+                self._on_drained(dropped)
+        vt_mod._drain_stale = _instrumented_drain
+
+    def teardown(self):
+        force_math_mod.app_globals = self._saved.get("force_globals",
+                                                      force_math_mod.app_globals)
+        vt_mod.app_globals = self._saved.get("vt_globals", vt_mod.app_globals)
+        if "publish_message" in self._saved:
+            routes_mod.publish_message = self._saved["publish_message"]
+        if "electrode_pub" in self._saved:
+            routes_mod.electrode_state_change_publisher = self._saved["electrode_pub"]
+        if "drain" in self._saved:
+            vt_mod._drain_stale = self._saved["drain"]
+        self._saved.clear()
+
+
+def _mailbox_size(ctx, topic) -> int:
+    """Best-effort count of queued messages for ``topic`` (for the drained
+    readout only). Reaches into the mailbox internals — fine for a harness."""
+    try:
+        return ctx._mailboxes[topic]._queue.qsize()
+    except Exception:                                   # pragma: no cover
+        return 0

--- a/volume_threshold_protocol_controls/demos/vt_test_panel.py
+++ b/volume_threshold_protocol_controls/demos/vt_test_panel.py
@@ -1,0 +1,74 @@
+"""Lightweight Qt view for the volume-threshold test app.
+
+Pure display: the runner pushes state in via these slots (all called on the
+GUI thread). Shows the current phase, this phase's target vs the latest
+injected capacitance, a HOLD/ADVANCE status, a running event log, and a
+big PASS/FAIL banner once the run finishes.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QLabel, QPlainTextEdit, QVBoxLayout, QWidget,
+)
+
+
+class VTTestPanel(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Volume Threshold — stale-capacitance test")
+        self.resize(560, 460)
+
+        layout = QVBoxLayout(self)
+
+        title = QLabel("Volume Threshold stale-capacitance test")
+        title.setStyleSheet("font-size: 15px; font-weight: bold;")
+        layout.addWidget(title)
+
+        self._phase = QLabel("Phase –/–   target – pF")
+        self._phase.setStyleSheet("font-family: monospace; font-size: 13px;")
+        layout.addWidget(self._phase)
+
+        self._reading = QLabel("current – pF    status: –")
+        self._reading.setStyleSheet("font-family: monospace; font-size: 13px;")
+        layout.addWidget(self._reading)
+
+        self._log = QPlainTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setStyleSheet("font-family: monospace; font-size: 12px;")
+        layout.addWidget(self._log, stretch=1)
+
+        self._banner = QLabel("running…")
+        self._banner.setAlignment(Qt.AlignCenter)
+        self._banner.setStyleSheet(
+            "font-size: 16px; font-weight: bold; padding: 10px; "
+            "background: #444; color: white; border-radius: 4px;")
+        layout.addWidget(self._banner)
+
+        self._target = 0.0
+
+    # --- slots (GUI thread) ---------------------------------------------
+
+    def set_phase(self, idx: int, total: int, target_pf: float) -> None:
+        self._target = target_pf
+        self._phase.setText(
+            f"Phase {idx}/{total}   target {target_pf:.2f} pF")
+
+    def set_reading(self, pf: float, holding: bool) -> None:
+        status = "HOLD" if holding else "ADVANCE"
+        rel = "below" if pf < self._target else "≥ target"
+        self._reading.setText(
+            f"current {pf:6.2f} pF  ({rel})    status: {status}")
+
+    def log(self, message: str) -> None:
+        self._log.appendPlainText(message)
+
+    def log_text(self) -> str:
+        return self._log.toPlainText()
+
+    def set_verdict(self, passed: bool, text: str) -> None:
+        color = "#1a7f37" if passed else "#b3261e"
+        label = "PASS" if passed else "FAIL"
+        self._banner.setText(f"STALE-CAP FIX: {label} — {text}")
+        self._banner.setStyleSheet(
+            f"font-size: 16px; font-weight: bold; padding: 10px; "
+            f"background: {color}; color: white; border-radius: 4px;")

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -251,6 +251,10 @@ class VolumeThresholdHandler(BaseColumnHandler):
                 )
             except TimeoutError:
                 continue
+            # A pause that landed while we were blocked in wait_for: ignore
+            # this actuation and loop back so the pause branch handles it.
+            if pause_event is not None and pause_event.is_set():
+                continue
             try:
                 channels = _json.loads(payload).get("channels") or []
             except (TypeError, ValueError):
@@ -439,6 +443,10 @@ class VolumeThresholdHandler(BaseColumnHandler):
                     timeout=min(CAP_POLL_TIMEOUT_S, remaining),
                 )
             except TimeoutError:
+                continue
+            # A pause that landed while we were blocked in wait_for: drop this
+            # reading (don't advance on it) and loop back to the pause branch.
+            if pause_event is not None and pause_event.is_set():
                 continue
             current = _parse_capacitance_pf(cap_payload)
             if current is None:

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -180,7 +180,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
     If the target is NOT reached within the phase's duration, the handler
     opens a recovery dialog via ``ctx.prompt_gui`` (which pauses the run):
     the operator can extend the time + lower the coverage and retry,
-    proceed anyway, or stop the run.
+    proceed anyway, or pause the run.
     """
 
     priority = 30
@@ -308,7 +308,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
                    actuated_area, phase_duration_s):
         """
         Monitor one phase to its deadline; on a miss, open the recovery
-        dialog and apply the operator's choice (retry / proceed / stop).
+        dialog and apply the operator's choice (retry / proceed / pause).
         Returns the (possibly updated) coverage percent to carry forward.
         """
         # calculate threshold capacitance
@@ -343,7 +343,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
             # Phase duration elapsed without reaching target -> ask the
             # operator. ctx.prompt_gui pauses the run, marshals the dialog
             # onto the GUI thread, and blocks here until they answer (or
-            # Stop / external Resume) — no message passing, no actors.
+            # external Resume) — no message passing, no actors.
             def _ask():
                 d = show_volume_threshold_recovery_dialog(
                     int(percent), last_cap, threshold_cap,
@@ -366,8 +366,11 @@ class VolumeThresholdHandler(BaseColumnHandler):
             decision = ctx.prompt_gui(_ask) or {"action": "proceed"}
             action = decision.get("action", "proceed")
 
-            if action == "stop":
-                ctx.protocol.stop_event.set()
+            if action == "pause":
+                # Re-pause after prompt_gui's auto-resume, so the run freezes
+                # (RoutesHandler blocks on pause_event while still holding this
+                # phase) until the operator resumes from the toolbar.
+                ctx.protocol.pause()
                 return percent
             if action == "proceed":
                 ctx.phase_advance_event.set()

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -119,6 +119,25 @@ def _parse_capacitance_pf(raw):
         return None
 
 
+def _drain_stale(ctx, topic):
+    """Discard every message already queued on ``topic`` so the caller only
+    observes readings that arrive afterwards.
+
+    ``CAPACITANCE_UPDATED`` is a continuous stream the DropBot publishes into
+    a per-step mailbox that is never cleared between phases. Without this
+    drain, a phase would be evaluated against capacitance measured during the
+    PREVIOUS phase (before this phase's electrodes were actuated and the
+    droplet settled): an end-of-previous-phase HIGH reading would satisfy the
+    threshold instantly and advance the phase before any liquid arrived. The
+    mailbox is FIFO and returns the oldest item first, so we pop until empty.
+    """
+    while True:
+        try:
+            ctx.wait_for(topic, timeout=0.0)
+        except TimeoutError:
+            return
+
+
 class VolumeThresholdColumnModel(BaseColumnModel):
     """Per-step volume threshold as a PERCENTAGE (0-100; 0 disables).
 
@@ -249,7 +268,38 @@ class VolumeThresholdHandler(BaseColumnHandler):
                        actuated_area):
         """Target capacitance (pF) the actuated electrodes must reach:
         ``((percent/100) * full_cap_over_area + filler_cap_over_area) * actuated_area``
-        (see the module docstring's MATH EXPLAINED block)."""
+        (see the module docstring's MATH EXPLAINED block).
+
+        ``full_cap_over_area`` is the full-electrode (liquid-covered) value,
+        i.e. ``liquid_capacitance_over_area - filler_capacitance_over_area``.
+
+        With liquid=7.5, filler=1.1 (so full=6.4) pF/mm^2 and a 4.35 mm^2
+        electrode, 100% coverage targets the full liquid-covered capacitance
+        (== liquid * area == 7.5 * 4.35):
+
+        >>> round(VolumeThresholdHandler._threshold_cap(100, 6.4, 1.1, 4.35), 3)
+        32.625
+
+        0% coverage falls back to just the filler baseline (1.1 * 4.35):
+
+        >>> round(VolumeThresholdHandler._threshold_cap(0, 6.4, 1.1, 4.35), 3)
+        4.785
+
+        50% coverage sits halfway up the full range above the baseline:
+
+        >>> round(VolumeThresholdHandler._threshold_cap(50, 6.4, 1.1, 4.35), 3)
+        18.705
+
+        Zero actuated area -> no target:
+
+        >>> VolumeThresholdHandler._threshold_cap(100, 6.4, 1.1, 0.0)
+        0.0
+
+        Zero filler baseline -> pure coverage of the full value (6.4 * 4.35):
+
+        >>> round(VolumeThresholdHandler._threshold_cap(100, 6.4, 0.0, 4.35), 3)
+        27.84
+        """
         requested_coverage_cap_over_area = (percent / 100) * full_cap_over_area
         return (requested_coverage_cap_over_area
                 + filler_cap_over_area) * actuated_area
@@ -342,6 +392,11 @@ class VolumeThresholdHandler(BaseColumnHandler):
           * "timeout" — deadline elapsed without meeting target.
           * "stopped" — stop_event / step_phases_done_event fired.
         ``last_cap`` is the most recent parsed pF reading (or None)."""
+        # Drop capacitance samples buffered before now — they were measured
+        # during the previous phase, before this phase's electrodes were
+        # actuated, and would otherwise advance the phase prematurely. We only
+        # act on readings produced after monitoring begins.
+        _drain_stale(ctx, CAPACITANCE_UPDATED)
         stop_event = ctx.protocol.stop_event
         last = None
         while (not stop_event.is_set()

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -232,8 +232,19 @@ class VolumeThresholdHandler(BaseColumnHandler):
         phase_duration_s = float(getattr(row, "duration_s", 0.0) or 0.0)
 
         stop_event = ctx.protocol.stop_event
+        pause_event = getattr(ctx.protocol, "pause_event", None)
         while (not stop_event.is_set()
                and not ctx.step_phases_done_event.is_set()):
+            # While the run is paused (operator manually moving around the
+            # protocol) the column stays inert: it neither picks up actuations
+            # nor monitors. On resume, discard anything that arrived during the
+            # pause — manual electrode moves and their capacitance — so we only
+            # react to the protocol's own next phase, never a manual move.
+            if pause_event is not None and pause_event.is_set():
+                pause_event.wait_cleared()
+                _drain_stale(ctx, ELECTRODES_STATE_CHANGE)
+                _drain_stale(ctx, CAPACITANCE_UPDATED)
+                continue
             try:
                 payload = ctx.wait_for(
                     ELECTRODES_STATE_CHANGE, timeout=PHASE_POLL_TIMEOUT_S,
@@ -394,16 +405,31 @@ class VolumeThresholdHandler(BaseColumnHandler):
           * "reached" — target met; phase_advance_event set.
           * "timeout" — deadline elapsed without meeting target.
           * "stopped" — stop_event / step_phases_done_event fired.
-        ``last_cap`` is the most recent parsed pF reading (or None)."""
+        ``last_cap`` is the most recent parsed pF reading (or None).
+
+        While the run is paused this blocks without counting toward the
+        deadline or acting on readings, so a pause never advances the phase
+        or pops the recovery dialog (which only opens on a genuine timeout)."""
         # Drop capacitance samples buffered before now — they were measured
         # during the previous phase, before this phase's electrodes were
         # actuated, and would otherwise advance the phase prematurely. We only
         # act on readings produced after monitoring begins.
         _drain_stale(ctx, CAPACITANCE_UPDATED)
         stop_event = ctx.protocol.stop_event
+        pause_event = getattr(ctx.protocol, "pause_event", None)
         last = None
         while (not stop_event.is_set()
                and not ctx.step_phases_done_event.is_set()):
+            # Paused mid-phase: freeze rather than counting down to a timeout
+            # (which would pop the dialog) or advancing on a manual reading.
+            # Paused time is not charged to the deadline; readings taken while
+            # paused are dropped on resume.
+            if pause_event is not None and pause_event.is_set():
+                paused_at = time.monotonic()
+                pause_event.wait_cleared()
+                deadline += time.monotonic() - paused_at
+                _drain_stale(ctx, CAPACITANCE_UPDATED)
+                continue
             remaining = deadline - time.monotonic()
             if remaining <= 0.0:
                 return "timeout", last

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -7,9 +7,29 @@ The column stores a 0-100 PERCENT (Int). Each phase ends early once the
 measured capacitance of the actuated electrodes reaches this percent of
 their calibrated FULL (liquid-covered) capacitance:
 
-    target = (percent / 100) * liquid_capacitance_over_area * actuated_area
+threshold_cap = ((percent / 100) * full_electrode_capacitance_over_area + filler_capacitance_over_area) * actuated_area
 
-The filler/baseline value is NOT used in this formula.
+****** MATH EXPLAINED: WE get this from the following: ****************************************************************
+
+1. Full electrode capacitance over area is liquid_capacitance_over_area - filler_capacitance_over_area from the
+device viewer calibrations published on app globals = full_electrode_capacitance_over_area
+
+2. The current capacitance is from the dropbot's capacitance stream. This needs to be normalized by actuated area,
+and baseline filler cap subtracted = (current_cap / actuated_area) - filler_capacitance_over_area
+
+3. The user provides the threshold percent from which we can get the
+requested_coverage_cap_over_area = (percent / 100) * full_electrode_capacitance_over_area
+
+4. So we need:
+
+(current_cap / actuated_area) - filler_capacitance_over_area >= requested_coverage_cap_over_area
+
+=> current_cap >= (requested_coverage_cap_over_area + filler_capacitance_over_area) * actuated_area
+
+=> threshold_cap = (requested_coverage_cap_over_area + filler_capacitance_over_area) * actuated_area
+= ((percent / 100) * full_electrode_capacitance_over_area + filler_capacitance_over_area) * actuated_area
+
+***********************************************************************************************************************
 
 Calibration + area source: read straight from app_globals (the
 Redis-backed globals manager). The DV models publish there on change
@@ -39,6 +59,8 @@ import time
 
 from traits.api import Int
 
+from device_viewer.consts import CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY
+from dropbot_protocol_controls.services.force_math import current_full_electrode_capacitance_per_unit_area
 from logger.logger_service import get_logger
 
 from microdrop_application.helpers import get_microdrop_redis_globals_manager
@@ -63,6 +85,8 @@ from ..consts import (
 )
 from ..views.recovery_dialog import show_volume_threshold_recovery_dialog
 
+from microdrop_utils.ureg_helpers import ureg
+
 logger = get_logger(__name__)
 
 # The Redis-backed globals manager, where the device-viewer models publish
@@ -72,49 +96,26 @@ logger = get_logger(__name__)
 # Tests monkeypatch this module attribute with a plain dict.
 app_globals = get_microdrop_redis_globals_manager()
 
-_LIQUID_CAP_KEY = "liquid_capacitance_over_area"
-_CHANNEL_AREAS_KEY = "channel_electrode_areas_scaled_map"
 
-
-def _read_full_cap_over_area(app_globals):
-    """The FULL (liquid-covered) capacitance-per-unit-area from
-    app_globals, or None when absent / non-positive / unparseable."""
-    try:
-        value = app_globals.get(_LIQUID_CAP_KEY)
-    except Exception:                              # pragma: no cover - defensive
-        return None
-    try:
-        value = float(value)
-    except (TypeError, ValueError):
-        return None
-    return value if value > 0 else None
-
-
-def _read_channel_areas(app_globals):
+def _read_channel_areas():
     """channel-id(str) -> summed electrode area (mm^2) from app_globals,
     or {} when absent. Keys are strings because the source Dict(Int,Float)
     is JSON-round-tripped through Redis; callers look up str(channel)."""
     try:
-        areas = app_globals.get(_CHANNEL_AREAS_KEY)
+        areas = app_globals.get(CHANNEL_AREAS_KEY)
     except Exception:                              # pragma: no cover - defensive
         return {}
     return areas if isinstance(areas, dict) else {}
 
 
 def _parse_capacitance_pf(raw):
-    """Pull the numeric pF value out of a CAPACITANCE_UPDATED payload.
-    Returns None on any parse failure (handler skips and waits for the
-    next reading rather than crashing)."""
+    """Pull the capacitance, normalized to pF, out of a CAPACITANCE_UPDATED
+    payload. Returns None on any parse failure (handler skips and waits for
+    the next reading rather than crashing)."""
     try:
-        data = _json.loads(raw)
-    except (TypeError, ValueError):
-        return None
-    cap_str = data.get("capacitance")
-    if not isinstance(cap_str, str):
-        return None
-    try:
-        return float(cap_str.split("pF")[0])
-    except (ValueError, AttributeError):
+        return ureg(_json.loads(raw).get("capacitance")).to("pF").magnitude
+    except Exception as e:
+        logger.debug(f"PROTOCOL TREE (volume_threshold_column): Cannot parse capacitance due to error: {e}", exc_info=True)
         return None
 
 
@@ -124,7 +125,7 @@ class VolumeThresholdColumnModel(BaseColumnModel):
     Each phase ends early once the measured capacitance of the phase's
     actuated electrodes reaches this percent of their calibrated FULL
     (liquid-covered) capacitance:
-        target = (percent / 100) * liquid_capacitance_over_area * actuated_area
+        threshold_cap = ((percent / 100) * full_electrode_capacitance_over_area + filler_capacitance_over_area) * actuated_area
     """
 
     def trait_for_row(self):
@@ -152,8 +153,8 @@ class VolumeThresholdHandler(BaseColumnHandler):
     channel-area map from app_globals (published by the DV models).
     Per phase: read the actuated channels from the ELECTRODES_STATE_CHANGE
     payload RoutesHandler publishes, sum their areas, compute
-    ``target = (percent/100) * full_cap_over_area * actuated_area``, and
-    poll CAPACITANCE_UPDATED until ``current >= target`` -> set
+    ``threshold_cap = ((percent/100) * full_cap_over_area + filler_cap_over_area) * actuated_area``,
+    and poll CAPACITANCE_UPDATED until ``current >= threshold_cap`` -> set
     ctx.phase_advance_event (RoutesHandler's _cooperative_sleep wakes on
     it) -> loop back for the next phase boundary.
 
@@ -191,14 +192,25 @@ class VolumeThresholdHandler(BaseColumnHandler):
         if getattr(ctx.protocol, "preview_mode", False):
             return
 
-        full_cap_over_area = _read_full_cap_over_area(app_globals)
-        channel_areas = _read_channel_areas(app_globals)
+        # get known quants from globals. the liquid_cap - filler_cap = current_full_electrode_capacitance/area
+        # and channel areas to normalize cap readings from dropbot
+        full_cap_over_area = current_full_electrode_capacitance_per_unit_area()
+        channel_areas = _read_channel_areas()
+
         if full_cap_over_area is None or not channel_areas:
             logger.warning(
                 "volume_threshold: missing calibration "
-                "(liquid_capacitance_over_area) or channel areas in "
+                "(liquid + filler capacitance) or channel areas in "
                 "app_globals; calibrate + load a device first. Skipping.")
             return
+
+        filler_cap_over_area = app_globals.get(FILLER_CAPACITANCE_KEY)
+        if filler_cap_over_area is None:
+            logger.warning(
+                "volume_threshold: filler capacitance missing in app_globals; "
+                "Defaulting to 0 pF/mm^2")
+
+            filler_cap_over_area = 0
 
         # The phase's wall-clock budget. RoutesHandler dwells this long per
         # phase (per_phase_dwell = row.duration_s); we treat it as the
@@ -229,7 +241,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
             # A coverage change the operator makes in the recovery dialog
             # carries forward to subsequent phases of this step.
             percent = self._run_phase(
-                ctx, row, percent, full_cap_over_area, actuated_area,
+                ctx, row, percent, full_cap_over_area, filler_cap_over_area, actuated_area,
                 phase_duration_s,
             )
             # Do NOT return — loop back to monitor the next phase.
@@ -238,19 +250,34 @@ class VolumeThresholdHandler(BaseColumnHandler):
             # ELECTRODES_STATE_CHANGE, which our outer loop picks up. The
             # loop exits only on stop_event or step_phases_done_event.
 
-    def _run_phase(self, ctx, row, percent, full_cap_over_area,
+    @staticmethod
+    def _threshold_cap(percent, full_cap_over_area, filler_cap_over_area,
+                       actuated_area):
+        """Target capacitance (pF) the actuated electrodes must reach:
+        ``((percent/100) * full_cap_over_area + filler_cap_over_area) * actuated_area``
+        (see the module docstring's MATH EXPLAINED block)."""
+        requested_coverage_cap_over_area = (percent / 100) * full_cap_over_area
+        return (requested_coverage_cap_over_area
+                + filler_cap_over_area) * actuated_area
+
+    def _run_phase(self, ctx, row, percent, full_cap_over_area, filler_cap_over_area,
                    actuated_area, phase_duration_s):
-        """Monitor one phase to its deadline; on a miss, open the recovery
+        """
+        Monitor one phase to its deadline; on a miss, open the recovery
         dialog and apply the operator's choice (retry / proceed / stop).
-        Returns the (possibly updated) coverage percent to carry forward."""
-        target = (percent / 100.0) * full_cap_over_area * actuated_area
+        Returns the (possibly updated) coverage percent to carry forward.
+        """
+        # calculate threshold capacitance
+        threshold_cap = self._threshold_cap(
+            percent, full_cap_over_area, filler_cap_over_area,
+            actuated_area)
 
         # No phase duration => no meaningful "end of phase": fall back to the
         # legacy re-sync cadence (one CAP_POLL_TIMEOUT_S window, no dialog)
         # and let the outer loop re-read the next phase.
         if phase_duration_s <= 0.0:
             self._monitor_until_threshold(
-                ctx, target, time.monotonic() + CAP_POLL_TIMEOUT_S)
+                ctx, threshold_cap, time.monotonic() + CAP_POLL_TIMEOUT_S)
             return percent
 
         # When the step is looping on a duration budget, the dialog offers a
@@ -264,7 +291,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
         deadline = time.monotonic() + phase_duration_s
         while True:
             status, last_cap = self._monitor_until_threshold(
-                ctx, target, deadline)
+                ctx, threshold_cap, deadline)
             if status != "timeout":
                 # "reached" (phase_advance_event already set) or "stopped".
                 return percent
@@ -275,7 +302,7 @@ class VolumeThresholdHandler(BaseColumnHandler):
             # Stop / external Resume) — no message passing, no actors.
             def _ask():
                 d = show_volume_threshold_recovery_dialog(
-                    int(percent), last_cap, target,
+                    int(percent), last_cap, threshold_cap,
                     duration_mode=in_duration_mode)
                 if d.get("action") == "retry":
                     extend_s = float(d.get("extend_s", 0.0) or 0.0)
@@ -304,7 +331,9 @@ class VolumeThresholdHandler(BaseColumnHandler):
 
             # "retry": apply the new coverage + extension and keep monitoring.
             percent = int(decision.get("new_percent", percent))
-            target = (percent / 100.0) * full_cap_over_area * actuated_area
+            threshold_cap = self._threshold_cap(
+                percent, full_cap_over_area, filler_cap_over_area,
+                actuated_area)
             extend_s = float(decision.get("extend_s", 0.0) or 0.0)
             deadline = time.monotonic() + max(extend_s, 0.0)
 

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -205,12 +205,6 @@ class VolumeThresholdHandler(BaseColumnHandler):
             return
 
         filler_cap_over_area = app_globals.get(FILLER_CAPACITANCE_KEY)
-        if filler_cap_over_area is None:
-            logger.warning(
-                "volume_threshold: filler capacitance missing in app_globals; "
-                "Defaulting to 0 pF/mm^2")
-
-            filler_cap_over_area = 0
 
         # The phase's wall-clock budget. RoutesHandler dwells this long per
         # phase (per_phase_dwell = row.duration_s); we treat it as the

--- a/volume_threshold_protocol_controls/tests/test_volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/tests/test_volume_threshold_column.py
@@ -100,11 +100,26 @@ def _make_handler_ctx(monkeypatch, *, threshold=0, preview=False,
 
 def _good_globals():
     """app_globals with calibration + a channel-area map (string keys,
-    as Redis JSON round-trip produces). Channel 1 -> 1.0 mm^2."""
+    as Redis JSON round-trip produces). Channel 1 -> 1.0 mm^2.
+
+    Includes the filler key so the handler's threshold calc finds it; the
+    full (liquid-covered) cap/area comes from
+    current_full_electrode_capacitance_per_unit_area, stubbed via
+    _stub_full_cap in tests that exercise the monitor loop."""
     return {
         "liquid_capacitance_over_area": 5.0,
+        "filler_capacitance_over_area": 0.0,
         "channel_electrode_areas_scaled_map": {"1": 1.0},
     }
+
+
+def _stub_full_cap(monkeypatch, value=5.0):
+    """Stub the live full-electrode cap/area reader. It reads force_math's
+    own app_globals (not this module's), so monkeypatching the handler's
+    app_globals dict alone wouldn't feed it — pin the value directly."""
+    monkeypatch.setattr(
+        mod, "current_full_electrode_capacitance_per_unit_area",
+        lambda: value)
 
 
 # --- early-return guards ------------------------------------------
@@ -149,22 +164,27 @@ def test_handler_returns_when_channel_areas_missing(monkeypatch):
 # --- crossing behaviour -------------------------------------------
 
 def test_handler_sets_phase_advance_when_capacitance_crosses_target(monkeypatch):
-    """channels [1] -> area 1.0; liquid 5.0; percent 50 -> target=2.5pF.
-    A 3.0pF reading crosses. A daemon sets step_phases_done_event so the
-    outer loop exits after the crossing (mirrors RoutesHandler finishing)."""
+    """channels [1] -> area 1.0; full cap/area 5.0; percent 50 -> target 2.5pF.
+    A 3.0pF reading that ARRIVES AFTER monitoring begins crosses and advances.
+    (A reading buffered BEFORE the phase is flushed as stale — see
+    test_handler_ignores_stale_capacitance_buffered_before_phase.) A daemon
+    delivers the reading then sets step_phases_done_event so the outer loop
+    exits (mirrors RoutesHandler finishing)."""
     from dropbot_controller.consts import CAPACITANCE_UPDATED
     from electrode_controller.consts import ELECTRODES_STATE_CHANGE
     handler, row, ctx, enq = _make_handler_ctx(
         monkeypatch, threshold=50, app_globals=_good_globals())
+    _stub_full_cap(monkeypatch, 5.0)
     enq(ELECTRODES_STATE_CHANGE,
         json.dumps({"electrodes": ["e1"], "channels": [1]}))
-    enq(CAPACITANCE_UPDATED,
-        json.dumps({"capacitance": "3.0pF", "voltage": "100V"}))
 
-    def _done_soon():
+    def _deliver_then_done():
+        time.sleep(0.02)
+        enq(CAPACITANCE_UPDATED,
+            json.dumps({"capacitance": "3.0pF", "voltage": "100V"}))
         time.sleep(0.05)
         ctx.step_phases_done_event.set()
-    threading.Thread(target=_done_soon, daemon=True).start()
+    threading.Thread(target=_deliver_then_done, daemon=True).start()
 
     handler.on_step(row, ctx)
     assert ctx.phase_advance_event.is_set() is True
@@ -175,10 +195,40 @@ def test_handler_does_not_set_event_when_below_target(monkeypatch):
     from electrode_controller.consts import ELECTRODES_STATE_CHANGE
     handler, row, ctx, enq = _make_handler_ctx(
         monkeypatch, threshold=50, app_globals=_good_globals())
+    _stub_full_cap(monkeypatch, 5.0)
     enq(ELECTRODES_STATE_CHANGE,
         json.dumps({"electrodes": ["e1"], "channels": [1]}))
+
+    def _deliver_then_done():
+        time.sleep(0.02)
+        enq(CAPACITANCE_UPDATED,
+            json.dumps({"capacitance": "2.0pF", "voltage": "100V"}))   # < 2.5
+        time.sleep(0.05)
+        ctx.step_phases_done_event.set()
+    threading.Thread(target=_deliver_then_done, daemon=True).start()
+
+    handler.on_step(row, ctx)
+    assert ctx.phase_advance_event.is_set() is False
+
+
+def test_handler_ignores_stale_capacitance_buffered_before_phase(monkeypatch):
+    """Regression: a HIGH capacitance reading already buffered when a phase
+    begins was measured during the PREVIOUS phase (before this phase's
+    electrodes were actuated). It must be flushed as stale, NOT trigger an
+    immediate advance — otherwise the phase 'proceeds really fast' though no
+    liquid has arrived. full cap/area 5.0; percent 50 -> target 2.5pF; the
+    stale 99pF reading dwarfs the target but is pre-buffered, so no advance."""
+    from dropbot_controller.consts import CAPACITANCE_UPDATED
+    from electrode_controller.consts import ELECTRODES_STATE_CHANGE
+    handler, row, ctx, enq = _make_handler_ctx(
+        monkeypatch, threshold=50, app_globals=_good_globals())
+    _stub_full_cap(monkeypatch, 5.0)
+    enq(ELECTRODES_STATE_CHANGE,
+        json.dumps({"electrodes": ["e1"], "channels": [1]}))
+    # Stale reading left in the mailbox from the previous phase, far above
+    # target. Pre-buffered -> must be drained, not acted on.
     enq(CAPACITANCE_UPDATED,
-        json.dumps({"capacitance": "2.0pF", "voltage": "100V"}))   # < 2.5
+        json.dumps({"capacitance": "99.0pF", "voltage": "100V"}))
 
     def _done_soon():
         time.sleep(0.05)
@@ -195,6 +245,7 @@ def test_handler_skips_phase_when_actuated_area_is_zero(monkeypatch):
     from electrode_controller.consts import ELECTRODES_STATE_CHANGE
     handler, row, ctx, enq = _make_handler_ctx(
         monkeypatch, threshold=50, app_globals=_good_globals())
+    _stub_full_cap(monkeypatch, 5.0)
     enq(ELECTRODES_STATE_CHANGE,
         json.dumps({"electrodes": ["e9"], "channels": [99]}))   # 99 not in map
 

--- a/volume_threshold_protocol_controls/tests/test_volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/tests/test_volume_threshold_column.py
@@ -73,8 +73,10 @@ def _make_handler_ctx(monkeypatch, *, threshold=0, preview=False,
     row = MagicMock()
     row.volume_threshold = threshold
 
+    from pluggable_protocol_tree.execution.events import PauseEvent
     proto = MagicMock()
     proto.stop_event = stop_event or threading.Event()
+    proto.pause_event = PauseEvent()          # not paused by default
     proto.preview_mode = preview
 
     ctx = MagicMock()
@@ -256,6 +258,30 @@ def test_handler_skips_phase_when_actuated_area_is_zero(monkeypatch):
 
     handler.on_step(row, ctx)
     assert ctx.phase_advance_event.is_set() is False
+
+
+def test_handler_inert_while_paused(monkeypatch):
+    """While the run is paused (operator manually moving around the
+    protocol), the column must stay inert: even with a phase actuation
+    queued, it neither advances the phase nor pops the recovery dialog.
+    It blocks until resumed; here it resumes to a finished step."""
+    from electrode_controller.consts import ELECTRODES_STATE_CHANGE
+    handler, row, ctx, enq = _make_handler_ctx(
+        monkeypatch, threshold=50, app_globals=_good_globals())
+    _stub_full_cap(monkeypatch, 5.0)
+    ctx.protocol.pause_event.set()                      # paused before on_step
+    enq(ELECTRODES_STATE_CHANGE,
+        json.dumps({"electrodes": ["e1"], "channels": [1]}))
+
+    def _resume_then_done():
+        time.sleep(0.05)
+        ctx.protocol.pause_event.clear()                # resume...
+        ctx.step_phases_done_event.set()                # ...to a finished step
+    threading.Thread(target=_resume_then_done, daemon=True).start()
+
+    handler.on_step(row, ctx)
+    assert ctx.phase_advance_event.is_set() is False
+    ctx.prompt_gui.assert_not_called()
 
 
 def test_plugin_default_lists_the_column():

--- a/volume_threshold_protocol_controls/views/recovery_dialog.py
+++ b/volume_threshold_protocol_controls/views/recovery_dialog.py
@@ -8,7 +8,8 @@ out:
     coverage target to Y%, then keep monitoring against the new target.
   * **Proceed anyway** — give up on the threshold for this phase and let
     the protocol continue (the troubleshooting escape hatch).
-  * **Stop** — abort the run.
+  * **Pause Protocol** — pause the run (the operator resumes it later from
+    the toolbar) instead of aborting.
 
 This module is pure Qt widget code: ``show_volume_threshold_recovery_dialog``
 builds a modal dialog, ``exec()``s it, and returns a plain decision dict.
@@ -20,7 +21,7 @@ Decision dict shapes:
     {"action": "retry", "extend_s": float, "new_percent": int,
      "count_toward_duration": bool}   # last key only in duration mode
     {"action": "proceed"}
-    {"action": "stop"}
+    {"action": "pause"}
 
 ``count_toward_duration`` (duration-looping steps only): when True the extra
 time is charged against the loop's duration budget (the run still ends on
@@ -40,11 +41,11 @@ _DEFAULT_EXTEND_S = 5.0
 
 
 class _RecoveryDialog(QDialog):
-    """Two-field recovery prompt with retry / proceed / stop buttons.
+    """Two-field recovery prompt with retry / proceed / pause buttons.
 
     The chosen action is captured in ``self._action``; window-close or Esc
-    defaults to "proceed" — the least destructive outcome (continue the
-    run rather than abort it or hang)."""
+    defaults to "proceed" — the least disruptive outcome (continue the
+    run rather than pause it or hang)."""
 
     def __init__(self, current_percent, current_cap, target_cap,
                  duration_mode=False, parent=None):
@@ -100,17 +101,17 @@ class _RecoveryDialog(QDialog):
         # "&&" renders a literal ampersand (single "&" is a Qt mnemonic).
         retry_btn = QPushButton("Apply && retry")
         proceed_btn = QPushButton("Proceed anyway")
-        stop_btn = QPushButton("Stop")
+        pause_btn = QPushButton("Pause Protocol")
         retry_btn.clicked.connect(lambda: self._choose("retry"))
         proceed_btn.clicked.connect(lambda: self._choose("proceed"))
-        stop_btn.clicked.connect(lambda: self._choose("stop"))
+        pause_btn.clicked.connect(lambda: self._choose("pause"))
         retry_btn.setDefault(True)
 
         buttons = QHBoxLayout()
         buttons.addWidget(retry_btn)
         buttons.addWidget(proceed_btn)
         buttons.addStretch(1)
-        buttons.addWidget(stop_btn)
+        buttons.addWidget(pause_btn)
         layout.addLayout(buttons)
 
     def _choose(self, action: str) -> None:
@@ -152,7 +153,7 @@ def show_volume_threshold_recovery_dialog(
         {"action": "retry", "extend_s": float, "new_percent": int,
          "count_toward_duration": bool}   # last key only when duration_mode
         {"action": "proceed"}
-        {"action": "stop"}
+        {"action": "pause"}
     """
     dialog = _RecoveryDialog(current_percent, current_cap, target_cap,
                              duration_mode=duration_mode, parent=parent)


### PR DESCRIPTION
## Summary

Volume-threshold per-step column behavior changes. **Stacked on #454** (the app-global key + force-math refactor it depends on) — base will retarget to `main` once #454 merges.

### Filler-inclusive threshold math
Per-phase target now includes the filler baseline:
`threshold_cap = ((percent/100) * full_cap_over_area + filler_cap_over_area) * actuated_area`, extracted into a shared `_threshold_cap()` helper so the initial and retry computations stay in sync. Derivation documented in the module docstring; doctests cover the 100%/0%/50% and zero-area / zero-filler cases.

### Parsing + recovery-dialog fixes
- Reads calibration via `current_full_electrode_capacitance_per_unit_area()` and the shared key constants.
- Parses `CAPACITANCE_UPDATED` payloads with `ureg(...).to("pF")` so any unit normalizes to pF; parse failures log at `debug` (runs every poll).
- Recovery dialog: passes `threshold_cap` (not the undefined legacy `target`) and recomputes it on retry so a lowered coverage actually takes effect.
- Removed a redundant/unreachable filler-None guard.

### Fix: premature phase advance on stale capacitance
`CAPACITANCE_UPDATED` is a continuous stream the DropBot publishes into a per-step FIFO mailbox that is never flushed between phases, so a new phase's first reading was measured during the *previous* phase (before its electrodes actuated) — a leftover high reading satisfied the threshold instantly and the phase "proceeded really fast even if the capacitance is not high enough." Added `_drain_stale()`, called at the start of each monitoring window, so only readings produced after monitoring begins are considered.

## Test plan
- [ ] `volume_threshold_protocol_controls/tests/test_volume_threshold_column.py` — includes a regression test that a pre-buffered high reading must not advance the phase; crossing/below-target tests now deliver readings after monitoring starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)