### PR TITLE
Grey out read-only protocol-tree columns (#473)

### DIFF
--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -461,9 +461,10 @@ def make_routes_column():
     # saved protocols and user-tuned wait times.
     return Column(
         model=RoutesColumnModel(
-            col_id="routes", col_name="Electrodes", default_value=[],
+            col_id="routes", col_name="Routes", default_value=[],
         ),
         view=RoutesSummaryView(),
         handler=RoutesHandler(),
+        preference_display_name="Electrodes / Routes"
     )
 

--- a/pluggable_protocol_tree/models/column.py
+++ b/pluggable_protocol_tree/models/column.py
@@ -136,11 +136,11 @@ class Column(HasTraits):
     view = Instance(IColumnView)
     handler = Instance(IColumnHandler)
 
-    #: Identity of this column UNIT (model+view+handler) for unit-level
-    #: maps like the ack-wait grid. Defaults to the model's col_id;
-    #: compound expansion overrides it so every synthesized field cell
-    #: reports the compound's base_id instead of its own field id.
-    id = Str()
+    id = Str(desc="Identity of this column UNIT (model+view+handler) for unit-level; "
+                  "maps like the ack-wait grid. Defaults to the model's col_id; "
+                  "compound expansion overrides it so every synthesized field cell; "
+                  "reports the compound's base_id instead of its own field id.")
+    preference_display_name = Str(desc="Name to use for this column in preferences panes")
 
     def _id_default(self):
         return self.model.col_id

--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -154,15 +154,21 @@ class ProtocolPreferences(PreferencesHelper):
                 getattr(column.handler, "default_ack_time_s", 0.0) or 0.0)
             if default_ack_time_s <= 0:
                 continue
-            # Display name for the grid's key column: single columns
-            # (incl. compound field cells) carry col_name; an unexpanded
-            # compound shows its owner field's label. setdefault: a
-            # compound's field cells share one id and arrive owner-first,
-            # so the owner's label wins.
+            # Display name for the grid's key column. An optional
+            # ``preference_display_name`` on the column overrides everything
+            # (lets a column show a different label here than in the tree
+            # header); otherwise single columns (incl. compound field cells)
+            # carry col_name, an unexpanded compound shows its owner field's
+            # label, and the id is the last resort. setdefault: a compound's
+            # field cells share one id and arrive owner-first, so the owner's
+            # label wins.
             field_specs = getattr(column.model, "field_specs", None)
