### PR TITLE
PPT-18: timeout=float("inf") wait-forever convention for ctx.wait_for

### DIFF
--- a/dropbot_protocol_controls/protocol_columns/droplet_check_column.py
+++ b/dropbot_protocol_controls/protocol_columns/droplet_check_column.py
@@ -139,12 +139,12 @@ class DropletCheckHandler(BaseColumnHandler):
                 "missing":   missing,
             }),
         )
-        # 24h is "effectively infinite" for a user-facing dialog;
-        # stop_event is the real cancellation path. wait_for requires
-        # a finite float — None would crash deadline math.
+        # Wait forever for the user's decision — float("inf") is the
+        # wait_for convention for that (PPT-18); stop_event is the
+        # cancellation path.
         decision_raw = ctx.wait_for(
             DROPLET_CHECK_DECISION_RESPONSE,
-            timeout=86_400.0,
+            timeout=float("inf"),
             predicate=lambda payload: json.loads(payload).get("step_uuid") == row.uuid,
         )
         decision = json.loads(decision_raw).get("choice")

--- a/dropbot_protocol_controls/tests/test_droplet_check_handler.py
+++ b/dropbot_protocol_controls/tests/test_droplet_check_handler.py
@@ -340,7 +340,7 @@ def test_decision_wait_uses_predicate_filtering_by_step_uuid(published):
     assert predicate(json.dumps({"step_uuid": "OTHER_STEP", "choice": "x"})) is False
 
 
-def test_decision_wait_uses_24h_timeout(published):
+def test_decision_wait_uses_infinite_timeout(published):
     handler = DropletCheckHandler()
     row = _FakeRow(uuid="abc", check_droplets=True, electrodes=["e1"])
     ctx = _FakeStepCtx(_FakeProtocolCtx({"e1": 1}))
@@ -354,4 +354,4 @@ def test_decision_wait_uses_24h_timeout(published):
     handler.on_post_step(row, ctx)
 
     _, timeout, _ = ctx.wait_for_calls[1]
-    assert timeout == 86_400.0                  # spec § 4 design note
+    assert timeout == float("inf")              # PPT-18 wait-forever convention

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -321,7 +321,7 @@ class StepContext(HasTraits):
             ) from None
 
 
-    def wait(self, events: list[threading.Event], timeout: float = 86400):
+    def wait(self, events: list[threading.Event], timeout: float = float("inf")):
         """Pause the run and block the worker thread until an event fires.
 
         Used by hooks that hand control to the UI mid-step (e.g. the
@@ -330,14 +330,16 @@ class StepContext(HasTraits):
         them trips. On a normal acknowledge it resumes the protocol before
         returning; on Stop it aborts.
 
-        The default ``timeout`` of 86400s (24h) is "effectively infinite"
-        for an operator-facing wait — the real cancellation path is the
-        protocol's ``stop_event`` (pass it in ``events``).
+        The default ``timeout`` of ``float("inf")`` waits forever — right
+        for an operator-facing wait, where the real cancellation path is
+        the protocol's ``stop_event`` (pass it in ``events``). Pass a
+        finite timeout to bound the wait instead.
 
         Args:
             events: events to wake on. Include ``protocol.stop_event`` to
                 make Stop abort the wait.
-            timeout: seconds before raising ``TimeoutError``.
+            timeout: seconds before raising ``TimeoutError``;
+                ``float("inf")`` (the default) never times out.
 
         Returns ``None``. Raises:
           * ``TimeoutError`` after ``timeout`` seconds with nothing set.
@@ -400,7 +402,8 @@ class StepContext(HasTraits):
                 f"Timed out after {timeout}s wait"
             ) from None
 
-    def prompt_gui(self, gui_callable: Callable, *, timeout: float = 86400):
+    def prompt_gui(self, gui_callable: Callable, *,
+                   timeout: float = float("inf")):
         """Run ``gui_callable`` on the GUI thread, paused, and return its result.
 
         The dialog counterpart to :meth:`wait`. Where ``wait`` only parks the
@@ -419,7 +422,9 @@ class StepContext(HasTraits):
 
         Args:
             gui_callable: zero-arg callable invoked on the GUI thread.
