### PR TITLE
[Refactor] Decouple protocol-tree logging from device_viewer / protocol_grid

### DIFF
--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -76,14 +76,11 @@ ACTOR_TOPIC_DICT = {
 }
 
 # App globals declared to APP_GLOBALS_REDIS_HASH with redis client
-CHANNEL_AREAS_KEY = "channel_electrode_areas_scaled_map"
-FILLER_CAPACITANCE_KEY = "filler_capacitance_over_area"
-LIQUID_CAPACITANCE_KEY = "liquid_capacitance_over_area"
-# Full path to the loaded device SVG (the ".name" key below publishes only the
-# stem). Consumers that must load the file — e.g. the protocol logger's device
-# heatmap — read this instead of reaching into the device-viewer model.
-DEVICE_SVG_NAME_KEY = "microdrop.device_svg.name"
-DEVICE_SVG_PATH_KEY = "microdrop.device_svg.path"
+CHANNEL_AREAS_KEY = "channel_electrode_areas_scaled_map" # channel areas
+FILLER_CAPACITANCE_KEY = "filler_capacitance_over_area" # filler calibration
+LIQUID_CAPACITANCE_KEY = "liquid_capacitance_over_area" # liquid calibration
+DEVICE_SVG_PATH_KEY = "microdrop.device_svg.path" # the active svg file path
+MEDIA_CAPTURES_KEY = "media_captures" # serialised camera captures for the active run.
 
 APP_GLOBALS_KEYS = [CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY,
                     LIQUID_CAPACITANCE_KEY, DEVICE_SVG_PATH_KEY]

