### PR TITLE
Bulk Set Values for the protocol tree (#474)

### DIFF
--- a/docs/superpowers/specs/2026-06-16-bulk-set-values-protocol-tree-design.md
+++ b/docs/superpowers/specs/2026-06-16-bulk-set-values-protocol-tree-design.md
@@ -1,0 +1,130 @@
+# Bulk Set Values for the pluggable protocol tree (#474)
+
+Mirror of legacy `protocol_grid` issues #167 ("Apply parameter to multiple
+steps in bulk") and #285 ("Checkbox to apply new bulk parameters to all nested
+groups"), rebuilt on the new tree's data model.
+
+## Goal
+
+Let the user set one or more column values across all currently-selected steps
+in a single action. When a **group** is selected, by default only its
+first-level child steps are affected; an "Apply to all nested groups" checkbox
+extends the write to every descendant step.
+
+## Why it's small on the new model
+
+The `RowManager` already provides the write primitive:
+
+- `set_values(paths, col_id, value)` — writes `value` to `col_id` on each path
+  and fires `cell_changed` per row, so the protocol state tracker's dirty
+  bookkeeping, the Route-Reps-Dur reconciliation, and the device-viewer sync
+  all run exactly as they do for a manual cell edit.
+- `step_type()` — builds a fresh default step row (the dialog's template).
+- `_walk()` / `GroupRow.children` — group traversal.
+
+There is **no undo stack** in this tree (unlike the device viewer), so the apply
+path needs nothing beyond `set_values`.
+
+## Components
+
+### 1. Trigger — `ProtocolTreeWidget._on_context_menu`
+
+Add a **"Bulk Set Values…"** action to the existing right-click menu, beside
+Copy / Cut / Paste / Delete. It calls `_bulk_set_values()`. With no rows
+selected it is a no-op (the dialog never opens).
+
+### 2. `RowManager.steps_under(paths, recursive=False) -> list[Path]`
+
+Resolves a selection into the **step** paths to write to:
+
+- A selected step (`not isinstance(row, GroupRow)`) contributes its own path.
+- A selected group contributes its **direct child steps**, or **all descendant
+  steps** when `recursive` is true (groups themselves are never written to).
+- Result is de-duplicated (a step that is both directly selected and under a
+  selected group appears once) and order-preserving.
+
+Lives on `RowManager` because it derives target rows from the tree structure.
+Pure model logic — unit-testable headless.
+
+### 3. `BulkSetDialog(QDialog)` — new `views/bulk_set_dialog.py`
+
+Built around a throwaway **template step row** = `manager.step_type()`.
+
+- **Settable columns** = columns whose view, evaluated against the template
+  step, is editable or user-checkable: `get_flags(template) & ItemIsEditable`
+  or `& ItemIsUserCheckable`. Read-only columns (type, id, derived cells) and
+  group-only columns are excluded automatically.
+- One grid row per settable column: `[☐ Apply] [col_name] [value widget]`.
+  - Value widget for editable columns: `col.view.create_editor(self, template)`
+    (the column's own line-edit / spinbox / combobox), seeded via
+    `set_editor_data(editor, default)` where `default = col.model.get_value(template)`.
+  - Value widget for checkbox columns (`create_editor` returns `None`, view is
+    checkable): a `QCheckBox`.
+  - The value widget is disabled until its **Apply** box is ticked.
+- Bottom: **`[☐ Apply to all nested groups]`** then `[Cancel] [OK]`.
+- API:
+  - `values() -> dict[str, Any]` — `{col_id: value}` for ticked rows only;
+    editable values via `col.view.get_editor_data(editor)`, checkbox values via
+    `QCheckBox.isChecked()`.
+  - `apply_nested -> bool` — the nested-groups checkbox state.
+
+The template row makes this elegant: the dialog reuses each column's real editor
+widget and value plumbing instead of re-deriving per-type widgets, and the row
+serves as the `create_editor` context for row-dependent bounds (e.g. trail
+overlay ≤ trail length − 1 reads the template's trail length).
+
+### 4. Apply — `ProtocolTreeWidget._bulk_set_values()`
+
+1. `paths = [self._index_to_path(i) for i in self.tree.selectionModel().selectedRows(0)]`
+   (same source `_paste` uses).
+2. If `paths` is empty, return.
+3. `dialog = BulkSetDialog(self._manager, parent=self)`; if `dialog.exec()` is
+   not Accepted, return.
+4. `targets = self._manager.steps_under(paths, recursive=dialog.apply_nested)`.
+5. For each `col_id, value` in `dialog.values().items()`:
+   `self._manager.set_values(targets, col_id, value)`.
+
+## Data flow
+
+```
+right-click → "Bulk Set Values…"
+  → selectedRows → paths
+  → BulkSetDialog(manager) → {col_id: value}, apply_nested
+  → manager.steps_under(paths, recursive=apply_nested) → step paths
+  → manager.set_values(paths, col_id, value)  [per column]
+      → cell_changed per (path, col_id)
+          → protocol_state_tracker (dirty) + Route-Reps-Dur reconcile + DV sync
+```
+
+## Error handling
+
+- Empty selection: no dialog, no-op.
+- Selection containing only groups with no descendant steps: `steps_under`
+  returns `[]`; `set_values([])` is a harmless no-op.
+- Stale paths are not a concern — the dialog is modal, so the tree can't mutate
+  between selection capture and apply.
+
+## Scope / YAGNI
+
+- Targets are always **steps**; groups are only ever expanded, never written
+  to, so no per-row "is this column valid for a group" check is needed.
+- Compound columns whose view exposes no single value widget (`create_editor`
+  is `None` and the view is not checkable) are simply not listed as settable in
+  v1. Per-field bulk-set for compounds can follow later if needed.
+- No undo integration (the tree has no undo stack).
+
+## Testing
+
+- `RowManager.steps_under` (headless): single step; a group → direct children
+  only; a group with `recursive=True` → all descendants; dedup when a step is
+  both directly selected and under a selected group; group with no steps → `[]`.
+- `BulkSetDialog` (with `qapp`): `values()` returns only ticked columns with the
+  edited values; unticked columns are absent; `apply_nested` reflects the
+  checkbox.
+
+## Files
+
+- New: `pluggable_protocol_tree/views/bulk_set_dialog.py`
+- Edit: `pluggable_protocol_tree/views/tree_widget.py` (menu item + `_bulk_set_values`)
+- Edit: `pluggable_protocol_tree/models/row_manager.py` (`steps_under`)
+- Tests: `tests/test_row_manager.py` (or a new `test_bulk_set.py`) + a dialog test.

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -492,6 +492,42 @@ class RowManager(HasTraits):
             fn(self.get_row(p))
         self.rows_changed = True
 
+    def steps_under(self, paths: List[Path], recursive: bool = False) -> List[Path]:
+        """Resolve a selection into the step paths a bulk write should target.
+
+        A selected step contributes its own path; a selected group contributes
+        its direct child steps, or every descendant step when ``recursive``.
+        Groups are never targeted directly. The result is order-preserving and
+        de-duplicated — a step both directly selected and reached under a
+        selected group appears once.
+        """
+        targets: List[Path] = []
+        seen = set()
+
+        def add(path: Path) -> None:
+            key = tuple(path)
+            if key not in seen:
+                seen.add(key)
+                targets.append(key)
+
+        for path in paths:
+            try:
+                row = self.get_row(path)
+            except (IndexError, KeyError):
+                continue
+            if not isinstance(row, GroupRow):
+                add(path)
+            elif recursive:
+                # _walk yields the group itself first, then descendants.
+                for sub_path, sub_row in self._walk(row, tuple(path)):
+                    if sub_row is not row and not isinstance(sub_row, GroupRow):
+                        add(sub_path)
+            else:
+                for i, child in enumerate(row.children):
+                    if not isinstance(child, GroupRow):
+                        add(tuple(path) + (i,))
+        return targets
+
     def _column_by_id(self, col_id: str) -> IColumn:
         for c in self.columns:
             if c.model.col_id == col_id:

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -472,17 +472,22 @@ class RowManager(HasTraits):
 
     # --- imperative bulk write ---
 
-    def set_value(self, path: Path, col_id: str, value) -> None:
-        col = self._column_by_id(col_id)
+    def _set_value(self, path: Path, col: 'IColumn', value):
         row = self.get_row(path)
         col.model.set_value(row, value)
-        self.cell_changed = {"path": tuple(path), "col_id": col_id}
+        # cell_changed carries the per-cell model col_id (NOT col.id, which is
+        # the compound base_id for synthesized field cells) — that's what the
+        # delegate/setData emit and what the tree model + state tracker match on.
+        self.cell_changed = {"path": tuple(path), "col_id": col.model.col_id}
+
+    def set_value(self, path: Path, col_id: str, value) -> None:
+        col = self._column_by_id(col_id)
+        self._set_value(path, col, value)
 
     def set_values(self, paths: List[Path], col_id: str, value) -> None:
         col = self._column_by_id(col_id)
-        for p in paths:
-            col.model.set_value(self.get_row(p), value)
-            self.cell_changed = {"path": tuple(p), "col_id": col_id}
+        for path in paths:
+            self._set_value(path, col, value)
 
     def apply(self, paths: List[Path], fn) -> None:
         # `fn` is arbitrary — could touch any column on any row, or

--- a/pluggable_protocol_tree/tests/test_bulk_set.py
+++ b/pluggable_protocol_tree/tests/test_bulk_set.py
@@ -1,0 +1,81 @@
+"""Tests for bulk-set: RowManager.steps_under + BulkSetDialog (#474)."""
+
+import pytest
+
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+
+
+@pytest.fixture
+def manager():
+    return RowManager(columns=[
+        make_type_column(), make_id_column(),
+        make_name_column(), make_duration_column(),
+    ])
+
+
+# --- RowManager.steps_under ---
+
+def test_steps_under_single_step(manager):
+    s = manager.add_step()
+    assert manager.steps_under([s]) == [(0,)]
+
+
+def test_steps_under_group_first_level_only(manager):
+    g = manager.add_group()                 # (0,)
+    manager.add_step(parent_path=g)         # (0, 0)
+    sub = manager.add_group(parent_path=g)  # (0, 1)
+    manager.add_step(parent_path=sub)       # (0, 1, 0)
+    # Non-recursive: only the group's direct child steps, not the nested one.
+    assert manager.steps_under([g]) == [(0, 0)]
+
+
+def test_steps_under_group_recursive(manager):
+    g = manager.add_group()                 # (0,)
+    manager.add_step(parent_path=g)         # (0, 0)
+    sub = manager.add_group(parent_path=g)  # (0, 1)
+    manager.add_step(parent_path=sub)       # (0, 1, 0)
+    assert manager.steps_under([g], recursive=True) == [(0, 0), (0, 1, 0)]
+
+
+def test_steps_under_dedups_step_and_enclosing_group(manager):
+    g = manager.add_group()                 # (0,)
+    s = manager.add_step(parent_path=g)     # (0, 0)
+    # The step is both directly selected and reached under its group — once.
+    assert manager.steps_under([s, g]) == [(0, 0)]
+
+
+def test_steps_under_empty_group(manager):
+    g = manager.add_group()
+    assert manager.steps_under([g]) == []
+
+
+# --- BulkSetDialog ---
+
+def test_dialog_lists_only_settable_columns(qapp, manager):
+    from pluggable_protocol_tree.views.bulk_set_dialog import BulkSetDialog
+    dialog = BulkSetDialog(manager)
+    settable = set(dialog._rows)
+    assert {"duration_s", "name"} <= settable
+    assert "type" not in settable and "id" not in settable
+
+
+def test_dialog_values_only_includes_ticked_columns(qapp, manager):
+    from pluggable_protocol_tree.views.bulk_set_dialog import BulkSetDialog
+    dialog = BulkSetDialog(manager)
+    assert dialog.values() == {}
+    apply_checkbox, _reader = dialog._rows["duration_s"]
+    apply_checkbox.setChecked(True)
+    # The editor was seeded with the template's default duration.
+    assert dialog.values() == {"duration_s": manager.step_type().duration_s}
+
+
+def test_dialog_apply_nested_flag(qapp, manager):
+    from pluggable_protocol_tree.views.bulk_set_dialog import BulkSetDialog
+    dialog = BulkSetDialog(manager)
+    assert dialog.apply_nested is False
+    dialog.nested_checkbox.setChecked(True)
+    assert dialog.apply_nested is True

--- a/pluggable_protocol_tree/views/bulk_set_dialog.py
+++ b/pluggable_protocol_tree/views/bulk_set_dialog.py
@@ -1,0 +1,139 @@
+"""Bulk Set Values dialog for the pluggable protocol tree (issue #474).
+
+Lets the user write one or more column values across every selected step in a
+single action. Built around a throwaway *template* step row
+(``manager.step_type()``): each settable column reuses its own editor widget
+(line edit / spin box / combo box) and value plumbing via the column view, so
+the dialog never reimplements per-type widgets. Checkbox columns — whose view
+has no editor widget — get a plain QCheckBox.
+
+The caller reads back ``values()`` (``{col_id: value}`` for the ticked rows)
+and ``apply_nested`` and applies them with ``RowManager.set_values`` /
+``steps_under``.
+"""
+
+from pyface.qt.QtCore import Qt
+from pyface.qt.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QGridLayout,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+
+class BulkSetDialog(QDialog):
+    """Pick one or more column values to apply across the selected steps.
+
+    Args:
+        manager: the RowManager — supplies the column set and a template step
+            row for seeding editors / resolving editor bounds.
+        parent: parent QWidget.
+    """
+
+    def __init__(self, manager, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Bulk Set Values")
+        self._manager = manager
+        # A default step row: the editor context (row-dependent bounds read it)
+        # and the source of each column's seed value.
+        self._template = manager.step_type()
+        # col_id -> (apply_checkbox, value_reader)
+        self._rows = {}
+
+        outer = QVBoxLayout(self)
+
+        intro = QLabel(
+            "Tick the parameters to set and choose their values. They are "
+            "applied to every selected step."
+        )
+        intro.setWordWrap(True)
+        outer.addWidget(intro)
+
+        grid_host = QWidget()
+        grid = QGridLayout(grid_host)
+        grid.setColumnStretch(1, 1)
+        row = 0
+        for column in manager.columns:
+            built = self._build_column_row(column)
+            if built is None:
+                continue
+            apply_checkbox, value_widget = built
+            grid.addWidget(apply_checkbox, row, 0)
+            grid.addWidget(value_widget, row, 1)
+            row += 1
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(grid_host)
+        outer.addWidget(scroll, 1)
+
+        self.nested_checkbox = QCheckBox("Apply to all nested groups")
+        outer.addWidget(self.nested_checkbox)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        outer.addWidget(buttons)
+
+    def _build_column_row(self, column):
+        """Return ``(apply_checkbox, value_widget)`` for a settable column, or
+        None for a column that can't be bulk-set.
+
+        Settable = the column view is editable or user-checkable on a step.
+        Read-only columns (type, id, derived cells) and group-only columns are
+        excluded automatically. Records a value reader in ``self._rows``.
+        """
+        flags = column.view.get_flags(self._template)
+        editable = bool(flags & Qt.ItemIsEditable)
+        checkable = bool(flags & Qt.ItemIsUserCheckable)
+        if not (editable or checkable):
+            return None
+
+        default = column.model.get_value(self._template)
+        apply_checkbox = QCheckBox(column.model.col_name)
+
+        if editable:
+            value_widget = column.view.create_editor(self, self._template)
+            if value_widget is None:
+                # Editable flag but no editor widget — nothing to bulk-set.
+                return None
+            column.view.set_editor_data(value_widget, default)
+            reader = (
+                lambda col=column, w=value_widget: col.view.get_editor_data(w)
+            )
+        else:
+            # Checkbox column: the view edits via the Qt check role, not an
+            # editor widget, so present a plain checkbox seeded with the default.
+            value_widget = QCheckBox()
+            value_widget.setChecked(bool(default))
+            reader = lambda w=value_widget: w.isChecked()
+
+        # The value only matters once the user opts the column in.
+        value_widget.setEnabled(False)
+        apply_checkbox.toggled.connect(value_widget.setEnabled)
+
+        self._rows[column.model.col_id] = (apply_checkbox, reader)
+        return apply_checkbox, value_widget
+
+    def values(self) -> dict:
+        """``{col_id: value}`` for every ticked Apply row (others omitted)."""
+        return {
+            col_id: reader()
+            for col_id, (apply_checkbox, reader) in self._rows.items()
+            if apply_checkbox.isChecked()
+        }
+
+    @property
+    def apply_nested(self) -> bool:
+        """Whether to recurse into nested groups when expanding selected groups."""
+        return self.nested_checkbox.isChecked()

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -5,11 +5,14 @@ from pyface.qt.QtCore import (
     Qt, QItemSelectionModel, QModelIndex, Signal,
 )
 from pyface.qt.QtGui import QKeySequence, QShortcut
-from pyface.qt.QtWidgets import QWidget, QVBoxLayout, QTreeView, QMenu, QAbstractItemView
+from pyface.qt.QtWidgets import (
+    QWidget, QVBoxLayout, QTreeView, QMenu, QAbstractItemView, QDialog,
+)
 
 from pluggable_protocol_tree.models.row import GroupRow
 from pluggable_protocol_tree.models.row_manager import RowManager
 from pluggable_protocol_tree.services.preferences import ProtocolPreferences
+from pluggable_protocol_tree.views.bulk_set_dialog import BulkSetDialog
 from pluggable_protocol_tree.views.delegate import ProtocolItemDelegate
 from pluggable_protocol_tree.views.qt_tree_model import MvcTreeModel
 
@@ -201,6 +204,8 @@ class ProtocolTreeWidget(QWidget):
         menu.addAction("Cut", self._cut)
         menu.addAction("Paste", self._paste)
         menu.addSeparator()
+        menu.addAction("Bulk Set Values…", self._bulk_set_values)
+        menu.addSeparator()
         menu.addAction("Delete", self._delete_selection)
         menu.exec(self.tree.viewport().mapToGlobal(pos))
 
@@ -289,6 +294,32 @@ class ProtocolTreeWidget(QWidget):
             self._manager.paste(target_path=target)
         except Exception:
             logger.exception("Paste failed")
+
+    def _bulk_set_values(self):
+        """Open the Bulk Set dialog and apply the chosen values to every
+        selected step. Groups expand to their child steps — first level only,
+        or all descendants when 'Apply to all nested groups' is ticked."""
+        paths = [self._index_to_path(i)
+                 for i in self.tree.selectionModel().selectedRows(0)]
+        if not paths:
+            return
+        dialog = BulkSetDialog(self._manager, parent=self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        updates = dialog.values()
+        targets = self._manager.steps_under(paths, recursive=dialog.apply_nested)
+        if not updates or not targets:
+            return
+        # Direct model writes (set_values) rather than per-row handler
+        # on_interact: a bulk action must not pop the per-cell confirm dialogs
+        # some handlers raise (e.g. route_repetitions). The pane's cell_changed
+        # reconciliation still runs for derived columns.
+        for col_id, value in updates.items():
+            self._manager.set_values(targets, col_id, value)
+        logger.info(
+            f"Bulk set {list(updates)} on {len(targets)} step(s) "
+            f"(nested={dialog.apply_nested})"
+        )
 
     def _delete_selection(self):
         """Remove the currently-selected rows. Defensive: stale paths


### PR DESCRIPTION
Closes #474.

Mirror of legacy `protocol_grid` bulk-apply (#167 + #285) for the pluggable protocol tree.

## UX
Right-click in the tree → **"Bulk Set Values…"** → a dialog with one row per settable column: a **per-column "Apply" checkbox** gating the column's own editor, plus an **"Apply to all nested groups"** checkbox. On OK, each ticked value is written to every selected step. A selected **group** expands to its **first-level child steps**, or **all descendant steps** when the nested checkbox is ticked.

## Design
- **`RowManager.steps_under(paths, recursive=False)`** — resolves the selection to deduped, order-preserving **step** paths (groups are only expanded, never written to).
- **`BulkSetDialog`** — built around a throwaway template step row (`manager.step_type()`) so each column reuses its real editor widget + value plumbing (`create_editor` / `set_editor_data` / `get_editor_data`); checkbox columns get a `QCheckBox`. Settable = view is editable or checkable on a step, so read-only columns (type, id, derived cells) are excluded automatically. Exposes `values()` and `apply_nested`.
- **Apply** uses `RowManager.set_values(paths, col_id, value)` (already fires `cell_changed` per row → dirty tracking, Route-Reps-Dur reconciliation, and DV sync all run). The direct model write is deliberate: a bulk action must not pop the per-cell confirm dialogs some handlers raise in `on_interact` (e.g. `route_repetitions`).

No undo stack exists in this tree, so nothing else is needed.

## Tests
`steps_under` (single step, group first-level-only, group recursive, dedup of a step under a selected group, empty group) and `BulkSetDialog` (only settable columns listed, `values()` includes only ticked columns, `apply_nested` flag). 8 tests, all green locally.

## Known v1 limitation
Row-dependent editor bounds (e.g. trail-overlay ≤ trail-length−1) use the template row's default, so trail-overlay bulk-set is conservatively bounded. Noted in the design spec (`docs/superpowers/specs/2026-06-16-bulk-set-values-protocol-tree-design.md`).