-            timeout: seconds before the underlying wait raises TimeoutError.
+            timeout: seconds before the underlying wait raises TimeoutError;
+                ``float("inf")`` (the default) never times out — Stop is
+                the cancellation path.
 
         Returns the callable's result, or ``None`` if the wait ended without
         it finishing (external Resume before the user answered). Raises:

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -27,6 +27,10 @@ def wait_first(events: list, timeout: float) -> Optional[threading.Event]:
     expose a kqueue/epoll-style multi-event wait, and rolling a
     waker-channel implementation is more code than the executor needs.
 
+    ``timeout=float("inf")`` waits forever — the deadline arithmetic
+    handles it naturally (``remaining`` never reaches zero), so one of
+    ``events`` becomes the only exit path.
+
     The poll interval is small enough that responsiveness is dominated
     by the OS scheduler, not by the polling cadence.
     """
@@ -67,6 +71,10 @@ class Mailbox:
         Raises ``TimeoutError`` if the deadline elapses with no match.
         Raises ``AbortError`` if ``stop_event`` is set, either before
         the call or while the call is blocked.
+
+        ``timeout=float("inf")`` is the convention for "wait forever":
+        no TimeoutError is ever raised and cancellation relies solely
+        on ``stop_event``.
         """
         if stop_event.is_set():
             raise AbortError("stop_event set before wait_for")
@@ -276,6 +284,11 @@ class StepContext(HasTraits):
                  predicate: Optional[Callable] = None):
         """Block until a message on ``topic`` satisfying ``predicate``
         arrives, or the timeout/stop fires.
+
+        ``timeout=float("inf")`` is the convention for "wait forever"
+        (e.g. a user-decision dialog): no TimeoutError is ever raised
+        and the protocol's stop_event becomes the only cancellation
+        path.
 
         Returns the payload. Raises:
           * ``KeyError`` if ``topic`` was not declared in any handler's

--- a/pluggable_protocol_tree/tests/test_message_prompt_column.py
+++ b/pluggable_protocol_tree/tests/test_message_prompt_column.py
@@ -1,7 +1,7 @@
 """Tests for the message-prompt column handler's guard logic.
 
 These cover the two paths that don't touch Qt — the empty-message no-op
-and the already-stopped abort — so they run headless without a running
+and the already-stopped skip — so they run headless without a running
 event loop. The dialog path itself (QTimer.singleShot -> information()
 -> event set -> ctx.wait returns) needs a Qt application and is exercised
 by the StepContext.wait tests in test_step_context.py plus manual/demo
@@ -11,13 +11,10 @@ runs of run_widget.py.
 import threading
 import types
 
-import pytest
-
 from pluggable_protocol_tree.builtins.message_prompt_column import (
     MsgPromptColumnHandler, make_message_prompt_column,
 )
 from pluggable_protocol_tree.execution.events import PauseEvent
-from pluggable_protocol_tree.execution.exceptions import AbortError
 from pluggable_protocol_tree.execution.step_context import ProtocolContext
 
 
@@ -53,15 +50,20 @@ def test_empty_message_is_a_noop():
     assert proto.pause_event.is_set() is False
 
 
-def test_aborts_when_already_stopped_before_prompt():
+def test_skips_prompt_when_already_stopped():
+    """A stopped protocol skips the prompt entirely (logged warning) —
+    on_pre_step returns without showing a dialog or parking the worker;
+    the executor's own stop handling aborts the run."""
     handler = MsgPromptColumnHandler()
     proto = _make_proto()
     proto.stop_event.set()
     ctx = _FakeCtx(proto)
     row = types.SimpleNamespace(message_prompt="Load 100uL")
 
-    with pytest.raises(AbortError):
-        handler.on_pre_step(row, ctx)
+    handler.on_pre_step(row, ctx)
+
+    # No dialog, no wait — the guard returned before the prompt path.
+    assert ctx.waited is None
 
 
 def test_factory_wires_model_view_handler():

--- a/pluggable_protocol_tree/tests/test_message_prompt_column.py
+++ b/pluggable_protocol_tree/tests/test_message_prompt_column.py
@@ -30,7 +30,7 @@ class _FakeCtx:
         self.protocol = protocol
         self.waited = None
 
-    def wait(self, events, timeout=86400):
+    def wait(self, events, timeout=float("inf")):
         self.waited = events
 
 