-            column_names.setdefault(column.id, (
-                getattr(column.model, "col_name", "")
-                or (field_specs()[0].col_name if field_specs else column.id)))
+            display_name = (
+                getattr(column, "preference_display_name", "")
+                or getattr(column.model, "col_name", "")
+                or (field_specs()[0].col_name if field_specs else column.id)
+            )
+            column_names.setdefault(column.id, display_name)
             default_ack_times[column.id] = default_ack_time_s
         ack_times = {
             col_id: self.protocol_tree_ack_times.get(col_id, default_ack_time_s)

--- a/pluggable_protocol_tree/tests/test_qt_tree_model.py
+++ b/pluggable_protocol_tree/tests/test_qt_tree_model.py
@@ -56,6 +56,24 @@ def test_header_data(manager):
         assert qm.headerData(col_idx, Qt.Horizontal, Qt.DisplayRole) == col.model.col_name
 
 
+def test_read_only_column_gets_grey_background(qapp, manager):
+    """Read-only columns (type/id) render with the light-grey fill (issue #359)."""
+    from pyface.qt.QtCore import Qt
+    manager.add_step(values={"name": "Hello"})
+    qm = MvcTreeModel(manager)
+    type_idx = [c.model.col_id for c in manager.columns].index("type")
+    assert qm.data(qm.index(0, type_idx), Qt.BackgroundRole) == qm._read_only_brush()
+
+
+def test_editable_column_has_no_read_only_background(qapp, manager):
+    """Editable columns (name) keep the default background — no read-only fill."""
+    from pyface.qt.QtCore import Qt
+    manager.add_step(values={"name": "Hello"})
+    qm = MvcTreeModel(manager)
+    name_idx = [c.model.col_id for c in manager.columns].index("name")
+    assert qm.data(qm.index(0, name_idx), Qt.BackgroundRole) is None
+
+
 def test_widget_exposes_public_index_to_path(qapp):
     """Public alias for the previously-private _index_to_path. PPT-10.2
     needs this for the device-viewer sync controller to resolve tree

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -11,6 +11,7 @@ from functools import partial
 from pyface.qt.QtCore import QAbstractItemModel, QModelIndex, Qt, Signal
 from pyface.qt.QtGui import QBrush, QColor
 
+from microdrop_style.helpers import is_dark_mode
 from pluggable_protocol_tree.models.row import GroupRow
 
 
@@ -28,6 +29,13 @@ class MvcTreeModel(QAbstractItemModel):
 
     _ACTIVE_BG = QBrush(QColor(0, 90, 200))  # solid blue
     _ACTIVE_FG = QBrush(QColor(255, 255, 255))
+
+    # Light-grey fill for read-only cells so they read as non-editable — the
+    # same cue the legacy protocol_grid used (issue #359). A cell is read-only
+    # here when it is neither editable nor user-checkable: checkbox cells are
+    # non-editable by design but stay interactive, so they keep the normal bg.
+    _READ_ONLY_BG_LIGHT = QBrush(QColor("#E8E8E8"))
+    _READ_ONLY_BG_DARK = QBrush(QColor("#3A3A3A"))
 
     def __init__(self, row_manager, parent=None):
         super().__init__(parent)
@@ -95,6 +103,11 @@ class MvcTreeModel(QAbstractItemModel):
 
     # ------------ data / flags / header ------------
 
+    @classmethod
+    def _read_only_brush(cls):
+        """Background brush for read-only cells, theme-aware (mirror of #359)."""
+        return cls._READ_ONLY_BG_DARK if is_dark_mode() else cls._READ_ONLY_BG_LIGHT
+
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid():
             return None
@@ -106,6 +119,14 @@ class MvcTreeModel(QAbstractItemModel):
                 return self._ACTIVE_BG
             if role == Qt.ForegroundRole:
                 return self._ACTIVE_FG
+
+        # Read-only cells get the light-grey fill (mirror of protocol_grid
+        # #359): read-only == neither editable nor user-checkable. The
+        # active-row highlight above already returned for that row.
+        if role == Qt.BackgroundRole:
+            flags = col.view.get_flags(node)
+            if not (flags & Qt.ItemIsEditable) and not (flags & Qt.ItemIsUserCheckable):
+                return self._read_only_brush()
 
         value = col.model.get_value(node)
 


### PR DESCRIPTION
Closes #473.

## Read-only column styling (#473)
Mirrors the legacy `protocol_grid` cue (#359): read-only cells in the protocol tree now render with a light-grey background fill so they read as non-editable.

- `MvcTreeModel.data()` returns a theme-aware brush (`#E8E8E8` light / `#3A3A3A` dark — the same hexes the old grid used) for `Qt.BackgroundRole` on read-only cells.
- "Read-only" is defined exactly as the legacy: flags neither `ItemIsEditable` nor `ItemIsUserCheckable`, so checkbox cells (non-editable but interactive) keep the normal background.
- The active-row highlight still wins over the read-only fill.
- Read-only-ness comes straight off the existing `col.view.get_flags(node)` — no new flag plumbing.
- Tests: read-only column (type) → grey brush; editable column (name) → no fill.

## Bonus: per-pane column display name
A column can now carry an optional `preference_display_name` (new `Column` trait). When set, the Protocol Settings (ack-wait) grid uses it in preference to `col_name` — falling back to `col_name`, the compound owner's field label, then the id. Applied to the routes column so its tree header reads **"Routes"** while the settings grid reads **"Electrodes / Routes"**.

## Testing
Per the usual workflow, manual verification in the app; the two new unit tests cover the read-only brush logic headlessly.
