### PR TITLE
Fix device-viewer step-mode drawing, step-param sync, and step navigation

### DIFF
--- a/device_viewer/models/route.py
+++ b/device_viewer/models/route.py
@@ -285,14 +285,14 @@ class RouteLayerManager(HasTraits):
         """
         with self._suppress_repeat_exclusion():
             self.trait_set(
-                duration=params["duration"],
-                repetitions=params["repetitions"],
-                repeat_duration=params["repeat_duration"],
-                trail_length=params["trail_length"],
-                trail_overlay=params["trail_overlay"],
-                soft_start=params["soft_start"],
-                soft_terminate=params["soft_terminate"],
-                linear_repeats=params["linear_repeats"],
+                duration=float(params["duration"]),
+                repetitions=int(params["repetitions"]),
+                repeat_duration=int(params["repeat_duration"]),
+                trail_length=int(params["trail_length"]),
+                trail_overlay=int(params["trail_overlay"]),
+                soft_start=bool(params["soft_start"]),
+                soft_terminate=bool(params["soft_terminate"]),
+                linear_repeats=bool(params["linear_repeats"]),
             )
         self.mark_params_committed()
 

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -16,7 +16,7 @@ from microdrop_application.dialogs.pyface_wrapper import (
     YES,
     FileDialog,
     confirm,
-    error, warning,
+    error, warning, CANCEL
 )
 from pyface.qt.QtCore import QPointF, QSizeF, Qt, QTimer
 from pyface.qt.QtGui import QGraphicsScene, QColor, QBrush, QFont
@@ -428,6 +428,9 @@ class DeviceViewerDockPane(TraitsDockPane):
             self.model.routes.apply_execution_params(message_model.execution_params)
             return
 
+        if step_changed and message_model.execution_params and not self.model.protocol_running:
+            self._check_unsaved_execution_params()
+
         if message_model.uuid == self.model.uuid:
             return  # Ignore messages that are from the same model
 
@@ -486,6 +489,36 @@ class DeviceViewerDockPane(TraitsDockPane):
         self._publish_geometry_if_changed()
 
         QApplication.processEvents()
+
+    def _check_unsaved_execution_params(self):
+        # ask user if they want to save changes if there are any before moving on
+        if not self.model.protocol_running:
+            if self.model.routes.commit_enabled and self._last_applied_step_id:
+                logger.warning(f"Unsaved route execution settings for last step {self._last_applied_step_id}")
+
+                choice = warning(
+                    None,
+                    "Save your execution settings to current protocol step?",
+                    title="Uncommitted Execution Settings",
+                    informative=(
+                        f"You've changed this step's execution settings in the device viewer "
+                        f"but haven't committed them to the protocol.<br><br>"
+                        f"<b>Commit</b> writes them to the step. "
+                        f"<b>Discard</b> reverts to the step's saved values."
+                    ),
+                    ok_label="Commit",
+                    cancel_label="Discard",
+                )
+
+                if choice == CANCEL:
+                    logger.debug("Discarding unsaved route execution settings")
+
+                elif choice == OK:
+                    prev_id = self._last_applied_step_id
+                    params = self.model.routes._current_params()
+                    logger.info(f"Sending protocol step: {prev_id} execution settings: {params}")
+                    commit_msg = StepParamsCommitMessage(step_id=prev_id, **params)
+                    publish_message(topic=STEP_PARAMS_COMMIT, message=commit_msg.serialize())
 
     @observe("_disable_state_messages")
     def __disable_state_messages_change_log(self, event):
@@ -1185,7 +1218,7 @@ class DeviceViewerDockPane(TraitsDockPane):
             return
 
         try:
-            logger.info("Processing device view model state change...")
+            logger.debug("Processing device view model state change...")
             self.model_change_handler_with_timeout(event)
             self.message_buffer = gui_models_to_message_model(self.model).serialize()
             logger.info(

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -413,21 +413,20 @@ class DeviceViewerDockPane(TraitsDockPane):
 
         message_model = DeviceViewerMessageModel.deserialize(message_model_serial)
 
-        if message_model.step_id != self._last_applied_step_id:
-            if self._apply_step_transition(message_model):
-                self._last_applied_step_id = message_model.step_id
-            # On cancel we do NOT update _last_applied_step_id.
-            # The grid's selection remains visually on the new row, but the
-            # sidebar stays on the old values — see spec open item re:
-            # forcing the grid to revert selection.
-        elif message_model.execution_params and not self.model.protocol_running:
-            # Same-step refresh: the protocol widget echoing back a commit
-            # after its own reconciliation (e.g. the tree recalculating
-            # Route Reps Dur). Reload + rebaseline silently — no
-            # uncommitted-changes prompt, the step did not change.
-            self.model.routes.apply_execution_params(
-                message_model.execution_params
-            )
+        step_changed = message_model.step_id != self._last_applied_step_id
+
+        if not step_changed and message_model.execution_params and not self.model.protocol_running:
+            # Same-step refresh: the protocol widget echoing back its own
+            # reconciliation (e.g. the tree recalculating Route Reps Dur
+            # after the DV wrote routes to the step). Reload + rebaseline
+            # the sidebar params, then STOP — falling through to the
+            # reset()/reapply below would clear_routes() in the middle of a
+            # free-hand draw, wiping the in-progress route and selected
+            # layer and kicking the user out of draw mode. Routes only ever
+            # flow DV -> tree, never back, so there is nothing else to sync.
+            logger.info(f"Device Viewer: Applying new execution params from protocol side for step {message_model.step_id};\n\n Params: {message_model.execution_params}\n\n")
+            self.model.routes.apply_execution_params(message_model.execution_params)
+            return
 
         if message_model.uuid == self.model.uuid:
             return  # Ignore messages that are from the same model
@@ -465,6 +464,20 @@ class DeviceViewerDockPane(TraitsDockPane):
             self.model.routes.add_layer(Route(route=route.copy()), None, color)
         self.model.routes.selected_layer = None
 
+        # Pull the step's execution params into the sidebar AFTER the routes
+        # exist. reset() above transiently empties the layers, which flips
+        # repeats_frozen on (no loop present) and pins Repetitions/Repeat Dur
+        # to 1/0; applying the params now — with the real route set in place —
+        # means that pin can't clobber the pulled values (e.g. a loop step's
+        # Repetitions snapping back to 1). Also baselines the sidebar so the
+        # commit button starts disabled.
+        if step_changed:
+            if message_model.execution_params:
+                self.model.routes.apply_execution_params(message_model.execution_params)
+            else:
+                self.model.routes.clear_committed_baseline()
+            self._last_applied_step_id = message_model.step_id
+
         self._disable_state_messages = False  # Re-enable state messages after reset
         self._undoing = False
         self.undo_manager.active_stack.clear()  # Clear the undo stack
@@ -480,53 +493,6 @@ class DeviceViewerDockPane(TraitsDockPane):
             logger.warning("Device viewer will not be processing device view model state change since state messages are disabled.")
         else:
             logger.info("Device viewer will process device view model state changes")
-
-    def _apply_step_transition(self, message_model):
-        """Pull execution params from the newly-selected step into the sidebar.
-
-        If the sidebar is dirty, prompt Commit/Discard/Cancel. Returns True if
-        the caller should update _last_applied_step_id, False on cancel.
-        """
-        if self.model.routes.commit_enabled and self._last_applied_step_id:
-            choice = self._prompt_uncommitted_changes()
-            if choice == "cancel":
-                return False
-            if choice == "commit":
-                prev_id = self._last_applied_step_id
-                params = self.model.routes._current_params()
-                commit_msg = StepParamsCommitMessage(step_id=prev_id, **params)
-                publish_message(
-                    topic=STEP_PARAMS_COMMIT, message=commit_msg.serialize()
-                )
-            # "discard" falls through to apply the new step.
-
-        if message_model.execution_params:
-            self.model.routes.apply_execution_params(message_model.execution_params)
-        else:
-            self.model.routes.clear_committed_baseline()
-        return True
-
-    def _prompt_uncommitted_changes(self) -> str:
-        """Modal Commit/Discard/Cancel dialog. Returns 'commit', 'discard', or 'cancel'."""
-        from PySide6.QtWidgets import QMessageBox
-        box = QMessageBox()
-        box.setWindowTitle("Uncommitted execution parameters")
-        box.setText(
-            f"You have uncommitted execution parameter changes for step "
-            f"{self._last_applied_step_id}."
-        )
-        box.setInformativeText("Commit the changes to that step, discard them, or cancel?")
-        commit_btn = box.addButton("Commit", QMessageBox.AcceptRole)
-        discard_btn = box.addButton("Discard", QMessageBox.DestructiveRole)
-        cancel_btn = box.addButton("Cancel", QMessageBox.RejectRole)
-        box.setDefaultButton(cancel_btn)
-        box.exec()
-        clicked = box.clickedButton()
-        if clicked is commit_btn:
-            return "commit"
-        if clicked is discard_btn:
-            return "discard"
-        return "cancel"
 
     @observe("model:routes:commit_to_step_btn")
     def _on_commit_to_step_btn_fired(self, event):

--- a/microdrop_application/dialogs/pyface_wrapper.py
+++ b/microdrop_application/dialogs/pyface_wrapper.py
@@ -109,6 +109,21 @@ def _with_checkbox(dialog, result):
     return result
 
 
+def _apply_ok_cancel_labels(dialog, ok_label: str = "OK", cancel_label: str = "Exit") -> None:
+    """Rename the affirmative ("OK") and dismiss ("Exit") buttons of a styled
+    OK/Cancel dialog.
+
+    A label left at its default, or a button the dialog doesn't have (e.g. no
+    "Exit" when ``cancel=False``), is a no-op: ``set_button_text`` ignores
+    unknown buttons and preserves each button's role styling across the rename,
+    and the dialog's result mapping is keyed on the result code, not the label.
+    """
+    if ok_label != "OK":
+        dialog.set_button_text("OK", ok_label)
+    if cancel_label != "Exit":
+        dialog.set_button_text("Exit", cancel_label)
+
+
 def confirm(
     parent: Optional[QWidget] = None,
     message: str = "",
@@ -181,10 +196,15 @@ def information(
     text_format: Optional[str] = None,
     detail_collapsible: Optional[bool] = True,
     timeout: Optional[int] = 0,
+    ok_label: str = "OK",
+    cancel_label: str = "Exit",
     **kwargs
 ):
     """
     Pyface-compatible information dialog using styled BaseMessageDialog.