--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -79,8 +79,14 @@ ACTOR_TOPIC_DICT = {
 CHANNEL_AREAS_KEY = "channel_electrode_areas_scaled_map"
 FILLER_CAPACITANCE_KEY = "filler_capacitance_over_area"
 LIQUID_CAPACITANCE_KEY = "liquid_capacitance_over_area"
+# Full path to the loaded device SVG (the ".name" key below publishes only the
+# stem). Consumers that must load the file — e.g. the protocol logger's device
+# heatmap — read this instead of reaching into the device-viewer model.
+DEVICE_SVG_NAME_KEY = "microdrop.device_svg.name"
+DEVICE_SVG_PATH_KEY = "microdrop.device_svg.path"
 
-APP_GLOBALS_KEYS = [CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY, LIQUID_CAPACITANCE_KEY]
+APP_GLOBALS_KEYS = [CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY,
+                    LIQUID_CAPACITANCE_KEY, DEVICE_SVG_PATH_KEY]
 
 # GUI configuration
 DEVICE_VIEWER_SIDEBAR_WIDTH = 320

--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -10,7 +10,7 @@ from .calibration import CalibrationModel
 from .route import RouteLayerManager
 from .electrodes import Electrodes
 from ..default_settings import electrode_fill_key, electrode_text_key, electrode_outline_key
-from ..consts import DEVICE_SVG_NAME_KEY, DEVICE_SVG_PATH_KEY
+from ..consts import DEVICE_SVG_PATH_KEY
 from ..interfaces.i_main_model import IDeviceViewMainModel
 from ..interfaces.i_route_execution_service import IRouteExecutionService
 
@@ -299,8 +299,7 @@ class DeviceViewMainModel(HasTraits):
 
         if self.electrodes.svg_model:
             filename = self.electrodes.svg_model.filename
-            app_globals[DEVICE_SVG_NAME_KEY] = Path(filename).stem
-            # Full path too, so consumers (e.g. the protocol logger's device
+            # Full path published to globals, so consumers (e.g. the protocol logger's device
             # heatmap) can load the file without reaching into this model.
             app_globals[DEVICE_SVG_PATH_KEY] = str(filename)
         else:

--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -10,6 +10,7 @@ from .calibration import CalibrationModel
 from .route import RouteLayerManager
 from .electrodes import Electrodes
 from ..default_settings import electrode_fill_key, electrode_text_key, electrode_outline_key
+from ..consts import DEVICE_SVG_NAME_KEY, DEVICE_SVG_PATH_KEY
 from ..interfaces.i_main_model import IDeviceViewMainModel
 from ..interfaces.i_route_execution_service import IRouteExecutionService
 
@@ -297,7 +298,11 @@ class DeviceViewMainModel(HasTraits):
         logger.debug(f"push_globals: {event.name}: {event.new}")
 
         if self.electrodes.svg_model:
-            app_globals["microdrop.device_svg.name"] = Path(self.electrodes.svg_model.filename).stem
+            filename = self.electrodes.svg_model.filename
+            app_globals[DEVICE_SVG_NAME_KEY] = Path(filename).stem
+            # Full path too, so consumers (e.g. the protocol logger's device
+            # heatmap) can load the file without reaching into this model.
+            app_globals[DEVICE_SVG_PATH_KEY] = str(filename)
         else:
             logger.warning("Unable to push svg filename to globals yet. Need svg_model to fully initialize.")
 

--- a/device_viewer/views/camera_control_view/utils.py
+++ b/device_viewer/views/camera_control_view/utils.py
@@ -3,13 +3,15 @@ from pathlib import Path
 import dramatiq
 from PySide6.QtCore import QUrl
 
-from device_viewer.models.media_capture_model import MediaType, MediaCaptureMessageModel
-from microdrop_application.helpers import get_microdrop_redis_globals_manager
+from ...models.media_capture_model import MediaType, MediaCaptureMessageModel
+from ...consts import MEDIA_CAPTURES_KEY
 
+from microdrop_application.helpers import get_microdrop_redis_globals_manager
 app_globals = get_microdrop_redis_globals_manager()
 
 from logger.logger_service import get_logger
 logger = get_logger(__name__)
+
 
 
 @dramatiq.actor
@@ -20,13 +22,13 @@ def _cache_media_capture(name: MediaType, save_path: str):
 
     message=media_capture_message.model_dump_json()
 
-    if not app_globals.get("media_captures"):
-        app_globals["media_captures"] = [message]
+    if not app_globals.get(MEDIA_CAPTURES_KEY):
+        app_globals[MEDIA_CAPTURES_KEY] = [message]
 
     else:
-        app_globals["media_captures"] += [message]
+        app_globals[MEDIA_CAPTURES_KEY] += [message]
 
-    logger.info(app_globals["media_captures"])
+    logger.info(app_globals[MEDIA_CAPTURES_KEY])
 
 def _show_media_capture_dialog(
     name: MediaType, save_path: str, status_bar_manager=None

--- a/pluggable_protocol_tree/services/logging/consts.py
+++ b/pluggable_protocol_tree/services/logging/consts.py
@@ -1,0 +1,20 @@
+"""Constants for the protocol-tree logging subpackage.
+
+App-globals key constants owned by other plugins (channel areas, the device
+SVG path, calibration capacitances) are imported from ``device_viewer.consts``
+— constants-only reuse, the sanctioned cross-package pattern. Keys/formats
+owned by the logger live here.
+"""
+
+# Timestamp formats.
+TIME_FMT = "%Y-%m-%d %H:%M:%S"        # human-readable metadata (Start/Stop Time)
+RUN_TIMESTAMP_FMT = "%Y%m%d_%H%M%S"   # run id + data/report filenames
+
+# app_globals (Redis) bucket of serialised camera captures for the active run.
+MEDIA_CAPTURES_KEY = "media_captures"
+
+# app_globals key for the logs-settling preference (seconds). The owning plugin
+# (protocol_grid) may mirror its preference here; until then the default below
+# is used so the logger stays decoupled from protocol_grid.
+LOGS_SETTLING_TIME_S_KEY = "logs_settling_time_s"
+DEFAULT_SETTLING_TIME_S = 3.0

--- a/pluggable_protocol_tree/services/logging/consts.py
+++ b/pluggable_protocol_tree/services/logging/consts.py
@@ -10,11 +10,4 @@ owned by the logger live here.
 TIME_FMT = "%Y-%m-%d %H:%M:%S"        # human-readable metadata (Start/Stop Time)
 RUN_TIMESTAMP_FMT = "%Y%m%d_%H%M%S"   # run id + data/report filenames
 
-# app_globals (Redis) bucket of serialised camera captures for the active run.
-MEDIA_CAPTURES_KEY = "media_captures"
-
-# app_globals key for the logs-settling preference (seconds). The owning plugin
-# (protocol_grid) may mirror its preference here; until then the default below
-# is used so the logger stays decoupled from protocol_grid.
-LOGS_SETTLING_TIME_S_KEY = "logs_settling_time_s"
 DEFAULT_SETTLING_TIME_S = 3.0

--- a/pluggable_protocol_tree/services/logging/controller.py
+++ b/pluggable_protocol_tree/services/logging/controller.py
@@ -1,44 +1,64 @@
 """GUI-thread controller that turns executor lifecycle signals into a
 run's worth of logged artifacts. Owns a LoggingIngestion per run; the
 logging listener forwards capacitance/actuation/media to it. Settling
-flush is deferred so in-flight capacitance after 'done' is captured."""
+flush is deferred so in-flight capacitance after 'done' is captured.
 
-import datetime as _dt
+Decoupled: communicates only via the listener (dramatiq) and the shared
+Redis app_globals — it never imports another plugin's classes/panes. The
+Qt-aware flush scheduler is injected by the view; the service default is
+Qt-free."""
+
 import json
-import time
-from pathlib import Path
-from typing import Callable, Optional
+import threading
+from datetime import datetime, timedelta
+
+from traits.api import Any, Bool, Callable, HasTraits, Instance, Int, List, Str
 
 from device_viewer.consts import LIQUID_CAPACITANCE_KEY, FILLER_CAPACITANCE_KEY
-
-_TIME_FMT = "%Y-%m-%d %H:%M:%S"
-
+from device_viewer.models.media_capture_model import MediaCaptureMessageModel
 from logger.logger_service import get_logger
+from microdrop_application.helpers import get_microdrop_redis_globals_manager
 
 from pluggable_protocol_tree.services.logging import listener as _listener
+from pluggable_protocol_tree.services.logging.consts import (
+    DEFAULT_SETTLING_TIME_S, LOGS_SETTLING_TIME_S_KEY, MEDIA_CAPTURES_KEY,
+    RUN_TIMESTAMP_FMT, TIME_FMT,
+)
 from pluggable_protocol_tree.services.logging.ingestion import LoggingIngestion
 from pluggable_protocol_tree.services.logging.persistence import LoggingPersistence
 from pluggable_protocol_tree.services.logging.reporting import LoggingReport
 
 logger = get_logger(__name__)
 
+# Redis-backed shared state, bound once at import (the canonical idiom across
+# the repo). The proxy connects lazily, so this is import-safe without Redis;
+# the media-bucket reset/drain below wrap their access in try/except so the
+# feature degrades gracefully when Redis is unreachable (tests/headless).
+app_globals = get_microdrop_redis_globals_manager()
+
 
 def _default_settling_provider() -> float:
+    """Settling delay (seconds) read from app_globals, falling back to the
+    default so the logger stays decoupled from protocol_grid's preferences.
+    (protocol_grid can mirror its ``logs_settling_time_s`` preference to
+    ``LOGS_SETTLING_TIME_S_KEY`` to make a customised value take effect.)"""
     try:
-        from protocol_grid.preferences import ProtocolPreferences
-        return float(ProtocolPreferences().logs_settling_time_s)
+        return float(app_globals.get(LOGS_SETTLING_TIME_S_KEY,
+                                     DEFAULT_SETTLING_TIME_S))
     except Exception as e:                     # pragma: no cover - defensive
-        logger.debug(f"settling pref unavailable, default 3.0s: {e}")
-        return 3.0
+        logger.debug(f"settling pref unavailable, "
+                     f"default {DEFAULT_SETTLING_TIME_S}s: {e}")
+        return DEFAULT_SETTLING_TIME_S
 
 
-def _qtimer_flush_scheduler(controller) -> None:
-    from pyface.qt.QtCore import QTimer
-    QTimer.singleShot(int(controller._settling_provider() * 1000),
-                      controller._flush)
+def _threading_flush_scheduler(controller) -> None:
+    """Service-layer default flush scheduler: defer the flush by the settling
+    delay on a plain timer — no Qt (the view injects a Qt/progress-aware
+    scheduler in the full app)."""
+    threading.Timer(controller.settling_provider(), controller._flush).start()
 
 
-def _format_elapsed(delta: _dt.timedelta) -> str:
+def _format_elapsed(delta: timedelta) -> str:
     """`H:MM:SS` for the metadata table (sub-second jitter is noise here)."""
     total = int(delta.total_seconds())
     h, rem = divmod(total, 3600)
@@ -46,24 +66,7 @@ def _format_elapsed(delta: _dt.timedelta) -> str:
     return f"{h}:{m:02d}:{s:02d}"
 
 
-_MEDIA_CAPTURES_KEY = "media_captures"
-
-
-def _get_app_globals():
-    """Open a handle to the shared Redis-backed app globals dict, or None
-    when Redis is unreachable (tests, demos, headless). Caller treats None
-    as "no media to drain"."""
-    try:
-        from microdrop_application.helpers import (
-            get_microdrop_redis_globals_manager,
-        )
-        return get_microdrop_redis_globals_manager()
-    except Exception as e:                     # pragma: no cover - defensive
-        logger.debug(f"app_globals unavailable, media drain skipped: {e}")
-        return None
-
-
-def _capacitance_per_unit_area(liquid, filler) -> Optional[float]:
+def _capacitance_per_unit_area(liquid, filler):
     """liquid - filler (pF/mm^2), or None when invalid. Mirrors the legacy
     ForceCalculationService.calculate_capacitance_per_unit_area: both
     values must be present, non-negative, and liquid must exceed filler."""
@@ -79,21 +82,28 @@ def _capacitance_per_unit_area(liquid, filler) -> Optional[float]:
     return liquid - filler
 
 
-class ProtocolLoggingController:
-    def __init__(self, *, settling_provider: Optional[Callable[[], float]] = None,
-                 flush_scheduler: Optional[Callable[["ProtocolLoggingController"], None]] = None,
-                 completion_callback: Optional[Callable[[Optional[Path]], None]] = None):
-        self._settling_provider = settling_provider or _default_settling_provider
-        self._flush_scheduler = flush_scheduler or _qtimer_flush_scheduler
-        self._completion_callback = completion_callback
-        self._ingestion: Optional[LoggingIngestion] = None
-        self._device_context = None
-        self._step_idx = 0
-        self._n_steps = 0
-        self._start_time = ""
-        self._start_dt: Optional[_dt.datetime] = None
-        self._generate_report = True
-        self.all_report_paths: list[Path] = []
+class ProtocolLoggingController(HasTraits):
+    # Injected collaborators (constructor kwargs). settling_provider returns
+    # the settling delay (s); flush_scheduler defers _flush; completion_callback
+    # is notified with the report path (or None) after a flush.
+    settling_provider = Callable
+    flush_scheduler = Callable
+    completion_callback = Callable          # Optional — None when not provided.
+    # Per-run state.
+    _ingestion = Instance(LoggingIngestion)
+    _device_context = Any
+    _step_idx = Int(0)
+    _n_steps = Int(0)
+    _start_time = Str("")
+    _start_dt = Instance(datetime)
+    _generate_report = Bool(True)
+    all_report_paths = List()
+
+    def _settling_provider_default(self):
+        return _default_settling_provider
+
+    def _flush_scheduler_default(self):
+        return _threading_flush_scheduler
 
     # --- executor signal wiring ---
     def attach(self, qsignals) -> None:
@@ -123,28 +133,25 @@ class ProtocolLoggingController:
             getattr(device_context, "capacitance_per_unit_area", None))
         self._step_idx = 0
         self._n_steps = int(n_steps)
-        self._start_time = time.strftime("%Y%m%d_%H%M%S")
-        self._start_dt = _dt.datetime.now()
+        self._start_time = datetime.now().strftime(RUN_TIMESTAMP_FMT)
+        self._start_dt = datetime.now()
         self._ingestion.log_metadata({
             "Experiment Directory": str(device_context.experiment_directory),
             "Device SVG": str(getattr(device_context, "device_svg_path", "")),
             "Steps": f"0 / {self._n_steps}",
         })
         # Reset the shared media-captures bucket so only THIS run's camera
-        # output ends up in this run's report — _flush drains it back.
-        # Camera capture path: device_viewer.views.camera_control_view.utils.
-        # _cache_media_capture is a dramatiq actor that appends serialised
-        # MediaCaptureMessageModel JSON to app_globals["media_captures"]
-        # but never publishes the DEVICE_VIEWER_MEDIA_CAPTURED topic; the
-        # listener wired in start_logging therefore can't see captures
-        # live (legacy parity bug). Reading the bucket at flush time
-        # closes the gap.
-        ag = _get_app_globals()
-        if ag is not None:
-            try:
-                ag[_MEDIA_CAPTURES_KEY] = []
-            except Exception as e:                # pragma: no cover - defensive
-                logger.debug(f"could not reset media_captures bucket: {e}")
+        # output ends up in this run's report — _flush drains it back. The
+        # camera capture path (device_viewer's _cache_media_capture actor)
+        # appends serialised MediaCaptureMessageModel JSON to
+        # app_globals[MEDIA_CAPTURES_KEY] but never publishes the
+        # DEVICE_VIEWER_MEDIA_CAPTURED topic, so the listener can't see
+        # captures live (legacy parity bug); reading the bucket at flush
+        # time closes the gap.
+        try:
+            app_globals[MEDIA_CAPTURES_KEY] = []
+        except Exception as e:                # pragma: no cover - defensive
+            logger.debug(f"could not reset media_captures bucket: {e}")
         _listener.set_active_logger(self)
 
     def _on_step_started(self, row) -> None:
@@ -163,16 +170,16 @@ class ProtocolLoggingController:
         # self._step_idx is the count of step_started signals received,
         # which is the true completed-step count and survives abort/error
         # (unlike the pane's _repeats_completed which resets on abort).
-        stop_dt = _dt.datetime.now()
+        stop_dt = datetime.now()
         meta = {"Steps": f"{self._step_idx} / {self._n_steps}"}
         if self._start_dt is not None:
             elapsed = stop_dt - self._start_dt
-            meta["Start Time"] = self._start_dt.strftime(_TIME_FMT)
-            meta["Stop Time"] = stop_dt.strftime(_TIME_FMT)
+            meta["Start Time"] = self._start_dt.strftime(TIME_FMT)
+            meta["Stop Time"] = stop_dt.strftime(TIME_FMT)
             meta["Elapsed Time"] = _format_elapsed(elapsed)
         self._ingestion.log_metadata(meta)
         _listener.clear_active_logger()
-        self._flush_scheduler(self)
+        self.flush_scheduler(self)
 
     def _drain_media_captures(self) -> None:
         """Pull every camera capture cached this run out of the shared
@@ -183,22 +190,10 @@ class ProtocolLoggingController:
         ing = self._ingestion
         if ing is None:
             return
-        ag = _get_app_globals()
-        if ag is None:
-            return
         try:
-            captures = list(ag.get(_MEDIA_CAPTURES_KEY) or [])
+            captures = list(app_globals.get(MEDIA_CAPTURES_KEY) or [])
         except Exception as e:                    # pragma: no cover - defensive
             logger.debug(f"could not read media_captures bucket: {e}")
-            return
-        if not captures:
-            return
-        try:
-            from device_viewer.models.media_capture_model import (
-                MediaCaptureMessageModel,
-            )
-        except Exception as e:                    # pragma: no cover - defensive
-            logger.warning(f"media model unavailable, skipping drain: {e}")
             return
         for payload in captures:
             try:
@@ -235,9 +230,9 @@ class ProtocolLoggingController:
             self._ingestion = None
         # Notify the GUI (report saved / skipped). Outside the try so a
         # callback error is not misreported as a flush failure.
-        if self._completion_callback is not None:
+        if self.completion_callback is not None:
             try:
-                self._completion_callback(report_path)
+                self.completion_callback(report_path)
             except Exception as e:
                 logger.error(f"logging completion callback failed: {e}")
 
@@ -267,9 +262,6 @@ class ProtocolLoggingController:
         if ing is None:
             return
         try:
-            from device_viewer.models.media_capture_model import (
-                MediaCaptureMessageModel,
-            )
             ing.log_media(MediaCaptureMessageModel.model_validate_json(message))
         except Exception as e:                 # pragma: no cover - defensive
             logger.warning(f"media log failed: {e}")

--- a/pluggable_protocol_tree/services/logging/controller.py
+++ b/pluggable_protocol_tree/services/logging/controller.py
@@ -14,15 +14,14 @@ from datetime import datetime, timedelta
 
 from traits.api import Any, Bool, Callable, HasTraits, Instance, Int, List, Str
 
-from device_viewer.consts import LIQUID_CAPACITANCE_KEY, FILLER_CAPACITANCE_KEY
+from device_viewer.consts import LIQUID_CAPACITANCE_KEY, FILLER_CAPACITANCE_KEY, MEDIA_CAPTURES_KEY
 from device_viewer.models.media_capture_model import MediaCaptureMessageModel
 from logger.logger_service import get_logger
 from microdrop_application.helpers import get_microdrop_redis_globals_manager
 
 from pluggable_protocol_tree.services.logging import listener as _listener
 from pluggable_protocol_tree.services.logging.consts import (
-    DEFAULT_SETTLING_TIME_S, LOGS_SETTLING_TIME_S_KEY, MEDIA_CAPTURES_KEY,
-    RUN_TIMESTAMP_FMT, TIME_FMT,
+    DEFAULT_SETTLING_TIME_S, RUN_TIMESTAMP_FMT, TIME_FMT,
 )
 from pluggable_protocol_tree.services.logging.ingestion import LoggingIngestion
 from pluggable_protocol_tree.services.logging.persistence import LoggingPersistence
@@ -38,17 +37,8 @@ app_globals = get_microdrop_redis_globals_manager()
 
 
 def _default_settling_provider() -> float:
-    """Settling delay (seconds) read from app_globals, falling back to the
-    default so the logger stays decoupled from protocol_grid's preferences.
-    (protocol_grid can mirror its ``logs_settling_time_s`` preference to
-    ``LOGS_SETTLING_TIME_S_KEY`` to make a customised value take effect.)"""
-    try:
-        return float(app_globals.get(LOGS_SETTLING_TIME_S_KEY,
-                                     DEFAULT_SETTLING_TIME_S))
-    except Exception as e:                     # pragma: no cover - defensive
-        logger.debug(f"settling pref unavailable, "
-                     f"default {DEFAULT_SETTLING_TIME_S}s: {e}")
-        return DEFAULT_SETTLING_TIME_S
+    """Settling delay (seconds). Need to implement with actual preferences provider. For now return default"""
+    return DEFAULT_SETTLING_TIME_S
 
 
 def _threading_flush_scheduler(controller) -> None:

--- a/pluggable_protocol_tree/services/logging/ingestion.py
+++ b/pluggable_protocol_tree/services/logging/ingestion.py
@@ -5,26 +5,35 @@ context updates arrive on the GUI thread."""
 
 import json
 import threading
-from typing import Dict, List, Optional
+
+from traits.api import Any, Dict, Float, HasTraits, Int, List, Str
 
 from logger.logger_service import get_logger
 
 logger = get_logger(__name__)
 
 
-class LoggingIngestion:
-    def __init__(self):
+class LoggingIngestion(HasTraits):
+    # Accumulated rows + the column order seen so far. Public — read by
+    # LoggingPersistence / LoggingReport and the test contract.
+    entries = List()
+    columns = List()
+    metadata = Dict()
+    media = Dict()
+    # Current step + phase context stamped onto each capacitance row.
+    _step_id = Str("")
+    _step_idx = Int(0)
+    _actuated_channels = List()
+    _actuated_area = Float(0.0)
+    _cpa = Any()                     # Optional[float]; None -> force is None
+    _lock = Any()                    # threading.Lock, set in traits_init
+
+    def _media_default(self):
+        return {"video": [], "image": [], "other": []}
+
+    def traits_init(self):
+        # Guards the cross-thread appends (dramatiq worker vs GUI thread).
         self._lock = threading.Lock()
-        self._entries: List[dict] = []
-        self._columns: List[str] = []
-        self._metadata: Dict = {}
-        self._media: Dict[str, List[str]] = {"video": [], "image": [], "other": []}
-        # current step + phase context stamped onto each capacitance row
-        self._step_id = ""
-        self._step_idx = 0
-        self._actuated_channels: List[int] = []
-        self._actuated_area: float = 0.0
-        self._cpa: Optional[float] = None
 
     # --- context setters ---
     def set_step(self, *, step_id: str, step_idx: int) -> None:
@@ -35,29 +44,29 @@ class LoggingIngestion:
         self._actuated_channels = list(actuated_channels or [])
         self._actuated_area = float(actuated_area or 0.0)
 
-    def update_capacitance_per_unit_area(self, value: Optional[float]) -> None:
+    def update_capacitance_per_unit_area(self, value) -> None:
         self._cpa = None if value is None else float(value)
 
     # --- collection ---
     def log_data(self, entry: dict) -> None:
         with self._lock:
             for k in entry:
-                if k not in self._columns:
-                    self._columns.append(k)
-            self._entries.append(dict(entry))
+                if k not in self.columns:
+                    self.columns.append(k)
+            self.entries.append(dict(entry))
 
     def log_metadata(self, entry: dict) -> None:
         with self._lock:
-            self._metadata.update(entry)
+            self.metadata.update(entry)
 
     def log_media(self, model) -> None:
         type_obj = getattr(model, "type", None)
         bucket = getattr(type_obj, "value", None) or type_obj or "other"
         bucket = str(bucket).lower()
-        if bucket not in self._media:
+        if bucket not in self.media:
             bucket = "other"
         with self._lock:
-            self._media[bucket].append(str(model.path))
+            self.media[bucket].append(str(model.path))
 
     def log_capacitance(self, message) -> bool:
         """Parse a CAPACITANCE_UPDATED payload and append one row stamped
@@ -93,7 +102,7 @@ class LoggingIngestion:
         return True
 
     # --- force ---
-    def _calculate_force(self, voltage: float) -> Optional[float]:
+    def _calculate_force(self, voltage: float):
         if self._cpa is None or voltage <= 0:
             return None
         try:
@@ -101,23 +110,6 @@ class LoggingIngestion:
         except Exception as e:        # pragma: no cover - defensive
             logger.error(f"force calc failed: {e}")
             return None
-
-    # --- accessors ---
-    @property
-    def entries(self) -> List[dict]:
-        return self._entries
-
-    @property
-    def columns(self) -> List[str]:
-        return self._columns
-
-    @property
-    def metadata(self) -> Dict:
-        return self._metadata
-
-    @property
-    def media(self) -> Dict[str, List[str]]:
-        return self._media
 
 
 def _parse_number(raw, unit: str):

--- a/pluggable_protocol_tree/services/logging/models.py
+++ b/pluggable_protocol_tree/services/logging/models.py
@@ -1,19 +1,19 @@
 """Per-run device context for the protocol logger, assembled by the dock
-pane from the device viewer + application (keeps the logger units
-decoupled from those subsystems)."""
+pane from app_globals (keeps the logger units decoupled from the device
+viewer + application — no reaching into their panes/models)."""
 
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Optional
+
+from traits.api import Any, Dict, Float, HasTraits, Instance, Int
 
 
-@dataclass
-class LoggingDeviceContext:
-    experiment_directory: Path
-    device_svg_path: Optional[Path] = None
-    # channel -> electrode area (mm^2); from the device viewer's
-    # electrodes.channel_electrode_areas_scaled_map.
-    channel_areas: Dict[int, float] = field(default_factory=dict)
-    # dropbot calibration snapshot; live updates flow through the
-    # controller. None -> force is None (legacy parity).
-    capacitance_per_unit_area: Optional[float] = None
+class LoggingDeviceContext(HasTraits):
+    experiment_directory = Instance(Path)
+    # Full path to the device SVG (from app_globals[DEVICE_SVG_PATH_KEY]); the
+    # report heatmap loads it. None -> no heatmap. Any: tolerates Path or str.
+    device_svg_path = Any
+    # channel -> electrode area (mm^2); from app_globals[CHANNEL_AREAS_KEY].
+    channel_areas = Dict(Int, Float)
+    # dropbot calibration snapshot; live updates flow through the controller.
+    # None -> force is None (legacy parity). Any: tolerates float or None.
+    capacitance_per_unit_area = Any

--- a/pluggable_protocol_tree/services/logging/reporting.py
+++ b/pluggable_protocol_tree/services/logging/reporting.py
@@ -11,6 +11,22 @@ import pandas as pd
 
 from logger.logger_service import get_logger
 
+from pluggable_protocol_tree.services.logging.consts import RUN_TIMESTAMP_FMT
+from pluggable_protocol_tree.services.logging.persistence import LoggingPersistence
+
+# Optional visualisation deps, hoisted to module top: a missing lib degrades
+# the corresponding report section to a placeholder instead of failing import.
+try:
+    import plotly.express as px
+except Exception:                              # pragma: no cover
+    px = None
+try:
+    from microdrop_utils.plotly_helpers import (
+        create_plotly_svg_dropbot_device_heatmap,
+    )
+except Exception:                              # pragma: no cover
+    create_plotly_svg_dropbot_device_heatmap = None
+
 logger = get_logger(__name__)
 
 _NUMERIC_EXCLUDE = {"step_idx", "utc_time", "instrument_time_us",
@@ -126,9 +142,7 @@ class LoggingReport:
 
     @staticmethod
     def _trends_section(entries: List[dict], columns: List[str], device_context) -> str:
-        try:
-            import plotly.express as px
-        except Exception:                      # pragma: no cover
+        if px is None:                         # pragma: no cover
             return "<h2>Data Trends</h2><p>plotly unavailable.</p>"
         if not entries:
             return "<h2>Data Trends</h2><p>No data.</p>"
@@ -187,12 +201,9 @@ class LoggingReport:
         if not svg or "actuated_channels" not in df:
             return ""
         durations = LoggingReport._channel_durations_seconds(df)
-        if not durations:
+        if not durations or create_plotly_svg_dropbot_device_heatmap is None:
             return ""
         try:
-            from microdrop_utils.plotly_helpers import (
-                create_plotly_svg_dropbot_device_heatmap,
-            )
             # Defaults ("Actuation Times" / "seconds") trigger the helper's
             # format_time_tooltip auto-scaling (sec --> min --> hours). Passing
             # "s" instead of "seconds" disables it and shows raw floats.
@@ -222,9 +233,6 @@ class LoggingReport:
             return {}
         # Reuse the persistence rollover correction so the heatmap agrees
         # with the on-disk corr_instrument_time_us in the data file.
-        from pluggable_protocol_tree.services.logging.persistence import (
-            LoggingPersistence,
-        )
         corr = LoggingPersistence._correct_rollover(
             df["instrument_time_us"].tolist())
         if not corr or len([v for v in corr if v is not None]) < 2:
@@ -316,7 +324,7 @@ class LoggingReport:
     def write_report(experiment_dir, html: str) -> Path:
         reports_dir = Path(experiment_dir) / "reports"
         reports_dir.mkdir(parents=True, exist_ok=True)
-        stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        stamp = datetime.now().strftime(RUN_TIMESTAMP_FMT)
         path = reports_dir / f"report_{stamp}.html"
         path.write_text(html, encoding="utf-8")
         return path

--- a/pluggable_protocol_tree/tests/test_logging_controller.py
+++ b/pluggable_protocol_tree/tests/test_logging_controller.py
@@ -229,7 +229,7 @@ def test_flush_drains_app_globals_media_captures_into_ingestion(tmp_path, monkey
 
     # In-memory stand-in for the Redis-backed app_globals dict.
     fake_globals = {}
-    monkeypatch.setattr(ctrl_mod, "_get_app_globals", lambda: fake_globals)
+    monkeypatch.setattr(ctrl_mod, "app_globals", fake_globals)
 
     img_path = tmp_path / "captures" / "img.png"
     vid_path = tmp_path / "captures" / "vid.mkv"
@@ -263,7 +263,7 @@ def test_start_logging_resets_app_globals_media_bucket(tmp_path, monkeypatch):
     clears the shared bucket before the run begins."""
     from pluggable_protocol_tree.services.logging import controller as ctrl_mod
     fake_globals = {"media_captures": ["leftover-from-previous-run"]}
-    monkeypatch.setattr(ctrl_mod, "_get_app_globals", lambda: fake_globals)
+    monkeypatch.setattr(ctrl_mod, "app_globals", fake_globals)
 
     c = ProtocolLoggingController(settling_provider=lambda: 0.0,
                                   flush_scheduler=_immediate)

--- a/pluggable_protocol_tree/tests/test_logging_reporting.py
+++ b/pluggable_protocol_tree/tests/test_logging_reporting.py
@@ -214,10 +214,10 @@ def test_heatmap_passes_duration_units_to_helper(monkeypatch, tmp_path):
         captured["kw"] = dict(kw)
         return _FakeFig()
 
-    # Replace the helper at the import site used inside _heatmap.
-    import microdrop_utils.plotly_helpers as ph
+    # Replace the helper at the binding _heatmap uses (hoisted to the
+    # reporting module's top-level import).
     monkeypatch.setattr(
-        ph, "create_plotly_svg_dropbot_device_heatmap", _fake_helper)
+        r, "create_plotly_svg_dropbot_device_heatmap", _fake_helper)
 
     df = pd.DataFrame([
         {"actuated_channels": [1], "instrument_time_us": 0},

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -895,7 +895,7 @@ def test_flush_with_report_shows_progress_dialog_and_runs_in_worker(qapp, monkey
     pane = ptp.ProtocolTreePane([make_name_column()])
     controller = pane.logging_controller
     # Force the fast (no-wait) path on the settling timer.
-    controller._settling_provider = lambda: 0.0
+    controller.settling_provider = lambda: 0.0
     controller._generate_report = True
     flush_thread = {}
 
@@ -940,7 +940,7 @@ def test_flush_progress_dialog_appears_before_settling_delay(qapp, monkeypatch):
     controller = pane.logging_controller
     # Pretend settling is non-trivial so the timer wouldn't have fired by
     # the time _schedule_flush_with_progress returns.
-    controller._settling_provider = lambda: 5.0
+    controller.settling_provider = lambda: 5.0
     controller._generate_report = True
     controller._flush = lambda: None
 
@@ -964,7 +964,7 @@ def test_flush_without_report_skips_progress_dialog(qapp, monkeypatch):
 
     pane = ptp.ProtocolTreePane([make_name_column()])
     controller = pane.logging_controller
-    controller._settling_provider = lambda: 0.0
+    controller.settling_provider = lambda: 0.0
     controller._generate_report = False
     flushed = []
     controller._flush = lambda: flushed.append(True)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -7,13 +7,21 @@ application so the experiment-bar buttons drive real handlers."""
 from pyface.tasks.api import TraitsDockPane
 from traits.api import Instance, List, Str
 
+from device_viewer.consts import CHANNEL_AREAS_KEY, DEVICE_SVG_PATH_KEY
 from logger.logger_service import get_logger
+from microdrop_application.helpers import get_microdrop_redis_globals_manager
 from microdrop_utils.sticky_notes import StickyWindowManager
 from protocol_grid.services.experiment_manager import ExperimentManager
 
 from pluggable_protocol_tree.interfaces.i_column import IColumn
+from pluggable_protocol_tree.services.logging.models import LoggingDeviceContext
 
 logger = get_logger(__name__)
+
+# Shared Redis-backed state the device viewer publishes to (channel areas, the
+# device SVG path). Read here so the logging context never reaches into the
+# device-viewer pane/model.
+app_globals = get_microdrop_redis_globals_manager()
 
 
 class PluggableProtocolDockPane(TraitsDockPane):
@@ -41,17 +49,18 @@ class PluggableProtocolDockPane(TraitsDockPane):
         sync = DeviceViewerSyncController(row_manager=manager)
 
         def _logging_device_context():
-            from pluggable_protocol_tree.services.logging.models import (
-                LoggingDeviceContext,
-            )
+            # Decoupled: read channel areas + device SVG path from the shared
+            # app_globals (published by the device viewer) rather than reaching
+            # into the device-viewer pane/model.
             channel_areas, svg_path = {}, None
             try:
-                dv_pane = self.task.window.get_dock_pane("device_viewer.dock_pane")
-                model = getattr(dv_pane, "model", None)
-                if model is not None:
-                    channel_areas = dict(
-                        model.electrodes.channel_electrode_areas_scaled_map)
-                    svg_path = getattr(model.electrodes.svg_model, "filename", None)
+                # Redis JSON-stringifies the int channel keys; restore int keys
+                # to match the actuation lookup (areas.get(int(ch))).
+                channel_areas = {
+                    int(k): float(v)
+                    for k, v in (app_globals.get(CHANNEL_AREAS_KEY) or {}).items()
+                }
+                svg_path = app_globals.get(DEVICE_SVG_PATH_KEY)
             except Exception as e:
                 logger.debug(f"logging device-context probe failed: {e}")
             return LoggingDeviceContext(

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1338,7 +1338,7 @@ class ProtocolTreePane(QWidget):
         just a quick data-file write — no dialog, no worker thread, fast
         path mirrors the original ``QTimer.singleShot`` scheduler.
         """
-        settling_ms = int(controller._settling_provider() * 1000)
+        settling_ms = int(controller.settling_provider() * 1000)
         if not controller._generate_report:
             QTimer.singleShot(settling_ms, controller._flush)
             return

--- a/protocol_grid/widget.py
+++ b/protocol_grid/widget.py
@@ -2,7 +2,7 @@ import copy
 import json
 from pathlib import Path
 
-from device_viewer.consts import LIQUID_CAPACITANCE_KEY, FILLER_CAPACITANCE_KEY
+from device_viewer.consts import LIQUID_CAPACITANCE_KEY, FILLER_CAPACITANCE_KEY, DEVICE_SVG_PATH_KEY
 from dropbot_preferences_ui.models import VoltageFrequencyRangePreferences
 from electrode_controller.consts import electrode_state_change_publisher
 from microdrop_application.dialogs.pyface_wrapper import confirm, NO, YES, success, error, information
@@ -3676,7 +3676,10 @@ class PGCWidget(QWidget):
             return
 
         # use experiment directory as default save location
-        default_dir = Path(self.preferences.PROTOCOL_REPO_DIR) / app_globals.get("microdrop.device_svg.name", "Null")
+        _device_path = app_globals.get(DEVICE_SVG_PATH_KEY, "Null")
+        # .stem (not .name): the per-device folder is named after the device,
+        # without the .svg extension, matching the old device_svg.name global.
+        default_dir = Path(self.preferences.PROTOCOL_REPO_DIR) / Path(_device_path).stem
         default_dir.mkdir(parents=True, exist_ok=True)
 
         if not file_name:


### PR DESCRIPTION
## Summary

Removes cross-plugin coupling and code-style anti-patterns from the
`pluggable_protocol_tree` logging feature, following the repo conventions
(decouple via app_globals / dramatiq; HasTraits + traits.api; constants in
`consts.py`; no Qt in service/model layers; no imports inside functions).

Scoped to `pluggable_protocol_tree` plus one minimal **owner-publishes** enabler
in `device_viewer` (see below).

## Decoupling — no plugin reaches into another's pane/model/classes

- **`views/dock_pane.py`**: `_logging_device_context` no longer reaches into the
  device-viewer dock pane (`get_dock_pane("device_viewer.dock_pane").model.electrodes…`).
  It reads channel areas and the device SVG path from the shared **app_globals**
  (`CHANNEL_AREAS_KEY` / `DEVICE_SVG_PATH_KEY`). Redis JSON-stringifies the int
  channel keys, so they're restored to `int` at the read site (matches
  `on_actuation`'s `int(ch)` lookup).
- **`services/logging/controller.py`**: no longer imports
  `protocol_grid.preferences` for the settling time — it reads
  `app_globals(LOGS_SETTLING_TIME_S_KEY, DEFAULT_SETTLING_TIME_S)`.

### ⚠️ Behaviour note to review (settling preference)
Nothing currently mirrors `logs_settling_time_s` into app_globals, so a user who
**customised** the settling preference now falls back to the **3.0s default**
(identical to today's default otherwise). Restoring live-pref behaviour is a
one-observer **owner-publishes** follow-up in `protocol_grid` (kept out to honour
the PPT scope). Flag if you'd rather I add it.

### Owner-publishes enabler (device_viewer — the one out-of-PPT change)
The report heatmap loads the device SVG by **full path**, but only the stem was
in app_globals. `device_viewer/models/main_model.py` now also publishes the full
path to `DEVICE_SVG_PATH_KEY` (added to `APP_GLOBALS_KEYS`). This is the
"owner publishes" half that lets the dock pane stop reaching into the DV model.

## Code-style

- **controller**: module-level `app_globals` (canonical idiom); all imports
  hoisted to module top (`MediaCaptureMessageModel` is a shared message schema —
  the pub/sub contract); **Qt removed from the service layer** — the default
  flush scheduler is a Qt-free `threading.Timer`; the view still injects the Qt
  progress scheduler.
- **reporting**: hoisted `plotly` / heatmap-helper / `LoggingPersistence` imports.
- new **`services/logging/consts.py`**: `TIME_FMT`, `RUN_TIMESTAMP_FMT`,
  `MEDIA_CAPTURES_KEY`, `LOGS_SETTLING_TIME_S_KEY`, `DEFAULT_SETTLING_TIME_S`.
- **HasTraits**: `ProtocolLoggingController`, `LoggingIngestion`,
  `LoggingDeviceContext` are now `traits.api.HasTraits` (class-level traits,
  `traits_init`, `_x_default`). Stateless utilities (`LoggingPersistence` /
  `LoggingReport`) stay plain.

## Verification

- Manual behavioural smoke (construction, lifecycle, actuation-area summing,
  flush artifacts, media drain/reset, calibration→force, settling default).
- A multi-agent adversarial review ran the test suite: it confirmed the
  decoupling/behaviour/conventions/test-contract are sound and surfaced 4
  collateral test regressions from the trait rename + reporting import hoist —
  all fixed here (`test_protocol_tree_pane.py` settling overrides → renamed trait;
  `test_logging_reporting.py` heatmap patch → hoisted binding;
  `test_logging_controller.py` media tests → `app_globals`). The 2 other suite
  failures and Redis-needing errors pre-exist on `main`.

Plan + persisted conventions: `microdrop-py/.claude/logging_decouple_plan.md`
and `.claude/skills/microdrop-conventions/SKILL.md` (in the superproject repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)