### PR TITLE
Lock realtime icon during protocol run; revert restores ack-grid display names

### DIFF
--- a/microdrop_application/preferences_dialog.py
+++ b/microdrop_application/preferences_dialog.py
@@ -109,6 +109,15 @@ class PreferencesDialog(_PreferencesDialog):
         # revert on closing the dialog window which did not even do anything since the super class revert returned nothing.
         # Since we are changing the revert to do changes, we need to make sure to avoid the revert call on dialog close.
 
+        def _choose_preference_trait_for_revert(trait_name):
+            # Persisted preference traits revert to their defaults, except those
+            # tagged `no_revert=True` in their declaration, which keep their
+            # current value when the user presses Revert.
+            return (
+                pane._model._is_preference_trait(trait_name)
+                and not pane._model.trait(trait_name).no_revert
+            )
+
         if info.ui.control.isVisible():
 
             # find all the panes in the selected tab, and reset their preference traits.
@@ -116,10 +125,12 @@ class PreferencesDialog(_PreferencesDialog):
 
                 trait_names = list(
                     filter(
-                        pane._model._is_preference_trait,
+                        _choose_preference_trait_for_revert,
                         pane._model.trait_names(),
                     )
                 )
+
+
 
                 pane._model.reset_traits(trait_names)
 

--- a/microdrop_utils/pyside_helpers.py
+++ b/microdrop_utils/pyside_helpers.py
@@ -572,9 +572,10 @@ class ClickableToggleIcon(QLabel):
     """
     toggled = Signal(bool)
 
-    def __init__(self, icon_str, active_inactive_stylesheets: tuple, active_inactive_tooptips: tuple, parent=None):
+    def __init__(self, icon_str, active_inactive_stylesheets: tuple, active_inactive_tooptips: tuple, locked_tooltip: str = None, parent=None):
         super().__init__(icon_str, parent)
         self.is_active = False
+        self._locked = False
 
         self._active_stylesheet = active_inactive_stylesheets[0]
         self._inactive_stylesheet = active_inactive_stylesheets[1]
@@ -583,6 +584,7 @@ class ClickableToggleIcon(QLabel):
         self._active_tooltip = active_inactive_tooptips[0]
         self._inactive_tooltip = active_inactive_tooptips[1]
         self._disabled_tooltip = active_inactive_tooptips[2] if len(active_inactive_tooptips) > 2 else self._inactive_tooltip
+        self._locked_tooltip = locked_tooltip
 
         self.setCursor(Qt.PointingHandCursor)
         self.update_style()
@@ -591,11 +593,27 @@ class ClickableToggleIcon(QLabel):
 
     def setEnabled(self, enabled):
         super().setEnabled(enabled)
-        self.setCursor(Qt.PointingHandCursor if enabled else Qt.ArrowCursor)
+        self._update_cursor()
         self.update_style()
 
+    def setLocked(self, locked):
+        """Lock the icon: keep its active/inactive appearance but ignore clicks.
+
+        Distinct from disabling — used when the control is temporarily
+        unavailable for a reason other than being offline/greyed-out
+        (e.g. a protocol is running), so greying it out or showing the
+        "disconnected" tooltip would be misleading.
+        """
+        self._locked = locked
+        self._update_cursor()
+        self.update_style()
+
+    def _update_cursor(self):
+        interactive = self.isEnabled() and not self._locked
+        self.setCursor(Qt.PointingHandCursor if interactive else Qt.ArrowCursor)
+
     def mousePressEvent(self, event):
-        if event.button() == Qt.LeftButton and self.isEnabled():
+        if event.button() == Qt.LeftButton and self.isEnabled() and not self._locked:
             self.is_active = not self.is_active
             self.update_style()
             self.toggled.emit(self.is_active)
@@ -608,6 +626,9 @@ class ClickableToggleIcon(QLabel):
         if not self.isEnabled():
             self.setToolTip(self._disabled_tooltip)
             self.setStyleSheet(self._disabled_stylesheet + _tooltip_style)
+        elif self._locked:
+            self.setToolTip(self._locked_tooltip)
+            self.setStyleSheet((self._active_stylesheet if self.is_active else self._inactive_stylesheet) + _tooltip_style)
         elif self.is_active:
             self.setToolTip(self._active_tooltip)
             self.setStyleSheet(self._active_stylesheet + _tooltip_style)

--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesCategory, PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Bool, Dict, Directory, Enum, Float, Str
+from traits.api import Bool, Dict, Directory, Enum, Float, Str, observe
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import Group, View, Item
 
@@ -109,22 +109,32 @@ class ProtocolPreferences(PreferencesHelper):
     # item): {col_id: display col_name} so the ack-wait grid shows
     # "Electrodes" / "Voltage (V)" while staying keyed by the stable
     # col_id. Refreshed on every seed — display names follow provider
-    # renames, they are not user edits.
+    # renames, they are not user edits. Reverts to
+    # protocol_tree_default_column_names (the default method below) so a
+    # Settings-dialog revert rebuilds the grid with the right display
+    # names alongside the reverted values, instead of blanking them.
     protocol_tree_column_names = Dict(Str, Str)
 
-    # Persisted snapshot of the plugin providers' default_ack_time_s
-    # values ({col_id: seconds}). This is what a Settings-dialog revert
-    # restores: reverting resets protocol_tree_ack_times to its default,
-    # and the default method below reads this trait. Seeding rewrites it
-    # only when the contributed defaults actually differ from what is
-    # stored — the boot-time load of saved USER values never touches it
-    # (a module-global backup tried this before and got overwritten with
+    # Persisted snapshots of the plugin providers' contributed values:
+    # default_ack_time_s ({col_id: seconds}) and display name
+    # ({col_id: col_name}). These are what a Settings-dialog revert
+    # restores: reverting resets protocol_tree_ack_times /
+    # protocol_tree_column_names to their defaults, and the default
+    # methods below read these traits. Seeding rewrites each only when
+    # the contributed values actually differ from what is stored — the
+    # boot-time load of saved USER values never touches them (a
+    # module-global backup tried this before and got overwritten with
     # the user's values on every launch, making revert a no-op).
-    protocol_tree_default_ack_times = Dict(Str, Float)
+    protocol_tree_default_ack_times = Dict(Str, Float, no_revert=True)
+    protocol_tree_default_column_names = Dict(Str, Str, no_revert=True)
 
     def _protocol_tree_ack_times_default(self):
-        # Copy: the snapshot must not alias the live trait dict.
+        # Copy: the live dict must not alias the snapshot dict.
         return dict(self.protocol_tree_default_ack_times)
+
+    def _protocol_tree_column_names_default(self):
+        # Copy: the live dict must not alias the snapshot dict.
+        return dict(self.protocol_tree_default_column_names)
 
     def _PROTOCOL_REPO_DIR_default(self) -> Path:
         default_dir = Path(ETSConfig.user_data) / "Protocols"
@@ -144,11 +154,13 @@ class ProtocolPreferences(PreferencesHelper):
         A persisted user edit wins over the provider default; entries
         whose key matches no current column are dropped, so the grid
         always mirrors the live column set.
-        ``protocol_tree_default_ack_times`` (the revert snapshot) and
+        ``protocol_tree_default_ack_times`` /
+        ``protocol_tree_default_column_names`` (the revert snapshots) and
         ``protocol_tree_column_names`` (column.id -> display name) are
         rebuilt alongside — provider data, not user edits."""
         default_ack_times = {}
