### PR TITLE
[PPT-23] Protocol status trackers: elapsed/active times + step/phase counters (issue #467)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-protocol-status-trackers.md
+++ b/docs/superpowers/plans/2026-06-16-protocol-status-trackers.md
@@ -1,0 +1,1224 @@
+# Protocol Status Trackers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the protocol status-bar timing/counting out of `ProtocolTreePane` into a Qt-free `HasTraits` model driven by a small reusable controller, add the six time readouts (elapsed + active for protocol/step/phase) and Step n/N + Phase n/N counters, and bind the existing `StatusBar` to the model.
+
+**Architecture:** Model (`ProtocolStatusModel` + `ScopeStopwatch`, pure) ← Controller (`ProtocolStatusController`, HasTraits, owns model, subscribes to `ExecutorSignals`) → View (`StatusBar.bind(model)`: Traits observers + a 10 Hz poll timer). The dock pane and the standalone demo window each own a controller. Model is mutated only on the GUI thread, so observers drive widgets directly with no Qt-signal bridge.
+
+**Tech Stack:** Python, Traits (enthought), PySide6/pyface Qt, pytest.
+
+Spec: `docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md`.
+
+**Test command (verify once at Task 1, reuse everywhere):**
+`pixi run pytest pluggable_protocol_tree/tests/<file> -v` run from `microdrop-py/src`. If that path fails, try `cd microdrop-py && pixi run pytest src/pluggable_protocol_tree/tests/<file> -v`. Pure-model/controller tests need no Redis/Qt.
+
+---
+
+### Task 1: `ScopeStopwatch` timing primitive
+
+**Files:**
+- Create: `pluggable_protocol_tree/models/stopwatch.py`
+- Test: `pluggable_protocol_tree/tests/test_stopwatch.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# pluggable_protocol_tree/tests/test_stopwatch.py
+"""Unit tests for ScopeStopwatch (pure, fake-clock)."""
+from pluggable_protocol_tree.models.stopwatch import ScopeStopwatch
+
+
+def test_not_started_reads_zero():
+    sw = ScopeStopwatch()
+    assert sw.elapsed(100.0) == 0.0
+    assert sw.active(100.0) == 0.0
+
+
+def test_elapsed_and_active_tick_together_when_running():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    assert sw.elapsed(2.0) == 2.0
+    assert sw.active(2.0) == 2.0
+
+
+def test_elapsed_ignores_pause_active_freezes():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.pause(1.0)          # active frozen at 1.0; elapsed keeps going
+    assert sw.elapsed(5.0) == 5.0
+    assert sw.active(5.0) == 1.0
+    sw.resume(5.0)         # active resumes from 1.0
+    assert sw.elapsed(6.0) == 6.0
+    assert sw.active(6.0) == 2.0
+
+
+def test_stop_freezes_both():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(3.0)
+    assert sw.elapsed(99.0) == 3.0
+    assert sw.active(99.0) == 3.0
+
+
+def test_resume_after_stop_is_noop():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(3.0)
+    sw.resume(10.0)
+    assert sw.elapsed(99.0) == 3.0
+    assert sw.active(99.0) == 3.0
+
+
+def test_pause_before_start_is_noop():
+    sw = ScopeStopwatch()
+    sw.pause(5.0)
+    sw.start(10.0)
+    assert sw.active(12.0) == 2.0
+
+
+def test_start_resets_prior_accumulation():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(5.0)
+    sw.start(100.0)        # restart from zero
+    assert sw.elapsed(102.0) == 2.0
+    assert sw.active(102.0) == 2.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_stopwatch.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pluggable_protocol_tree.models.stopwatch'`. (This run also confirms the working test command for the rest of the plan.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# pluggable_protocol_tree/models/stopwatch.py
+"""Pause-aware stopwatch primitive for protocol status timing (issue #467).
+
+Tracks two clocks for one scope (protocol / step / phase):
+
+  * elapsed -- wall-clock since start; never freezes on pause.
+  * active  -- excludes paused intervals; freezes between pause()/resume().
+
+Every method takes ``now`` (a monotonic timestamp) rather than calling the
+clock itself, so timing is fully deterministic under test. No Qt, no
+threads.
+"""
+
+
+class ScopeStopwatch:
+    __slots__ = ("_elapsed_anchor", "_elapsed_accum",
+                 "_active_anchor", "_active_accum")
+
+    def __init__(self):
+        # monotonic when ticking began; None => stopped/never-started.
+        self._elapsed_anchor = None
+        self._elapsed_accum = 0.0
+        # monotonic of current running segment; None => paused/stopped.
+        self._active_anchor = None
+        self._active_accum = 0.0
+
+    def start(self, now):
+        """(Re)start both clocks from zero; begin ticking and running."""
+        self._elapsed_anchor = now
+        self._elapsed_accum = 0.0
+        self._active_anchor = now
+        self._active_accum = 0.0
+
+    def pause(self, now):
+        """Freeze the active clock; elapsed keeps ticking."""
+        if self._active_anchor is not None:
+            self._active_accum += now - self._active_anchor
+            self._active_anchor = None
+
+    def resume(self, now):
+        """Unfreeze the active clock. No-op if not started or already running."""
+        if self._elapsed_anchor is not None and self._active_anchor is None:
+            self._active_anchor = now
+
+    def stop(self, now):
+        """Freeze BOTH clocks at their current values."""
+        if self._active_anchor is not None:
+            self._active_accum += now - self._active_anchor
+            self._active_anchor = None
+        if self._elapsed_anchor is not None:
+            self._elapsed_accum += now - self._elapsed_anchor
+            self._elapsed_anchor = None
+
+    def elapsed(self, now):
+        """Wall-clock seconds since start (ignores pauses)."""
+        running = 0.0 if self._elapsed_anchor is None else now - self._elapsed_anchor
+        return self._elapsed_accum + running
+
+    def active(self, now):
+        """Active seconds since start (excludes paused intervals)."""
+        running = 0.0 if self._active_anchor is None else now - self._active_anchor
+        return self._active_accum + running
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_stopwatch.py -v`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/models/stopwatch.py pluggable_protocol_tree/tests/test_stopwatch.py
+git commit -m "Add ScopeStopwatch timing primitive (issue #467)"
+```
+
+---
+
+### Task 2: `ProtocolStatusModel`
+
+**Files:**
+- Create: `pluggable_protocol_tree/models/protocol_status.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_status_model.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# pluggable_protocol_tree/tests/test_protocol_status_model.py
+"""Unit tests for ProtocolStatusModel (pure, fake-clock, no Qt)."""
+from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
+
+
+def test_protocol_start_sets_total_and_runs():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=3)
+    assert m.step_total == 3
+    assert m.step_index == 0
+    assert m.running is True
+    assert m.protocol_clock.elapsed(2.0) == 2.0
+
+
+def test_step_start_increments_and_resets_phase():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=3)
+    m.on_step_start(0.0, "Step A", "Step B")
+    assert m.step_index == 1
+    assert m.recent_step_name == "Step A"
+    assert m.next_step_name == "Step B"
+    assert m.phase_index == 0
+    assert m.phase_total == 0
+    assert m.step_clock.elapsed(1.0) == 1.0
+    m.on_step_start(1.0, "Step B", "-")
+    assert m.step_index == 2
+    # step clock restarted at t=1.0
+    assert m.step_clock.elapsed(3.0) == 2.0
+
+
+def test_phase_start_sets_counts_and_target():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.on_phase_start(0.0, phase_index=2, phase_total=4, phase_target_s=1.5)
+    assert m.phase_index == 2
+    assert m.phase_total == 4
+    assert m.phase_target_s == 1.5
+    assert m.phase_clock.elapsed(0.5) == 0.5
+    m.on_phase_extended(0.5)
+    assert m.phase_target_s == 2.0
+
+
+def test_pause_freezes_active_not_elapsed_all_scopes():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.on_phase_start(0.0, 1, 1, 1.0)
+    m.pause(1.0)
+    assert m.paused is True
+    # elapsed keeps going, active frozen at 1.0
+    assert m.protocol_clock.elapsed(5.0) == 5.0
+    assert m.protocol_clock.active(5.0) == 1.0
+    assert m.step_clock.active(5.0) == 1.0
+    assert m.phase_clock.active(5.0) == 1.0
+    m.resume(5.0)
+    assert m.paused is False
+    assert m.protocol_clock.active(6.0) == 2.0
+
+
+def test_step_start_while_paused_keeps_active_frozen():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=2)
+    m.on_step_start(0.0, "A", "B")
+    m.pause(1.0)
+    m.on_step_start(2.0, "B", "-")   # new step begins while paused
+    # new step's active must not run until resume
+    assert m.step_clock.active(4.0) == 0.0
+    assert m.step_clock.elapsed(4.0) == 2.0
+    m.resume(4.0)
+    assert m.step_clock.active(5.0) == 1.0
+
+
+def test_repetition_and_rep_chain():
+    m = ProtocolStatusModel()
+    m.on_repetition(1, 3)
+    assert m.repeats_completed == 1
+    assert m.repeats_total == 3
+    m.set_rep_chain("rep 2/3 of 'Wash'")
+    assert m.rep_chain_label == "rep 2/3 of 'Wash'"
+
+
+def test_stop_freezes_all_and_clears_running():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.stop(3.0)
+    assert m.running is False
+    assert m.protocol_clock.elapsed(99.0) == 3.0
+    assert m.step_clock.elapsed(99.0) == 3.0
+
+
+def test_reset_restores_defaults():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=5)
+    m.on_step_start(0.0, "A", "B")
+    m.reset()
+    assert m.step_index == 0
+    assert m.step_total == 0
+    assert m.recent_step_name == "-"
+    assert m.running is False
+    assert m.protocol_clock.elapsed(9.0) == 0.0
+
+
+def test_observers_fire_on_counter_change():
+    m = ProtocolStatusModel()
+    seen = []
+    m.observe(lambda e: seen.append(e.new), "step_index")
+    m.on_protocol_start(0.0, 2)
+    m.on_step_start(0.0, "A", "B")
+    assert 1 in seen
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_model.py -v`
+Expected: FAIL with `ModuleNotFoundError: ... protocol_status`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# pluggable_protocol_tree/models/protocol_status.py
+"""HasTraits model for the protocol status bar (issue #467).
+
+Holds the observable counters / names and three ScopeStopwatch clocks
+(protocol / step / phase), and encapsulates the timing *rules* (a new step
+resets the phase clock; pause freezes active but not elapsed; ...). Pure:
+no Qt, no threads, no direct clock calls -- every timing method takes
+``now`` so the model is unit-testable with a fake clock.
+
+The view binds to the observable traits (discrete updates) and polls the
+clocks for the continuously-changing time readouts. See
+ProtocolStatusController for the executor-signal -> model wiring.
+"""
+
+from traits.api import Bool, Float, HasTraits, Instance, Int, Str
+
+from pluggable_protocol_tree.models.stopwatch import ScopeStopwatch
+
+
+class ProtocolStatusModel(HasTraits):
+    # --- counters ---
+    step_index = Int(0)
+    step_total = Int(0)
+    phase_index = Int(0)
+    phase_total = Int(0)
+    repeats_completed = Int(0)
+    repeats_total = Int(1)
+
+    # --- names / labels ---
+    recent_step_name = Str("-")
+    next_step_name = Str("-")
+    rep_chain_label = Str("")
+
+    # --- phase target (for the "elapsed / target" readout) ---
+    phase_target_s = Float(0.0)
+
+    # --- run state ---
+    running = Bool(False)
+    paused = Bool(False)
+
+    # --- clocks (plain helpers; default-constructed per model) ---
+    protocol_clock = Instance(ScopeStopwatch, ())
+    step_clock = Instance(ScopeStopwatch, ())
+    phase_clock = Instance(ScopeStopwatch, ())
+
+    # --- rule methods ---
+
+    def reset(self):
+        self.trait_set(
+            step_index=0, step_total=0, phase_index=0, phase_total=0,
+            repeats_completed=0, repeats_total=1,
+            recent_step_name="-", next_step_name="-", rep_chain_label="",
+            phase_target_s=0.0, running=False, paused=False,
+        )
+        self.protocol_clock = ScopeStopwatch()
+        self.step_clock = ScopeStopwatch()
+        self.phase_clock = ScopeStopwatch()
+
+    def on_protocol_start(self, now, step_total):
+        self.reset()
+        self.step_total = int(step_total)
+        self.running = True
+        self.protocol_clock.start(now)
+
+    def on_step_start(self, now, recent_name, next_name):
+        self.step_index += 1
+        self.recent_step_name = recent_name
+        self.next_step_name = next_name
+        self.phase_index = 0
+        self.phase_total = 0
+        self.phase_target_s = 0.0
+        self.step_clock.start(now)
+        self.phase_clock = ScopeStopwatch()      # fresh, unstarted
+        if self.paused:                          # started mid-pause: keep frozen
+            self.step_clock.pause(now)
+
+    def on_phase_start(self, now, phase_index, phase_total, phase_target_s):
+        self.phase_index = int(phase_index)
+        self.phase_total = int(phase_total)
+        try:
+            self.phase_target_s = float(phase_target_s)
+        except (TypeError, ValueError):
+            self.phase_target_s = 0.0
+        self.phase_clock.start(now)
+        if self.paused:
+            self.phase_clock.pause(now)
+
+    def on_phase_extended(self, extra_s):
+        try:
+            self.phase_target_s += float(extra_s)
+        except (TypeError, ValueError):
+            pass
+
+    def pause(self, now):
+        self.paused = True
+        self.protocol_clock.pause(now)
+        self.step_clock.pause(now)
+        self.phase_clock.pause(now)
+
+    def resume(self, now):
+        self.paused = False
+        self.protocol_clock.resume(now)
+        self.step_clock.resume(now)
+        self.phase_clock.resume(now)
+
+    def on_repetition(self, completed, total):
+        self.repeats_completed = int(completed)
+        self.repeats_total = int(total)
+
+    def set_rep_chain(self, label):
+        self.rep_chain_label = label
+
+    def stop(self, now):
+        self.running = False
+        self.paused = False
+        self.protocol_clock.stop(now)
+        self.step_clock.stop(now)
+        self.phase_clock.stop(now)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_model.py -v`
+Expected: PASS (9 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/models/protocol_status.py pluggable_protocol_tree/tests/test_protocol_status_model.py
+git commit -m "Add ProtocolStatusModel state + timing rules (issue #467)"
+```
+
+---
+
+### Task 3: `ProtocolStatusController`
+
+**Files:**
+- Create: `pluggable_protocol_tree/services/protocol_status_controller.py`
+- Test: `pluggable_protocol_tree/tests/test_protocol_status_controller.py`
+
+The test uses tiny fakes for `qsignals` (a connectable signal) and `manager` (an execution-step iterator) — no Qt, no executor.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# pluggable_protocol_tree/tests/test_protocol_status_controller.py
+"""Unit tests for ProtocolStatusController (fake signals + manager, no Qt)."""
+from pluggable_protocol_tree.services.protocol_status_controller import (
+    ProtocolStatusController,
+)
+
+
+class _Sig:
+    """Minimal Qt-signal stand-in: connect() stores slots, emit() calls them."""
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def disconnect(self, slot):
+        self._slots.remove(slot)
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _Signals:
+    def __init__(self):
+        for name in (
+            "protocol_started", "step_started", "step_repetition",
+            "phase_started", "phase_extended", "protocol_paused",
+            "protocol_resumed", "protocol_repetition_finished",
+            "protocol_finished", "protocol_aborted", "protocol_error",
+        ):
+            setattr(self, name, _Sig())
+
+
+class _Row:
+    def __init__(self, name, path):
+        self.name = name
+        self.path = path
+
+
+class _Manager:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def iter_execution_steps(self):
+        return iter(list(self._rows))
+
+
+def _make(rows=None):
+    rows = rows or [_Row("A", (0,)), _Row("B", (1,))]
+    sigs = _Signals()
+    clock = {"t": 0.0}
+    ctrl = ProtocolStatusController(
+        qsignals=sigs, manager=_Manager(rows), clock=lambda: clock["t"],
+    )
+    return ctrl, sigs, clock, rows
+
+
+def test_protocol_started_counts_steps():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    assert ctrl.model.step_total == 2
+    assert ctrl.model.running is True
+
+
+def test_step_started_sets_name_and_next():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    assert ctrl.model.step_index == 1
+    assert ctrl.model.recent_step_name == "A"
+    assert ctrl.model.next_step_name == "B"
+
+
+def test_pause_resume_drive_model_with_clock():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    clock["t"] = 1.0
+    sigs.protocol_paused.emit()
+    assert ctrl.model.paused is True
+    assert ctrl.model.protocol_clock.active(5.0) == 1.0
+
+
+def test_phase_started_and_extended():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    sigs.phase_started.emit(2, 4, 1.5)
+    assert ctrl.model.phase_index == 2
+    assert ctrl.model.phase_total == 4
+    assert ctrl.model.phase_target_s == 1.5
+    sigs.phase_extended.emit(0.5)
+    assert ctrl.model.phase_target_s == 2.0
+
+
+def test_rep_chain_formatting():
+    ctrl, sigs, clock, rows = _make()
+    sigs.step_repetition.emit([("Wash", 2, 3)])
+    assert ctrl.model.rep_chain_label == "rep 2/3 of 'Wash'"
+    sigs.step_repetition.emit([])
+    assert ctrl.model.rep_chain_label == ""
+
+
+def test_terminal_signals_stop():
+    for term in ("protocol_finished", "protocol_aborted"):
+        ctrl, sigs, clock, rows = _make()
+        sigs.protocol_started.emit()
+        getattr(sigs, term).emit()
+        assert ctrl.model.running is False
+
+
+def test_error_stops():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.protocol_error.emit("boom")
+    assert ctrl.model.running is False
+
+
+def test_disconnect_stops_updates():
+    ctrl, sigs, clock, rows = _make()
+    ctrl.disconnect()
+    sigs.protocol_started.emit()
+    assert ctrl.model.step_total == 0   # not wired anymore
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_controller.py -v`
+Expected: FAIL with `ModuleNotFoundError: ... protocol_status_controller`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# pluggable_protocol_tree/services/protocol_status_controller.py
+"""Links executor lifecycle signals to a ProtocolStatusModel (issue #467).
+
+A small HasTraits adapter owned by the composition root (the dock pane in
+the full app; the demo window standalone). It owns the model, connects one
+slot per ExecutorSignals signal, and translates each into a single model
+method call stamped with ``now``. No formatting, no widgets -- the view
+binds to ``self.model`` separately.
+
+Invariant: ExecutorSignals is a QObject delivering via queued connections,
+so these slots run on the GUI thread; the model is therefore mutated only
+on the GUI thread and its observers may drive widgets directly.
+"""
+
+import time
+
+from traits.api import Any, Callable, HasTraits, Instance
+
+from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
+
+
+class ProtocolStatusController(HasTraits):
+    #: The status model this controller drives. The view binds to it.
+    model = Instance(ProtocolStatusModel, ())
+
+    #: ExecutorSignals QObject (duck-typed; any object exposing the
+    #: signals works -- keeps Qt types out of the signature and tests Qt-free).
+    qsignals = Any()
+
+    #: RowManager -- needed for the step count and next-step name.
+    manager = Any()
+
+    #: Monotonic clock source; overridable in tests.
+    clock = Callable(time.monotonic)
+
+    def traits_init(self):
+        self._connect()
+
+    # --- wiring ---
+
+    def _pairs(self):
+        s = self.qsignals
+        return (
+            (s.protocol_started, self._on_protocol_started),
+            (s.step_started, self._on_step_started),
+            (s.step_repetition, self._on_step_repetition),
+            (s.phase_started, self._on_phase_started),
+            (s.phase_extended, self._on_phase_extended),
+            (s.protocol_paused, self._on_paused),
+            (s.protocol_resumed, self._on_resumed),
+            (s.protocol_repetition_finished, self._on_repetition_finished),
+            (s.protocol_finished, self._on_stopped),
+            (s.protocol_aborted, self._on_stopped),
+            (s.protocol_error, self._on_error),
+        )
+
+    def _connect(self):
+        if self.qsignals is None:
+            return
+        for sig, slot in self._pairs():
+            sig.connect(slot)
+
+    def disconnect(self):
+        if self.qsignals is None:
+            return
+        for sig, slot in self._pairs():
+            try:
+                sig.disconnect(slot)
+            except (RuntimeError, TypeError):
+                pass
+
+    # --- slots (executor signal -> model) ---
+
+    def _on_protocol_started(self):
+        self.model.on_protocol_start(self.clock(), self._count_steps())
+
+    def _on_step_started(self, row):
+        self.model.on_step_start(self.clock(), row.name, self._next_name(row))
+
+    def _on_step_repetition(self, rep_chain):
+        self.model.set_rep_chain(self._fmt_chain(rep_chain))
+
+    def _on_phase_started(self, phase_index, phase_total, phase_duration_s):
+        self.model.on_phase_start(
+            self.clock(), phase_index, phase_total, phase_duration_s)
+
+    def _on_phase_extended(self, extra_s):
+        self.model.on_phase_extended(extra_s)
+
+    def _on_paused(self):
+        self.model.pause(self.clock())
+
+    def _on_resumed(self):
+        self.model.resume(self.clock())
+
+    def _on_repetition_finished(self, completed, total):
+        self.model.on_repetition(completed, total)
+
+    def _on_stopped(self):
+        self.model.stop(self.clock())
+
+    def _on_error(self, _msg):
+        self.model.stop(self.clock())
+
+    # --- helpers (need manager) ---
+
+    def _count_steps(self):
+        try:
+            return sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            return 0
+
+    def _next_name(self, current):
+        steps = self.manager.iter_execution_steps()
+        cur_path = tuple(current.path)
+        for row in steps:
+            if tuple(row.path) == cur_path:
+                nxt = next(steps, None)
+                return nxt.name if nxt is not None else "-"
+        return "-"
+
+    @staticmethod
+    def _fmt_chain(rep_chain):
+        if not rep_chain:
+            return ""
+        return " · ".join(
+            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_controller.py -v`
+Expected: PASS (8 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/protocol_status_controller.py pluggable_protocol_tree/tests/test_protocol_status_controller.py
+git commit -m "Add ProtocolStatusController wiring executor signals to model (issue #467)"
+```
+
+---
+
+### Task 4: `StatusBar.bind(model)` + combined time fields
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/navigation_bar.py` (the `StatusBar` class, ~382-531)
+
+No new automated test (pure-Qt view; verified via the demo-window test in Task 7 and manual run in Task 8). This task is a structural view change.
+
+- [ ] **Step 1: Add a poll-interval constant near the top of `navigation_bar.py`**
+
+Find the module-level constants area (near other `*_MS` / width constants) and add:
+
+```python
+STATUS_POLL_INTERVAL_MS = 100   # 10 Hz refresh for the live time readouts
+```
+
+- [ ] **Step 2: Ensure `QTimer` and `time` are imported**
+
+At the top of `navigation_bar.py`, confirm/add:
+```python
+import time
+from pyface.qt.QtCore import QTimer   # use the same Qt import style already in this file
+```
+(If the file already imports `QTimer`/`Qt` from a specific module, add `QTimer` to that existing import rather than a new line.)
+
+- [ ] **Step 3: Widen the three time labels and set neutral initial text**
+
+In `StatusBar.__init__`, replace the three label constructions:
+
+```python
+        self.lbl_total_time = QLabel("Total Time: 0 s")
+        self.lbl_total_time.setFixedWidth(120)
+        self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_step_time = QLabel("Step Time: 0 s")
+        self.lbl_step_time.setFixedWidth(115)
+        self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+```
+
+with:
+
+```python
+        self.lbl_total_time = QLabel("Protocol 0.0s (act 0.0s)")
+        self.lbl_total_time.setFixedWidth(190)
+        self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+
+        self.lbl_step_time = QLabel("Step 0.0s (act 0.0s)")
+        self.lbl_step_time.setFixedWidth(170)
+        self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+```
+
+And change the phase label's initial text + width:
+
+```python
+        self.lbl_phase_time = QLabel("Phase 0/0  0.0s/0.0s (act 0.0s)")
+        self.lbl_phase_time.setFixedWidth(260)
+        self.lbl_phase_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        self.lbl_phase_time.setVisible(False)
+```
+
+- [ ] **Step 4: Add `_model`/`_poll_timer` attributes at the end of `__init__`**
+
+At the very end of `StatusBar.__init__` (after `self._apply_styling()` / the colorScheme connect), add:
+
+```python
+        # Bound lazily via bind(); until then the labels show their
+        # neutral initial text.
+        self._model = None
+        self._poll_timer = None
+```
+
+- [ ] **Step 5: Add the `bind` + refresh methods to `StatusBar`**
+
+Add these methods to the `StatusBar` class (e.g. right after `_apply_styling`):
+
+```python
+    def bind(self, model):
+        """Bind this status bar to a ProtocolStatusModel.
+
+        Discrete traits (counters, names, rep-chain) drive label text via
+        Traits observers; the continuously-changing time readouts are
+        refreshed by a 10 Hz poll timer that runs only while a protocol is
+        active. Safe to touch widgets in the observers: the model is mutated
+        only on the GUI thread (see ProtocolStatusController)."""
+        self._model = model
+        if self._poll_timer is None:
+            self._poll_timer = QTimer(self)
+            self._poll_timer.setInterval(STATUS_POLL_INTERVAL_MS)
+            self._poll_timer.timeout.connect(self._refresh_times)
+
+        model.observe(self._on_counts_changed,
+                      "step_index, step_total, phase_index, phase_total")
+        model.observe(self._on_repeats_changed,
+                      "repeats_completed, repeats_total")
+        model.observe(self._on_names_changed,
+                      "recent_step_name, next_step_name, rep_chain_label")
+        model.observe(self._on_running_changed, "running")
+
+        self._refresh_counts()
+        self._refresh_repeats()
+        self._refresh_names()
+        self._refresh_times()
+
+    # --- observer handlers (discrete) ---
+
+    def _on_counts_changed(self, event):
+        self._refresh_counts()
+
+    def _on_repeats_changed(self, event):
+        self._refresh_repeats()
+
+    def _on_names_changed(self, event):
+        self._refresh_names()
+
+    def _on_running_changed(self, event):
+        if self._poll_timer is None:
+            return
+        if event.new:
+            if not self._poll_timer.isActive():
+                self._poll_timer.start()
+        else:
+            self._refresh_times()        # final freeze-frame
+            self._poll_timer.stop()
+
+    # --- refreshers ---
+
+    def _refresh_counts(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_step_progress.setText(f"Step {m.step_index}/{m.step_total}")
+
+    def _refresh_repeats(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_repeat_protocol_status.setText(f"{m.repeats_completed}/")
+
+    def _refresh_names(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_recent_step.setText(f"Most Recent Step: {m.recent_step_name}")
+        self.lbl_next_step.setText(f"Next Step: {m.next_step_name}")
+        if m.rep_chain_label:
+            self.lbl_step_repetition.setText(m.rep_chain_label)
+            self.lbl_step_repetition.setVisible(True)
+        else:
+            self.lbl_step_repetition.setText("")
+            self.lbl_step_repetition.setVisible(False)
+
+    def _refresh_times(self):
+        m = self._model
+        if m is None:
+            return
+        now = time.monotonic()
+        self.lbl_total_time.setText(
+            f"Protocol {m.protocol_clock.elapsed(now):.1f}s "
+            f"(act {m.protocol_clock.active(now):.1f}s)"
+        )
+        self.lbl_step_time.setText(
+            f"Step {m.step_clock.elapsed(now):.1f}s "
+            f"(act {m.step_clock.active(now):.1f}s)"
+        )
+        if m.phase_total > 0:
+            head = f"Phase {m.phase_index}/{m.phase_total}"
+        elif m.phase_index > 0:
+            head = f"Phase {m.phase_index}"
+        else:
+            head = "Phase"
+        self.lbl_phase_time.setText(
+            f"{head}  {m.phase_clock.elapsed(now):.1f}s/"
+            f"{m.phase_target_s:.1f}s (act {m.phase_clock.active(now):.1f}s)"
+        )
+```
+
+- [ ] **Step 6: Verify the file imports cleanly**
+
+Run: `pixi run python -c "import pluggable_protocol_tree.views.navigation_bar"`
+Expected: no output, exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/navigation_bar.py
+git commit -m "Add StatusBar.bind(model) + combined time fields (issue #467)"
+```
+
+---
+
+### Task 5: Strip status logic from `ProtocolTreePane`
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/protocol_tree_pane.py`
+
+Goal: remove the embedded status state + display, KEEP every non-status responsibility. Work slot-by-slot. After this task the pane no longer updates the status bar by itself; Task 6 wires the controller that does.
+
+- [ ] **Step 1: Remove the status state-vars block**
+
+Delete these lines from `__init__` (currently ~246-273):
+```python
+        self._step_index = 0
+        self._step_total = 0
+        self._step_started_at: float | None = None
+        self._phase_started_at: float | None = None
+        self._phase_target: float | None = None
+        self._phase_index = 0
+        self._phase_total = 0
+        self._current_row = None
+        self._repeats_total = 1
+        self._repeats_completed = 0
+```
+KEEP `self._current_run_preview_mode`, `self._pause_phases`, `self._pause_phase_idx`, `self._start_pending`, `self._wait_active` (non-status). Also delete the status label aliases:
+```python
+        self._status_step_label = self.status_bar.lbl_step_progress
+        self._status_step_time_label = self.status_bar.lbl_step_time
+        self._status_reps_label = self.status_bar.lbl_step_repetition
+        self._status_phase_time_label = (
+            self.status_bar.lbl_phase_time if self.phase_ack_topic is not None
+            else None
+        )
+```
+and the tick timer:
+```python
+        self._tick_timer = QTimer(self)
+        self._tick_timer.setInterval(STATUS_TICK_INTERVAL_MS)
+        self._tick_timer.timeout.connect(self._refresh_status)
+```
+
+NOTE on `_repeats_total`/`_repeats_completed`: these feed `_update_repeat_status_label` / `_on_error`. They move to the model. In `_start_protocol_run` (~627-632) the lines
+```python
+        self._repeats_total = repeats
+        self._repeats_completed = 0
+        ...
+        self._update_repeat_status_label()
+```
+become (the spin box value is the desired total; the model gets it once the run starts):
+```python
+        self._current_run_preview_mode = preview_mode
+```
+Delete `_update_repeat_status_label` (the model + StatusBar own the repeat label now) and remove its other call sites (`_on_error`). In `_on_error`, delete:
+```python
+        self._repeats_total = 0
+        self._repeats_completed = 0
+        self._update_repeat_status_label()
+```
+
+- [ ] **Step 2: Trim `_on_protocol_started` to its non-status duties**
+
+Replace (~409-419) with:
+```python
+    def _on_protocol_started(self):
+        self._start_pending = False
+        self.protocol_running_changed.emit(True)
+        self._publish_protocol_running("True")
+        logger.info("Protocol started")
+```
+
+- [ ] **Step 3: Trim `_on_step_started` to its non-status duties**
+
+The slot is also connected to `widget.highlight_active_row` separately, so the pane's own `_on_step_started` keeps only what isn't status. Its current body is entirely status + the explanatory NOTE comment. Replace (~421-454) with:
+```python
+    def _on_step_started(self, row):
+        # Row highlighting is wired separately (widget.highlight_active_row).
+        # Status counters / timers are owned by ProtocolStatusController now.
+        #
+        # NOTE: we deliberately do NOT publish the static step view to the
+        # DV here. RoutesHandler publishes a per-phase display for every
+        # phase while a protocol runs, which is authoritative; publishing a
+        # static row view here raced with phase 1 and cleared it.
+        pass
+```
+(Keep the slot — it documents the deliberate no-op and remains a connection point. If the project lints against empty slots, leave the comment + `return`.)
+
+- [ ] **Step 4: Reduce phase/step/repetition status slots to no-ops or remove**
+
+Delete `_on_phase_started`, `_on_phase_extended`, `_on_step_repetition`, `_on_step_finished`, `_refresh_status`, and `_next_step_name` (all status-only; `_next_step_name` moved to the controller).
+
+Then remove their signal connections in `_wire_executor_signals` (~360-370):
+```python
+        self.executor.qsignals.step_started.connect(self._on_step_started)
+        self.executor.qsignals.step_finished.connect(self._on_step_finished)
+        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
+        ...
+        self.executor.qsignals.phase_started.connect(self._on_phase_started)
+        self.executor.qsignals.phase_extended.connect(self._on_phase_extended)
+```
+Keep `step_started.connect(self.widget.highlight_active_row)`. Keep the `_on_step_started` no-op connection only if you kept the slot; otherwise drop both the slot and its connect. Keep `protocol_started.connect(self._on_protocol_started)`, `protocol_error.connect(self._on_error)`, and the `protocol_wait_*` connections (loading screen — non-status).
+
+- [ ] **Step 5: Check pause/resume + pause-phase code for status references**
+
+`_on_protocol_paused` / `_on_protocol_resumed` (button-state machine) and the pause-phase navigation may reference removed vars (`_current_row`, `_phase_index`, `_phase_total`, `_phase_started_at`, `_tick_timer`). Grep and fix:
+
+Run: `git grep -nE "_step_index|_step_total|_step_started_at|_phase_started_at|_phase_target|_phase_index|_phase_total|_current_row|_tick_timer|_refresh_status|_status_step_label|_status_step_time_label|_status_reps_label|_status_phase_time_label|_update_repeat_status_label|_next_step_name|_repeats_total|_repeats_completed" -- pluggable_protocol_tree/views/protocol_tree_pane.py`
+
+For each remaining hit that is genuinely about **status display**, remove it. For any that the **pause-phase navigation** needs (e.g. it independently tracks the current row/phase to drive the phase nav buttons), keep that logic but give it its own private var that does NOT alias status (e.g. keep a local `self._nav_current_row` set where the pane needs it). If the pause-phase logic was *reusing* the old `_current_row`/`_phase_*` status vars, re-introduce minimal private vars for navigation only, set from the relevant signals the pane still listens to. Document why with a short comment.
+
+Also remove the now-unused imports (`time`, `QTimer`, `STATUS_TICK_INTERVAL_MS`) if nothing else in the file uses them.
+
+- [ ] **Step 6: Verify import + grep is clean**
+
+Run: `pixi run python -c "import pluggable_protocol_tree.views.protocol_tree_pane"`
+Expected: exit 0 (ImportError/NameError here means a missed reference — fix it).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/protocol_tree_pane.py
+git commit -m "Strip embedded status logic from ProtocolTreePane (issue #467)"
+```
+
+---
+
+### Task 6: Wire the controller in the dock pane
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/dock_pane.py`
+
+- [ ] **Step 1: Add the import + trait**
+
+Add the import near the other `services` imports:
+```python
+from pluggable_protocol_tree.services.protocol_status_controller import (
+    ProtocolStatusController,
+)
+```
+Add the trait to `PluggableProtocolDockPane` (next to `protocol_state_tracker`):
+```python
+    status_controller = Instance(ProtocolStatusController)
+```
+
+- [ ] **Step 2: Instantiate + bind in `create_contents`**
+
+In `create_contents`, after the `pane = ProtocolTreePane(...)` block and before `pane._seed_default_step_if_empty()`, add:
+```python
+        # The dock pane is the app's HasTraits composition root: it owns the
+        # status controller that links the executor's Qt signals to the
+        # status model, and binds the (view-only) status bar to that model.
+        self.status_controller = ProtocolStatusController(
+            qsignals=pane.executor.qsignals,
+            manager=self.manager,
+        )
+        pane.status_bar.bind(self.status_controller.model)
+```
+
+- [ ] **Step 3: Verify import**
+
+Run: `pixi run python -c "import pluggable_protocol_tree.views.dock_pane"`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/dock_pane.py
+git commit -m "Dock pane owns ProtocolStatusController and binds status bar (issue #467)"
+```
+
+---
+
+### Task 7: Migrate the demo window + its tests
+
+**Files:**
+- Modify: `pluggable_protocol_tree/demos/base_demo_window.py`
+- Modify: `pluggable_protocol_tree/tests/test_base_demo_window.py`
+
+- [ ] **Step 1: Build the controller in the demo window**
+
+In `BasePluggableProtocolDemoWindow.__init__`, after `self.pane = ProtocolTreePane(...)` (just after the `phase_acked` wiring, ~228), add:
+```python
+        from pluggable_protocol_tree.services.protocol_status_controller import (
+            ProtocolStatusController,
+        )
+        self.status_controller = ProtocolStatusController(
+            qsignals=self.pane.executor.qsignals,
+            manager=self.pane.manager,
+        )
+        self.pane.status_bar.bind(self.status_controller.model)
+```
+
+- [ ] **Step 2: Replace the removed status-internal properties with a model accessor**
+
+Delete the properties that proxy removed pane internals (`_status_step_label`, `_status_step_time_label`, `_status_reps_label`, `_status_phase_time_label`, `_tick_timer`, `_step_index` [+setter], `_step_total` [+setter], `_step_started_at` [+setter], `_phase_started_at` [+setter], `_current_row` [+setter]) — base_demo_window.py ~449-507.
+
+Keep `experiment_label` and `_on_protocol_terminated` (but see Step 3). Add one accessor so tests can reach the model and the live labels:
+```python
+    @property
+    def status_model(self):
+        return self.status_controller.model
+
+    @property
+    def status_bar(self):                 # already exists -- keep
+        return self.pane.status_bar
+```
+(If `status_bar` already exists, don't duplicate it.)
+
+- [ ] **Step 3: Fix `_on_protocol_terminated`**
+
+The pane may still expose `_on_protocol_terminated`; if it does and it no longer resets status (status resets via the model on the next run / on `stop`), keep the demo-readout reset part only:
+```python
+    def _on_protocol_terminated(self):
+        """Test hook -- pane terminator + reset demo readouts."""
+        self.pane._on_protocol_terminated()
+        for readout in self.config.status_readouts:
+            slug = _slug(readout.label)
+            label = self._readout_labels.get(slug)
+            if label is not None:
+                label.setText(f"{readout.label}: {readout.initial}")
+```
+(unchanged if `pane._on_protocol_terminated` still exists; if Task 5 removed it, drop the first line.)
+
+- [ ] **Step 4: Rewrite the coupled tests in `test_base_demo_window.py`**
+
+The pure timing/counter behaviors are already covered by `test_protocol_status_model.py` / `test_protocol_status_controller.py`. In `test_base_demo_window.py`, DELETE the tests that assert on removed internals:
+- the `_status_step_label.text() == "Step 0/0"` assertion form (now `Step 0/0` text comes from the model bind; rewrite — see below),
+- `test_window_tick_timer_runs_at_10_hz` (the pane tick timer is gone),
+- the `_phase_started_at`/`_step_started_at`/`_current_row` manipulation tests,
+- the elapsed-into-`_status_step_time_label` test,
+- the `_tick_timer.isActive()` test.
+
+REPLACE them with window-level tests that go through the model + bound labels. Example replacements (adapt to the file's existing fixtures/helpers):
+```python
+def test_status_bar_reflects_model_step_counter(qapp):
+    w = _make_window()              # use the file's existing window factory
+    w.status_model.on_protocol_start(0.0, step_total=3)
+    w.status_model.on_step_start(0.0, "A", "B")
+    qapp.processEvents()
+    assert w.status_bar.lbl_step_progress.text() == "Step 1/3"
+
+
+def test_status_bar_poll_timer_runs_only_while_running(qapp):
+    w = _make_window()
+    assert not w.status_bar._poll_timer.isActive()
+    w.status_model.running = True
+    qapp.processEvents()
+    assert w.status_bar._poll_timer.isActive()
+    w.status_model.running = False
+    qapp.processEvents()
+    assert not w.status_bar._poll_timer.isActive()
+
+
+def test_status_bar_rep_chain_label(qapp):
+    w = _make_window()
+    w.status_model.set_rep_chain("rep 2/3 of 'Wash'")
+    qapp.processEvents()
+    assert w.status_bar.lbl_step_repetition.text() == "rep 2/3 of 'Wash'"
+    w.status_model.set_rep_chain("")
+    qapp.processEvents()
+    assert w.status_bar.lbl_step_repetition.text() == ""
+```
+Keep all tests in the file that are unrelated to status (experiment label, readouts, navigation, etc.) unchanged.
+
+- [ ] **Step 5: Run the demo-window test file**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_base_demo_window.py -v`
+Expected: PASS (no references to removed internals; new status tests green). Fix any remaining `AttributeError` for removed members by routing through `status_model` / the bound labels.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pluggable_protocol_tree/demos/base_demo_window.py pluggable_protocol_tree/tests/test_base_demo_window.py
+git commit -m "Migrate demo window + tests to status model/controller (issue #467)"
+```
+
+---
+
+### Task 8: Full regression + manual smoke
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the new + migrated test files together**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_stopwatch.py pluggable_protocol_tree/tests/test_protocol_status_model.py pluggable_protocol_tree/tests/test_protocol_status_controller.py pluggable_protocol_tree/tests/test_base_demo_window.py -v`
+Expected: all PASS.
+
+- [ ] **Step 2: Run the broader pane/protocol-tree test subset to catch regressions**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests -k "not redis and not dropbot" -q`
+Expected: no new failures vs. baseline. Investigate any failure referencing removed status members.
+
+- [ ] **Step 3: Manual smoke (GUI)**
+
+Run a demo that shows the status bar (e.g. `pixi run python -m pluggable_protocol_tree.demos.run_widget_auto`), start a protocol, and confirm: Protocol/Step/Phase time fields update live, active freezes on pause while elapsed keeps counting, Step n/N and Phase n/N advance, recent/next step + rep-chain update, and everything freezes at the final frame on completion.
+
+- [ ] **Step 4: Final commit (if any manual-fix tweaks were needed)**
+
+```bash
+git add -A
+git commit -m "Polish protocol status trackers after smoke test (issue #467)"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** elapsed×3 + active×3 (ScopeStopwatch elapsed/active × protocol/step/phase clocks — Tasks 1-2, displayed Task 4); Step n/N (model.step_index/total → lbl_step_progress); Phase n/N (model.phase_index/total → phase field); pause freezes active not elapsed (Task 2 tests); MVC separation (Tasks 2/3/4); dock pane as composition-root controller owner (Task 6); demo reuse (Task 7); deferred navigate-while-paused (explicitly out of scope, no task — correct).
+- **Placeholder scan:** none — every code step has full code; integration steps name exact members and provide the replacement text.
+- **Type/name consistency:** `ProtocolStatusModel`, `ProtocolStatusController`, `ScopeStopwatch`, method names (`on_protocol_start`, `on_step_start`, `on_phase_start`, `on_phase_extended`, `pause`, `resume`, `on_repetition`, `set_rep_chain`, `stop`, `reset`), clock methods (`start/pause/resume/stop/elapsed/active`), and view members (`bind`, `_poll_timer`, `lbl_step_progress`, `lbl_total_time`, `lbl_step_time`, `lbl_phase_time`, `lbl_step_repetition`) are consistent across tasks.
+- **Risk note:** Task 5 Step 5 is the only judgement-heavy step (untangling pause-phase navigation from status vars); it is gated by an import check and the Task 8 regression subset.

--- a/docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md
+++ b/docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md
@@ -1,0 +1,240 @@
+# Protocol Status Trackers — Design (issue #467 / PPT-23)
+
+## Problem
+
+The protocol status bar must show, while a protocol runs:
+
+- **Elapsed times** (wall-clock; do **not** freeze on pause) for protocol, step, phase.
+- **Active times** (do freeze on pause) for protocol, step, phase.
+- **Counters**: `Step n/N` and `Phase n/N`.
+
+Today all of this logic is embedded directly in `ProtocolTreePane`
+(`views/protocol_tree_pane.py`): per-run counters (`_step_index`,
+`_step_total`, `_phase_index`, `_phase_total`), raw `time.monotonic()`
+start stamps (`_step_started_at`, `_phase_started_at`), a 10 Hz
+`_tick_timer`, and a `_refresh_status()` that pokes `QLabel` text
+directly. The pane is simultaneously the model, the controller, and the
+view. That tangle is hard to test (needs Qt + a live executor) and hard
+to extend (the six new readouts and counters pile more state onto the
+widget).
+
+`StatusBar` (`views/navigation_bar.py`) is already a dumb strip of
+`QLabel`s, so the view layer mostly exists; what's missing is a real
+model and a clean updater.
+
+## Scope
+
+**In scope:** the model/controller/view separation, all six time
+readouts (elapsed + active for protocol/step/phase), and `Step n/N` +
+`Phase n/N` counters that reflect **executor** state.
+
+**Deferred to a follow-up issue:** the navigate-while-paused clause
+("changing the selected step/phase while paused updates the counters and
+makes the run resume from there with a reset timer"). That requires new
+executor *resume-from-arbitrary-step/phase* semantics plus tree-selection
+wiring — a change to execution semantics, not status tracking. The model
+is designed so adding it later is a localized change (a `reset`/`seek`
+method + a selection→controller hook), not a rewrite.
+
+## Naming note
+
+A `PluggableProtocolStateTracker` already exists in
+`services/protocol_state_tracker.py`, but it tracks **file** state
+(loaded name, dirty/modified, `is_active`), not run timing. To avoid
+confusion the new pieces use **"status"**: `ProtocolStatusModel`,
+`ProtocolStatusController`. `PluggableProtocolStateTracker` is also the
+precedent for this design — it already drives the dock-pane title purely
+through Traits observers (`@observe("protocol_name, is_modified, ...")`),
+which is exactly the model→view-via-observers pattern used here.
+
+## Architecture (MVC)
+
+```
+ExecutorSignals ──(Qt queued, GUI thread)──▶ ProtocolStatusController
+                                                     │  (signal → model method)
+                                                     ▼
+                                           ProtocolStatusModel  (HasTraits, no Qt)
+                                                     │  Traits observers (discrete)
+                                                     │  + QTimer poll (continuous)
+                                                     ▼
+                                              StatusBar (QLabels)
+```
+
+Three units, each independently understandable and testable:
+
+- **Model** — state + timing **rules**. Pure HasTraits, no Qt, no
+  threads, no `time` calls (clock passed in). The brain.
+- **Controller** ("handler") — subscribes to `ExecutorSignals`, maps
+  each signal to one model method call. No formatting, no widgets.
+- **View** — `StatusBar` binds to the model: Traits observers update the
+  discrete labels; a `QTimer` polls the stopwatches for the smoothly
+  changing time fields.
+
+### Load-bearing invariant
+
+**The model is only ever mutated on the GUI thread.** It holds because
+`ExecutorSignals` is a `QObject` delivering via queued connections, so
+the controller's slots run on the GUI thread; therefore the model's
+Traits observers also fire on the GUI thread and may touch widgets
+directly. This is why **no Qt-signal bridge is needed** (unlike
+`DeviceViewerSyncController._Bridge`, which guards against off-thread
+mutation). The controller asserts GUI-thread affinity on each slot in
+debug builds.
+
+## Component 1 — `ScopeStopwatch` (`models/stopwatch.py`)
+
+A generic, Qt-free primitive tracking two clocks for one scope. Every
+method takes `now` (a monotonic timestamp) so it never calls the clock
+itself — fully deterministic under test.
+
+State: `_elapsed_anchor`, `_elapsed_accum`, `_active_anchor`,
+`_active_accum` (all float / `None`).
+
+```
+start(now)   reset accums to 0; both anchors = now           (begins ticking + running)
+pause(now)   _active_accum += now - _active_anchor; _active_anchor = None   (elapsed keeps ticking)
+resume(now)  _active_anchor = now                            (no-op if already running / not started)
+stop(now)    fold BOTH anchors into accums; both = None      (freezes final elapsed + active)
+elapsed(now) _elapsed_accum + (now - _elapsed_anchor if ticking else 0)   # ignores pause
+active(now)  _active_accum  + (now - _active_anchor  if running else 0)    # freezes between pause/resume
+```
+
+- *Elapsed* clock pauses for nothing; only `start` (reset) and `stop`
+  affect it beyond free-running.
+- *Active* clock freezes during every pause→resume gap.
+- Not started → both anchors `None`, accums 0 → both read 0.
+
+Three instances per run cover all six readouts: `protocol`, `step`,
+`phase`.
+
+## Component 2 — `ProtocolStatusModel` (`models/protocol_status.py`)
+
+`HasTraits`, zero Qt.
+
+**Observable traits** (drive discrete view updates):
+`step_index`, `step_total`, `phase_index`, `phase_total`,
+`repeats_completed`, `repeats_total` (`Int`); `recent_step_name`,
+`next_step_name`, `rep_chain_label` (`Str`); `phase_target_s` (`Float`);
+`running`, `paused` (`Bool`).
+
+**Composed** (plain `ScopeStopwatch`): `protocol_clock`, `step_clock`,
+`phase_clock`.
+
+**Rule methods** (each takes `now` where timing is involved):
+
+| Method | Effect |
+|---|---|
+| `on_protocol_start(now, step_total)` | reset everything; `step_total=…`; `running=True`; `paused=False`; `protocol_clock.start(now)` |
+| `on_step_start(now, recent, next_)` | `step_index += 1`; set names; clear phase counters + `phase_target_s`; `step_clock.start(now)`; fresh (unstarted) phase clock |
+| `on_phase_start(now, idx, total, target)` | set `phase_index/total/target`; `phase_clock.start(now)` |
+| `on_phase_extended(extra)` | `phase_target_s += extra` |
+| `pause(now)` | `paused=True`; pause all three clocks |
+| `resume(now)` | `paused=False`; resume all three clocks |
+| `on_repetition(completed, total)` | set repeat counters |
+| `set_rep_chain(label)` | set `rep_chain_label` |
+| `stop(now)` | `running=False`; `paused=False`; stop (freeze) all three clocks |
+| `reset()` | counters→0, names→"-", clocks fresh, flags False |
+
+The rules ("increment step per step_start", "a new step resets the phase
+clock", "pause freezes active but not elapsed") live **here** — testable
+with a fake clock, no executor, no Qt.
+
+## Component 3 — `ProtocolStatusController` (`services/protocol_status_controller.py`)
+
+Thin adapter. Constructed with `model`, `qsignals` (`ExecutorSignals`),
+`manager` (`RowManager`, for the step count + next-step name), and
+`clock=time.monotonic`. Connects one slot per signal; each slot is a
+near one-liner that reads `now = self.clock()` and calls a model method.
+
+| `ExecutorSignals` | model call |
+|---|---|
+| `protocol_started` | `on_protocol_start(now, self._count_steps())` |
+| `step_started(row)` | `on_step_start(now, row.name, self._next_name(row))` |
+| `step_repetition(chain)` | `set_rep_chain(self._fmt_chain(chain))` |
+| `phase_started(i, n, d)` | `on_phase_start(now, i, n, d)` |
+| `phase_extended(x)` | `on_phase_extended(x)` |
+| `protocol_paused` | `pause(now)` |
+| `protocol_resumed` | `resume(now)` |
+| `protocol_repetition_finished(c, t)` | `on_repetition(c, t)` |
+| `protocol_finished` / `protocol_aborted` / `protocol_error` | `stop(now)` |
+
+`_count_steps`, `_next_name`, `_fmt_chain` move here from the pane (they
+need `manager`). The controller also exposes `disconnect()` for teardown.
+
+## Component 4 — View binding (`StatusBar.bind(model)` in `navigation_bar.py`)
+
+`StatusBar` gains `bind(model)` and the three combined time fields
+(replacing the current `lbl_total_time` / `lbl_step_time` /
+`lbl_phase_time`):
+
+- `Protocol 12.3s (act 9.1s)`
+- `Step 3.4s (act 2.1s)`
+- `Phase 2/4  1.2s/2.0s (act 1.0s)`
+
+plus the existing-style counters `Step n/N`, the rep-chain label, and the
+recent/next step marquees.
+
+`bind(model)`:
+
+- **Discrete** → `model.observe(...)` handlers update counter / name /
+  rep-chain labels and the `Phase n/N` portion.
+- **Continuous** → a 100 ms `QTimer`, started/stopped by observing
+  `running`, reads `model.<scope>_clock.elapsed(now)` / `.active(now)`
+  and writes the three time labels. The timer runs only while a protocol
+  is active, so an idle status bar costs nothing.
+
+All number→string formatting lives in the view. Touching widgets inside
+Traits observers is safe per the GUI-thread invariant above.
+
+## Component 5 — `ProtocolTreePane` refactor (`views/protocol_tree_pane.py`)
+
+Remove the embedded status logic: `_step_index`, `_step_total`,
+`_phase_index`, `_phase_total`, `_phase_target`, `_step_started_at`,
+`_phase_started_at`, `_tick_timer`, `_refresh_status`, and the
+status-only signal slots. In their place the pane:
+
+1. constructs `model = ProtocolStatusModel()`,
+2. constructs `controller = ProtocolStatusController(model=…, qsignals=self.executor.qsignals, manager=self.manager)`,
+3. calls `self.status_bar.bind(model)`.
+
+The pane keeps its **non-status** responsibilities that happen to share
+the same signals — e.g. `protocol_running_changed.emit(...)`, publishing
+`PROTOCOL_RUNNING`, error dialogs — on their own slots. Multiple slots
+per signal is fine.
+
+## Testing
+
+Pure-Python unit tests (no Qt, no executor):
+
+- `tests/test_stopwatch.py` — fake clock: elapsed ignores pause, active
+  freezes across pause→resume, `stop` freezes both, not-started reads 0.
+- `tests/test_protocol_status_model.py` — drive a realistic method
+  sequence (start → step → phase → pause → resume → repetition → stop)
+  with a fake `now`, asserting counters, names, flags, and clock reads at
+  each step.
+
+Controller mapping can be exercised by calling its slot methods directly
+with a stub `manager` and asserting model state; full Qt signal delivery
+is out of unit scope.
+
+## Separation directive (reusable convention)
+
+This issue establishes the pattern for status/UI features going forward:
+
+> Split into a **Qt-free `HasTraits` model** (state + rules) ← a
+> **controller** (external signals → model method calls) → a **view**
+> (Traits observers + a poll timer → widgets). Keep the model free of Qt
+> and of direct clock/IO calls (pass `now`/inputs in) so it is
+> unit-testable in isolation. Mutate the model only on the GUI thread so
+> observers can drive widgets directly without a Qt-signal bridge; if
+> off-thread mutation is unavoidable, add a `QObject` bridge
+> (cf. `DeviceViewerSyncController._Bridge`).
+
+The pane-as-model-controller-view tangle removed here is the
+anti-pattern this convention prevents.
+
+## Out of scope / non-goals
+
+- Navigate-while-paused resume-from-step (deferred, see Scope).
+- Persisting timing across app restarts.
+- Changing executor pause/resume semantics.

--- a/docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md
+++ b/docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md
@@ -141,10 +141,24 @@ with a fake clock, no executor, no Qt.
 
 ## Component 3 — `ProtocolStatusController` (`services/protocol_status_controller.py`)
 
-Thin adapter. Constructed with `model`, `qsignals` (`ExecutorSignals`),
-`manager` (`RowManager`, for the step count + next-step name), and
-`clock=time.monotonic`. Connects one slot per signal; each slot is a
-near one-liner that reads `now = self.clock()` and calls a model method.
+A small **`HasTraits`** adapter that **owns the model** and links the Qt
+layer to it. Constructed with `qsignals` (`ExecutorSignals`), `manager`
+(`RowManager`, for the step count + next-step name), and
+`clock=time.monotonic`; it creates its own `model = ProtocolStatusModel()`
+(exposed as `.model`). On construction it connects one slot per executor
+signal; each slot reads `now = self.clock()` and calls a model method.
+
+**Ownership / reuse.** The controller is *not* the dock pane itself, but
+the dock pane (the app's `HasTraits` composition root) **instantiates and
+owns it** — satisfying "the dock pane sets up the link between the Qt
+layer and the model." The standalone `BasePluggableProtocolDemoWindow`
+(used by demos and tests, with no dock pane) instantiates the **same**
+controller, so there is one wiring implementation and no duplication.
+This is why the controller is a standalone reusable class rather than
+slots on the dock pane: the pane is reused without a dock pane, and the
+wiring must come along.
+
+Each slot is a near one-liner: `now = self.clock()` then a model call.
 
 | `ExecutorSignals` | model call |
 |---|---|
@@ -160,6 +174,11 @@ near one-liner that reads `now = self.clock()` and calls a model method.
 
 `_count_steps`, `_next_name`, `_fmt_chain` move here from the pane (they
 need `manager`). The controller also exposes `disconnect()` for teardown.
+
+The controller deliberately does **not** subscribe to the demo-only
+`phase_acked` path or `protocol_wait_*`; those stay where they are (the
+pane / demo window own the pre-protocol loading screen and the demo ack
+plumbing). The controller is purely executor-lifecycle → status model.
 
 ## Component 4 — View binding (`StatusBar.bind(model)` in `navigation_bar.py`)
 
@@ -188,19 +207,66 @@ Traits observers is safe per the GUI-thread invariant above.
 
 ## Component 5 — `ProtocolTreePane` refactor (`views/protocol_tree_pane.py`)
 
-Remove the embedded status logic: `_step_index`, `_step_total`,
-`_phase_index`, `_phase_total`, `_phase_target`, `_step_started_at`,
-`_phase_started_at`, `_tick_timer`, `_refresh_status`, and the
-status-only signal slots. In their place the pane:
+Remove the embedded **status** logic: the state vars (`_step_index`,
+`_step_total`, `_phase_index`, `_phase_total`, `_phase_target`,
+`_step_started_at`, `_phase_started_at`, `_current_row`), the
+`_tick_timer`, `_refresh_status`, the `_status_*` label aliases, and the
+status-display bodies of `_on_protocol_started` / `_on_step_started` /
+`_on_phase_started` / `_on_phase_extended` / `_on_step_repetition` /
+`_on_step_finished`. `_next_step_name` moves to the controller.
 
-1. constructs `model = ProtocolStatusModel()`,
-2. constructs `controller = ProtocolStatusController(model=…, qsignals=self.executor.qsignals, manager=self.manager)`,
-3. calls `self.status_bar.bind(model)`.
+The pane does **not** itself create the model/controller — the
+composition root does (Component 6). The pane only needs to expose
+`self.status_bar` (already public) so the root can call
+`status_bar.bind(model)`.
 
-The pane keeps its **non-status** responsibilities that happen to share
-the same signals — e.g. `protocol_running_changed.emit(...)`, publishing
-`PROTOCOL_RUNNING`, error dialogs — on their own slots. Multiple slots
-per signal is fine.
+The pane **keeps** its non-status responsibilities that happen to share
+the same signals — `protocol_running_changed.emit(...)`, publishing
+`PROTOCOL_RUNNING`, the error dialog flow (`_on_error`), the button
+state machine, navigation, pause-phase handling, repeat-count label, and
+the pre-protocol wait/loading screen. Several of these are currently
+interleaved with status pokes in the same slot bodies, so the edit is
+surgical (remove the status lines, keep the rest), not whole-slot
+deletion. Multiple slots per signal is fine.
+
+## Component 6 — Composition roots wire model + controller
+
+Two roots construct and own the controller; neither duplicates logic.
+
+**`PluggableProtocolDockPane`** (`views/dock_pane.py`) — gains
+`status_controller = Instance(ProtocolStatusController)`. In
+`create_contents`, after the pane exists:
+
+```python
+self.status_controller = ProtocolStatusController(
+    qsignals=pane.executor.qsignals, manager=self.manager)
+pane.status_bar.bind(self.status_controller.model)
+```
+
+**`BasePluggableProtocolDemoWindow`** (`demos/base_demo_window.py`) — does
+the same after building `self.pane`, storing `self.status_controller`.
+Its status-internal properties (`_step_index`, `_step_total`,
+`_step_started_at`, `_phase_started_at`, `_current_row`, `_tick_timer`,
+`_status_step_label`, `_status_step_time_label`, `_status_reps_label`,
+`_status_phase_time_label`) are **removed**; demos/tests read
+`window.status_controller.model` instead.
+
+## Test migration
+
+`tests/test_base_demo_window.py` currently asserts on the removed pane
+internals (e.g. `_status_step_label.text()`, `_tick_timer.interval()`,
+`_phase_started_at` set on ack, terminate resets `_step_started_at`,
+`_status_reps_label`, elapsed text). These tests pin the *old*
+implementation. They are migrated:
+
+- Behaviors that are really **model/controller** logic (counters,
+  elapsed/active, rep-chain formatting, reset-on-terminate) move to the
+  new `test_protocol_status_model.py` / `test_protocol_status_controller.py`
+  (pure, no Qt) — which is strictly better coverage.
+- The few genuinely window-level assertions (the StatusBar shows the
+  bound values; the poll timer ticks while running) are rewritten against
+  `window.status_controller.model` and the new combined labels, or
+  deleted if fully superseded.
 
 ## Testing
 

--- a/pluggable_protocol_tree/demos/base_demo_window.py
+++ b/pluggable_protocol_tree/demos/base_demo_window.py
@@ -227,6 +227,18 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         if config.phase_ack_topic is not None:
             self.phase_acked.connect(self.pane._on_phase_ack)
 
+        # Standalone composition root (no dock pane here): own the status
+        # controller that links the executor's Qt signals to the status model
+        # and bind the status bar to it (issue #467).
+        from pluggable_protocol_tree.services.protocol_status_controller import (
+            ProtocolStatusController,
+        )
+        self.status_controller = ProtocolStatusController(
+            qsignals=self.pane.executor.qsignals,
+            manager=self.pane.manager,
+        )
+        self.pane.status_bar.bind(self.status_controller.model)
+
         self._side_panel = None
         if config.side_panel_factory is not None:
             side = config.side_panel_factory(self.pane.manager)
@@ -447,64 +459,13 @@ class BasePluggableProtocolDemoWindow(QMainWindow):
         return self.pane.experiment_label
 
     @property
-    def _status_step_label(self):
-        return self.pane._status_step_label
+    def status_model(self):
+        """The ProtocolStatusModel bound to the status bar (issue #467).
 
-    @property
-    def _status_step_time_label(self):
-        return self.pane._status_step_time_label
-
-    @property
-    def _status_reps_label(self):
-        return self.pane._status_reps_label
-
-    @property
-    def _status_phase_time_label(self):
-        return self.pane._status_phase_time_label
-
-    @property
-    def _tick_timer(self):
-        return self.pane._tick_timer
-
-    @property
-    def _step_index(self):
-        return self.pane._step_index
-
-    @_step_index.setter
-    def _step_index(self, value):
-        self.pane._step_index = value
-
-    @property
-    def _step_total(self):
-        return self.pane._step_total
-
-    @_step_total.setter
-    def _step_total(self, value):
-        self.pane._step_total = value
-
-    @property
-    def _step_started_at(self):
-        return self.pane._step_started_at
-
-    @_step_started_at.setter
-    def _step_started_at(self, value):
-        self.pane._step_started_at = value
-
-    @property
-    def _phase_started_at(self):
-        return self.pane._phase_started_at
-
-    @_phase_started_at.setter
-    def _phase_started_at(self, value):
-        self.pane._phase_started_at = value
-
-    @property
-    def _current_row(self):
-        return self.pane._current_row
-
-    @_current_row.setter
-    def _current_row(self, value):
-        self.pane._current_row = value
+        Status counters / timers used to be pane internals proxied here;
+        they now live in the model the controller drives. Tests read this
+        and the bound StatusBar labels instead."""
+        return self.status_controller.model
 
     def _on_protocol_terminated(self):
         """Test hook — calls the pane's terminator + resets demo readouts."""

--- a/pluggable_protocol_tree/models/protocol_status.py
+++ b/pluggable_protocol_tree/models/protocol_status.py
@@ -1,0 +1,117 @@
+"""HasTraits model for the protocol status bar (issue #467).
+
+Holds the observable counters / names and three ScopeStopwatch clocks
+(protocol / step / phase), and encapsulates the timing *rules* (a new step
+resets the phase clock; pause freezes active but not elapsed; ...). Pure:
+no Qt, no threads, no direct clock calls -- every timing method takes
+``now`` so the model is unit-testable with a fake clock.
+
+The view binds to the observable traits (discrete updates) and polls the
+clocks for the continuously-changing time readouts. See
+ProtocolStatusController for the executor-signal -> model wiring.
+"""
+
+from traits.api import Bool, Float, HasTraits, Instance, Int, Str
+
+from pluggable_protocol_tree.models.stopwatch import ScopeStopwatch
+
+
+class ProtocolStatusModel(HasTraits):
+    # --- counters ---
+    step_index = Int(0)
+    step_total = Int(0)
+    phase_index = Int(0)
+    phase_total = Int(0)
+    repeats_completed = Int(0)
+    repeats_total = Int(1)
+
+    # --- names / labels ---
+    recent_step_name = Str("-")
+    next_step_name = Str("-")
+    rep_chain_label = Str("")
+
+    # --- phase target (for the "elapsed / target" readout) ---
+    phase_target_s = Float(0.0)
+
+    # --- run state ---
+    running = Bool(False)
+    paused = Bool(False)
+
+    # --- clocks (plain helpers; default-constructed per model) ---
+    protocol_clock = Instance(ScopeStopwatch, ())
+    step_clock = Instance(ScopeStopwatch, ())
+    phase_clock = Instance(ScopeStopwatch, ())
+
+    # --- rule methods ---
+
+    def reset(self):
+        self.trait_set(
+            step_index=0, step_total=0, phase_index=0, phase_total=0,
+            repeats_completed=0, repeats_total=1,
+            recent_step_name="-", next_step_name="-", rep_chain_label="",
+            phase_target_s=0.0, running=False, paused=False,
+        )
+        self.protocol_clock = ScopeStopwatch()
+        self.step_clock = ScopeStopwatch()
+        self.phase_clock = ScopeStopwatch()
+
+    def on_protocol_start(self, now, step_total):
+        self.reset()
+        self.step_total = int(step_total)
+        self.running = True
+        self.protocol_clock.start(now)
+
+    def on_step_start(self, now, recent_name, next_name):
+        self.step_index += 1
+        self.recent_step_name = recent_name
+        self.next_step_name = next_name
+        self.phase_index = 0
+        self.phase_total = 0
+        self.phase_target_s = 0.0
+        self.step_clock.start(now)
+        self.phase_clock = ScopeStopwatch()      # fresh, unstarted
+        if self.paused:                          # started mid-pause: keep frozen
+            self.step_clock.pause(now)
+
+    def on_phase_start(self, now, phase_index, phase_total, phase_target_s):
+        self.phase_index = int(phase_index)
+        self.phase_total = int(phase_total)
+        try:
+            self.phase_target_s = float(phase_target_s)
+        except (TypeError, ValueError):
+            self.phase_target_s = 0.0
+        self.phase_clock.start(now)
+        if self.paused:
+            self.phase_clock.pause(now)
+
+    def on_phase_extended(self, extra_s):
+        try:
+            self.phase_target_s += float(extra_s)
+        except (TypeError, ValueError):
+            pass
+
+    def pause(self, now):
+        self.paused = True
+        self.protocol_clock.pause(now)
+        self.step_clock.pause(now)
+        self.phase_clock.pause(now)
+
+    def resume(self, now):
+        self.paused = False
+        self.protocol_clock.resume(now)
+        self.step_clock.resume(now)
+        self.phase_clock.resume(now)
+
+    def on_repetition(self, completed, total):
+        self.repeats_completed = int(completed)
+        self.repeats_total = int(total)
+
+    def set_rep_chain(self, label):
+        self.rep_chain_label = label
+
+    def stop(self, now):
+        self.running = False
+        self.paused = False
+        self.protocol_clock.stop(now)
+        self.step_clock.stop(now)
+        self.phase_clock.stop(now)

--- a/pluggable_protocol_tree/models/protocol_status.py
+++ b/pluggable_protocol_tree/models/protocol_status.py
@@ -45,15 +45,22 @@ class ProtocolStatusModel(HasTraits):
     # --- rule methods ---
 
     def reset(self):
+        """Return to idle: zero counters/names and all three clocks.
+
+        Used both at the start of a run (on_protocol_start) and as the
+        post-protocol teardown (the controller calls this on the terminal
+        signals that fire right after the executor's on_post_protocol_end).
+        Clocks are zeroed BEFORE flipping ``running`` so the view's
+        running->False refresh paints 0.0, not the final frozen time."""
+        self.protocol_clock = ScopeStopwatch()
+        self.step_clock = ScopeStopwatch()
+        self.phase_clock = ScopeStopwatch()
         self.trait_set(
             step_index=0, step_total=0, phase_index=0, phase_total=0,
             repeats_completed=0, repeats_total=1,
             recent_step_name="-", next_step_name="-", rep_chain_label="",
             phase_target_s=0.0, running=False, paused=False,
         )
-        self.protocol_clock = ScopeStopwatch()
-        self.step_clock = ScopeStopwatch()
-        self.phase_clock = ScopeStopwatch()
 
     def on_protocol_start(self, now, step_total):
         self.reset()
@@ -108,10 +115,3 @@ class ProtocolStatusModel(HasTraits):
 
     def set_rep_chain(self, label):
         self.rep_chain_label = label
-
-    def stop(self, now):
-        self.running = False
-        self.paused = False
-        self.protocol_clock.stop(now)
-        self.step_clock.stop(now)
-        self.phase_clock.stop(now)

--- a/pluggable_protocol_tree/models/stopwatch.py
+++ b/pluggable_protocol_tree/models/stopwatch.py
@@ -1,0 +1,61 @@
+"""Pause-aware stopwatch primitive for protocol status timing (issue #467).
+
+Tracks two clocks for one scope (protocol / step / phase):
+
+  * elapsed -- wall-clock since start; never freezes on pause.
+  * active  -- excludes paused intervals; freezes between pause()/resume().
+
+Every method takes ``now`` (a monotonic timestamp) rather than calling the
+clock itself, so timing is fully deterministic under test. No Qt, no
+threads.
+"""
+
+
+class ScopeStopwatch:
+    __slots__ = ("_elapsed_anchor", "_elapsed_accum",
+                 "_active_anchor", "_active_accum")
+
+    def __init__(self):
+        # monotonic when ticking began; None => stopped/never-started.
+        self._elapsed_anchor = None
+        self._elapsed_accum = 0.0
+        # monotonic of current running segment; None => paused/stopped.
+        self._active_anchor = None
+        self._active_accum = 0.0
+
+    def start(self, now):
+        """(Re)start both clocks from zero; begin ticking and running."""
+        self._elapsed_anchor = now
+        self._elapsed_accum = 0.0
+        self._active_anchor = now
+        self._active_accum = 0.0
+
+    def pause(self, now):
+        """Freeze the active clock; elapsed keeps ticking."""
+        if self._active_anchor is not None:
+            self._active_accum += now - self._active_anchor
+            self._active_anchor = None
+
+    def resume(self, now):
+        """Unfreeze the active clock. No-op if not started or already running."""
+        if self._elapsed_anchor is not None and self._active_anchor is None:
+            self._active_anchor = now
+
+    def stop(self, now):
+        """Freeze BOTH clocks at their current values."""
+        if self._active_anchor is not None:
+            self._active_accum += now - self._active_anchor
+            self._active_anchor = None
+        if self._elapsed_anchor is not None:
+            self._elapsed_accum += now - self._elapsed_anchor
+            self._elapsed_anchor = None
+
+    def elapsed(self, now):
+        """Wall-clock seconds since start (ignores pauses)."""
+        running = 0.0 if self._elapsed_anchor is None else now - self._elapsed_anchor
+        return self._elapsed_accum + running
+
+    def active(self, now):
+        """Active seconds since start (excludes paused intervals)."""
+        running = 0.0 if self._active_anchor is None else now - self._active_anchor
+        return self._active_accum + running

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -96,10 +96,13 @@ class ProtocolStatusController(HasTraits):
         self.model.on_repetition(completed, total)
 
     def _on_stopped(self):
-        self.model.stop(self.clock())
+        # Terminal signals (finished / aborted) fire immediately after the
+        # executor's on_post_protocol_end teardown, i.e. once the whole run
+        # (all repeats) is done -- reset the trackers back to idle here.
+        self.model.reset()
 
     def _on_error(self, _msg):
-        self.model.stop(self.clock())
+        self.model.reset()
 
     # --- helpers (need manager) ---
 

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -1,0 +1,127 @@
+"""Links executor lifecycle signals to a ProtocolStatusModel (issue #467).
+
+A small HasTraits adapter owned by the composition root (the dock pane in
+the full app; the demo window standalone). It owns the model, connects one
+slot per ExecutorSignals signal, and translates each into a single model
+method call stamped with ``now``. No formatting, no widgets -- the view
+binds to ``self.model`` separately.
+
+Invariant: ExecutorSignals is a QObject delivering via queued connections,
+so these slots run on the GUI thread; the model is therefore mutated only
+on the GUI thread and its observers may drive widgets directly.
+"""
+
+import time
+
+from traits.api import Any, Callable, HasTraits, Instance
+
+from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
+
+
+class ProtocolStatusController(HasTraits):
+    #: The status model this controller drives. The view binds to it.
+    model = Instance(ProtocolStatusModel, ())
+
+    #: ExecutorSignals QObject (duck-typed; any object exposing the
+    #: signals works -- keeps Qt types out of the signature and tests Qt-free).
+    qsignals = Any()
+
+    #: RowManager -- needed for the step count and next-step name.
+    manager = Any()
+
+    #: Monotonic clock source; overridable in tests.
+    clock = Callable(time.monotonic)
+
+    def traits_init(self):
+        self._connect()
+
+    # --- wiring ---
+
+    def _pairs(self):
+        s = self.qsignals
+        return (
+            (s.protocol_started, self._on_protocol_started),
+            (s.step_started, self._on_step_started),
+            (s.step_repetition, self._on_step_repetition),
+            (s.phase_started, self._on_phase_started),
+            (s.phase_extended, self._on_phase_extended),
+            (s.protocol_paused, self._on_paused),
+            (s.protocol_resumed, self._on_resumed),
+            (s.protocol_repetition_finished, self._on_repetition_finished),
+            (s.protocol_finished, self._on_stopped),
+            (s.protocol_aborted, self._on_stopped),
+            (s.protocol_error, self._on_error),
+        )
+
+    def _connect(self):
+        if self.qsignals is None:
+            return
+        for sig, slot in self._pairs():
+            sig.connect(slot)
+
+    def disconnect(self):
+        if self.qsignals is None:
+            return
+        for sig, slot in self._pairs():
+            try:
+                sig.disconnect(slot)
+            except (RuntimeError, TypeError):
+                pass
+
+    # --- slots (executor signal -> model) ---
+
+    def _on_protocol_started(self):
+        self.model.on_protocol_start(self.clock(), self._count_steps())
+
+    def _on_step_started(self, row):
+        self.model.on_step_start(self.clock(), row.name, self._next_name(row))
+
+    def _on_step_repetition(self, rep_chain):
+        self.model.set_rep_chain(self._fmt_chain(rep_chain))
+
+    def _on_phase_started(self, phase_index, phase_total, phase_duration_s):
+        self.model.on_phase_start(
+            self.clock(), phase_index, phase_total, phase_duration_s)
+
+    def _on_phase_extended(self, extra_s):
+        self.model.on_phase_extended(extra_s)
+
+    def _on_paused(self):
+        self.model.pause(self.clock())
+
+    def _on_resumed(self):
+        self.model.resume(self.clock())
+
+    def _on_repetition_finished(self, completed, total):
+        self.model.on_repetition(completed, total)
+
+    def _on_stopped(self):
+        self.model.stop(self.clock())
+
+    def _on_error(self, _msg):
+        self.model.stop(self.clock())
+
+    # --- helpers (need manager) ---
+
+    def _count_steps(self):
+        try:
+            return sum(1 for _ in self.manager.iter_execution_steps())
+        except Exception:
+            return 0
+
+    def _next_name(self, current):
+        steps = self.manager.iter_execution_steps()
+        cur_path = tuple(current.path)
+        for row in steps:
+            if tuple(row.path) == cur_path:
+                nxt = next(steps, None)
+                return nxt.name if nxt is not None else "-"
+        return "-"
+
+    @staticmethod
+    def _fmt_chain(rep_chain):
+        if not rep_chain:
+            return ""
+        return " · ".join(
+            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+        )

--- a/pluggable_protocol_tree/tests/test_base_demo_window.py
+++ b/pluggable_protocol_tree/tests/test_base_demo_window.py
@@ -199,7 +199,8 @@ def test_window_has_status_bar_with_step_label(qapp):
     w = BasePluggableProtocolDemoWindow(cfg)
     assert w.statusBar() is not None        # bottom (readouts only)
     assert w.status_bar is not None         # top (legacy-look StatusBar)
-    assert w._status_step_label.text() == "Step 0/0"
+    # bind() paints the model's "Step 0/0" via the step-progress label.
+    assert w.status_bar.lbl_step_progress.text() == "Step 0/0"
 
 
 def test_window_status_step_elapsed_label_exists(qapp):
@@ -209,7 +210,7 @@ def test_window_status_step_elapsed_label_exists(qapp):
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._status_step_time_label is not None
+    assert w.status_bar.lbl_step_time is not None
 
 
 def test_window_executor_step_started_connected_to_tree_highlight(qapp):
@@ -234,19 +235,34 @@ def test_window_executor_step_started_connected_to_tree_highlight(qapp):
         w.widget.highlight_active_row = orig
 
 
-def test_window_tick_timer_runs_at_10_hz(qapp):
-    """Tick timer interval should be 100 ms (10 Hz)."""
+def test_window_status_poll_timer_runs_at_10_hz(qapp):
+    """The status bar's time-poll timer interval should be 100 ms (10 Hz)."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._tick_timer.interval() == 100
+    assert w.status_bar._poll_timer.interval() == 100
+
+
+def test_window_status_poll_timer_runs_only_while_running(qapp):
+    """The poll timer starts when the model goes running and stops on stop."""
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.demos.base_demo_window import (
+        BasePluggableProtocolDemoWindow,
+    )
+    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
+    w = BasePluggableProtocolDemoWindow(cfg)
+    assert not w.status_bar._poll_timer.isActive()
+    w.status_model.running = True
+    assert w.status_bar._poll_timer.isActive()
+    w.status_model.running = False
+    assert not w.status_bar._poll_timer.isActive()
 
 
 def test_phase_ack_topic_none_hides_phase_timer(qapp):
-    """When phase_ack_topic=None, no phase elapsed label in status bar."""
+    """When phase_ack_topic=None, the phase time label is hidden."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -254,11 +270,11 @@ def test_phase_ack_topic_none_hides_phase_timer(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
                      phase_ack_topic=None)
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._status_phase_time_label is None
+    assert w.status_bar.lbl_phase_time.isHidden()
 
 
 def test_phase_ack_topic_set_creates_phase_label(qapp):
-    """When phase_ack_topic set, phase elapsed label is in status bar."""
+    """When phase_ack_topic set, the phase time label is shown."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -266,11 +282,11 @@ def test_phase_ack_topic_set_creates_phase_label(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
                      phase_ack_topic="x/applied")
     w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._status_phase_time_label is not None
+    assert not w.status_bar.lbl_phase_time.isHidden()
 
 
-def test_phase_acked_signal_resets_phase_timer(qapp):
-    """Emitting the phase_acked signal sets _phase_started_at = monotonic()."""
+def test_phase_started_signal_updates_phase_counters(qapp):
+    """phase_started -> controller -> model phase counters + bound label."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -278,15 +294,10 @@ def test_phase_acked_signal_resets_phase_timer(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()],
                      phase_ack_topic="x/applied")
     w = BasePluggableProtocolDemoWindow(cfg)
-    # Set the current row so phase ack handler doesn't early-return.
-    w._current_row = object()
-    w._step_started_at = None
-    before = w._phase_started_at
-    w.phase_acked.emit()
-    assert w._phase_started_at is not None
-    assert w._phase_started_at != before
-    # First ack also sets step_started_at if it was None.
-    assert w._step_started_at is not None
+    w.executor.qsignals.protocol_started.emit()
+    w.executor.qsignals.phase_started.emit(2, 4, 1.0)
+    assert w.status_model.phase_index == 2
+    assert w.status_model.phase_total == 4
 
 
 def test_status_readout_creates_label_with_initial_text(qapp):
@@ -533,8 +544,12 @@ def test_window_side_panel_uses_splitter(qapp):
     assert w._side_panel is side_widget
 
 
-def test_clear_all_highlights_resets_status(qapp):
-    """After protocol terminates, status labels reset and step counters cleared."""
+def test_protocol_terminated_resets_demo_readouts(qapp):
+    """_on_protocol_terminated resets the demo readout labels to initial.
+
+    (Status-bar counters/timers are owned by ProtocolStatusModel and reset
+    on the next run; that behavior is covered by the model/controller tests.)
+    """
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -546,16 +561,8 @@ def test_clear_all_highlights_resets_status(qapp):
         ],
     )
     w = BasePluggableProtocolDemoWindow(cfg)
-    # Simulate state mid-run.
-    w._step_index = 2
-    w._step_total = 3
-    w._step_started_at = 100.0
     w._readout_labels["voltage"].setText("Voltage: 99 V")
-    w._status_step_label.setText("Step 2 / 3")
-    # Terminate.
     w._on_protocol_terminated()
-    assert w._status_step_label.text() == "Step 0/0"
-    assert w._step_started_at is None
     assert w._readout_labels["voltage"].text() == "Voltage: --"
 
 
@@ -637,24 +644,9 @@ def test_post_build_setup_default_is_no_op(qapp):
     BasePluggableProtocolDemoWindow(cfg)
 
 
-def test_status_bar_has_reps_label(qapp):
-    """The status bar exposes _status_reps_label.
-
-    Initial text is the StatusBar widget's "Repetition 0/0" placeholder
-    (legacy protocol_grid look) — was the empty string when the label
-    was a permanent widget on the bottom QStatusBar.
-    """
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.demos.base_demo_window import (
-        BasePluggableProtocolDemoWindow,
-    )
-    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
-    w = BasePluggableProtocolDemoWindow(cfg)
-    assert w._status_reps_label.text() == "Repetition 0/0"
-
-
 def test_step_repetition_renders_chain(qapp):
-    """step_repetition with a non-empty chain renders 'rep i/n of name'."""
+    """step_repetition with a non-empty chain renders 'rep i/n of name'
+    through the controller -> model -> bound rep-chain label."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
@@ -662,38 +654,20 @@ def test_step_repetition_renders_chain(qapp):
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
     w.executor.qsignals.step_repetition.emit([("Wash", 2, 3)])
-    assert w._status_reps_label.text() == "rep 2/3 of 'Wash'"
+    assert w.status_bar.lbl_step_repetition.text() == "rep 2/3 of 'Wash'"
 
 
 def test_step_repetition_empty_chain_clears(qapp):
-    """An empty rep chain clears the reps label."""
+    """An empty rep chain clears the rep-chain label."""
     from pluggable_protocol_tree.builtins.type_column import make_type_column
     from pluggable_protocol_tree.demos.base_demo_window import (
         BasePluggableProtocolDemoWindow,
     )
     cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
     w = BasePluggableProtocolDemoWindow(cfg)
-    w._status_reps_label.setText("rep 1/3 of 'Wash'")
+    w.executor.qsignals.step_repetition.emit([("Wash", 1, 3)])
     w.executor.qsignals.step_repetition.emit([])
-    assert w._status_reps_label.text() == ""
-
-
-def test_step_finished_freezes_step_elapsed_label(qapp):
-    """step_finished calls _refresh_status, which paints the final
-    elapsed value into _status_step_time_label."""
-    import time
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.demos.base_demo_window import (
-        BasePluggableProtocolDemoWindow,
-    )
-    cfg = DemoConfig(columns_factory=lambda: [make_type_column()])
-    w = BasePluggableProtocolDemoWindow(cfg)
-    # Simulate mid-step state: started a known duration ago.
-    w._step_started_at = time.monotonic() - 1.5
-    w.executor.qsignals.step_finished.emit(None)
-    text = w._status_step_time_label.text()
-    assert text.startswith("Step ")
-    assert "1." in text or "1.5" in text   # close enough — within tick window
+    assert w.status_bar.lbl_step_repetition.text() == ""
 
 
 def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
@@ -721,5 +695,5 @@ def test_protocol_error_resets_state_and_calls_dialog(qapp, monkeypatch):
     w.executor.qsignals.protocol_error.emit("kaboom")
     assert nb.btn_play.isEnabled()
     assert not nb.btn_stop.isEnabled()
-    assert not w._tick_timer.isActive()
+    assert not w.status_bar._poll_timer.isActive()
     assert calls == [("Protocol error", "kaboom")]

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -1,0 +1,123 @@
+"""Unit tests for ProtocolStatusController (fake signals + manager, no Qt)."""
+from pluggable_protocol_tree.services.protocol_status_controller import (
+    ProtocolStatusController,
+)
+
+
+class _Sig:
+    """Minimal Qt-signal stand-in: connect() stores slots, emit() calls them."""
+    def __init__(self):
+        self._slots = []
+
+    def connect(self, slot):
+        self._slots.append(slot)
+
+    def disconnect(self, slot):
+        self._slots.remove(slot)
+
+    def emit(self, *args):
+        for slot in list(self._slots):
+            slot(*args)
+
+
+class _Signals:
+    def __init__(self):
+        for name in (
+            "protocol_started", "step_started", "step_repetition",
+            "phase_started", "phase_extended", "protocol_paused",
+            "protocol_resumed", "protocol_repetition_finished",
+            "protocol_finished", "protocol_aborted", "protocol_error",
+        ):
+            setattr(self, name, _Sig())
+
+
+class _Row:
+    def __init__(self, name, path):
+        self.name = name
+        self.path = path
+
+
+class _Manager:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def iter_execution_steps(self):
+        return iter(list(self._rows))
+
+
+def _make(rows=None):
+    rows = rows or [_Row("A", (0,)), _Row("B", (1,))]
+    sigs = _Signals()
+    clock = {"t": 0.0}
+    ctrl = ProtocolStatusController(
+        qsignals=sigs, manager=_Manager(rows), clock=lambda: clock["t"],
+    )
+    return ctrl, sigs, clock, rows
+
+
+def test_protocol_started_counts_steps():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    assert ctrl.model.step_total == 2
+    assert ctrl.model.running is True
+
+
+def test_step_started_sets_name_and_next():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    assert ctrl.model.step_index == 1
+    assert ctrl.model.recent_step_name == "A"
+    assert ctrl.model.next_step_name == "B"
+
+
+def test_pause_resume_drive_model_with_clock():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    clock["t"] = 1.0
+    sigs.protocol_paused.emit()
+    assert ctrl.model.paused is True
+    assert ctrl.model.protocol_clock.active(5.0) == 1.0
+
+
+def test_phase_started_and_extended():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.step_started.emit(rows[0])
+    sigs.phase_started.emit(2, 4, 1.5)
+    assert ctrl.model.phase_index == 2
+    assert ctrl.model.phase_total == 4
+    assert ctrl.model.phase_target_s == 1.5
+    sigs.phase_extended.emit(0.5)
+    assert ctrl.model.phase_target_s == 2.0
+
+
+def test_rep_chain_formatting():
+    ctrl, sigs, clock, rows = _make()
+    sigs.step_repetition.emit([("Wash", 2, 3)])
+    assert ctrl.model.rep_chain_label == "rep 2/3 of 'Wash'"
+    sigs.step_repetition.emit([])
+    assert ctrl.model.rep_chain_label == ""
+
+
+def test_terminal_signals_stop():
+    for term in ("protocol_finished", "protocol_aborted"):
+        ctrl, sigs, clock, rows = _make()
+        sigs.protocol_started.emit()
+        getattr(sigs, term).emit()
+        assert ctrl.model.running is False
+
+
+def test_error_stops():
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started.emit()
+    sigs.protocol_error.emit("boom")
+    assert ctrl.model.running is False
+
+
+def test_disconnect_stops_updates():
+    ctrl, sigs, clock, rows = _make()
+    ctrl.disconnect()
+    sigs.protocol_started.emit()
+    assert ctrl.model.step_total == 0   # not wired anymore

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -101,19 +101,26 @@ def test_rep_chain_formatting():
     assert ctrl.model.rep_chain_label == ""
 
 
-def test_terminal_signals_stop():
+def test_terminal_signals_reset_trackers():
+    # Finished / aborted are the post-protocol teardown: reset to idle.
     for term in ("protocol_finished", "protocol_aborted"):
         ctrl, sigs, clock, rows = _make()
         sigs.protocol_started.emit()
+        sigs.step_started.emit(rows[0])
+        clock["t"] = 5.0
         getattr(sigs, term).emit()
         assert ctrl.model.running is False
+        assert ctrl.model.step_index == 0
+        assert ctrl.model.step_total == 0
+        assert ctrl.model.protocol_clock.elapsed(9.0) == 0.0
 
 
-def test_error_stops():
+def test_error_resets_trackers():
     ctrl, sigs, clock, rows = _make()
     sigs.protocol_started.emit()
     sigs.protocol_error.emit("boom")
     assert ctrl.model.running is False
+    assert ctrl.model.step_total == 0
 
 
 def test_disconnect_stops_updates():

--- a/pluggable_protocol_tree/tests/test_protocol_status_model.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_model.py
@@ -79,17 +79,7 @@ def test_repetition_and_rep_chain():
     assert m.rep_chain_label == "rep 2/3 of 'Wash'"
 
 
-def test_stop_freezes_all_and_clears_running():
-    m = ProtocolStatusModel()
-    m.on_protocol_start(0.0, step_total=1)
-    m.on_step_start(0.0, "A", "-")
-    m.stop(3.0)
-    assert m.running is False
-    assert m.protocol_clock.elapsed(99.0) == 3.0
-    assert m.step_clock.elapsed(99.0) == 3.0
-
-
-def test_reset_restores_defaults():
+def test_reset_restores_defaults_and_zeroes_clocks():
     m = ProtocolStatusModel()
     m.on_protocol_start(0.0, step_total=5)
     m.on_step_start(0.0, "A", "B")
@@ -98,7 +88,10 @@ def test_reset_restores_defaults():
     assert m.step_total == 0
     assert m.recent_step_name == "-"
     assert m.running is False
+    # Clocks zeroed (reset is also the post-protocol teardown).
     assert m.protocol_clock.elapsed(9.0) == 0.0
+    assert m.step_clock.elapsed(9.0) == 0.0
+    assert m.phase_clock.elapsed(9.0) == 0.0
 
 
 def test_observers_fire_on_counter_change():

--- a/pluggable_protocol_tree/tests/test_protocol_status_model.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_model.py
@@ -1,0 +1,110 @@
+"""Unit tests for ProtocolStatusModel (pure, fake-clock, no Qt)."""
+from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
+
+
+def test_protocol_start_sets_total_and_runs():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=3)
+    assert m.step_total == 3
+    assert m.step_index == 0
+    assert m.running is True
+    assert m.protocol_clock.elapsed(2.0) == 2.0
+
+
+def test_step_start_increments_and_resets_phase():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=3)
+    m.on_step_start(0.0, "Step A", "Step B")
+    assert m.step_index == 1
+    assert m.recent_step_name == "Step A"
+    assert m.next_step_name == "Step B"
+    assert m.phase_index == 0
+    assert m.phase_total == 0
+    assert m.step_clock.elapsed(1.0) == 1.0
+    m.on_step_start(1.0, "Step B", "-")
+    assert m.step_index == 2
+    # step clock restarted at t=1.0
+    assert m.step_clock.elapsed(3.0) == 2.0
+
+
+def test_phase_start_sets_counts_and_target():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.on_phase_start(0.0, phase_index=2, phase_total=4, phase_target_s=1.5)
+    assert m.phase_index == 2
+    assert m.phase_total == 4
+    assert m.phase_target_s == 1.5
+    assert m.phase_clock.elapsed(0.5) == 0.5
+    m.on_phase_extended(0.5)
+    assert m.phase_target_s == 2.0
+
+
+def test_pause_freezes_active_not_elapsed_all_scopes():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.on_phase_start(0.0, 1, 1, 1.0)
+    m.pause(1.0)
+    assert m.paused is True
+    # elapsed keeps going, active frozen at 1.0
+    assert m.protocol_clock.elapsed(5.0) == 5.0
+    assert m.protocol_clock.active(5.0) == 1.0
+    assert m.step_clock.active(5.0) == 1.0
+    assert m.phase_clock.active(5.0) == 1.0
+    m.resume(5.0)
+    assert m.paused is False
+    assert m.protocol_clock.active(6.0) == 2.0
+
+
+def test_step_start_while_paused_keeps_active_frozen():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=2)
+    m.on_step_start(0.0, "A", "B")
+    m.pause(1.0)
+    m.on_step_start(2.0, "B", "-")   # new step begins while paused
+    # new step's active must not run until resume
+    assert m.step_clock.active(4.0) == 0.0
+    assert m.step_clock.elapsed(4.0) == 2.0
+    m.resume(4.0)
+    assert m.step_clock.active(5.0) == 1.0
+
+
+def test_repetition_and_rep_chain():
+    m = ProtocolStatusModel()
+    m.on_repetition(1, 3)
+    assert m.repeats_completed == 1
+    assert m.repeats_total == 3
+    m.set_rep_chain("rep 2/3 of 'Wash'")
+    assert m.rep_chain_label == "rep 2/3 of 'Wash'"
+
+
+def test_stop_freezes_all_and_clears_running():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=1)
+    m.on_step_start(0.0, "A", "-")
+    m.stop(3.0)
+    assert m.running is False
+    assert m.protocol_clock.elapsed(99.0) == 3.0
+    assert m.step_clock.elapsed(99.0) == 3.0
+
+
+def test_reset_restores_defaults():
+    m = ProtocolStatusModel()
+    m.on_protocol_start(0.0, step_total=5)
+    m.on_step_start(0.0, "A", "B")
+    m.reset()
+    assert m.step_index == 0
+    assert m.step_total == 0
+    assert m.recent_step_name == "-"
+    assert m.running is False
+    assert m.protocol_clock.elapsed(9.0) == 0.0
+
+
+def test_observers_fire_on_counter_change():
+    m = ProtocolStatusModel()
+    seen = []
+    m.observe(lambda e: seen.append(e.new), "step_index")
+    m.on_protocol_start(0.0, 2)
+    m.on_step_start(0.0, "A", "B")
+    assert 1 in seen

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -189,50 +189,6 @@ def test_pane_returns_to_idle_after_protocol_finished(qapp, monkeypatch):
     assert not nb.btn_stop.isEnabled()
 
 
-def test_pane_step_started_updates_status_label(qapp):
-    """Emitting step_started increments the step counter label."""
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
-
-    class FakeRow:
-        path = []
-        name = "Step A"
-        duration_s = 0.0
-
-        def dotted_path(self):
-            return ""   # mirrors BaseRow.dotted_path for an empty path
-
-    pane = ProtocolTreePane([make_type_column()])
-    pane._step_total = 3
-    pane.executor.qsignals.step_started.emit(FakeRow())
-    assert pane._status_step_label.text() == "Step 1 / 3"
-
-
-def test_pane_tick_timer_runs_at_10_hz(qapp):
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
-
-    pane = ProtocolTreePane([make_type_column()])
-    assert pane._tick_timer.interval() == 100
-
-
-def test_pane_phase_started_signal_sets_phase_timer(qapp):
-    """Phase timing is driven by the executor's phase_started signal
-    (independent of hardware ack), so the status bar tracks the executor
-    regardless of whether an ack arrives."""
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
-
-    pane = ProtocolTreePane([make_type_column()], phase_ack_topic="x/applied")
-    pane._current_row = object()
-    pane._step_started_at = None
-    pane.executor.qsignals.phase_started.emit(1, 3, 0.5)
-    assert pane._phase_started_at is not None
-    assert pane._step_started_at is not None
-    assert pane._phase_index == 1
-    assert pane._phase_total == 3
-
-
 def test_pane_phase_acked_is_noop_for_timer(qapp):
     """phase_acked no longer sets the phase timer — that moved to
     phase_started so external acks don't fight the executor-driven clock."""
@@ -265,7 +221,6 @@ def test_pane_protocol_error_resets_to_idle_and_calls_dialog(qapp, monkeypatch):
     assert pane.navigation_bar.btn_stop.isEnabled()
     pane.executor.qsignals.protocol_error.emit("kaboom")
     assert not pane.navigation_bar.btn_stop.isEnabled()
-    assert not pane._tick_timer.isActive()
     assert calls == [("Protocol error", "kaboom")]
 
 
@@ -1630,40 +1585,5 @@ def test_import_into_selected_group_skips_columns_not_in_live_set(qapp,
     # The unknown column id must NOT have leaked onto the row as an
     # orphan attribute.
     assert not hasattr(new_step, "unknown_plugin_col")
-
-
-def test_refresh_status_running_index_without_total(qapp):
-    """Dynamic VT loop: phase_total == 0 but phase_index > 0 -> show the
-    running phase number with NO denominator."""
-    import time as _t
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
-
-    pane = ProtocolTreePane([make_type_column()], phase_ack_topic="x/applied")
-    pane._step_started_at = _t.monotonic()
-    pane._phase_started_at = _t.monotonic()
-    pane._phase_index = 7
-    pane._phase_total = 0
-    pane._phase_target = 1.0
-    pane._refresh_status()
-    text = pane._status_phase_time_label.text()
-    assert "Phase 7" in text
-    assert "Phase 7/" not in text          # no denominator
-
-
-def test_refresh_status_index_over_total_when_known(qapp):
-    """Static/count path: phase_total > 0 -> unchanged 'i/N' rendering."""
-    import time as _t
-    from pluggable_protocol_tree.builtins.type_column import make_type_column
-    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
-
-    pane = ProtocolTreePane([make_type_column()], phase_ack_topic="x/applied")
-    pane._step_started_at = _t.monotonic()
-    pane._phase_started_at = _t.monotonic()
-    pane._phase_index = 2
-    pane._phase_total = 5
-    pane._phase_target = 0.5
-    pane._refresh_status()
-    assert "Phase 2/5" in pane._status_phase_time_label.text()
 
 

--- a/pluggable_protocol_tree/tests/test_stopwatch.py
+++ b/pluggable_protocol_tree/tests/test_stopwatch.py
@@ -1,0 +1,59 @@
+"""Unit tests for ScopeStopwatch (pure, fake-clock)."""
+from pluggable_protocol_tree.models.stopwatch import ScopeStopwatch
+
+
+def test_not_started_reads_zero():
+    sw = ScopeStopwatch()
+    assert sw.elapsed(100.0) == 0.0
+    assert sw.active(100.0) == 0.0
+
+
+def test_elapsed_and_active_tick_together_when_running():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    assert sw.elapsed(2.0) == 2.0
+    assert sw.active(2.0) == 2.0
+
+
+def test_elapsed_ignores_pause_active_freezes():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.pause(1.0)          # active frozen at 1.0; elapsed keeps going
+    assert sw.elapsed(5.0) == 5.0
+    assert sw.active(5.0) == 1.0
+    sw.resume(5.0)         # active resumes from 1.0
+    assert sw.elapsed(6.0) == 6.0
+    assert sw.active(6.0) == 2.0
+
+
+def test_stop_freezes_both():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(3.0)
+    assert sw.elapsed(99.0) == 3.0
+    assert sw.active(99.0) == 3.0
+
+
+def test_resume_after_stop_is_noop():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(3.0)
+    sw.resume(10.0)
+    assert sw.elapsed(99.0) == 3.0
+    assert sw.active(99.0) == 3.0
+
+
+def test_pause_before_start_is_noop():
+    sw = ScopeStopwatch()
+    sw.pause(5.0)
+    sw.start(10.0)
+    assert sw.active(12.0) == 2.0
+
+
+def test_start_resets_prior_accumulation():
+    sw = ScopeStopwatch()
+    sw.start(0.0)
+    sw.stop(5.0)
+    sw.start(100.0)        # restart from zero
+    assert sw.elapsed(102.0) == 2.0
+    assert sw.active(102.0) == 2.0

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -7,6 +7,7 @@ from microdrop_application.dialogs.pyface_wrapper import confirm, NO
 from pluggable_protocol_tree.consts import REPEAT_DURATION_RECALC_TRIGGERS, ACK_WAIT_FOREVER
 from pluggable_protocol_tree.services.phase_math import effective_repetitions_for_duration, estimate_repeat_duration_s
 from pluggable_protocol_tree.services.protocol_state_tracker import PluggableProtocolStateTracker
+from pluggable_protocol_tree.services.protocol_status_controller import ProtocolStatusController
 from pyface.tasks.api import TraitsDockPane
 from traits.api import Instance, List, Str, observe
 
@@ -37,6 +38,11 @@ class PluggableProtocolDockPane(TraitsDockPane):
     experiment_manager = Instance(ExperimentManager)
     quick_actions = List(desc="Quick actions to mount under the tree.")
     protocol_state_tracker = Instance(PluggableProtocolStateTracker)
+
+    #: Links the executor's Qt signals to the status model and binds the
+    #: status bar to it (issue #467). The dock pane is the app's HasTraits
+    #: composition root that "sets up the link" between Qt and the model.
+    status_controller = Instance(ProtocolStatusController)
 
     #: Protocol preferences model (the "microdrop.protocol" node). Bound to
     #: the live application's preferences in create_contents, then passed
@@ -86,6 +92,14 @@ class PluggableProtocolDockPane(TraitsDockPane):
             protocol_state_tracker=self.protocol_state_tracker,
             parent=parent,
         )
+
+        # The dock pane owns the status controller (executor signals -> status
+        # model) and binds the (view-only) status bar to that model.
+        self.status_controller = ProtocolStatusController(
+            qsignals=pane.executor.qsignals,
+            manager=self.manager,
+        )
+        pane.status_bar.bind(self.status_controller.model)
 
         # Legacy protocol_grid parity: the full app opens with one default
         # step when no protocol is loaded (no-op once a protocol is loaded).

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -100,6 +100,10 @@ class PluggableProtocolDockPane(TraitsDockPane):
             manager=self.manager,
         )
         pane.status_bar.bind(self.status_controller.model)
+        # Phase trackers are always shown in the full app (issue #467); the
+        # pane only auto-reveals the phase field when a phase_ack_topic is set
+        # (demo path), so make it explicit here.
+        pane.status_bar.lbl_phase_time.setVisible(True)
 
         # Legacy protocol_grid parity: the full app opens with one default
         # step when no protocol is loaded (no-op once a protocol is loaded).

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -6,6 +6,8 @@ until PPT-9 deletes ``protocol_grid``; this module is the canonical
 location going forward.
 """
 
+import time
+
 from pyface.qt.QtCore import Qt, QTimer
 from pyface.qt.QtGui import QAction
 from pyface.qt.QtWidgets import (
@@ -28,6 +30,11 @@ from microdrop_style.icons.icons import (
 # action at a glance.
 ICON_PREVIEW = "video_search"
 from microdrop_utils.pyside_helpers import MarqueeLabel
+
+# 10 Hz refresh for the live (continuously-changing) time readouts in the
+# status bar. Discrete fields (counters, names) update via Traits observers
+# instead; only the elapsed/active clocks need polling.
+STATUS_POLL_INTERVAL_MS = 100
 
 
 class NavigationBar(QWidget):
@@ -399,20 +406,23 @@ class StatusBar(QScrollArea):
         layout.setContentsMargins(5, 0, 5, 0)
         layout.setSpacing(5)
 
-        self.lbl_total_time = QLabel("Total Time: 0 s")
-        self.lbl_total_time.setFixedWidth(120)
+        # Combined per-scope time readouts (issue #467): each shows the
+        # elapsed (wall) time and, in parens, the active (pause-aware) time.
+        # Driven by bind() from a ProtocolStatusModel.
+        self.lbl_total_time = QLabel("Protocol 0.0s (act 0.0s)")
+        self.lbl_total_time.setFixedWidth(190)
         self.lbl_total_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        self.lbl_step_time = QLabel("Step Time: 0 s")
-        self.lbl_step_time.setFixedWidth(115)
+        self.lbl_step_time = QLabel("Step 0.0s (act 0.0s)")
+        self.lbl_step_time.setFixedWidth(170)
         self.lbl_step_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
-        # Phase time slot — not in the legacy StatusBar layout, but
-        # callers (BasePluggableProtocolDemoWindow) want to surface
-        # the per-phase ack timer here. Hidden by default; the demo
-        # window reveals it iff DemoConfig.phase_ack_topic is set.
-        self.lbl_phase_time = QLabel("Phase 0/0  0.00s / 0.00s")
-        self.lbl_phase_time.setFixedWidth(220)
+        # Phase time slot — "Phase n/N  elapsed/target (act active)". Hidden
+        # by default; the composition root reveals it (the demo window iff
+        # DemoConfig.phase_ack_topic is set; the dock pane when phase
+        # tracking applies).
+        self.lbl_phase_time = QLabel("Phase 0/0  0.0s/0.0s (act 0.0s)")
+        self.lbl_phase_time.setFixedWidth(260)
         self.lbl_phase_time.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         self.lbl_phase_time.setVisible(False)
 
@@ -492,8 +502,112 @@ class StatusBar(QScrollArea):
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
         self.setFixedHeight(40)
 
+        # Bound lazily via bind(); until then the labels show their neutral
+        # initial text.
+        self._model = None
+        self._poll_timer = None
+
         self._apply_styling()
         QApplication.styleHints().colorSchemeChanged.connect(self._apply_styling)
+
+    def bind(self, model):
+        """Bind this status bar to a ProtocolStatusModel.
+
+        Discrete traits (counters, names, rep-chain) drive label text via
+        Traits observers; the continuously-changing time readouts are
+        refreshed by a 10 Hz poll timer that runs only while a protocol is
+        active. Safe to touch widgets in the observers: the model is mutated
+        only on the GUI thread (see ProtocolStatusController)."""
+        self._model = model
+        if self._poll_timer is None:
+            self._poll_timer = QTimer(self)
+            self._poll_timer.setInterval(STATUS_POLL_INTERVAL_MS)
+            self._poll_timer.timeout.connect(self._refresh_times)
+
+        model.observe(self._on_counts_changed,
+                      "step_index, step_total, phase_index, phase_total")
+        model.observe(self._on_repeats_changed,
+                      "repeats_completed, repeats_total")
+        model.observe(self._on_names_changed,
+                      "recent_step_name, next_step_name, rep_chain_label")
+        model.observe(self._on_running_changed, "running")
+
+        self._refresh_counts()
+        self._refresh_repeats()
+        self._refresh_names()
+        self._refresh_times()
+
+    # --- observer handlers (discrete) ---
+
+    def _on_counts_changed(self, event):
+        self._refresh_counts()
+
+    def _on_repeats_changed(self, event):
+        self._refresh_repeats()
+
+    def _on_names_changed(self, event):
+        self._refresh_names()
+
+    def _on_running_changed(self, event):
+        if self._poll_timer is None:
+            return
+        if event.new:
+            if not self._poll_timer.isActive():
+                self._poll_timer.start()
+        else:
+            self._refresh_times()        # final freeze-frame
+            self._poll_timer.stop()
+
+    # --- refreshers ---
+
+    def _refresh_counts(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_step_progress.setText(f"Step {m.step_index}/{m.step_total}")
+
+    def _refresh_repeats(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_repeat_protocol_status.setText(f"{m.repeats_completed}/")
+
+    def _refresh_names(self):
+        m = self._model
+        if m is None:
+            return
+        self.lbl_recent_step.setText(f"Most Recent Step: {m.recent_step_name}")
+        self.lbl_next_step.setText(f"Next Step: {m.next_step_name}")
+        if m.rep_chain_label:
+            self.lbl_step_repetition.setText(m.rep_chain_label)
+            self.lbl_step_repetition.setVisible(True)
+        else:
+            self.lbl_step_repetition.setText("")
+            self.lbl_step_repetition.setVisible(False)
+
+    def _refresh_times(self):
+        m = self._model
+        if m is None:
+            return
+        now = time.monotonic()
+        self.lbl_total_time.setText(
+            f"Protocol {m.protocol_clock.elapsed(now):.1f}s "
+            f"(act {m.protocol_clock.active(now):.1f}s)"
+        )
+        self.lbl_step_time.setText(
+            f"Step {m.step_clock.elapsed(now):.1f}s "
+            f"(act {m.step_clock.active(now):.1f}s)"
+        )
+        if m.phase_total > 0:
+            head = f"Phase {m.phase_index}/{m.phase_total}"
+        elif m.phase_index > 0:
+            head = f"Phase {m.phase_index}"
+        else:
+            head = "Phase"
+        self.lbl_phase_time.setText(
+            f"{head}  {m.phase_clock.elapsed(now):.1f}s/"
+            f"{m.phase_target_s:.1f}s (act {m.phase_clock.active(now):.1f}s)"
+        )
 
     def _apply_styling(self):
         if is_dark_mode():

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import threading
-import time
 from pathlib import Path
 import html as _html
 
@@ -89,8 +88,6 @@ logger = get_logger(__name__)
 # reads are wrapped in try/except where no-Redis must be tolerated.
 app_globals = get_microdrop_redis_globals_manager()
 
-# Tick rate for the elapsed-time status labels (10 Hz).
-STATUS_TICK_INTERVAL_MS = 100
 # Auto-dismiss timeout for the preview-complete toast.
 PREVIEW_COMPLETE_TOAST_MS = 3000
 # app_globals value used when no device SVG path has been published
@@ -243,16 +240,11 @@ class ProtocolTreePane(QWidget):
             ),
         ]
 
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at: float | None = None
-        self._phase_started_at: float | None = None
-        self._phase_target: float | None = None
-        self._phase_index = 0
-        self._phase_total = 0
+        # Status-bar timing/counting now lives in ProtocolStatusModel, driven
+        # by ProtocolStatusController and bound to the StatusBar by the
+        # composition root (dock pane / demo window). The pane keeps only the
+        # nav-relevant current row + pause-phase cursor below.
         self._current_row = None
-        self._repeats_total = 1
-        self._repeats_completed = 0
         self._current_run_preview_mode = False
         self._pause_phases: list = []
         self._pause_phase_idx: int = 0
@@ -263,18 +255,6 @@ class ProtocolTreePane(QWidget):
         # True while the pre-protocol wait loading screen is up, so pause/resume
         # know to freeze/restart its countdown.
         self._wait_active = False
-
-        self._status_step_label = self.status_bar.lbl_step_progress
-        self._status_step_time_label = self.status_bar.lbl_step_time
-        self._status_reps_label = self.status_bar.lbl_step_repetition
-        self._status_phase_time_label = (
-            self.status_bar.lbl_phase_time if self.phase_ack_topic is not None
-            else None
-        )
-
-        self._tick_timer = QTimer(self)
-        self._tick_timer.setInterval(STATUS_TICK_INTERVAL_MS)
-        self._tick_timer.timeout.connect(self._refresh_status)
 
         self._wire_executor_signals()
         self._wire_button_state_machine()
@@ -357,17 +337,15 @@ class ProtocolTreePane(QWidget):
         self.executor.qsignals.step_started.connect(
             self.widget.highlight_active_row,
         )
+        # Pane keeps the nav-relevant current row; status counters/timers are
+        # owned by ProtocolStatusController.
         self.executor.qsignals.step_started.connect(self._on_step_started)
-        self.executor.qsignals.step_finished.connect(self._on_step_finished)
-        self.executor.qsignals.step_repetition.connect(self._on_step_repetition)
         self.executor.qsignals.protocol_wait_started.connect(
             self._on_protocol_wait_started)
         self.executor.qsignals.protocol_wait_finished.connect(
             self._on_protocol_wait_finished)
         self.executor.qsignals.protocol_started.connect(self._on_protocol_started)
         self.executor.qsignals.protocol_error.connect(self._on_error)
-        self.executor.qsignals.phase_started.connect(self._on_phase_started)
-        self.executor.qsignals.phase_extended.connect(self._on_phase_extended)
         if self.phase_ack_topic is not None:
             self.phase_acked.connect(self._on_phase_ack)
 
@@ -384,8 +362,6 @@ class ProtocolTreePane(QWidget):
         self.executor.qsignals.protocol_resumed.connect(self._on_protocol_resumed)
         self.executor.qsignals.protocol_finished.connect(self._on_protocol_finished)
         self.executor.qsignals.protocol_aborted.connect(self._on_protocol_aborted)
-        self.executor.qsignals.protocol_repetition_finished.connect(
-            self._on_protocol_repetition_finished)
 
     def _wire_navigation_buttons(self):
         nb = self.navigation_bar
@@ -410,38 +386,14 @@ class ProtocolTreePane(QWidget):
         self._start_pending = False
         self.protocol_running_changed.emit(True)
         self._publish_protocol_running("True")
-        try:
-            self._step_total = sum(1 for _ in self.manager.iter_execution_steps())
-        except Exception:
-            self._step_total = 0
-        self._step_index = 0
-        self._status_step_label.setText(f"Step 0 / {self._step_total}")
-        logger.info(f"Protocol started ({self._step_total} steps)")
+        logger.info("Protocol started")
 
     def _on_step_started(self, row):
-        self._step_index += 1
+        # The pane keeps only the nav-relevant current row; the status
+        # counters/timers/labels are owned by ProtocolStatusController +
+        # ProtocolStatusModel and bound to the StatusBar by the
+        # composition root.
         self._current_row = row
-        self._step_started_at = time.monotonic()
-        self._phase_started_at = None
-        self._phase_index = 0
-        self._phase_total = 0
-        try:
-            self._phase_target = float(getattr(row, "duration_s", 0.0) or 0.0)
-        except (TypeError, ValueError):
-            self._phase_target = None
-        logger.info(
-            f"Step started: {self._step_index}/{self._step_total} "
-            f"[{row.dotted_path()}] {row.name!r}"
-        )
-        self._status_step_label.setText(
-            f"Step {self._step_index} / {self._step_total}"
-        )
-        self.status_bar.lbl_recent_step.setText(f"Most Recent Step: {row.name}")
-        self.status_bar.lbl_next_step.setText(
-            f"Next Step: {self._next_step_name(row)}"
-        )
-        if not self._tick_timer.isActive():
-            self._tick_timer.start()
 
         # NOTE: we deliberately do NOT publish the static step view to the
         # DV here. RoutesHandler publishes a per-phase display for every
@@ -453,71 +405,15 @@ class ProtocolTreePane(QWidget):
         # editable=True) consistently landed AFTER phase 1 and cleared it,
         # making the animation appear to begin at the second position.
 
-    def _next_step_name(self, current):
-        steps = self.manager.iter_execution_steps()
-        cur_path = tuple(current.path)
-        for row in steps:
-            if tuple(row.path) == cur_path:
-                next_row = next(steps, None)
-                return next_row.name if next_row is not None else "-"
-        return "-"
-
     def _on_phase_ack(self):
         # Phase boundary now comes from the executor's phase_started
         # signal (independent of hardware ack). Kept as a no-op so
-        # external code emitting phase_acked doesn't fight the timer.
+        # external code emitting phase_acked doesn't fight anything.
         return
-
-    def _on_phase_started(self, phase_index, phase_total, phase_duration_s):
-        """Executor signal: a new phase has begun. Reset the elapsed
-        clock and update the Phase x/y label so the status bar tracks
-        the executor regardless of whether a hardware ack arrives."""
-        if self._current_row is None:
-            return
-        now = time.monotonic()
-        if self._step_started_at is None:
-            self._step_started_at = now
-        self._phase_started_at = now
-        self._phase_index = int(phase_index)
-        self._phase_total = int(phase_total)
-        try:
-            self._phase_target = float(phase_duration_s)
-        except (TypeError, ValueError):
-            self._phase_target = None
-        self._refresh_status()
-
-    def _on_phase_extended(self, extra_s):
-        """A handler extended the current phase (e.g. volume threshold
-        holding for more wetting time). Grow the displayed target so the
-        'elapsed / target' readout stays honest while the phase is held."""
-        if self._current_row is None:
-            return
-        try:
-            self._phase_target = (self._phase_target or 0.0) + float(extra_s)
-        except (TypeError, ValueError):
-            return
-        self._refresh_status()
-
-    def _on_step_repetition(self, rep_chain):
-        if not rep_chain:
-            self._status_reps_label.setText("")
-            self._status_reps_label.setVisible(False)
-            return
-        parts = [
-            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
-        ]
-        self._status_reps_label.setText(" · ".join(parts))
-        self._status_reps_label.setVisible(True)
-
-    def _on_step_finished(self, _row):
-        self._refresh_status()
 
     def _on_error(self, msg):
         logger.error(f"Protocol error: {msg}")
         self._publish_protocol_running("False")
-        self._repeats_total = 0
-        self._repeats_completed = 0
-        self._update_repeat_status_label()
         # Immediate teardown only; the completion flow is deferred so the
         # error dialog is shown before the "Generate Run Summary?" prompt.
         self._on_protocol_terminated(RUN_OUTCOME_ERROR)
@@ -562,35 +458,6 @@ class ProtocolTreePane(QWidget):
         safe = escape_html_multiline(fallback_msg)
         return f"<p style='margin:0;color:{red};'>{safe}</p>"
 
-    @attempt_func_execution_with_error_dialog
-    def _refresh_status(self):
-        if self._step_started_at is None:
-            return
-        step_elapsed = time.monotonic() - self._step_started_at
-        self._status_step_time_label.setText(f"Step {step_elapsed:5.2f}s")
-        if self._status_phase_time_label is not None:
-            phase_elapsed = (
-                0.0 if self._phase_started_at is None
-                else time.monotonic() - self._phase_started_at
-            )
-            target = self._phase_target if self._phase_target is not None else 0.0
-            if self._phase_total > 0:
-                self._status_phase_time_label.setText(
-                    f"Phase {self._phase_index}/{self._phase_total}  "
-                    f"{phase_elapsed:4.2f}s / {target:.2f}s"
-                )
-            elif self._phase_index > 0:
-                # Dynamic duration loop: total is unknown while looping, so
-                # show the running phase number with no misleading denominator.
-                self._status_phase_time_label.setText(
-                    f"Phase {self._phase_index}  "
-                    f"{phase_elapsed:4.2f}s / {target:.2f}s"
-                )
-            else:
-                self._status_phase_time_label.setText(
-                    f"Phase {phase_elapsed:5.2f}s / {target:.2f}s"
-                )
-
     # --- button state machine ----------------------------------------
 
     def _set_idle_button_state(self):
@@ -626,10 +493,7 @@ class ProtocolTreePane(QWidget):
 
     def _start_protocol_run(self, preview_mode):
         repeats = self.status_bar.edit_repeat_protocol.value()
-        self._repeats_total = repeats
-        self._repeats_completed = 0
         self._current_run_preview_mode = preview_mode
-        self._update_repeat_status_label()
         start_path = self._selected_step_path()
         logger.info(
             f"Protocol run starting: {repeats} rep(s), "
@@ -646,11 +510,6 @@ class ProtocolTreePane(QWidget):
             start_step_path=start_path,
             preview_mode=preview_mode,
             repeats=repeats,
-        )
-
-    def _update_repeat_status_label(self):
-        self.status_bar.lbl_repeat_protocol_status.setText(
-            f"{self._repeats_completed}/"
         )
 
     def _selected_step_path(self):
@@ -691,7 +550,6 @@ class ProtocolTreePane(QWidget):
     def _on_protocol_paused(self):
         logger.info("Protocol paused")
         self.navigation_bar.show_resume_state()
-        self._tick_timer.stop()
         if self._wait_active:
             # Freeze the loading-screen countdown in lockstep with the
             # executor's frozen pre-protocol wait.
@@ -706,8 +564,6 @@ class ProtocolTreePane(QWidget):
         self.navigation_bar.show_pause_state()
         if self._wait_active:
             self.loading_overlay.resume()
-        if self._current_row is not None:
-            self._tick_timer.start()
         self.navigation_bar.merge_phase_controls_to_play_button()
 
     def _on_protocol_finished(self):
@@ -715,22 +571,12 @@ class ProtocolTreePane(QWidget):
         # once at the end of the whole run; the per-rep label is updated by
         # _on_protocol_repetition_finished during the run.
         self._publish_protocol_running("False")
-        logger.info(
-            f"Protocol finished ({self._repeats_completed}/{self._repeats_total})"
-        )
+        logger.info("Protocol finished")
         self._on_protocol_terminated(RUN_OUTCOME_FINISHED)
-
-    def _on_protocol_repetition_finished(self, completed, total):
-        self._repeats_completed = completed
-        self._repeats_total = total
-        self._update_repeat_status_label()
 
     def _on_protocol_aborted(self):
         logger.info("Protocol aborted by user")
         self._publish_protocol_running("False")
-        self._repeats_total = 0
-        self._repeats_completed = 0
-        self._update_repeat_status_label()
         self._on_protocol_terminated(RUN_OUTCOME_ABORTED)
 
     def _on_protocol_terminated(self, outcome=RUN_OUTCOME_FINISHED):
@@ -745,7 +591,6 @@ class ProtocolTreePane(QWidget):
         self.loading_overlay.stop_loading()
         self.clear_highlights()
         self._set_idle_button_state()
-        self._tick_timer.stop()
         self.navigation_bar.merge_phase_controls_to_play_button()
         self._pause_phases = []
         self._pause_phase_idx = 0
@@ -1024,30 +869,15 @@ class ProtocolTreePane(QWidget):
 
     @attempt_func_execution_with_error_dialog
     def clear_highlights(self):
-        """Reset the tree's selection + active-row highlight + per-step
-        labels to the idle visual state."""
+        """Reset the tree's selection + active-row highlight to the idle
+        visual state. Status-bar fields are owned by ProtocolStatusModel and
+        reset on the next run (on_protocol_start)."""
         with self._suppress_sync_publish():
             self.widget.highlight_active_row(None)
             self.widget.tree.clearSelection()
             self.widget.tree.setCurrentIndex(QModelIndex())
 
-        self._step_index = 0
-        self._step_total = 0
-        self._step_started_at = None
-        self._phase_started_at = None
-        self._phase_target = None
-        self._phase_index = 0
-        self._phase_total = 0
         self._current_row = None
-
-        self._status_step_label.setText("Step 0/0")
-        self._status_step_time_label.setText("Step Time: 0 s")
-        self._status_reps_label.setText("Repetition 0/0")
-        self._status_reps_label.setVisible(True)
-        self.status_bar.lbl_recent_step.setText("Most Recent Step: -")
-        self.status_bar.lbl_next_step.setText("Next Step: -")
-        if self._status_phase_time_label is not None:
-            self._status_phase_time_label.setText("Phase 0/0  0.00s / 0.00s")
 
     def _logs_settling_time_s(self) -> float:
         """Settling provider injected into the logging controller. Reads


### PR DESCRIPTION
## What

Adds the full set of protocol status-bar trackers requested in #467 and, in doing so, extracts the status logic out of `ProtocolTreePane` into a clean model / controller / view split.

**Trackers (per #467):**
- **Elapsed** times (wall-clock, do NOT freeze on pause) for protocol / step / phase
- **Active** times (freeze on pause) for protocol / step / phase
- **Step n/N** and **Phase n/N** counters

Each of the three time fields renders both values together, e.g. `Protocol 12.3s (act 9.1s)`, `Step 3.4s (act 2.1s)`, `Phase 2/4  1.2s/2.0s (act 1.0s)`.

## How — MVC separation

- **Model** — `models/protocol_status.py` `ProtocolStatusModel` (+ `models/stopwatch.py` `ScopeStopwatch`): a Qt-free `HasTraits` model holding the counters/names and three stopwatches, encapsulating the timing rules (a new step resets the phase clock; pause freezes active but not elapsed; ...). No Qt, no threads, no direct clock calls — `now` is passed in, so it's fully unit-testable.
- **Controller** — `services/protocol_status_controller.py` `ProtocolStatusController`: a small `HasTraits` adapter that owns the model and maps each `ExecutorSignals` signal to one model method call. The dock pane owns it in the full app; the standalone demo window owns the same one (so the reusable pane needs no dock pane).
- **View** — `StatusBar.bind(model)` (`views/navigation_bar.py`): Traits observers drive the discrete labels; a 10 Hz poll timer (running only while a protocol runs) refreshes the live time fields.

Model is mutated only on the GUI thread (queued `ExecutorSignals`), so observers drive widgets directly with no Qt-signal bridge.

**Teardown reset:** on the terminal signals (which fire right after the executor's `on_post_protocol_end`, i.e. once all repeats finish or the run is stopped), the controller resets the model so all timers/counters return to idle. `reset()` zeroes the clocks before flipping `running` so the final repaint shows `0.0`, not the frozen time.

**Phase field** is now always visible in the full app.

## Scope

Delivers the trackers + separation. **Deferred** to a follow-up: the navigate-while-paused clause (changing the selected step/phase while paused resuming from there with a reset timer) — that needs new executor resume-from-arbitrary-step semantics, beyond status tracking. The model is structured so adding it later is localized.

## Tests

New pure unit tests (no Qt, no executor): `test_stopwatch.py`, `test_protocol_status_model.py`, `test_protocol_status_controller.py` (elapsed-ignores-pause vs active-freezes, counters, phase reset, rep-chain, teardown reset, signal→model mapping). Pane/demo-window status tests migrated to the model/controller coverage. Verified end-to-end via `run_widget_auto` (full 3-step protocol, 9 phases, clean finish, trackers reset to idle).

Design + plan: `docs/superpowers/specs/2026-06-16-protocol-status-trackers-design.md`, `docs/superpowers/plans/2026-06-16-protocol-status-trackers.md`.

Closes #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)