### PR TITLE
[PPT-17] Validate loaded protocol against current device (#423)

### DIFF
--- a/docs/superpowers/plans/2026-06-11-issue-423-protocol-load-validation.md
+++ b/docs/superpowers/plans/2026-06-11-issue-423-protocol-load-validation.md
@@ -1,0 +1,833 @@
+# Protocol-load Validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Validate a loaded protocol against the current device at load time, surfacing electrode-ID, stale-channel, and orphan-column problems as a GUI dialog (File > Open) or printed logger output (headless load).
+
+**Architecture:** A pure, side-effect-free `validate_protocol(data, columns, device_map) -> ValidationReport` reads the raw serialized JSON. Two interchangeable presenters render the same report: `confirm_report` (a two-tier `pyface_wrapper` dialog that can abort the load) and `log_report` (logger output that never blocks). Headless `RowManager.from_json` / `set_state_from_json` call the validator + `log_report`; the GUI `load_from_dialog` runs the validator + `confirm_report` and only mutates on Proceed.
+
+**Tech Stack:** Python, Traits (`RowManager`), PySide6/Pyface dialogs (`microdrop_application.dialogs.pyface_wrapper`), pytest. Run tests with:
+`pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest`
+
+---
+
+## File structure
+
+- **Create** `pluggable_protocol_tree/services/protocol_validator.py` — `Finding`, `ValidationReport`, `validate_protocol`, helpers (`_row_dotted_ids`, `_value_index`, `_electrodes_in_row`), and the two presenters (`log_report`, `confirm_report`) + `_format_html` / `_format_detail`. Constants: `PROCEED`, `CANCEL`, `SEVERITY_WARNING`, `SEVERITY_ERROR`, `ROUTES_COL_ID`, `ELECTRODES_COL_ID`.
+- **Create** `pluggable_protocol_tree/tests/test_protocol_validator.py` — unit tests for the validator + presenters.
+- **Modify** `pluggable_protocol_tree/models/row_manager.py` — add `device_electrode_to_channel=None, report_findings=True` to `from_json` and `set_state_from_json`; validate + `log_report` before applying state.
+- **Modify** `pluggable_protocol_tree/views/protocol_tree_pane.py` — `load_from_dialog` runs `validate_protocol` + `confirm_report`, aborts on Cancel, calls `set_state_from_json(..., report_findings=False)` on Proceed.
+
+The validator's serialized-JSON contract (from `services/persistence.py`):
+`data["fields"] == ["depth","uuid","type","name", *col_ids]`; each `data["rows"]` entry is `[depth, uuid, type, name, *values]`; the `routes` value is `list[list[str]]`, the `electrodes` value is `list[str]`; `data["columns"]` is a list of `{"id": col_id, ...}`; `data["protocol_metadata"]["electrode_to_channel"]` is `{electrode_id: channel_int}`.
+
+---
+
+## Task 1: Validator data types + orphan-column check
+
+**Files:**
+- Create: `pluggable_protocol_tree/services/protocol_validator.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# pluggable_protocol_tree/tests/test_protocol_validator.py
+"""Tests for the pure protocol-load validator and its presenters."""
+
+from types import SimpleNamespace
+
+from pluggable_protocol_tree.services.protocol_validator import (
+    validate_protocol, ValidationReport, Finding,
+    SEVERITY_ERROR, SEVERITY_WARNING,
+)
+
+
+def fake_columns(*col_ids):
+    """Minimal stand-ins for live IColumn objects: only .model.col_id is read."""
+    return [SimpleNamespace(model=SimpleNamespace(col_id=cid)) for cid in col_ids]
+
+
+def make_data(fields=None, rows=None, columns=None, metadata=None):
+    return {
+        "schema_version": 1,
+        "protocol_metadata": metadata or {},
+        "columns": columns or [],
+        "fields": fields or ["depth", "uuid", "type", "name"],
+        "rows": rows or [],
+    }
+
+
+def test_clean_protocol_is_empty():
+    data = make_data(columns=[{"id": "duration_s"}])
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert report.is_empty
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_orphan_column_is_error():
+    # Saved protocol references a "magnet" column whose plugin isn't loaded.
+    data = make_data(columns=[{"id": "duration_s"}, {"id": "magnet"}])
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert len(report.errors) == 1
+    finding = report.errors[0]
+    assert finding.severity == SEVERITY_ERROR
+    assert finding.category == "orphan_column"
+    assert finding.items == ["magnet"]
+    assert not report.is_empty
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pluggable_protocol_tree.services.protocol_validator'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# pluggable_protocol_tree/services/protocol_validator.py
+"""Pure protocol-load validation + presenters (issue #423, PPT-17).
+
+``validate_protocol`` reads the raw serialized protocol JSON (output of
+``services.persistence.serialize_tree``) and returns a structured
+``ValidationReport``. It performs three checks:
+
+  * orphan column   (error)   - a saved col_id has no live column; its
+                                 values are silently dropped by
+                                 ``deserialize_tree``.
+  * electrode id    (warning) - an electrode referenced by a step's
+                                 routes/electrodes doesn't exist on the
+                                 current device.
+  * stale channel   (warning) - the protocol's stored electrode->channel
+                                 disagrees with the device's current map.
+
+The function is side-effect free (no Qt, no RowManager, no I/O) so it is
+trivially unit-testable. Two presenters render a report: ``log_report``
+(headless, logger output) and ``confirm_report`` (GUI dialog).
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+# Presenter decisions.
+PROCEED = "proceed"
+CANCEL = "cancel"
+
+SEVERITY_WARNING = "warning"
+SEVERITY_ERROR = "error"
+
+# Builtin column ids whose values carry electrode references.
+ROUTES_COL_ID = "routes"
+ELECTRODES_COL_ID = "electrodes"
+
+
+@dataclass
+class Finding:
+    severity: str          # SEVERITY_WARNING | SEVERITY_ERROR
+    category: str          # "orphan_column" | "electrode_id" | "stale_channel"
+    title: str             # short human summary
+    items: List[str] = field(default_factory=list)  # detail lines
+
+
+@dataclass
+class ValidationReport:
+    findings: List[Finding] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_ERROR]
+
+    @property
+    def warnings(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_WARNING]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.findings
+
+
+def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationReport:
+    """Validate raw serialized protocol ``data`` against the live ``columns``
+    and the device's ``device_electrode_to_channel`` map. Never raises on
+    malformed input - returns an empty/partial report instead."""
+    findings: List[Finding] = []
+    if not isinstance(data, dict):
+        return ValidationReport(findings=findings)
+
+    col_specs = data.get("columns") or []
+
+    # --- orphan columns (device-independent) ---
+    live_ids = {c.model.col_id for c in (columns or [])}
+    orphan_ids = [
+        spec.get("id") for spec in col_specs
+        if isinstance(spec, dict) and spec.get("id") and spec.get("id") not in live_ids
+    ]
+    if orphan_ids:
+        findings.append(Finding(
+            severity=SEVERITY_ERROR,
+            category="orphan_column",
+            title=(f"{len(orphan_ids)} column(s) in this protocol have no "
+                   f"matching plugin; their values will be dropped on load"),
+            items=[str(cid) for cid in orphan_ids],
+        ))
+
+    return ValidationReport(findings=findings)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/protocol_validator.py pluggable_protocol_tree/tests/test_protocol_validator.py
+git commit -m "[PPT-17] Pure validator: ValidationReport + orphan-column check"
+```
+
+---
+
+## Task 2: Step dotted-id reconstruction + electrode-ID validity check
+
+**Files:**
+- Modify: `pluggable_protocol_tree/services/protocol_validator.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to test_protocol_validator.py
+from pluggable_protocol_tree.services.protocol_validator import _row_dotted_ids
+
+
+def test_dotted_ids_nested():
+    # depths [0,1,1,0] -> ["1","1.1","1.2","2"]
+    rows = [
+        [0, "u0", "group", "G"],
+        [1, "u1", "step", "A"],
+        [1, "u2", "step", "B"],
+        [0, "u3", "step", "C"],
+    ]
+    assert _row_dotted_ids(rows) == ["1", "1.1", "1.2", "2"]
+
+
+def test_unknown_electrode_in_electrodes_column():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [
+        [0, "u0", "step", "A", ["E1", "E99"]],
+        [0, "u1", "step", "B", ["E1"]],
+    ]
+    device_map = {"E1": 1}   # E99 is unknown
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("electrodes"), device_map)
+    warns = report.warnings
+    assert len(warns) == 1
+    assert warns[0].category == "electrode_id"
+    assert warns[0].items == ["E99  (steps 1)"]
+
+
+def test_unknown_electrode_in_routes_column():
+    fields = ["depth", "uuid", "type", "name", "routes"]
+    rows = [
+        [0, "u0", "step", "A", [["E1", "E2"], ["E2", "EX"]]],
+    ]
+    device_map = {"E1": 1, "E2": 2}   # EX unknown
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("routes"), device_map)
+    assert [f.category for f in report.warnings] == ["electrode_id"]
+    assert report.warnings[0].items == ["EX  (steps 1)"]
+
+
+def test_known_electrodes_no_findings():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1", "E2"]]]
+    device_map = {"E1": 1, "E2": 2}
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("electrodes"), device_map)
+    assert report.is_empty
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: FAIL (`ImportError: cannot import name '_row_dotted_ids'` and electrode-validity assertions)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the helpers above `validate_protocol`, and the electrode-validity block inside it (after the orphan block, before `return`):
+
+```python
+def _row_dotted_ids(rows):
+    """1-indexed dotted ids (e.g. '1.2') for each row, derived from the
+    ``depth`` sequence. Matches the dotted-id convention used by
+    device_viewer_sync._publish_for_row."""
+    stack = []  # stack[d] = running sibling count at depth d under current parent
+    out = []
+    for row in rows:
+        depth = int(row[0])
+        if len(stack) < depth + 1:
+            stack.extend([0] * (depth + 1 - len(stack)))
+        else:
+            del stack[depth + 1:]   # leaving a deeper level resets its counters
+        stack[depth] += 1
+        out.append(".".join(str(stack[i]) for i in range(depth + 1)))
+    return out
+
+
+def _value_index(fields, col_id):
+    """Index into a row's value slice (row[4:]) for ``col_id``, or None.
+    The first four fields are fixed row metadata (depth/uuid/type/name)."""
+    try:
+        field_pos = fields.index(col_id)
+    except ValueError:
+        return None
+    return field_pos - 4 if field_pos >= 4 else None
+
+
+def _electrodes_in_row(values, routes_idx, electrodes_idx):
+    """All electrode IDs referenced by one row's electrodes + routes values."""
+    out = set()
+    if electrodes_idx is not None and electrodes_idx < len(values):
+        val = values[electrodes_idx]
+        if isinstance(val, list):
+            out.update(str(e) for e in val)
+    if routes_idx is not None and routes_idx < len(values):
+        val = values[routes_idx]
+        if isinstance(val, list):
+            for route in val:
+                if isinstance(route, list):
+                    out.update(str(e) for e in route)
+    return out
+```
+
+Insert this block in `validate_protocol` just before `return`:
+
+```python
+    device_map = device_electrode_to_channel or {}
+    if device_map:
+        fields = data.get("fields") or []
+        rows = data.get("rows") or []
+        dotted = _row_dotted_ids(rows)
+        routes_idx = _value_index(fields, ROUTES_COL_ID)
+        electrodes_idx = _value_index(fields, ELECTRODES_COL_ID)
+
+        refs = {}   # electrode_id -> set of step dotted-ids
+        for i, row in enumerate(rows):
+            values = list(row[4:])
+            step_id = dotted[i] if i < len(dotted) else str(i + 1)
+            for eid in _electrodes_in_row(values, routes_idx, electrodes_idx):
+                refs.setdefault(eid, set()).add(step_id)
+
+        unknown = sorted(eid for eid in refs if eid not in device_map)
+        if unknown:
+            items = [f"{eid}  (steps {', '.join(sorted(refs[eid]))})"
+                     for eid in unknown]
+            findings.append(Finding(
+                severity=SEVERITY_WARNING,
+                category="electrode_id",
+                title=(f"{len(unknown)} electrode(s) referenced by this protocol "
+                       f"do not exist on the current device"),
+                items=items,
+            ))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: PASS (all Task 1 + Task 2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/protocol_validator.py pluggable_protocol_tree/tests/test_protocol_validator.py
+git commit -m "[PPT-17] Validator: electrode-ID validity check + dotted step ids"
+```
+
+---
+
+## Task 3: Stale-channel-mapping check + no-device / malformed-input behavior
+
+**Files:**
+- Modify: `pluggable_protocol_tree/services/protocol_validator.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to test_protocol_validator.py
+def test_stale_channel_mapping_flagged():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1"]]]
+    metadata = {"electrode_to_channel": {"E1": 5}}   # protocol thinks E1 -> ch 5
+    device_map = {"E1": 7}                           # device now maps E1 -> ch 7
+    report = validate_protocol(make_data(fields=fields, rows=rows, metadata=metadata),
+                               fake_columns("electrodes"), device_map)
+    stale = [f for f in report.warnings if f.category == "stale_channel"]
+    assert len(stale) == 1
+    assert stale[0].items == ["E1: protocol ch 5 -> device ch 7"]
+
+
+def test_matching_channel_not_flagged():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1"]]]
+    metadata = {"electrode_to_channel": {"E1": 7}}
+    device_map = {"E1": 7}
+    report = validate_protocol(make_data(fields=fields, rows=rows, metadata=metadata),
+                               fake_columns("electrodes"), device_map)
+    assert report.is_empty
+
+
+def test_no_device_map_skips_device_checks_but_reports_orphan():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E_DOES_NOT_EXIST"]]]
+    data = make_data(fields=fields, rows=rows,
+                     columns=[{"id": "electrodes"}, {"id": "ghost"}],
+                     metadata={"electrode_to_channel": {"E1": 1}})
+    report = validate_protocol(data, fake_columns("electrodes"), {})  # no device
+    # device checks skipped -> only the orphan-column error remains
+    assert [f.category for f in report.findings] == ["orphan_column"]
+
+
+def test_malformed_data_no_exception():
+    assert validate_protocol(None, fake_columns("x"), {"E1": 1}).is_empty
+    assert validate_protocol({}, fake_columns("x"), {"E1": 1}).is_empty
+    # rows missing value slots / wrong types must not raise
+    bad = {"columns": [{"id": "electrodes"}], "fields": ["depth", "uuid", "type", "name", "electrodes"],
+           "rows": [[0, "u", "step", "A"], [0, "u2", "step", "B", "notalist"]]}
+    report = validate_protocol(bad, fake_columns("electrodes"), {"E1": 1})
+    assert isinstance(report, ValidationReport)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: FAIL on `test_stale_channel_mapping_flagged` (no stale findings produced)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Inside the `if device_map:` block in `validate_protocol`, after the electrode-validity `if unknown:` block, add:
+
+```python
+        proto_map = (data.get("protocol_metadata") or {}).get("electrode_to_channel") or {}
+        stale = [
+            f"{eid}: protocol ch {proto_ch} -> device ch {device_map[eid]}"
+            for eid, proto_ch in sorted(proto_map.items())
+            if eid in device_map and device_map[eid] != proto_ch
+        ]
+        if stale:
+            findings.append(Finding(
+                severity=SEVERITY_WARNING,
+                category="stale_channel",
+                title=(f"{len(stale)} electrode(s) map to a different channel on "
+                       f"the current device than the protocol expects"),
+                items=stale,
+            ))
+```
+
+(The no-device skip and malformed-input safety are already covered by the
+`if not isinstance(data, dict)` guard, the `if device_map:` gate, and the
+`isinstance(val, list)` checks in `_electrodes_in_row`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: PASS (all validator tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/protocol_validator.py pluggable_protocol_tree/tests/test_protocol_validator.py
+git commit -m "[PPT-17] Validator: stale channel-mapping check"
+```
+
+---
+
+## Task 4: Presenters — `log_report` and `confirm_report`
+
+**Files:**
+- Modify: `pluggable_protocol_tree/services/protocol_validator.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to test_protocol_validator.py
+import logging
+
+from pluggable_protocol_tree.services import protocol_validator as pv
+from pluggable_protocol_tree.services.protocol_validator import (
+    log_report, confirm_report, PROCEED, CANCEL,
+)
+
+
+def _report_with_error_and_warning():
+    return ValidationReport(findings=[
+        Finding(SEVERITY_ERROR, "orphan_column", "1 orphan column", ["magnet"]),
+        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+    ])
+
+
+def test_log_report_levels(caplog):
+    with caplog.at_level(logging.WARNING):
+        log_report(_report_with_error_and_warning())
+    levels = {r.levelno for r in caplog.records}
+    assert logging.ERROR in levels      # orphan finding logged at ERROR
+    assert logging.WARNING in levels    # electrode finding logged at WARNING
+    text = caplog.text
+    assert "magnet" in text and "E99" in text
+
+
+def test_confirm_report_proceed(monkeypatch):
+    captured = {}
+
+    def fake_confirm(parent=None, message="", title="", **kwargs):
+        captured.update(title=title, kwargs=kwargs)
+        return pv.YES   # user clicked the proceed button
+
+    monkeypatch.setattr(pv, "confirm", fake_confirm, raising=False)
+    decision = confirm_report(_report_with_error_and_warning(), parent=None)
+    assert decision == PROCEED
+    # errors present -> the override-labelled proceed button + error title
+    assert captured["title"] == "Protocol has errors"
+    assert captured["kwargs"]["yes_label"] == "Load anyway (drop columns)"
+    assert captured["kwargs"]["no_label"] == ""
+    assert captured["kwargs"]["cancel"] is True
+
+
+def test_confirm_report_cancel(monkeypatch):
+    monkeypatch.setattr(pv, "confirm", lambda *a, **k: pv.CANCEL, raising=False)
+    report = ValidationReport(findings=[
+        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+    ])
+    assert confirm_report(report, parent=None) == CANCEL
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: FAIL (`ImportError: cannot import name 'log_report'`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `protocol_validator.py`. Import the dialog primitives at module top
+so tests can monkeypatch `pv.confirm` / read `pv.YES`:
+
+```python
+# add near the top imports
+from microdrop_application.dialogs.pyface_wrapper import confirm, YES
+```
+
+```python
+# append at end of protocol_validator.py
+def log_report(report) -> None:
+    """Headless presenter: emit each finding via the module logger. Errors at
+    ERROR level, warnings at WARNING level. Never blocks."""
+    for f in report.errors:
+        logger.error("Protocol load: %s", f.title)
+        for item in f.items:
+            logger.error("    - %s", item)
+    for f in report.warnings:
+        logger.warning("Protocol load: %s", f.title)
+        for item in f.items:
+            logger.warning("    - %s", item)
+
+
+def _format_html(report) -> str:
+    parts = []
+    if report.errors:
+        parts.append("<b>Errors</b><br>")
+        parts.extend(f"&bull; {f.title}<br>" for f in report.errors)
+    if report.warnings:
+        parts.append("<b>Warnings</b><br>")
+        parts.extend(f"&bull; {f.title}<br>" for f in report.warnings)
+    return "".join(parts)
+
+
+def _format_detail(report) -> str:
+    lines = []
+    for f in report.errors + report.warnings:
+        lines.append(f"[{f.severity.upper()}] {f.title}")
+        lines.extend(f"    - {item}" for item in f.items)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def confirm_report(report, parent=None) -> str:
+    """GUI presenter: one two-tier summary dialog. Returns PROCEED or CANCEL.
+
+    Uses exactly two buttons - a proceed button (yes_label) and Cancel - by
+    passing no_label="" to suppress confirm()'s default No button. When errors
+    are present the proceed button is the explicit drop-columns override."""
+    if report.errors:
+        title = "Protocol has errors"
+        proceed_label = "Load anyway (drop columns)"
+    else:
+        title = "Protocol warnings"
+        proceed_label = "Proceed anyway"
+    result = confirm(
+        parent,
+        message="",
+        title=title,
+        cancel=True,
+        yes_label=proceed_label,
+        no_label="",
+        cancel_label="Cancel",
+        informative=_format_html(report),
+        detail=_format_detail(report),
+    )
+    return PROCEED if result == YES else CANCEL
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: PASS (all validator + presenter tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/protocol_validator.py pluggable_protocol_tree/tests/test_protocol_validator.py
+git commit -m "[PPT-17] Presenters: log_report (headless) + confirm_report (dialog)"
+```
+
+---
+
+## Task 5: Headless wiring — `RowManager.from_json` / `set_state_from_json`
+
+**Files:**
+- Modify: `pluggable_protocol_tree/models/row_manager.py:508-544`
+- Test: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to test_protocol_validator.py
+import logging as _logging
+
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+
+
+def _basic_columns():
+    return [make_type_column(), make_name_column(), make_duration_column()]
+
+
+def test_set_state_from_json_logs_orphan_and_still_loads(caplog):
+    mgr = RowManager(columns=_basic_columns())
+    # A save that references a "magnet" column we don't have loaded.
+    data = {
+        "schema_version": 1,
+        "protocol_metadata": {},
+        "columns": [{"id": "duration_s"}, {"id": "magnet", "cls": "x.Y"}],
+        "fields": ["depth", "uuid", "type", "name", "duration_s", "magnet"],
+        "rows": [[0, "u0", "step", "A", 2.0, "ignored"]],
+    }
+    with caplog.at_level(_logging.ERROR):
+        mgr.set_state_from_json(data, columns=_basic_columns())
+    assert "magnet" in caplog.text                 # orphan finding printed
+    assert len(mgr.root.children) == 1             # load still happened
+
+
+def test_report_findings_false_suppresses_logging(caplog):
+    mgr = RowManager(columns=_basic_columns())
+    data = {
+        "schema_version": 1, "protocol_metadata": {},
+        "columns": [{"id": "magnet", "cls": "x.Y"}],
+        "fields": ["depth", "uuid", "type", "name", "magnet"],
+        "rows": [[0, "u0", "step", "A", "ignored"]],
+    }
+    with caplog.at_level(_logging.WARNING):
+        mgr.set_state_from_json(data, columns=_basic_columns(), report_findings=False)
+    assert "magnet" not in caplog.text
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -k "set_state_from_json or report_findings_false" -v`
+Expected: FAIL (`TypeError: set_state_from_json() got an unexpected keyword argument 'report_findings'`)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `row_manager.py`, replace `from_json` (lines 508-519) and
+`set_state_from_json` (lines 521-544) with the versions below. Only the
+signatures and the new validate/log block are added; the existing body is
+unchanged.
+
+```python
+    @classmethod
+    def from_json(cls, data: dict, columns: list,
+                  device_electrode_to_channel=None,
+                  report_findings: bool = True) -> "RowManager":
+        """Reconstruct a RowManager from a serialized payload.
+
+        When ``report_findings`` is True (headless default) the payload is
+        validated against ``columns`` + ``device_electrode_to_channel`` and any
+        findings are printed via the module logger before loading. The load
+        proceeds regardless - headless cannot prompt."""
+        from pluggable_protocol_tree.services.persistence import deserialize_tree
+        from pluggable_protocol_tree.services.protocol_validator import (
+            validate_protocol, log_report,
+        )
+        if report_findings:
+            report = validate_protocol(data, columns, device_electrode_to_channel)
+            if not report.is_empty:
+                log_report(report)
+        manager = cls(columns=list(columns))
+        root, metadata = deserialize_tree(
+            data, columns,
+            step_type=manager.step_type, group_type=manager.group_type,
+        )
+        manager.root = root
+        manager.protocol_metadata = metadata
+        return manager
+
+    def set_state_from_json(self, data: dict, columns: list,
+                            device_electrode_to_channel=None,
+                            report_findings: bool = True) -> None:
+        """Reconstruct tree state in-place from a serialized payload dynamically.
+
+        When ``report_findings`` is True (headless default) findings are
+        validated and printed via the module logger before applying state. The
+        GUI load path passes ``report_findings=False`` because it has already
+        shown them in a dialog."""
+        from pluggable_protocol_tree.services.persistence import deserialize_tree
+        from pluggable_protocol_tree.services.protocol_validator import (
+            validate_protocol, log_report,
+        )
+
+        if report_findings:
+            report = validate_protocol(data, columns, device_electrode_to_channel)
+            if not report.is_empty:
+                log_report(report)
+
+        # 1. Update columns. This triggers _on_columns_change via Traits,
+        #    which automatically rebuilds self.step_type and self.group_type.
+        self.columns = list(columns)
+
+        # 2. Deserialize the payload into a new root and metadata dict
+        root, metadata = deserialize_tree(
+            data, self.columns,
+            step_type=self.step_type,
+            group_type=self.group_type,
+        )
+
+        # 3. Apply the new state
+        self.root = root
+        self.protocol_metadata = metadata
+
+        # 4. Clear any dangling selection paths, as the old tree structure is gone
+        self.selection = []
+
+        # 5. Notify the UI/observers that the structure has completely changed
+        self.rows_changed = True
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_validator.py -v`
+Expected: PASS (all tests)
+
+- [ ] **Step 5: Run the existing row-manager + persistence suites for regressions**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_row_manager.py pluggable_protocol_tree/tests/test_persistence.py -v`
+Expected: PASS (no regressions — new params default to backward-compatible behavior)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pluggable_protocol_tree/models/row_manager.py pluggable_protocol_tree/tests/test_protocol_validator.py
+git commit -m "[PPT-17] Headless wiring: validate + log findings in from_json/set_state_from_json"
+```
+
+---
+
+## Task 6: GUI wiring — `load_from_dialog` runs the validator + dialog
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/protocol_tree_pane.py:1114-1136`
+
+- [ ] **Step 1: Add the import**
+
+At the top of `protocol_tree_pane.py` (with the other `pluggable_protocol_tree` imports), add:
+
+```python
+from pluggable_protocol_tree.services.protocol_validator import (
+    validate_protocol, confirm_report, CANCEL,
+)
+```
+
+- [ ] **Step 2: Replace the body of `load_from_dialog`**
+
+Replace lines 1128-1135 (the `try`/`except` block that parses + applies the
+JSON) with the validating version. The device map comes from the sync
+controller when present (authoritative device electrode->channel map); when
+absent, the validator skips the device-dependent checks.
+
+```python
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            columns = columns_factory()
+            device_map = None
+            if self.device_viewer_sync is not None:
+                device_map = dict(self.device_viewer_sync.electrode_ids_channels_map)
+            report = validate_protocol(data, columns, device_map)
+            if not report.is_empty:
+                if confirm_report(report, parent=parent or self) == CANCEL:
+                    return None
+            # report already shown in the dialog -> don't re-log it
+            self.manager.set_state_from_json(
+                data, columns=columns, report_findings=False,
+            )
+        except Exception as e:
+            error_dialog(parent=parent or self,
+                         title="Load error", message=str(e))
+            return None
+        return path
+```
+
+- [ ] **Step 3: Run the pane / file-menu suites**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py -v`
+Expected: PASS — a clean protocol produces an empty report, so the dialog never opens and the existing load behavior is unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/protocol_tree_pane.py
+git commit -m "[PPT-17] GUI wiring: validate + confirm dialog in load_from_dialog"
+```
+
+---
+
+## Task 7: Full-suite regression check + close-out
+
+- [ ] **Step 1: Run the whole pluggable_protocol_tree suite**
+
+Run: `pixi run --manifest-path ..\pixi-microdrop\microdrop-py\pyproject.toml python -m pytest pluggable_protocol_tree/tests/ -q`
+Expected: PASS (no regressions).
+
+- [ ] **Step 2: Push the branch and open a PR**
+
+```bash
+git push -u origin issue-423-protocol-load-validation
+gh pr create --repo Blue-Ocean-Technologies-Inc/Microdrop --base main \
+  --title "[PPT-17] Validate loaded protocol against current device (#423)" \
+  --body "Implements issue #423 core checks: electrode-ID validity, stale channel mappings, and orphan columns. Pure validator + GUI dialog / headless logger presenters. See docs/superpowers/specs/2026-06-11-issue-423-protocol-load-validation-design.md."
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** check 1 (electrode-ID validity) → Task 2; check 2 (stale channel) → Task 3; check 4 (orphan column) → Task 1; GUI two-tier dialog with drop-columns override → Task 4 + Task 6; headless logger output → Task 4 + Task 5; no-device skip + malformed-input safety → Task 3; device-truth source (`device_viewer_sync.electrode_ids_channels_map`) → Task 6. Deferred (loop well-formedness, structural sanity) are explicitly out of scope per the spec.
+- **Type consistency:** `Finding(severity, category, title, items)`, `ValidationReport.findings/errors/warnings/is_empty`, `validate_protocol(data, columns, device_electrode_to_channel)`, `log_report(report)`, `confirm_report(report, parent)`, constants `PROCEED`/`CANCEL`/`SEVERITY_ERROR`/`SEVERITY_WARNING` are used identically across all tasks.
+- **No placeholders:** every code step shows complete code; every run step shows the exact command + expected outcome.

--- a/docs/superpowers/specs/2026-06-11-issue-423-protocol-load-validation-design.md
+++ b/docs/superpowers/specs/2026-06-11-issue-423-protocol-load-validation-design.md
@@ -1,0 +1,208 @@
+# Protocol-load validation (issue #423, PPT-17) — design
+
+**Issue:** [#423](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/423)
+**Date:** 2026-06-11
+**Scope (this pass):** core device-compatibility checks — electrode-ID validity,
+stale channel mappings, and orphan-column detection. Loop-route
+well-formedness and structural-sanity checks are deferred to follow-ups.
+
+## Problem
+
+When a protocol is loaded into the pluggable protocol tree (File > Open, or the
+headless `RowManager.from_json` / `set_state_from_json` paths) there is currently
+**no validation** that it is compatible with the device currently loaded in the
+device viewer. A protocol authored on a different device (or hand-edited) can
+reference electrode IDs that don't exist, or that now map to a different channel.
+Today this only surfaces at run time as a silent per-phase skip
+(`RoutesHandler` logs `"electrode {e!r} has no channel mapping; actuation channel
+skipped"`), so a step appears to "do nothing" with no up-front warning. Columns
+whose contributing plugin is absent are likewise dropped silently during
+`deserialize_tree`.
+
+We want to catch these at **load time** and surface them — as a dialog in the
+GUI, and as printed log output in headless mode.
+
+## Scope
+
+Three checks this pass:
+
+| # | Check | Comparison | Severity |
+|---|-------|------------|----------|
+| 1 | **Electrode-ID validity** | every electrode ID referenced by any step's `routes` or `electrodes` column exists in the device's electrode set | warning |
+| 2 | **Stale channel mapping** | the protocol's stored `protocol_metadata["electrode_to_channel"][E]` equals the device's current channel for `E` | warning |
+| 4 | **Orphan column** | every saved `col_id` resolves to a live column (its plugin is loaded); otherwise its values are silently dropped on load | error |
+
+Out of scope (deferred): loop-route well-formedness (issue check 3) and
+structural sanity — reps/duration/trail ranges, empty steps, empty protocol
+(issue check 5).
+
+## Architecture
+
+Three isolated pieces. The validator is a pure function; presentation is split
+into two interchangeable presenters so the same report drives both GUI and
+headless flows.
+
+### 1. Pure validator — `pluggable_protocol_tree/services/protocol_validator.py`
+
+```python
+@dataclass(frozen=True)
+class Finding:
+    severity: str          # "warning" | "error"
+    category: str          # "electrode_id" | "stale_channel" | "orphan_column"
+    title: str             # short human summary
+    items: list[str]       # detail lines (e.g. "E12  (steps 1.2, 3)")
+
+@dataclass(frozen=True)
+class ValidationReport:
+    findings: list[Finding]
+    @property
+    def errors(self) -> list[Finding]: ...
+    @property
+    def warnings(self) -> list[Finding]: ...
+    @property
+    def is_empty(self) -> bool: ...
+
+def validate_protocol(
+    data: dict,
+    columns: list,
+    device_electrode_to_channel: dict | None,
+) -> ValidationReport:
+    ...
+```
+
+- **Pure**: no Qt, no `RowManager`, no I/O. Operates only on the raw serialized
+  JSON `data` (output of `serialize_tree`), the live column list, and the
+  device's electrode→channel map. Fully unit-testable with crafted dicts.
+- **Inputs it reads from `data`:**
+  - `data["columns"]` — list of `{"id": col_id, ...}` → orphan detection vs
+    `{c.model.col_id for c in columns}`.
+  - `data["fields"]` — to find the column index of `"routes"` and
+    `"electrodes"`.
+  - `data["rows"]` — `[depth, uuid, type, name, *values]`; the `routes` value is
+    `list[list[str]]`, the `electrodes` value is `list[str]`.
+  - `data["protocol_metadata"]["electrode_to_channel"]` — protocol's stored map
+    for the stale-mapping check.
+- **Step labels:** referenced-electrode findings name *which steps* reference an
+  ID. A 1-indexed dotted id (e.g. `1.2`) is reconstructed from the rows' `depth`
+  sequence using a per-depth counter stack, matching the existing `dotted_id`
+  convention in `device_viewer_sync._publish_for_row`
+  (`".".join(str(i + 1) for i in row.path)`).
+- **No-device behavior:** if `device_electrode_to_channel` is `None` or empty,
+  checks 1 and 2 are skipped (validity is undeterminable without a device). The
+  device-independent orphan-column check (4) always runs.
+
+#### Check details
+
+1. **Electrode-ID validity** — collect every electrode ID appearing in any
+   step's `routes` (flattened) or `electrodes`. Any not present as a key in
+   `device_electrode_to_channel` → one warning Finding listing each unknown ID
+   and the dotted ids of the steps referencing it.
+2. **Stale channel mapping** — for each electrode `E` in the protocol's
+   `electrode_to_channel` that is also a key in the device map: if
+   `protocol_map[E] != device_map[E]` → a warning Finding listing
+   `E: protocol ch X → device ch Y`. (Electrodes referenced by steps but absent
+   from the device map are already covered by check 1.)
+3. **Orphan column** — any `col_id` in `data["columns"]` not present in the live
+   column set → an error Finding. These values are dropped by `deserialize_tree`
+   today; the finding makes that data loss explicit.
+
+### 2. Presenters — same module
+
+```python
+PROCEED = "proceed"
+CANCEL  = "cancel"
+
+def confirm_report(report: ValidationReport, parent=None) -> str:
+    """GUI: one summary dialog via microdrop_application.dialogs.pyface_wrapper.
+    Returns PROCEED or CANCEL."""
+
+def log_report(report: ValidationReport) -> None:
+    """Headless: emit findings via get_logger(__name__) — logger.error() for
+    error findings, logger.warning() for warnings. Never blocks."""
+```
+
+- **`confirm_report`** builds a single two-tier summary dialog with
+  `pyface_wrapper.confirm` (no raw `QMessageBox`):
+  - **Errors present (orphan columns):** default action is Cancel; an explicit
+    `Load anyway (drop columns)` button maps to PROCEED. Errors and warnings are
+    listed in separate sections (HTML `informative`, full lists in the
+    collapsible `detail` pane).
+  - **Warnings only:** `Proceed anyway` / `Cancel`.
+- **`log_report`** formats each finding to a log line at the matching level.
+  Consistent with the rest of the codebase (every module uses
+  `logger.logger_service.get_logger`); console-visible and captured by handlers.
+
+### 3. Wiring
+
+**Headless** — `RowManager.from_json` and `set_state_from_json` gain:
+```python
+def set_state_from_json(self, data, columns,
+                        device_electrode_to_channel=None,
+                        report_findings=True): ...
+```
+When `report_findings` is true they call `validate_protocol(...)` +
+`log_report(...)` before applying state, then proceed regardless (headless
+cannot prompt; orphan columns still drop, exactly as today, but now printed).
+Every headless caller (tests, scripts, executor) thus gets findings printed for
+free. With no device map passed, checks 1 and 2 skip and orphan-column findings
+still print.
+
+**GUI** — `protocol_tree_pane.load_from_dialog` does the presentation itself so
+it can abort before mutating:
+```python
+data = json.load(f)
+columns = columns_factory()
+device_map = (self.device_viewer_sync.electrode_ids_channels_map
+              if self.device_viewer_sync is not None else None)
+report = validate_protocol(data, columns, device_map)
+if not report.is_empty and confirm_report(report, parent=self) == CANCEL:
+    return None
+self.manager.set_state_from_json(
+    data, columns=columns, report_findings=False,   # dialog already showed them
+)
+```
+`report_findings=False` prevents the dialog's findings from being *re-printed* by
+`set_state_from_json`.
+
+**Device truth** is `device_viewer_sync.electrode_ids_channels_map`, populated
+authoritatively from `DEVICE_VIEWER_GEOMETRY_CHANGED` (the loaded SVG's
+electrode→channel map). It is independent of the protocol's stored
+`electrode_to_channel`, which is exactly what makes the stale-mapping comparison
+meaningful.
+
+## Error handling
+
+- Malformed `data` (missing `columns`/`fields`/`rows` keys, non-list rows) — the
+  validator guards with `.get(...)` and defensive type checks and returns an
+  empty/partial report rather than raising; load proceeds to the existing
+  `set_state_from_json` try/except which already shows a `Load error` dialog for
+  truly broken files. The validator must never be the thing that breaks a load.
+- A `None` device-sync controller (demo windows that don't wire one) → device
+  map treated as absent → checks 1 & 2 skipped.
+
+## Testing
+
+- **Validator (primary):** unit tests with hand-built `data` dicts and fake
+  column lists / device maps.
+  - unknown electrode ID in `electrodes` and in `routes` → check-1 warning with
+    correct step dotted-ids.
+  - stale mapping (protocol ch ≠ device ch) → check-2 warning; matching mapping →
+    no finding.
+  - orphan `col_id` → check-4 error.
+  - empty/None device map → checks 1 & 2 skipped, orphan still reported.
+  - clean protocol → `is_empty` report.
+  - malformed `data` → no exception, empty/partial report.
+  - dotted-id reconstruction from nested `depth` sequence.
+- **Presenters:** `log_report` emits at the right levels (caplog);
+  `confirm_report` decision mapping with `pyface_wrapper.confirm` monkeypatched
+  (errors → default Cancel + override → PROCEED; warnings-only → Proceed/Cancel).
+- GUI `load_from_dialog` wiring is kept thin; not directly unit-tested (Qt file
+  dialog).
+
+## Likely touch points
+
+- New: `pluggable_protocol_tree/services/protocol_validator.py`
+- New: `pluggable_protocol_tree/tests/test_protocol_validator.py`
+- Edit: `pluggable_protocol_tree/models/row_manager.py`
+  (`from_json`, `set_state_from_json` signatures + validate/log call)
+- Edit: `pluggable_protocol_tree/views/protocol_tree_pane.py` (`load_from_dialog`)

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -506,9 +506,23 @@ class RowManager(HasTraits):
         )
 
     @classmethod
-    def from_json(cls, data: dict, columns: list) -> "RowManager":
-        """Reconstruct a RowManager from a serialized payload."""
+    def from_json(cls, data: dict, columns: list,
+                  device_electrode_to_channel=None,
+                  report_findings: bool = True) -> "RowManager":
+        """Reconstruct a RowManager from a serialized payload.
+
+        When ``report_findings`` is True (headless default) the payload is
+        validated against ``columns`` + ``device_electrode_to_channel`` and any
+        findings are printed via the module logger before loading. The load
+        proceeds regardless - headless cannot prompt."""
         from pluggable_protocol_tree.services.persistence import deserialize_tree
+        from pluggable_protocol_tree.services.protocol_validator import (
+            validate_protocol, log_report,
+        )
+        if report_findings:
+            report = validate_protocol(data, columns, device_electrode_to_channel)
+            if not report.is_empty:
+                log_report(report)
         manager = cls(columns=list(columns))
         root, metadata = deserialize_tree(
             data, columns,
@@ -518,9 +532,24 @@ class RowManager(HasTraits):
         manager.protocol_metadata = metadata
         return manager
 
-    def set_state_from_json(self, data: dict, columns: list) -> None:
-        """Reconstruct tree state in-place from a serialized payload dynamically."""
+    def set_state_from_json(self, data: dict, columns: list,
+                            device_electrode_to_channel=None,
+                            report_findings: bool = True) -> None:
+        """Reconstruct tree state in-place from a serialized payload dynamically.
+
+        When ``report_findings`` is True (headless default) findings are
+        validated and printed via the module logger before applying state. The
+        GUI load path passes ``report_findings=False`` because it has already
+        shown them in a dialog."""
         from pluggable_protocol_tree.services.persistence import deserialize_tree
+        from pluggable_protocol_tree.services.protocol_validator import (
+            validate_protocol, log_report,
+        )
+
+        if report_findings:
+            report = validate_protocol(data, columns, device_electrode_to_channel)
+            if not report.is_empty:
+                log_report(report)
 
         # 1. Update columns. This triggers _on_columns_change via Traits,
         #    which automatically rebuilds self.step_type and self.group_type.

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -153,4 +153,19 @@ def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationR
                 items=items,
             ))
 
+        proto_map = (data.get("protocol_metadata") or {}).get("electrode_to_channel") or {}
+        stale = [
+            f"{eid}: protocol ch {proto_ch} -> device ch {device_map[eid]}"
+            for eid, proto_ch in sorted(proto_map.items())
+            if eid in device_map and device_map[eid] != proto_ch
+        ]
+        if stale:
+            findings.append(Finding(
+                severity=SEVERITY_WARNING,
+                category="stale_channel",
+                title=(f"{len(stale)} electrode(s) map to a different channel on "
+                       f"the current device than the protocol expects"),
+                items=stale,
+            ))
+
     return ValidationReport(findings=findings)

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -55,6 +55,49 @@ class ValidationReport:
         return not self.findings
 
 
+def _row_dotted_ids(rows):
+    """1-indexed dotted ids (e.g. '1.2') for each row, derived from the
+    ``depth`` sequence. Matches the dotted-id convention used by
+    device_viewer_sync._publish_for_row."""
+    stack = []  # stack[d] = running sibling count at depth d under current parent
+    out = []
+    for row in rows:
+        depth = int(row[0])
+        if len(stack) < depth + 1:
+            stack.extend([0] * (depth + 1 - len(stack)))
+        else:
+            del stack[depth + 1:]   # leaving a deeper level resets its counters
+        stack[depth] += 1
+        out.append(".".join(str(stack[i]) for i in range(depth + 1)))
+    return out
+
+
+def _value_index(fields, col_id):
+    """Index into a row's value slice (row[4:]) for ``col_id``, or None.
+    The first four fields are fixed row metadata (depth/uuid/type/name)."""
+    try:
+        field_pos = fields.index(col_id)
+    except ValueError:
+        return None
+    return field_pos - 4 if field_pos >= 4 else None
+
+
+def _electrodes_in_row(values, routes_idx, electrodes_idx):
+    """All electrode IDs referenced by one row's electrodes + routes values."""
+    out = set()
+    if electrodes_idx is not None and electrodes_idx < len(values):
+        val = values[electrodes_idx]
+        if isinstance(val, list):
+            out.update(str(e) for e in val)
+    if routes_idx is not None and routes_idx < len(values):
+        val = values[routes_idx]
+        if isinstance(val, list):
+            for route in val:
+                if isinstance(route, list):
+                    out.update(str(e) for e in route)
+    return out
+
+
 def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationReport:
     """Validate raw serialized protocol ``data`` against the live ``columns``
     and the device's ``device_electrode_to_channel`` map. Never raises on
@@ -81,5 +124,33 @@ def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationR
                    f"matching plugin; their values will be dropped on load"),
             items=[str(cid) for cid in orphan_ids],
         ))
+
+    # --- electrode ID validity (device-dependent) ---
+    device_map = device_electrode_to_channel or {}
+    if device_map:
+        fields = data.get("fields") or []
+        rows = data.get("rows") or []
+        dotted = _row_dotted_ids(rows)
+        routes_idx = _value_index(fields, ROUTES_COL_ID)
+        electrodes_idx = _value_index(fields, ELECTRODES_COL_ID)
+
+        refs = {}   # electrode_id -> set of step dotted-ids
+        for i, row in enumerate(rows):
+            values = list(row[4:])
+            step_id = dotted[i] if i < len(dotted) else str(i + 1)
+            for eid in _electrodes_in_row(values, routes_idx, electrodes_idx):
+                refs.setdefault(eid, set()).add(step_id)
+
+        unknown = sorted(eid for eid in refs if eid not in device_map)
+        if unknown:
+            items = [f"{eid}  (steps {', '.join(sorted(refs[eid]))})"
+                     for eid in unknown]
+            findings.append(Finding(
+                severity=SEVERITY_WARNING,
+                category="electrode_id",
+                title=(f"{len(unknown)} electrode(s) referenced by this protocol "
+                       f"do not exist on the current device"),
+                items=items,
+            ))
 
     return ValidationReport(findings=findings)

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -11,7 +11,7 @@ The function is side-effect free (no Qt, no RowManager, no I/O) so it is
 trivially unit-testable.
 """
 
-from traits.api import HasTraits, Instance, List, Property, Str
+from traits.api import HasTraits, Instance, List, Property, Str, Enum
 
 from logger.logger_service import get_logger
 from microdrop_application.dialogs.pyface_wrapper import confirm, YES
@@ -31,10 +31,10 @@ ELECTRODES_COL_ID = "electrodes"
 
 
 class Finding(HasTraits):
-    severity = Str()       # SEVERITY_WARNING | SEVERITY_ERROR
-    category = Str()       # "orphan_column" | "electrode_id" | "stale_channel"
-    title = Str()          # short human summary
-    items = List(Str)      # detail lines
+    severity = Enum(SEVERITY_WARNING, SEVERITY_ERROR)
+    category = Enum("orphan_column", "electrode_id", "stale_channel")
+    title = Str()
+    items = List(Str, desc="detail lines")
 
 
 class ValidationReport(HasTraits):

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from typing import List
 
 from logger.logger_service import get_logger
+from microdrop_application.dialogs.pyface_wrapper import confirm, YES
 
 logger = get_logger(__name__)
 
@@ -169,3 +170,62 @@ def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationR
             ))
 
     return ValidationReport(findings=findings)
+
+
+def log_report(report) -> None:
+    """Headless presenter: emit each finding via the module logger. Errors at
+    ERROR level, warnings at WARNING level. Never blocks."""
+    for f in report.errors:
+        logger.error("Protocol load: %s", f.title)
+        for item in f.items:
+            logger.error("    - %s", item)
+    for f in report.warnings:
+        logger.warning("Protocol load: %s", f.title)
+        for item in f.items:
+            logger.warning("    - %s", item)
+
+
+def _format_html(report) -> str:
+    parts = []
+    if report.errors:
+        parts.append("<b>Errors</b><br>")
+        parts.extend(f"&bull; {f.title}<br>" for f in report.errors)
+    if report.warnings:
+        parts.append("<b>Warnings</b><br>")
+        parts.extend(f"&bull; {f.title}<br>" for f in report.warnings)
+    return "".join(parts)
+
+
+def _format_detail(report) -> str:
+    lines = []
+    for f in report.errors + report.warnings:
+        lines.append(f"[{f.severity.upper()}] {f.title}")
+        lines.extend(f"    - {item}" for item in f.items)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def confirm_report(report, parent=None) -> str:
+    """GUI presenter: one two-tier summary dialog. Returns PROCEED or CANCEL.
+
+    Uses exactly two buttons - a proceed button (yes_label) and Cancel - by
+    passing no_label="" to suppress confirm()'s default No button. When errors
+    are present the proceed button is the explicit drop-columns override."""
+    if report.errors:
+        title = "Protocol has errors"
+        proceed_label = "Load anyway (drop columns)"
+    else:
+        title = "Protocol warnings"
+        proceed_label = "Proceed anyway"
+    result = confirm(
+        parent,
+        message="",
+        title=title,
+        cancel=True,
+        yes_label=proceed_label,
+        no_label="",
+        cancel_label="Cancel",
+        informative=_format_html(report),
+        detail=_format_detail(report),
+    )
+    return PROCEED if result == YES else CANCEL

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -1,0 +1,90 @@
+"""Pure protocol-load validation + presenters (issue #423, PPT-17).
+
+``validate_protocol`` reads the raw serialized protocol JSON (output of
+``services.persistence.serialize_tree``) and returns a structured
+``ValidationReport``. It performs three checks:
+
+  * orphan column   (error)   - a saved col_id has no live column; its
+                                 values are silently dropped by
+                                 ``deserialize_tree``.
+  * electrode id    (warning) - an electrode referenced by a step's
+                                 routes/electrodes doesn't exist on the
+                                 current device.
+  * stale channel   (warning) - the protocol's stored electrode->channel
+                                 disagrees with the device's current map.
+
+The function is side-effect free (no Qt, no RowManager, no I/O) so it is
+trivially unit-testable. Two presenters render a report: ``log_report``
+(headless, logger output) and ``confirm_report`` (GUI dialog).
+"""
+
+from dataclasses import dataclass, field
+from typing import List
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+# Presenter decisions.
+PROCEED = "proceed"
+CANCEL = "cancel"
+
+SEVERITY_WARNING = "warning"
+SEVERITY_ERROR = "error"
+
+# Builtin column ids whose values carry electrode references.
+ROUTES_COL_ID = "routes"
+ELECTRODES_COL_ID = "electrodes"
+
+
+@dataclass
+class Finding:
+    severity: str          # SEVERITY_WARNING | SEVERITY_ERROR
+    category: str          # "orphan_column" | "electrode_id" | "stale_channel"
+    title: str             # short human summary
+    items: List[str] = field(default_factory=list)  # detail lines
+
+
+@dataclass
+class ValidationReport:
+    findings: List[Finding] = field(default_factory=list)
+
+    @property
+    def errors(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_ERROR]
+
+    @property
+    def warnings(self) -> List[Finding]:
+        return [f for f in self.findings if f.severity == SEVERITY_WARNING]
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.findings
+
+
+def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationReport:
+    """Validate raw serialized protocol ``data`` against the live ``columns``
+    and the device's ``device_electrode_to_channel`` map. Never raises on
+    malformed input - returns an empty/partial report instead."""
+    findings: List[Finding] = []
+    if not isinstance(data, dict):
+        return ValidationReport(findings=findings)
+
+    col_specs = data.get("columns") or []
+
+    # --- orphan columns (device-independent) ---
+    live_ids = {c.model.col_id for c in (columns or [])}
+    orphan_ids = [
+        spec.get("id") for spec in col_specs
+        if isinstance(spec, dict) and spec.get("id") and spec.get("id") not in live_ids
+    ]
+    if orphan_ids:
+        findings.append(Finding(
+            severity=SEVERITY_ERROR,
+            category="orphan_column",
+            title=(f"{len(orphan_ids)} column(s) in this protocol have no "
+                   f"matching plugin; their values will be dropped on load"),
+            items=[str(cid) for cid in orphan_ids],
+        ))
+
+    return ValidationReport(findings=findings)

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -2,20 +2,13 @@
 
 ``validate_protocol`` reads the raw serialized protocol JSON (output of
 ``services.persistence.serialize_tree``) and returns a structured
-``ValidationReport``. It performs three checks:
-
-  * orphan column   (error)   - a saved col_id has no live column; its
-                                 values are silently dropped by
-                                 ``deserialize_tree``.
-  * electrode id    (warning) - an electrode referenced by a step's
-                                 routes/electrodes doesn't exist on the
-                                 current device.
-  * stale channel   (warning) - the protocol's stored electrode->channel
-                                 disagrees with the device's current map.
+``ValidationReport``. The full module will perform three checks (orphan
+column / electrode id / stale channel) and provide two presenters
+(``log_report`` headless, ``confirm_report`` GUI dialog); checks beyond
+orphan-column and the presenters are added in later tasks.
 
 The function is side-effect free (no Qt, no RowManager, no I/O) so it is
-trivially unit-testable. Two presenters render a report: ``log_report``
-(headless, logger output) and ``confirm_report`` (GUI dialog).
+trivially unit-testable.
 """
 
 from dataclasses import dataclass, field
@@ -70,7 +63,9 @@ def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationR
     if not isinstance(data, dict):
         return ValidationReport(findings=findings)
 
-    col_specs = data.get("columns") or []
+    col_specs = data.get("columns")
+    if not isinstance(col_specs, list):
+        col_specs = []
 
     # --- orphan columns (device-independent) ---
     live_ids = {c.model.col_id for c in (columns or [])}

--- a/pluggable_protocol_tree/services/protocol_validator.py
+++ b/pluggable_protocol_tree/services/protocol_validator.py
@@ -11,8 +11,7 @@ The function is side-effect free (no Qt, no RowManager, no I/O) so it is
 trivially unit-testable.
 """
 
-from dataclasses import dataclass, field
-from typing import List
+from traits.api import HasTraits, Instance, List, Property, Str
 
 from logger.logger_service import get_logger
 from microdrop_application.dialogs.pyface_wrapper import confirm, YES
@@ -31,28 +30,27 @@ ROUTES_COL_ID = "routes"
 ELECTRODES_COL_ID = "electrodes"
 
 
-@dataclass
-class Finding:
-    severity: str          # SEVERITY_WARNING | SEVERITY_ERROR
-    category: str          # "orphan_column" | "electrode_id" | "stale_channel"
-    title: str             # short human summary
-    items: List[str] = field(default_factory=list)  # detail lines
+class Finding(HasTraits):
+    severity = Str()       # SEVERITY_WARNING | SEVERITY_ERROR
+    category = Str()       # "orphan_column" | "electrode_id" | "stale_channel"
+    title = Str()          # short human summary
+    items = List(Str)      # detail lines
 
 
-@dataclass
-class ValidationReport:
-    findings: List[Finding] = field(default_factory=list)
+class ValidationReport(HasTraits):
+    findings = List(Instance(Finding))
 
-    @property
-    def errors(self) -> List[Finding]:
+    errors = Property(observe="findings")
+    warnings = Property(observe="findings")
+    is_empty = Property(observe="findings")
+
+    def _get_errors(self):
         return [f for f in self.findings if f.severity == SEVERITY_ERROR]
 
-    @property
-    def warnings(self) -> List[Finding]:
+    def _get_warnings(self):
         return [f for f in self.findings if f.severity == SEVERITY_WARNING]
 
-    @property
-    def is_empty(self) -> bool:
+    def _get_is_empty(self):
         return not self.findings
 
 
@@ -103,7 +101,7 @@ def validate_protocol(data, columns, device_electrode_to_channel) -> ValidationR
     """Validate raw serialized protocol ``data`` against the live ``columns``
     and the device's ``device_electrode_to_channel`` map. Never raises on
     malformed input - returns an empty/partial report instead."""
-    findings: List[Finding] = []
+    findings = []
     if not isinstance(data, dict):
         return ValidationReport(findings=findings)
 

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane_file_menu.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 import pytest
 
 from microdrop_application.dialogs.pyface_wrapper import NO, YES
+from pluggable_protocol_tree.services.protocol_validator import CANCEL, PROCEED
 
 
 def _build_pane(qapp):
@@ -320,3 +321,78 @@ def test_application_exiting_proceeds_on_dirty_yes(qapp):
     ):
         pane._on_application_exiting(ev)
     assert ev.veto is False
+
+
+# --- validation cancel / proceed branches --------------------------------
+
+def _write_orphan_protocol(path):
+    """Write a protocol JSON that triggers a non-empty ValidationReport.
+
+    The 'definitely_not_a_real_col' column is not registered in the pane's
+    live columns ([type, name]) so it is an orphan column — a device-
+    independent finding that needs no device map to trigger.
+    """
+    data = {
+        "schema_version": 1,
+        "protocol_metadata": {},
+        "columns": [
+            {"id": "definitely_not_a_real_col", "cls": "x.Y"},
+        ],
+        "fields": ["depth", "uuid", "type", "name", "definitely_not_a_real_col"],
+        "rows": [
+            [0, "u0", "step", "loaded-step", "orphan-value"],
+        ],
+    }
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+
+def test_load_from_dialog_cancel_on_validation_findings_aborts_load(
+    qapp, tmp_path, monkeypatch
+):
+    """Findings present + user cancels -> load_from_dialog returns None and
+    the manager is untouched (no new steps from the temp file)."""
+    pane = _build_pane(qapp)
+    fixture = tmp_path / "orphan.json"
+    _write_orphan_protocol(fixture)
+
+    children_before = len(pane.manager.root.children)
+
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm_report",
+        lambda report, parent=None: CANCEL,
+    )
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        QFD.getOpenFileName.return_value = (str(fixture), "Protocol JSON (*.json)")
+        result = pane.load_from_dialog(lambda: list(pane.manager.columns))
+
+    assert result is None
+    assert len(pane.manager.root.children) == children_before
+
+
+def test_load_from_dialog_proceed_on_validation_findings_loads_file(
+    qapp, tmp_path, monkeypatch
+):
+    """Findings present + user proceeds -> load_from_dialog returns the path
+    and the manager reflects the loaded file (orphan column dropped)."""
+    pane = _build_pane(qapp)
+    fixture = tmp_path / "orphan.json"
+    _write_orphan_protocol(fixture)
+
+    monkeypatch.setattr(
+        "pluggable_protocol_tree.views.protocol_tree_pane.confirm_report",
+        lambda report, parent=None: PROCEED,
+    )
+
+    with patch(
+        "pluggable_protocol_tree.views.protocol_tree_pane.QFileDialog"
+    ) as QFD:
+        QFD.getOpenFileName.return_value = (str(fixture), "Protocol JSON (*.json)")
+        result = pane.load_from_dialog(lambda: list(pane.manager.columns))
+
+    assert result == str(fixture)
+    assert len(pane.manager.root.children) == 1
+    assert pane.manager.root.children[0].name == "loaded-step"

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -116,3 +116,46 @@ def test_known_electrodes_no_findings():
     report = validate_protocol(make_data(fields=fields, rows=rows),
                                fake_columns("electrodes"), device_map)
     assert report.is_empty