-        column_names = {}
+        default_column_names = {}
+
         for column in columns:
             default_ack_time_s = float(
                 getattr(column.handler, "default_ack_time_s", 0.0) or 0.0)
@@ -168,18 +180,22 @@ class ProtocolPreferences(PreferencesHelper):
                 or getattr(column.model, "col_name", "")
                 or (field_specs()[0].col_name if field_specs else column.id)
             )
-            column_names.setdefault(column.id, display_name)
+            default_column_names.setdefault(column.id, display_name)
             default_ack_times[column.id] = default_ack_time_s
+        # User edits win over provider defaults for ack times; display
+        # names are provider-only, so the live map mirrors the defaults.
         ack_times = {
             col_id: self.protocol_tree_ack_times.get(col_id, default_ack_time_s)
             for col_id, default_ack_time_s in default_ack_times.items()
         }
         if default_ack_times != self.protocol_tree_default_ack_times:
             self.protocol_tree_default_ack_times = default_ack_times
+        if default_column_names != self.protocol_tree_default_column_names:
+            self.protocol_tree_default_column_names = default_column_names
         if ack_times != self.protocol_tree_ack_times:
             self.protocol_tree_ack_times = ack_times
-        if column_names != self.protocol_tree_column_names:
-            self.protocol_tree_column_names = column_names
+        if default_column_names != self.protocol_tree_column_names:
+            self.protocol_tree_column_names = default_column_names
 
 
 protocol_tree_tab = PreferencesCategory(

--- a/template_status_and_controls/base_dock_pane.py
+++ b/template_status_and_controls/base_dock_pane.py
@@ -111,6 +111,12 @@ class BaseStatusDockPane(TraitsDockPane):
     # ------------------------------------------------------------------ #
     # Status-bar icon                                                       #
     # ------------------------------------------------------------------ #
+    @observe("model.icon_color", dispatch="ui")
+    def _sync_model_icon_color(self, event):
+        """Keep the icon color in sync with the model's connection state."""
+        if hasattr(self, "status_bar_icon"):
+            self.status_bar_icon.setStyleSheet(f"color: {event.new}")
+
     @observe("task:window:status_bar_manager")
     def _setup_statusbar_icon(self, event):
 
@@ -122,9 +128,6 @@ class BaseStatusDockPane(TraitsDockPane):
         icon = QLabel(ICON_DROP_EC)
         icon.setFont(font)
         icon.setStyleSheet(f"color: {self.model.DISCONNECTED_COLOR}")
-
-        # Keep the icon color in sync with the model's connection state.
-        self.model.observe(lambda e: icon.setStyleSheet(f"color: {e.new}"), "icon_color")
 
         self.status_bar_icon = icon
 
@@ -150,7 +153,8 @@ class BaseStatusDockPane(TraitsDockPane):
             "Click to <b>enable</b> realtime mode",
             "Cannot enable realtime mode. No device <b>connection</b>",
         )