+
+    *ok_label* / *cancel_label* rename the affirmative and dismiss buttons
+    (the latter only shown when ``cancel=True``).
 
         If *checkbox_text* is provided (via kwargs), a checkbox is added to the
     dialog and the return value becomes a ``(result, checked)`` tuple.
@@ -196,6 +216,7 @@ def information(
         return InformationDialog(exit=cancel, **opts)
 
     dialog = _prepare_dialog(create_dialog, parent, title, message, detail, detail_visible_lines, informative, text_format, detail_collapsible, **kwargs)
+    _apply_ok_cancel_labels(dialog, ok_label, cancel_label)
 
     if timeout: # temp message
         dialog.show()
@@ -217,10 +238,15 @@ def success(
     informative: Optional[str] = None,
     text_format: Optional[str] = None,
     timeout: Optional[int] = 0,
+    ok_label: str = "OK",
+    cancel_label: str = "Exit",
     **kwargs
 ):
     """
     Pyface-compatible success dialog using styled BaseMessageDialog.
+
+    *ok_label* / *cancel_label* rename the affirmative and dismiss buttons
+    (the latter only shown when ``cancel=True``).
 
         If *checkbox_text* is provided (via kwargs), a checkbox is added to the
     dialog and the return value becomes a ``(result, checked)`` tuple.
@@ -232,6 +258,7 @@ def success(
         return SuccessDialog(exit=cancel, **opts)
 
     dialog = _prepare_dialog(create_dialog, parent, title, message, detail, detail_visible_lines, informative, text_format, **kwargs)
+    _apply_ok_cancel_labels(dialog, ok_label, cancel_label)
 
     if timeout: # temp message
         dialog.show()
@@ -252,10 +279,15 @@ def warning(
     detail_visible_lines: Optional[int] = None,
     informative: Optional[str] = None,
     text_format: Optional[str] = None,
+    ok_label: str = "OK",
+    cancel_label: str = "Exit",
     **kwargs
 ):
     """
     Pyface-compatible warning dialog using styled BaseMessageDialog.
+
+    *ok_label* / *cancel_label* rename the affirmative and dismiss buttons
+    (the latter only shown when ``cancel=True``).
 
         If *checkbox_text* is provided (via kwargs), a checkbox is added to the
     dialog and the return value becomes a ``(result, checked)`` tuple.
@@ -267,6 +299,7 @@ def warning(
         return WarningAlertDialog(exit=cancel, **opts)
 
     dialog = _prepare_dialog(create_dialog, parent, title, message, detail, detail_visible_lines, informative, text_format, **kwargs)
+    _apply_ok_cancel_labels(dialog, ok_label, cancel_label)
 
     result = dialog.exec()
 
@@ -304,10 +337,14 @@ def error(
     detail_visible_lines: Optional[int] = None,
     informative: Optional[str] = None,
     text_format: Optional[str] = None,
+    ok_label: str = "OK",
+    cancel_label: str = "Exit",
     **kwargs
 ):
     """
     Pyface-compatible error dialog using styled BaseMessageDialog.
+
+    *ok_label* / *cancel_label* rename the affirmative and dismiss buttons.
 
         If *checkbox_text* is provided (via kwargs), a checkbox is added to the
     dialog and the return value becomes a ``(result, checked)`` tuple.
@@ -319,6 +356,7 @@ def error(
         return ErrorAlertDialog(error_details=None, **opts)  # Detail is handled by _prepare_dialog
 
     dialog = _prepare_dialog(create_dialog, parent, title, message, detail, detail_visible_lines, informative, text_format, **kwargs)
+    _apply_ok_cancel_labels(dialog, ok_label, cancel_label)
 
     result = dialog.exec()
 

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -64,11 +64,22 @@ def _execution_params_for_row(row) -> dict:
     StepParamsCommitMessage): the DV's ``repetitions`` is the tree's
     ``route_repetitions`` column, ``soft_terminate`` is ``soft_end``,
     and its ``repeat_duration`` spinner is integer-granular."""
+
+    ## The device viewer only has spinners to set the repeats num or repeat duration.
+    ## It does not have dialogs to change controls, simply indicates by resetting repeat duration to 0 if
+    ## repeat num in control, and repeat num to 1 and repeat duration to some number when duration based repeats.
+    if row.repeat_duration_controls:
+        repeat_duration = row.repeat_duration
+        route_repetitions = 1
+
+    else:
+        repeat_duration = 0.0
+        route_repetitions = row.route_repetitions
+
     return {
         "duration": float(getattr(row, "duration_s", 1.0) or 0.0),
-        "repetitions": int(getattr(row, "route_repetitions", 1) or 1),
-        "repeat_duration": int(round(float(
-            getattr(row, "repeat_duration", 0.0) or 0.0))),
+        "repetitions": int(route_repetitions),
+        "repeat_duration": int(round(float(repeat_duration))),
         "trail_length": int(getattr(row, "trail_length", 1) or 1),
         "trail_overlay": int(getattr(row, "trail_overlay", 0) or 0),
         "soft_start": bool(getattr(row, "soft_start", False)),
@@ -80,7 +91,15 @@ def _execution_params_for_row(row) -> dict:
 def _col_values_from_execution_params(params: dict) -> dict:
     """Inverse of _execution_params_for_row: DV sidebar contract keys ->
     tree column ids/types, ready for setattr onto a row."""
-    return {
+
+    # Of the Route Reps <-> Route Reps Dur pair, only the row's
+    # controlling knob is written — the pane's reconciliation pass
+    # recalculates the derived one, exactly as for a manual cell
+    # edit. The pop/reassign moves the controlling knob to the end
+    # of the write order so its reconcile sees the other committed
+    # values already in place.
+
+    result = {
         "duration_s": float(params["duration"]),
         "route_repetitions": int(params["repetitions"]),
         "repeat_duration": float(params["repeat_duration"]),
@@ -90,6 +109,18 @@ def _col_values_from_execution_params(params: dict) -> dict:
         "soft_end": bool(params["soft_terminate"]),
         "linear_repeats": bool(params["linear_repeats"]),
     }
+
+    result["repeat_duration_controls"] = bool(float(result["repeat_duration"]))
+
+    if result["repeat_duration_controls"]:
+        del result["route_repetitions"]
+        result["repeat_duration"] = result.pop("repeat_duration")
+    else:
+        del result["repeat_duration"]
+        result["route_repetitions"] = result.pop("route_repetitions")
+
+
+    return result
 
 
 class _Bridge(QObject):
@@ -369,22 +400,7 @@ class DeviceViewerSyncController(HasTraits):
             return
         path = tuple(row.path)
 
-        new_values = _col_values_from_execution_params(
-            commit_msg.model_dump(exclude={"step_id"})
-        )
-        # Of the Route Reps <-> Route Reps Dur pair, only the row's
-        # controlling knob is written — the pane's reconciliation pass
-        # recalculates the derived one, exactly as for a manual cell
-        # edit. The pop/reassign moves the controlling knob to the end
-        # of the write order so its reconcile sees the other committed
-        # values already in place.
-        if bool(getattr(row, "repeat_duration_controls", False)):
-            del new_values["route_repetitions"]
-            new_values["repeat_duration"] = new_values.pop("repeat_duration")
-        else:
-            del new_values["repeat_duration"]
-            new_values["route_repetitions"] = new_values.pop("route_repetitions")
-
+        new_values = _col_values_from_execution_params(commit_msg.model_dump(exclude={"step_id"}))
         # Direct trait writes bypass QtTreeModel.setData and the delegate,
         # so fire cell_changed per changed column — it drives both the
         # dirty tracker and the pane's repeat-duration reconciliation.

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -933,21 +933,21 @@ class ProtocolTreePane(QWidget):
     # --- step-cursor navigation -------------------------------------
     @attempt_func_execution_with_error_dialog
     def navigate_to_first_step(self):
-        steps = list(self.manager.iter_execution_steps())
+        steps = self._navigable_steps()
         if steps:
             logger.info(f"Nav: first step [{steps[0].dotted_path()}]")
             self._select_step(steps[0])
 
     @attempt_func_execution_with_error_dialog
     def navigate_to_last_step(self):
-        steps = list(self.manager.iter_execution_steps())
+        steps = self._navigable_steps()
         if steps:
             logger.info(f"Nav: last step [{steps[-1].dotted_path()}]")
             self._select_step(steps[-1])
 
     @attempt_func_execution_with_error_dialog
     def navigate_to_previous_step(self):
-        steps = list(self.manager.iter_execution_steps())
+        steps = self._navigable_steps()
         if not steps:
             return
         cur = self._current_step_in(steps)
@@ -961,7 +961,7 @@ class ProtocolTreePane(QWidget):
 
     @attempt_func_execution_with_error_dialog
     def navigate_to_next_step(self):
-        steps = list(self.manager.iter_execution_steps())
+        steps = self._navigable_steps()
         if not steps:
             return
         cur = self._current_step_in(steps)
@@ -990,6 +990,24 @@ class ProtocolTreePane(QWidget):
         )
         new_row = self.manager.get_row(new_path)
         self._select_step(new_row)
+
+    def _navigable_steps(self):
+        """Distinct steps in execution order for the step cursor.
+
+        iter_execution_steps() expands repetitions — a Reps=N step (or a
+        step nested under a Reps=N group) is yielded N times as the *same*
+        row. The cursor navigates structural steps, so collapse those
+        repeats to one entry per row; otherwise next/prev would re-select
+        the same row and the cursor would never advance past a repeated step.
+        """
+        seen = set()
+        steps = []
+        for row in self.manager.iter_execution_steps():
+            if row.uuid in seen:
+                continue
+            seen.add(row.uuid)
+            steps.append(row)
+        return steps
 
     def _current_step_in(self, steps):
         idx = self.widget.tree.currentIndex()


### PR DESCRIPTION
## Summary

Fixes a cluster of device-viewer / protocol-tree issues hit while drawing routes and navigating steps in step mode.

### 1. Remove the "Uncommitted execution parameters" popup
The Commit/Discard/Cancel modal that fired on every step switch with a dirty sidebar is gone. A step switch now silently discards uncommitted sidebar edits; the explicit **Commit** button is the only way to push them to a step.

### 2. Step-mode draws no longer get interrupted
Drawing a route in step mode used to drop out of draw mode after a few segments. Each segment round-trips through the protocol tree, which echoes back a same-step display-state message (the tree recalculating Route Reps Dur). That echo fell through to `reset()` → `clear_routes()`, wiping the in-progress route and selected layer mid-draw. The same-step refresh branch now reloads the sidebar params and returns instead of resetting. (Free mode was unaffected because it never writes routes back to a row.)

### 3. Step Repetitions no longer snap to 1
Pulling a loop step's params showed Repetitions reverting from its real value to 1. `apply_message_model` applied the execution params *before* re-adding the routes; `reset()` transiently empties the layers, which flips `repeats_frozen` on and pins Repetitions/Repeat Dur to 1/0, clobbering the just-applied value. Params are now applied **after** the routes are re-added.

### 4. Step-cursor navigation no longer traps on repeated steps
`navigate_to_next/previous_step` walked `iter_execution_steps()`, which expands repetitions — a Reps=N step is yielded N times as the same row. The cursor could never advance past a Reps>1 step. Navigation now uses `_navigable_steps()` (distinct rows, deduped by uuid). Run-time/executor counts that should include repetitions are untouched.

### 5. Execution-param round-trip robustness
`apply_execution_params` now coerces each value to its trait type, and the route-reps/repeat-duration controlling-knob selection is mapped explicitly in one shared place on the tree side.

## Testing
Manual verification in the running app (per the usual workflow); no automated test run.