+
+
+def test_stale_channel_mapping_flagged():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1"]]]
+    metadata = {"electrode_to_channel": {"E1": 5}}   # protocol thinks E1 -> ch 5
+    device_map = {"E1": 7}                           # device now maps E1 -> ch 7
+    report = validate_protocol(make_data(fields=fields, rows=rows, metadata=metadata),
+                               fake_columns("electrodes"), device_map)
+    stale = [f for f in report.warnings if f.category == "stale_channel"]
+    assert len(stale) == 1
+    assert stale[0].items == ["E1: protocol ch 5 -> device ch 7"]
+
+
+def test_matching_channel_not_flagged():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1"]]]
+    metadata = {"electrode_to_channel": {"E1": 7}}
+    device_map = {"E1": 7}
+    report = validate_protocol(make_data(fields=fields, rows=rows, metadata=metadata),
+                               fake_columns("electrodes"), device_map)
+    assert report.is_empty
+
+
+def test_no_device_map_skips_device_checks_but_reports_orphan():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E_DOES_NOT_EXIST"]]]
+    data = make_data(fields=fields, rows=rows,
+                     columns=[{"id": "electrodes"}, {"id": "ghost"}],
+                     metadata={"electrode_to_channel": {"E1": 1}})
+    report = validate_protocol(data, fake_columns("electrodes"), {})  # no device
+    # device checks skipped -> only the orphan-column error remains
+    assert [f.category for f in report.findings] == ["orphan_column"]
+
+
+def test_malformed_data_no_exception():
+    assert validate_protocol(None, fake_columns("x"), {"E1": 1}).is_empty
+    assert validate_protocol({}, fake_columns("x"), {"E1": 1}).is_empty
+    # rows missing value slots / wrong types must not raise
+    bad = {"columns": [{"id": "electrodes"}], "fields": ["depth", "uuid", "type", "name", "electrodes"],
+           "rows": [[0, "u", "step", "A"], [0, "u2", "step", "B", "notalist"]]}
+    report = validate_protocol(bad, fake_columns("electrodes"), {"E1": 1})
+    assert isinstance(report, ValidationReport)

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -171,8 +171,10 @@ from pluggable_protocol_tree.services.protocol_validator import (
 
 def _report_with_error_and_warning():
     return ValidationReport(findings=[
-        Finding(SEVERITY_ERROR, "orphan_column", "1 orphan column", ["magnet"]),
-        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+        Finding(severity=SEVERITY_ERROR, category="orphan_column",
+                title="1 orphan column", items=["magnet"]),
+        Finding(severity=SEVERITY_WARNING, category="electrode_id",
+                title="1 unknown electrode", items=["E99  (steps 1)"]),
     ])
 
 
@@ -206,7 +208,8 @@ def test_confirm_report_proceed(monkeypatch):
 def test_confirm_report_cancel(monkeypatch):
     monkeypatch.setattr(pv, "confirm", lambda *a, **k: pv.CANCEL, raising=False)
     report = ValidationReport(findings=[
-        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+        Finding(severity=SEVERITY_WARNING, category="electrode_id",
+                title="1 unknown electrode", items=["E99  (steps 1)"]),
     ])
     assert confirm_report(report, parent=None) == CANCEL
 

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -1,0 +1,43 @@
+"""Tests for the pure protocol-load validator and its presenters."""
+
+from types import SimpleNamespace
+
+from pluggable_protocol_tree.services.protocol_validator import (
+    validate_protocol, ValidationReport, Finding,
+    SEVERITY_ERROR, SEVERITY_WARNING,
+)
+
+
+def fake_columns(*col_ids):
+    """Minimal stand-ins for live IColumn objects: only .model.col_id is read."""
+    return [SimpleNamespace(model=SimpleNamespace(col_id=cid)) for cid in col_ids]
+
+
+def make_data(fields=None, rows=None, columns=None, metadata=None):
+    return {
+        "schema_version": 1,
+        "protocol_metadata": metadata or {},
+        "columns": columns or [],
+        "fields": fields or ["depth", "uuid", "type", "name"],
+        "rows": rows or [],
+    }
+
+
+def test_clean_protocol_is_empty():
+    data = make_data(columns=[{"id": "duration_s"}])
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert report.is_empty
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_orphan_column_is_error():
+    # Saved protocol references a "magnet" column whose plugin isn't loaded.
+    data = make_data(columns=[{"id": "duration_s"}, {"id": "magnet"}])
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert len(report.errors) == 1
+    finding = report.errors[0]
+    assert finding.severity == SEVERITY_ERROR
+    assert finding.category == "orphan_column"
+    assert finding.items == ["magnet"]
+    assert not report.is_empty

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from pluggable_protocol_tree.services.protocol_validator import (
     validate_protocol, ValidationReport, Finding,
     SEVERITY_ERROR, SEVERITY_WARNING,
+    _row_dotted_ids,
 )
 
 
@@ -68,3 +69,50 @@ def test_multiple_orphans_one_finding():
     report = validate_protocol(data, fake_columns("duration_s"), {})
     assert len(report.errors) == 1
     assert sorted(report.errors[0].items) == ["a", "b"]
+
+
+def test_dotted_ids_nested():
+    # depths [0,1,1,0] -> ["1","1.1","1.2","2"]
+    rows = [
+        [0, "u0", "group", "G"],
+        [1, "u1", "step", "A"],
+        [1, "u2", "step", "B"],
+        [0, "u3", "step", "C"],
+    ]
+    assert _row_dotted_ids(rows) == ["1", "1.1", "1.2", "2"]
+
+
+def test_unknown_electrode_in_electrodes_column():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [
+        [0, "u0", "step", "A", ["E1", "E99"]],
+        [0, "u1", "step", "B", ["E1"]],
+    ]
+    device_map = {"E1": 1}   # E99 is unknown
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("electrodes"), device_map)
+    warns = report.warnings
+    assert len(warns) == 1
+    assert warns[0].category == "electrode_id"
+    assert warns[0].items == ["E99  (steps 1)"]
+
+
+def test_unknown_electrode_in_routes_column():
+    fields = ["depth", "uuid", "type", "name", "routes"]
+    rows = [
+        [0, "u0", "step", "A", [["E1", "E2"], ["E2", "EX"]]],
+    ]
+    device_map = {"E1": 1, "E2": 2}   # EX unknown
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("routes"), device_map)
+    assert [f.category for f in report.warnings] == ["electrode_id"]
+    assert report.warnings[0].items == ["EX  (steps 1)"]
+
+
+def test_known_electrodes_no_findings():
+    fields = ["depth", "uuid", "type", "name", "electrodes"]
+    rows = [[0, "u0", "step", "A", ["E1", "E2"]]]
+    device_map = {"E1": 1, "E2": 2}
+    report = validate_protocol(make_data(fields=fields, rows=rows),
+                               fake_columns("electrodes"), device_map)
+    assert report.is_empty

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -41,3 +41,30 @@ def test_orphan_column_is_error():
     assert finding.category == "orphan_column"
     assert finding.items == ["magnet"]
     assert not report.is_empty