-        self.realtime_mode_icon = ClickableToggleIcon("live_tv", active_inactive_disabled_styles, active_inactive_disabled_tooltips)
+        realtime_mode_locked_tooltip = "Realtime mode is locked while a <b>protocol</b> is running"
+        self.realtime_mode_icon = ClickableToggleIcon("live_tv", active_inactive_disabled_styles, active_inactive_disabled_tooltips, locked_tooltip=realtime_mode_locked_tooltip)
         self.realtime_mode_icon.setFont(font)
         self.realtime_mode_icon.toggled.connect(lambda is_active: publish_message(topic=SET_REALTIME_MODE, message=str(is_active)))
 
@@ -160,19 +164,22 @@ class BaseStatusDockPane(TraitsDockPane):
         self.task.window.status_bar_manager.status_bar.insertPermanentWidget(2, horizontal_spacer_widget(10))
 
         # initial check: enable / disable icon based on initial connection status
-        self._enable_relatime_icon_based_on_modes()
+        self._enable_realtime_icon_based_on_modes()
 
-    @observe("model.connected")
-    @observe("model.protocol_running")
-    def _enable_relatime_icon_based_on_modes(self, event=None):
-        self.realtime_mode_icon.setEnabled(self.model.connected and not self.model.protocol_running)
+    @observe("model.connected", dispatch="ui")
+    @observe("model.protocol_running", dispatch="ui")
+    def _enable_realtime_icon_based_on_modes(self, event=None):
+        # Disabled (greyed + "no connection" tooltip) reflects connection only.
+        # While connected and a protocol is running, lock the icon instead:
+        # it keeps its normal appearance but is non-interactive.
+        self.realtime_mode_icon.setEnabled(self.model.connected)
+        self.realtime_mode_icon.setLocked(self.model.connected and self.model.protocol_running)
 
     # Sync icon state with model
-    @observe("model.realtime_mode")
+    @observe("model.realtime_mode", dispatch="ui")
     def _sync_realtime_icon(self, event):
         self.realtime_mode_icon.is_active = event.new
         self.realtime_mode_icon.update_style()
-
 
 def _build_status_icon_tooltip(
         disconnected_color,


### PR DESCRIPTION
## Summary

Three related UI/preferences fixes from one session.

### 1. Lock the realtime-mode status icon during a protocol run
`ClickableToggleIcon` previously conflated **disabled** (greyed out + "no device connection" tooltip + arrow cursor) with **non-interactive**. While the device is connected and a protocol is running, disabling the icon showed a misleading greyed/"no connection" state.

A new **locked** state keeps the icon's normal active/inactive appearance and shows a context tooltip ("Realtime mode is locked while a protocol is running"), but ignores clicks and uses an arrow cursor. The status dock pane now drives `setEnabled` from connection only and `setLocked` from connected-and-protocol-running.

### 2. `no_revert` trait metadata for the Settings dialog
Revert reset every preference trait to its default. It now skips traits declared with `no_revert=True`, using Traits metadata instead of a trait-name suffix — so persisted snapshots survive a revert.

### 3. Restore the ack-wait grid display names on revert
Column display names are now tracked alongside ack times so a Settings-dialog revert rebuilds the **Column Ack Wait Times** grid with the right labels *and* values, instead of blanking the names. Also fixes a latent `NameError` in `seed_ack_times_from_columns` and decouples the two snapshot writes so a provider rename refreshes names even when ack times are unchanged.

## Testing
Not run — changes verified by inspection; manual testing pending per usual workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)