--- a/pluggable_protocol_tree/tests/test_step_context.py
+++ b/pluggable_protocol_tree/tests/test_step_context.py
@@ -359,3 +359,55 @@ def test_executor_build_step_ctx_seeds_two_fresh_events():
     # And they must be distinct Event instances, not aliases.
     assert ctx_a.phase_advance_event is not ctx_b.phase_advance_event
     assert ctx_a.step_phases_done_event is not ctx_b.step_phases_done_event
+
+
+# --- timeout=float("inf") — the "wait forever" convention (PPT-18) ---
+
+
+def test_wait_first_infinite_timeout_returns_event_when_fired():
+    a = threading.Event()
+    threading.Timer(0.05, a.set).start()
+    fired = wait_first([a], timeout=float("inf"))
+    assert fired is a
+
+
+def test_mailbox_drain_one_infinite_timeout_returns_on_deposit():
+    """inf must survive the deadline math (deadline/remaining both inf)
+    and exit only via a deposit — never via TimeoutError."""
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, lambda: mb.deposit("hello")).start()
+    item = mb.drain_one(predicate=None, timeout=float("inf"), stop_event=stop)
+    assert item == "hello"
+
+
+def test_mailbox_drain_one_infinite_timeout_aborts_on_stop():
+    """With an infinite timeout, stop_event is the only cancellation
+    path — it must abort promptly."""
+    mb = Mailbox()
+    stop = threading.Event()
+    threading.Timer(0.05, stop.set).start()
+    start = time.monotonic()
+    import pytest
+    with pytest.raises(AbortError):
+        mb.drain_one(predicate=None, timeout=float("inf"), stop_event=stop)
+    assert time.monotonic() - start < 0.5
+
+
+def test_wait_for_infinite_timeout_returns_payload_when_message_arrives():
+    step = _make_step_ctx(["t/decision"])
+    threading.Timer(
+        0.05, lambda: step.deposit("t/decision", {"choice": "continue"})
+    ).start()
+    payload = step.wait_for("t/decision", timeout=float("inf"))
+    assert payload == {"choice": "continue"}
+
+
+def test_wait_for_infinite_timeout_aborts_when_stop_event_fires():
+    step = _make_step_ctx(["t/decision"])
+    threading.Timer(0.05, step.protocol.stop_event.set).start()
+    start = time.monotonic()
+    import pytest
+    with pytest.raises(AbortError):
+        step.wait_for("t/decision", timeout=float("inf"))
+    assert time.monotonic() - start < 0.5


### PR DESCRIPTION
Closes #406 (PPT-18).

## What

Adopts `timeout=float("inf")` as the convention for "wait forever" in the PPT wait machinery, replacing the 24h (`86_400.0` / `86400`) magic numbers. `timeout` stays a plain float — no `Optional[float]` / `None` branching; the deadline arithmetic handles `inf` naturally (`monotonic() + inf == inf`, `remaining` never reaches zero).

- **`step_context.py`** — documented the `float("inf")` convention on `wait_first`, `Mailbox.drain_one`, and `StepContext.wait_for` (docstring-only; the math already supports it). With an infinite timeout, `stop_event` is the sole cancellation path and `TimeoutError` is never raised.
- **Tests** — 5 new tests covering `float("inf")` through all three layers: returns when a deposit/message arrives, aborts promptly via `stop_event` (`AbortError`).
- **Droplet check handler** — `ctx.wait_for(DROPLET_CHECK_DECISION_RESPONSE, timeout=float("inf"))` instead of `86_400.0`; test renamed/updated accordingly.
- **`StepContext.wait` / `prompt_gui`** — these grew the same `timeout=86400` default since #406 was filed; their defaults are now `float("inf")` too (both call sites — message prompt, volume-threshold recovery — are operator-facing waits that pass `stop_event`). The message-prompt test fake mirrors the new default.
- **Stale test fix** — `test_aborts_when_already_stopped_before_prompt` expected `AbortError`, but the handler deliberately skips the prompt (logged warning) and returns when the protocol is already stopped. This was failing on `main` before this branch; the test now asserts the skip-and-return behavior (`test_skips_prompt_when_already_stopped`).

## Test plan

```
pixi run python -m pytest pluggable_protocol_tree/tests/test_step_context.py \
    dropbot_protocol_controls/tests/test_droplet_check_handler.py \
    pluggable_protocol_tree/tests/test_message_prompt_column.py
```

53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