+
+
+def test_non_list_columns_does_not_raise():
+    data = make_data()
+    data["columns"] = "corrupted"   # not a list
+    report = validate_protocol(data, fake_columns("x"), {})
+    assert report.is_empty
+
+
+def test_non_dict_column_spec_is_skipped():
+    data = make_data(columns=[42, {"id": "magnet"}])  # 42 is not a spec dict
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert [f.category for f in report.errors] == ["orphan_column"]
+    assert report.errors[0].items == ["magnet"]
+
+
+def test_none_columns_arg_treated_as_empty():
+    data = make_data(columns=[{"id": "magnet"}])
+    report = validate_protocol(data, None, {})  # no live columns
+    assert report.errors[0].items == ["magnet"]
+
+
+def test_multiple_orphans_one_finding():
+    data = make_data(columns=[{"id": "a"}, {"id": "b"}, {"id": "duration_s"}])
+    report = validate_protocol(data, fake_columns("duration_s"), {})
+    assert len(report.errors) == 1
+    assert sorted(report.errors[0].items) == ["a", "b"]

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -159,3 +159,53 @@ def test_malformed_data_no_exception():
            "rows": [[0, "u", "step", "A"], [0, "u2", "step", "B", "notalist"]]}
     report = validate_protocol(bad, fake_columns("electrodes"), {"E1": 1})
     assert isinstance(report, ValidationReport)
+
+
+import logging
+
+from pluggable_protocol_tree.services import protocol_validator as pv
+from pluggable_protocol_tree.services.protocol_validator import (
+    log_report, confirm_report, PROCEED, CANCEL,
+)
+
+
+def _report_with_error_and_warning():
+    return ValidationReport(findings=[
+        Finding(SEVERITY_ERROR, "orphan_column", "1 orphan column", ["magnet"]),
+        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+    ])
+
+
+def test_log_report_levels(caplog):
+    with caplog.at_level(logging.WARNING):
+        log_report(_report_with_error_and_warning())
+    levels = {r.levelno for r in caplog.records}
+    assert logging.ERROR in levels      # orphan finding logged at ERROR
+    assert logging.WARNING in levels    # electrode finding logged at WARNING
+    text = caplog.text
+    assert "magnet" in text and "E99" in text
+
+
+def test_confirm_report_proceed(monkeypatch):
+    captured = {}
+
+    def fake_confirm(parent=None, message="", title="", **kwargs):
+        captured.update(title=title, kwargs=kwargs)
+        return pv.YES   # user clicked the proceed button
+
+    monkeypatch.setattr(pv, "confirm", fake_confirm, raising=False)
+    decision = confirm_report(_report_with_error_and_warning(), parent=None)
+    assert decision == PROCEED
+    # errors present -> the override-labelled proceed button + error title
+    assert captured["title"] == "Protocol has errors"
+    assert captured["kwargs"]["yes_label"] == "Load anyway (drop columns)"
+    assert captured["kwargs"]["no_label"] == ""
+    assert captured["kwargs"]["cancel"] is True
+
+
+def test_confirm_report_cancel(monkeypatch):
+    monkeypatch.setattr(pv, "confirm", lambda *a, **k: pv.CANCEL, raising=False)
+    report = ValidationReport(findings=[
+        Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
+    ])
+    assert confirm_report(report, parent=None) == CANCEL

--- a/pluggable_protocol_tree/tests/test_protocol_validator.py
+++ b/pluggable_protocol_tree/tests/test_protocol_validator.py
@@ -209,3 +209,51 @@ def test_confirm_report_cancel(monkeypatch):
         Finding(SEVERITY_WARNING, "electrode_id", "1 unknown electrode", ["E99  (steps 1)"]),
     ])
     assert confirm_report(report, parent=None) == CANCEL
+
+
+import logging as _logging
+
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+
+
+def _basic_columns():
+    return [make_type_column(), make_name_column(), make_duration_column()]
+
+
+def test_set_state_from_json_logs_orphan_and_still_loads(caplog):
+    mgr = RowManager(columns=_basic_columns())
+    # A save that references a "magnet" column we don't have loaded.
+    data = {
+        "schema_version": 1,
+        "protocol_metadata": {},
+        "columns": [
+            {"id": "duration_s",
+             "cls": "pluggable_protocol_tree.builtins.duration_column.DurationColumnModel"},
+            {"id": "magnet", "cls": "x.Y"},
+        ],
+        "fields": ["depth", "uuid", "type", "name", "duration_s", "magnet"],
+        "rows": [[0, "u0", "step", "A", 2.0, "ignored"]],
+    }
+    with caplog.at_level(_logging.ERROR):
+        mgr.set_state_from_json(data, columns=_basic_columns())
+    assert "magnet" in caplog.text                 # orphan finding printed
+    assert len(mgr.root.children) == 1             # load still happened
+
+
+def test_report_findings_false_suppresses_logging(caplog):
+    mgr = RowManager(columns=_basic_columns())
+    data = {
+        "schema_version": 1, "protocol_metadata": {},
+        "columns": [{"id": "magnet", "cls": "x.Y"}],
+        "fields": ["depth", "uuid", "type", "name", "magnet"],
+        "rows": [[0, "u0", "step", "A", "ignored"]],
+    }
+    with caplog.at_level(_logging.WARNING):
+        mgr.set_state_from_json(data, columns=_basic_columns(), report_findings=False)
+    # The validator's log_report prefix must be absent — persistence.py may
+    # still log its own column-import warning, but the validator findings
+    # ("Protocol load: ...") are suppressed when report_findings=False.
+    assert "Protocol load:" not in caplog.text

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -61,6 +61,9 @@ from pluggable_protocol_tree.services.preferences import ProtocolPreferences
 from pluggable_protocol_tree.services.protocol_state_tracker import (
     PluggableProtocolStateTracker,
 )
+from pluggable_protocol_tree.services.protocol_validator import (
+    validate_protocol, confirm_report, CANCEL,
+)
 from pluggable_protocol_tree.execution.events import PauseEvent
 from pluggable_protocol_tree.execution.executor import ProtocolExecutor
 from pluggable_protocol_tree.execution.signals import ExecutorSignals
@@ -1128,7 +1131,18 @@ class ProtocolTreePane(QWidget):
         try:
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
-            self.manager.set_state_from_json(data, columns=columns_factory())
+            columns = columns_factory()
+            device_map = None
+            if self.device_viewer_sync is not None:
+                device_map = dict(self.device_viewer_sync.electrode_ids_channels_map)
+            report = validate_protocol(data, columns, device_map)
+            if not report.is_empty:
+                if confirm_report(report, parent=parent or self) == CANCEL:
+                    return None
+            # report already shown in the dialog -> don't re-log it
+            self.manager.set_state_from_json(
+                data, columns=columns, report_findings=False,
+            )
         except Exception as e:
             error_dialog(parent=parent or self,
                          title="Load error", message=str(e))

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -1132,6 +1132,8 @@ class ProtocolTreePane(QWidget):
             with open(path, "r", encoding="utf-8") as f:
                 data = json.load(f)
             columns = columns_factory()
+            # Device's current electrode->channel map (from DEVICE_VIEWER_GEOMETRY_CHANGED);
+            # None when no device/sync is wired -> validator skips device-dependent checks.
             device_map = None
             if self.device_viewer_sync is not None:
                 device_map = dict(self.device_viewer_sync.electrode_ids_channels_map)


### PR DESCRIPTION
## Summary

resolves #423 (PPT-17): validate a loaded protocol against the **currently loaded device** at load time, surfacing problems before a run rather than as silent per-phase skips at execution time.

Three checks (this pass — core device-compatibility, per the design doc):
- **Electrode-ID validity** *(warning)* — every electrode referenced by a step's `routes`/`electrodes` exists on the current device; lists the unknown IDs and which steps reference them.
- **Stale channel mapping** *(warning)* — the protocol's stored `electrode_to_channel` disagrees with the device's current channel for an electrode (`E1: protocol ch 5 -> device ch 7`).
- **Orphan column** *(error)* — a saved `col_id` has no live column (plugin not loaded); its values would be silently dropped on load.

Architecture — a pure, side-effect-free `validate_protocol(data, columns, device_map) -> ValidationReport` reads the raw serialized JSON, plus two interchangeable presenters over the same report:
- `confirm_report` — GUI two-tier dialog (warnings → *Proceed anyway*; errors → default *Cancel* with an explicit *Load anyway (drop columns)* override), via `microdrop_application.dialogs.pyface_wrapper`.
- `log_report` — headless logger output (errors at ERROR, warnings at WARNING); never blocks.

Wiring:
- **Headless** — `RowManager.from_json` / `set_state_from_json` gain `device_electrode_to_channel=None, report_findings=True`; they validate + log before applying, then proceed regardless (headless can't prompt). Backward-compatible defaults.
- **GUI** — `load_from_dialog` validates against the device's current map (`device_viewer_sync.electrode_ids_channels_map`, authoritative from `DEVICE_VIEWER_GEOMETRY_CHANGED`); aborts on Cancel, else loads with `report_findings=False` (dialog already showed the findings).

Out of scope (deferred follow-ups): loop-route well-formedness and structural-sanity checks.

Design + plan: `docs/superpowers/specs/2026-06-11-issue-423-protocol-load-validation-design.md`, `docs/superpowers/plans/2026-06-11-issue-423-protocol-load-validation.md`.

## Test Plan

- [x] ~21 unit tests for the pure validator (each check, electrode-vs-routes extraction, stale-vs-matching, no-device skip, malformed-input safety, dotted step ids, presenter log levels, confirm proceed/cancel button labels)
- [x] Headless wiring tests (orphan logged + load still happens; `report_findings=False` suppresses validator output)
- [x] Pane-level GUI tests (findings + Cancel → load aborts, manager untouched; findings + Proceed → file loads)
- [x] Regression gate green: `test_protocol_validator` + `test_row_manager` + `test_persistence` + `test_protocol_tree_pane_file_menu` + `test_compound_persistence` (105 passed) — compound columns confirmed not to produce spurious orphan findings
- [x] Manual: load a protocol authored on a different device into the GUI and confirm the warning dialog lists the unknown electrodes / stale channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)