### PR TITLE
Protocol timeline seek bar: scrub steps/phases, collapse repetitions

### DIFF
--- a/docs/superpowers/plans/2026-06-18-protocol-timeline-seek-bar.md
+++ b/docs/superpowers/plans/2026-06-18-protocol-timeline-seek-bar.md
@@ -1,0 +1,595 @@
+# Protocol Timeline Seek Bar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a video-style timeline seek bar to the pluggable protocol tree — a horizontal track with a tick per step and a draggable playhead, plus a secondary phase track for the current step — that redirects all navigation intent through the existing dock-pane controller.
+
+**Architecture:** A new pure-Qt `TimelineBar` view emits `step_seek_requested(int)` / `phase_seek_requested(int)` intents and exposes `rebuild()` / `set_position()` / `set_running()` push methods. The existing `PluggableProtocolDockPane` (the controller) connects those intents to the already-built `ProtocolStatusController.seek_to(step_path, phase_index)` + `preview_phase(...)` and pushes model state into the bar via its existing `dispatch="ui"` model observers. No new model; no executor changes.
+
+**Tech Stack:** Python, Traits/`@observe`, PySide6 via `pyface.qt`, pytest with the project's `qapp` fixture.
+
+## Global Constraints
+
+- Qt is imported **only** in view code. `TimelineBar` is a view, so Qt imports are allowed there; the controller wiring lives in the existing view file `views/dock_pane.py`. (microdrop-conventions: "never import Qt in service/model layers".)
+- Logging: `from logger.logger_service import get_logger; logger = get_logger(__name__)` — never `logging.getLogger`.
+- Use f-strings; no `%`/`.format()`.
+- Constants are `UPPER_SNAKE_CASE` at the top of the module (below imports).
+- Reuse existing names; do not mint parallel constants/helpers. The phase seek reuses the existing `seek_to` 0-based `phase_index` convention.
+- Steps-only track; phase sub-ticks appear **only** for the current step (granularity 1C). No group tier.
+- Seeking is always interactive; while **actively running (not paused)** a scrub is **preview-only** (B1) — `seek_to`'s executor side is paused-guarded, so it updates the model + DeviceViewer overlay and the executor reasserts at the next boundary. No executor changes.
+- View tests need no Redis/hardware → they live in the top-level `pluggable_protocol_tree/tests/` dir and use the `qapp` fixture.
+- **Working directory:** run all `git`, `pytest`, and `pixi` commands from the **`microdrop-py/src` submodule** (the inner git repo and Python source root). All paths below are relative to that directory. Python/pytest are invoked through `pixi` per the project's verified invocation (see the `pixi-python-invocation` memory) — if `pixi run python -m pytest <path>` differs in your env, match how the existing `pluggable_protocol_tree/tests` are run.
+
+## File Structure
+
+- **Create** `pluggable_protocol_tree/views/timeline_bar.py` — the `TimelineBar` `QWidget` (view only: paint + intent signals + push API).
+- **Create** `pluggable_protocol_tree/tests/test_timeline_bar.py` — unit tests for the widget (`qapp`).
+- **Modify** `pluggable_protocol_tree/views/protocol_tree_pane.py` — build `self.timeline_bar` and place it directly under the nav bar in `_build_layout`.
+- **Modify** `pluggable_protocol_tree/tests/test_protocol_tree_pane.py` — assert the pane exposes & places `timeline_bar`.
+- **Modify** `pluggable_protocol_tree/views/dock_pane.py` — connect the bar's intents to `seek_to`/`preview_phase`, push model state into the bar, refactor `_seek_relative_phase` to reuse a new `_seek_to_phase`.
+
+### Index alignment decision (resolves the spec's open item)
+
+The timeline's tick list is `ProtocolTreePane._navigable_steps()` — the same distinct-step-rows-in-execution-order list the nav buttons walk (repetitions collapsed to one entry per row). The playhead index is `dock_pane._current_step_in(steps)` (the same helper the nav buttons use). This keeps the timeline, the nav buttons, and `_select_step` perfectly aligned and sidesteps the execution-frame-vs-navigable-step mismatch. Phase position comes from the model's `phase_index` (1-based) / `phase_total`, which the controller already maintains for the executing/paused step.
+
+---
+
+### Task 1: `TimelineBar` view widget
+
+**Files:**
+- Create: `pluggable_protocol_tree/views/timeline_bar.py`
+- Test: `pluggable_protocol_tree/tests/test_timeline_bar.py`
+
+**Interfaces:**
+- Consumes: nothing (leaf view).
+- Produces:
+  - Signals: `step_seek_requested = Signal(int)` (0-based step index), `phase_seek_requested = Signal(int)` (0-based phase index).
+  - `rebuild(step_labels: list[str]) -> None` — set the major-tick count (`len(step_labels)`) and per-tick hover labels.
+  - `set_position(step_index: int, step_total: int, phase_index: int, phase_total: int) -> None` — move the step playhead (`step_index`, use `-1` for "none") and draw the phase track for the current step (`phase_index` 0-based, `phase_total`; phase track shown only when `phase_total > 1`).
+  - `set_running(running: bool) -> None` — toggle the preview-mode accent; the bar stays interactive.
+  - Pure helpers (for tests): `_step_index_at_x(x: int) -> int`, `_phase_index_at_x(x: int) -> int`, `_seek_at_point(point) -> None` (dispatches to the correct signal by which track row contains `point`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pluggable_protocol_tree/tests/test_timeline_bar.py`:
+
+```python
+"""TimelineBar is a pure rendering/intent widget: it paints a step track
+(one tick per step) plus a phase track for the current step, and emits
+step_seek_requested / phase_seek_requested when the user clicks a track.
+It holds no engine references and performs no seeking itself."""
+
+from pyface.qt.QtCore import QPoint
+from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+
+WIDTH = 400
+
+
+def _bar(qapp, labels=("S0", "S1", "S2", "S3")):
+    bar = TimelineBar()
+    bar.rebuild(list(labels))
+    bar.resize(WIDTH, bar.height())
+    return bar
+
+
+def test_rebuild_sets_step_count(qapp):
+    bar = _bar(qapp)
+    assert bar.step_count == 4
+
+
+def test_step_index_at_x_maps_across_width(qapp):
+    bar = _bar(qapp)
+    # 4 steps across the usable width -> first quarter is step 0, last is 3.
+    assert bar._step_index_at_x(bar._step_track_rect().left() + 1) == 0
+    assert bar._step_index_at_x(bar._step_track_rect().right() - 1) == 3
+
+
+def test_step_index_at_x_is_clamped(qapp):
+    bar = _bar(qapp)
+    assert bar._step_index_at_x(-50) == 0
+    assert bar._step_index_at_x(WIDTH + 50) == 3
+
+
+def test_click_on_step_track_emits_step_seek(qapp):
+    bar = _bar(qapp)
+    bar.set_position(0, 4, 0, 0)
+    captured = []
+    bar.step_seek_requested.connect(captured.append)
+    r = bar._step_track_rect()
+    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
+    assert captured == [3]
+
+
+def test_phase_track_hidden_without_multiple_phases(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 1)  # phase_total == 1 -> no phase track
+    assert bar._phase_track_visible() is False
+
+
+def test_click_on_phase_track_emits_phase_seek(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 5)  # current step has 5 phases
+    captured = []
+    bar.phase_seek_requested.connect(captured.append)
+    r = bar._phase_track_rect()
+    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
+    assert captured == [4]
+
+
+def test_set_running_does_not_break_interaction(qapp):
+    bar = _bar(qapp)
+    bar.set_position(0, 4, 0, 0)
+    bar.set_running(True)
+    captured = []
+    bar.step_seek_requested.connect(captured.append)
+    r = bar._step_track_rect()
+    bar._seek_at_point(QPoint(r.left() + 1, r.center().y()))
+    assert captured == [0]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run python -m pytest pluggable_protocol_tree/tests/test_timeline_bar.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'pluggable_protocol_tree.views.timeline_bar'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `pluggable_protocol_tree/views/timeline_bar.py`:
+
+```python
+"""TimelineBar — a video-style seek strip for the pluggable protocol tree.
+
+Pure view: it paints a step track (one tick per navigable step) with a
+playhead, and — only when the current step has more than one phase — a
+secondary phase track beneath it. Clicking either track emits an intent
+signal; the dock-pane controller translates that into a status-controller
+seek. The widget holds no engine references and never seeks itself.
+
+Mirrors NavigationBar's conventions: hugs its height (Expanding/Fixed),
+re-applies theme colours on colorSchemeChanged (deferred one event-loop
+tick, since is_dark_mode() can be briefly stale at signal time).
+"""
+
+from pyface.qt.QtCore import Qt, QRect, QTimer, Signal
+from pyface.qt.QtGui import QColor, QPainter, QPen
+from pyface.qt.QtWidgets import QApplication, QSizePolicy, QWidget
+
+from microdrop_style.colors import BLACK, GREY, SECONDARY_SHADE, WHITE
+from microdrop_style.helpers import is_dark_mode
+
+# Layout geometry (px). The widget is a fixed-height strip; the step track
+# sits on top, the phase track (shown only for multi-phase current steps)
+# directly below it.
+SIDE_MARGIN = 8
+BAR_HEIGHT = 34
+STEP_TRACK_TOP = 6
+STEP_TRACK_BOTTOM = 18
+PHASE_TRACK_TOP = 21
+PHASE_TRACK_BOTTOM = 29
+
+
+class TimelineBar(QWidget):
+    step_seek_requested = Signal(int)
+    phase_seek_requested = Signal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setFixedHeight(BAR_HEIGHT)
+        self.setMouseTracking(True)
+
+        self.step_count = 0
+        self._step_labels = []
+        self._step_index = -1
+        self._phase_index = 0
+        self._phase_total = 0
+        self._running = False
+
+        QApplication.styleHints().colorSchemeChanged.connect(
+            self._on_color_scheme_changed,
+        )
+
+    # --- push API (driven by the dock-pane controller) ---------------
+
+    def rebuild(self, step_labels):
+        self._step_labels = list(step_labels)
+        self.step_count = len(self._step_labels)
+        self.update()
+
+    def set_position(self, step_index, step_total, phase_index, phase_total):
+        # step_total is accepted for API symmetry with the status bar, but the
+        # tick count comes from rebuild()'s label list; trust step_count.
+        self._step_index = step_index
+        self._phase_index = phase_index
+        self._phase_total = phase_total
+        self.setToolTip(self._current_label())
+        self.update()
+
+    def set_running(self, running):
+        self._running = bool(running)
+        self.update()
+
+    # --- geometry / hit testing --------------------------------------
+
+    def _usable_width(self):
+        return max(1, self.width() - 2 * SIDE_MARGIN)
+
+    def _step_track_rect(self):
+        return QRect(SIDE_MARGIN, STEP_TRACK_TOP,
+                     self._usable_width(), STEP_TRACK_BOTTOM - STEP_TRACK_TOP)
+
+    def _phase_track_rect(self):
+        return QRect(SIDE_MARGIN, PHASE_TRACK_TOP,
+                     self._usable_width(), PHASE_TRACK_BOTTOM - PHASE_TRACK_TOP)
+
+    def _phase_track_visible(self):
+        return self._phase_total > 1
+
+    def _index_at_x(self, x, count):
+        if count <= 0:
+            return 0
+        seg = self._usable_width() / count
+        idx = int((x - SIDE_MARGIN) / seg)
+        return max(0, min(count - 1, idx))
+
+    def _step_index_at_x(self, x):
+        return self._index_at_x(x, self.step_count)
+
+    def _phase_index_at_x(self, x):
+        return self._index_at_x(x, self._phase_total)
+
+    def _seek_at_point(self, point):
+        if self._phase_track_visible() and self._phase_track_rect().contains(point):
+            self.phase_seek_requested.emit(self._phase_index_at_x(point.x()))
+        elif self._step_track_rect().contains(point):
+            self.step_seek_requested.emit(self._step_index_at_x(point.x()))
+
+    # --- mouse ------------------------------------------------------
+
+    def _event_point(self, event):
+        # PySide6: QMouseEvent.position() returns QPointF; older shims use pos().
+        if hasattr(event, "position"):
+            return event.position().toPoint()
+        return event.pos()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._seek_at_point(self._event_point(event))
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        # Scrub: while the left button is held, keep emitting as the pointer
+        # crosses ticks. Qt coalesces move events, so this is not per-pixel.
+        if event.buttons() & Qt.LeftButton:
+            self._seek_at_point(self._event_point(event))
+        super().mouseMoveEvent(event)
+
+    # --- labels / theme ---------------------------------------------
+
+    def _current_label(self):
+        if 0 <= self._step_index < len(self._step_labels):
+            return self._step_labels[self._step_index]
+        return ""
+
+    def _on_color_scheme_changed(self, *_):
+        QTimer.singleShot(0, self.update)
+
+    def _colors(self):
+        if is_dark_mode():
+            return dict(track=GREY["dark"], tick=GREY["lighter"], text=WHITE,
+                        head=SECONDARY_SHADE[300])
+        return dict(track=GREY["light"], tick=GREY["dark"], text=BLACK,
+                    head=SECONDARY_SHADE[700])
+
+    # --- paint ------------------------------------------------------
+
+    def _tick_center_x(self, index, count):
+        seg = self._usable_width() / max(1, count)
+        return int(SIDE_MARGIN + (index + 0.5) * seg)
+
+    def _paint_track(self, painter, rect, count, position, colors):
+        painter.setPen(QPen(QColor(colors["track"]), 2))
+        mid_y = rect.center().y()
+        painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
+        painter.setPen(QPen(QColor(colors["tick"]), 1))
+        for i in range(count):
+            x = self._tick_center_x(i, count)
+            painter.drawLine(x, rect.top(), x, rect.bottom())
+        if 0 <= position < count:
+            head_x = self._tick_center_x(position, count)
+            head_color = SECONDARY_SHADE[300] if self._running else colors["head"]
+            painter.setPen(QPen(QColor(head_color), 3))
+            painter.drawLine(head_x, rect.top() - 2, head_x, rect.bottom() + 2)
+
+    def paintEvent(self, event):
+        if self.step_count <= 0:
+            return
+        colors = self._colors()
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        self._paint_track(painter, self._step_track_rect(),
+                          self.step_count, self._step_index, colors)
+        if self._phase_track_visible():
+            self._paint_track(painter, self._phase_track_rect(),
+                              self._phase_total, self._phase_index, colors)
+        painter.end()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run python -m pytest pluggable_protocol_tree/tests/test_timeline_bar.py -v`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/timeline_bar.py \
+        pluggable_protocol_tree/tests/test_timeline_bar.py
+git commit -m "feat(protocol-tree): add TimelineBar seek widget (view)"
+```
+
+---
+
+### Task 2: Mount `TimelineBar` under the nav bar in `ProtocolTreePane`
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/protocol_tree_pane.py` (`__init__` build section near line 163-164; `_build_layout` at lines 249-258)
+- Test: `pluggable_protocol_tree/tests/test_protocol_tree_pane.py`
+
+**Interfaces:**
+- Consumes: `TimelineBar` from Task 1.
+- Produces: `pane.timeline_bar: TimelineBar`, laid out directly under `pane.navigation_bar` and above `pane.status_bar`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `pluggable_protocol_tree/tests/test_protocol_tree_pane.py`:
+
+```python
+def test_pane_has_timeline_bar_under_nav_bar(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.timeline_bar, TimelineBar)
+
+    layout = pane.layout()
+    nav_idx = layout.indexOf(pane.navigation_bar)
+    timeline_idx = layout.indexOf(pane.timeline_bar)
+    status_idx = layout.indexOf(pane.status_bar)
+    assert nav_idx < timeline_idx < status_idx
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pixi run python -m pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py::test_pane_has_timeline_bar_under_nav_bar -v`
+Expected: FAIL with `AttributeError: 'ProtocolTreePane' object has no attribute 'timeline_bar'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `protocol_tree_pane.py`, add the import near the other view imports (around line 55-58):
+
+```python
+from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+```
+
+In `__init__`, right after the `self._build_navigation_bar()` call (line 164), add:
+
+```python
+        self.timeline_bar = TimelineBar()
+```
+
+In `_build_layout` (lines 249-258), insert the timeline between the nav bar and the status bar:
+
+```python
+    def _build_layout(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        layout.addWidget(self.navigation_bar)
+        layout.addWidget(self.timeline_bar)
+        layout.addWidget(self.status_bar)
+        layout.addWidget(make_separator())
+        layout.addWidget(self.widget)
+        if self.quick_action_bar is not None:
+            layout.addWidget(self.quick_action_bar)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pixi run python -m pytest pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v`
+Expected: PASS (the new test plus all existing pane tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/protocol_tree_pane.py \
+        pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+git commit -m "feat(protocol-tree): mount TimelineBar under the nav bar"
+```
+
+---
+
+### Task 3: Wire `TimelineBar` into the dock-pane controller
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/dock_pane.py` — `create_contents` (signal connections + initial build, near line 245-259); `_seek_relative_phase` (lines 335-343); add `_seek_to_phase`, `_on_timeline_step_seek`, `_on_timeline_phase_seek`, `_refresh_timeline_position`, `_rebuild_timeline`; extend the model observers (`_on_counts_changed` line 793, `_on_current_step_path_changed` line 780, `_on_protocol_running_changed` line 807) and add a `manager:rows_changed` observer.
+- Test: manual GUI checklist + an import/structure smoke test (full dock-pane construction needs the Envisage task/window, so the seek path itself is covered by the already-passing `ProtocolStatusController` tests; the wiring is verified manually).
+
+**Interfaces:**
+- Consumes: `TimelineBar` signals + push API (Task 1), `pane.timeline_bar` (Task 2), existing `self.status_controller` (`ProtocolStatusController`) with `seek_to(step_path, phase_index)` and `preview_phase(step_path, phase_index, preview_mode)`, `self._pane._navigable_steps()`, `self._current_step_in(steps)`, `self._select_step(row)`, `self._current_run_preview_mode`, `self._current_row`.
+- Produces: a fully wired timeline — clicks seek, model changes move the playhead.
+
+- [ ] **Step 1: Refactor `_seek_relative_phase` to expose a reusable absolute-phase seek**
+
+Replace the existing `_seek_relative_phase` (lines 335-343) with:
+
+```python
+    def _seek_to_phase(self, target0):
+        """Seek the current step to absolute 0-based phase ``target0`` and
+        preview it. Shared by the nav-bar prev/next-phase buttons and the
+        timeline's phase track."""
+        sc = self.status_controller
+        if sc is None or self._current_row is None:
+            return
+        path = tuple(self._current_row.path)
+        sc.seek_to(path, target0)
+        sc.preview_phase(path, target0, self._current_run_preview_mode)
+        self._update_phase_nav_buttons()
+
+    def _seek_relative_phase(self, delta):
+        sc = self.status_controller
+        if sc is None:
+            return
+        # model phase_index is 1-based; convert to a 0-based absolute target.
+        self._seek_to_phase((sc.model.phase_index - 1) + delta)
+```
+
+- [ ] **Step 2: Add the timeline seek handlers + refresh helpers**
+
+Add these methods to the dock-pane class (next to the navigation helpers, after `_seek_relative_phase`):
+
+```python
+    # --- timeline seek bar (view -> controller) ----------------------
+
+    def _on_timeline_step_seek(self, step_index):
+        steps = self._pane._navigable_steps()
+        if not (0 <= step_index < len(steps)):
+            return
+        row = steps[step_index]
+        sc = self.status_controller
+        if sc is not None and sc.model.running and not sc.model.paused:
+            # B1: preview-only while actively running. Move the selection and
+            # preview the target; the executor reasserts at the next boundary.
+            self._pane.select_row(row)
+            self._current_row = row
+            path = tuple(row.path)
+            sc.seek_to(path, 0)
+            sc.preview_phase(path, 0, self._current_run_preview_mode)
+        else:
+            # Paused -> real seek; idle -> selection only (matches nav buttons).
+            self._select_step(row)
+
+    def _on_timeline_phase_seek(self, phase_index):
+        # The bar emits a 0-based phase index, exactly what _seek_to_phase wants.
+        self._seek_to_phase(phase_index)
+
+    # --- timeline seek bar (model -> view) ---------------------------
+
+    def _refresh_timeline_position(self):
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is None:
+            return
+        steps = self._pane._navigable_steps()
+        cur = self._current_step_in(steps)
+        model = self.status_controller.model if self.status_controller else None
+        phase_index0 = (model.phase_index - 1) if (model and model.phase_index > 0) else 0
+        phase_total = model.phase_total if model else 0
+        tb.set_position(cur if cur is not None else -1, len(steps),
+                        phase_index0, phase_total)
+
+    def _rebuild_timeline(self, event=None):
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is None:
+            return
+        steps = self._pane._navigable_steps()
+        tb.rebuild([(row.name or row.dotted_path()) for row in steps])
+        self._refresh_timeline_position()
+```
+
+- [ ] **Step 3: Connect the bar's intent signals + seed it in `create_contents`**
+
+In `create_contents`, right after the navigation-bar wiring block (after line 252, `nb.btn_last.clicked.connect(...)`), add:
+
+```python
+        # Timeline seek bar: clicks redirect through the status controller; the
+        # model observers below push the playhead position back.
+        tb = pane.timeline_bar
+        tb.step_seek_requested.connect(self._on_timeline_step_seek)
+        tb.phase_seek_requested.connect(self._on_timeline_phase_seek)
+```
+
+Then, just before `return pane` (line 265, after `pane._seed_default_step_if_empty()`), add:
+
+```python
+        # Initial timeline render (structure + position).
+        self._rebuild_timeline()
+```
+
+- [ ] **Step 4: Push model/structure changes into the bar**
+
+Extend the existing observers. In `_on_counts_changed` (line 793-796), append a call after the status-bar refresh:
+
+```python
+    @observe("status_controller:model:[step_index, step_total, phase_index, phase_total]", dispatch="ui", post_init=True)
+    def _on_counts_changed(self, event=None):
+        model = self.status_controller.model
+        self._pane.status_bar._refresh_counts(current=model.step_index, total=model.step_total)
+        self._refresh_timeline_position()
+```
+
+In `_on_current_step_path_changed` (line 780-790), append after `self._pane.widget.highlight_active_row(row)`:
+
+```python
+        self._refresh_timeline_position()
+```
+
+In `_on_protocol_running_changed` (line 807-823), append after the existing body (so the bar gets the preview accent):
+
+```python
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is not None:
+            tb.set_running(bool(event.new))
+```
+
+Add a new observer for structural changes (place it next to the other model observers, after `_on_current_step_path_changed`):
+
+```python
+    @observe("manager:rows_changed", dispatch="ui", post_init=True)
+    def _on_rows_changed_rebuild_timeline(self, event=None):
+        self._rebuild_timeline()
+```
+
+> Verify while implementing: `manager` must be a Traits trait on the dock pane for `@observe("manager:rows_changed", ...)` to fire. If `manager` is a plain attribute, instead call `self._rebuild_timeline()` from wherever the pane already handles `rows_changed` (search `rows_changed` in `dock_pane.py` / `protocol_tree_pane.py`) — do **not** add a second source of truth.
+
+- [ ] **Step 5: Smoke-test that the module imports and the wiring methods exist**
+
+Run:
+
+```bash
+pixi run python -c "import pluggable_protocol_tree.views.dock_pane as d; \
+print(all(hasattr(d.PluggableProtocolDockPane, m) for m in \
+['_seek_to_phase','_on_timeline_step_seek','_on_timeline_phase_seek', \
+'_refresh_timeline_position','_rebuild_timeline']))"
+```
+
+Expected output: `True`.
+
+- [ ] **Step 6: Run the affected automated tests**
+
+Run: `pixi run python -m pytest pluggable_protocol_tree/tests/test_protocol_status_controller.py pluggable_protocol_tree/tests/test_protocol_tree_pane.py pluggable_protocol_tree/tests/test_timeline_bar.py -v`
+Expected: PASS (the seek/refactor reuses already-tested controller methods; the view + pane tests still pass).
+
+- [ ] **Step 7: Manual GUI verification (ask the user to run)**
+
+Start Redis, then `pixi run python examples/run_device_viewer_pluggable.py`. Confirm:
+1. A timeline strip appears directly under the nav buttons, with one tick per step.
+2. Clicking a tick (idle) selects that step in the tree.
+3. Start a protocol, **pause**, click a tick → the tree highlight, the DeviceViewer overlay, and the status bar's "Step n/N" all move to that step; the phase track appears for a multi-phase step and clicking it moves the phase.
+4. While **actively running**, clicking a tick previews the target step on the DeviceViewer momentarily; the executor continues and the playhead snaps back to the executing step at the next boundary (B1).
+5. Toggle OS dark/light mode → the bar restyles.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/dock_pane.py
+git commit -m "feat(protocol-tree): wire TimelineBar seeks through the controller"
+```
+
+---
+
+## Notes / out of scope (follow-ups)
+
+- Idle-selected steps don't show phase sub-ticks (the model only tracks `phase_total` for the executing/paused step). Showing them would call `ProtocolStatusController._phase_total_for(row)` — deferred.
+- The phase track spans the full width representing the current step's phases (bigger hit area), rather than literally subdividing the current step's segment — a deliberate usability choice within the approved "phases on demand" scope.
+- Group bands, mid-run execution redirection (B2), and drag-throttling beyond Qt's event coalescing are out of scope.

--- a/docs/superpowers/specs/2026-06-18-protocol-timeline-seek-bar-design.md
+++ b/docs/superpowers/specs/2026-06-18-protocol-timeline-seek-bar-design.md
@@ -1,0 +1,158 @@
+# Protocol Timeline Seek Bar — Design
+
+**Date:** 2026-06-18
+**Plugin:** `pluggable_protocol_tree`
+**Status:** Approved (brainstorming) — pending implementation plan
+
+## Goal
+
+Add a video-style **timeline seek bar** to the pluggable protocol tree: a
+horizontal track with a tick per protocol step and a draggable playhead, so the
+user can scrub between steps (and, for the current step, between its phases) the
+way they would seek a video. It is a thin **view**; all navigation intent is
+redirected through the existing controller, which moves the protocol's current
+step first and then the phase within it. The rest of the UI reacts to those
+model changes in the existing event-driven way.
+
+## Scope decisions
+
+- **Granularity:** steps-only track; **phase sub-ticks appear only for the
+  current step** (like a video chapter expanding). No group tier.
+- **Run interaction:** seeking is always interactive. While a protocol is
+  **actively running** (not paused), a scrub is **preview-only** — it updates
+  the model position and the DeviceViewer overlay, but the live executor keeps
+  running and reasserts its real position at the next step/phase boundary.
+  Execution-affecting seeks happen when **paused/idle**, reusing the executor's
+  existing paused-guard. No executor changes.
+- **Form factor:** a **sub-widget of the existing dock pane**, sibling to
+  `NavigationBar` and `QuickActionBar` — *not* a new dock pane. This means the
+  dock pane already owns the live `RowManager`, `ProtocolExecutor`, and
+  `ProtocolStatusController`/`ProtocolStatusModel`; there is no instance-sharing
+  problem to solve.
+- **Rendering:** custom `paintEvent` (full control over the two-tier
+  major/minor ticks and playhead), not a styled `QSlider`.
+- **Placement:** directly under the nav bar, above the tree.
+
+## What already exists (reused, not rebuilt)
+
+Built for issue #471 ("navigate step/phase while paused"):
+
+- `RowManager.iter_execution_frames()` — the canonical ordered step sequence
+  (groups flattened, repetitions expanded). Index → row mapping for scrubbing.
+- `ProtocolStatusController.seek_to(step_path, phase_index)` — Qt-free
+  orchestration: records an executor resume target (paused-guarded) and SETs the
+  model's step/phase counters. Calling it while actively running updates the
+  model + preview only; the executor ignores the seek. (= the B1 behavior.)
+- `ProtocolStatusController.preview_phase(step_path, phase_index, preview_mode)`
+  — publishes the phase's electrodes to the DeviceViewer overlay (and hardware
+  unless in preview mode).
+- `ProtocolStatusController._phase_total_for(row)` / `_phases_for(row)` —
+  enumerate a step's phases (the count drives the phase sub-ticks).
+- `ProtocolStatusModel` single source of truth: `current_step_path`,
+  `step_index`, `step_total`, `phase_index`, `phase_total`, `running`, `paused`.
+- `PluggableProtocolDockPane` already observes these model traits with
+  `dispatch="ui"` and already builds/wires the sibling bars in
+  `create_contents`.
+
+## Architecture (MVC)
+
+```
+TimelineBar (View, Qt)                PluggableProtocolDockPane (Controller)        ProtocolStatusModel / RowManager (Model, Qt-free)
+─────────────────────                 ──────────────────────────────────────        ────────────────────────────────────────────────
+emits step_seek_requested(i)  ─────▶  resolve i → row via iter_execution_frames()
+emits phase_seek_requested(p) ─────▶  status_controller.seek_to(path, phase)  ────▶  current_step_path / phase_index SET
+                                      status_controller.preview_phase(...)            (executor honored only when paused)
+set_position(...) ◀───────────────── @observe(model: step/phase counters) ◀────────  trait change events (dispatch="ui")
+rebuild(labels)   ◀───────────────── @observe(manager: rows_changed)      ◀────────  structural change
+set_running(bool) ◀───────────────── @observe(model: running)            ◀────────  run-state change
+```
+
+The View knows nothing about the executor or controller; it emits intent and
+exposes push methods. The Controller is the existing dock pane — no new
+controller class. The Model is unchanged.
+
+## Component 1 — `TimelineBar` (new: `views/timeline_bar.py`)
+
+Pure `QWidget`, no business logic. Follows `NavigationBar` conventions:
+theme-aware styling re-applied on `QApplication.styleHints().colorSchemeChanged`
+(deferred one event-loop tick, per the existing `_on_color_scheme_changed`
+pattern); `QSizePolicy(Expanding, Fixed)` so it hugs its height.
+
+**Render (`paintEvent`):**
+- A horizontal track spanning the widget width.
+- One **major tick per execution step**, evenly spaced across `step_total`.
+- A **playhead** marker at `step_index`.
+- For the **current step only**, if `phase_total > 1`, finer **minor ticks**
+  subdividing that step's segment into `phase_total` slots, with the phase
+  playhead at `phase_index`.
+- Step name / dotted-path shown as a hover tooltip (reuse the row's
+  `dotted_path()` / `name`).
+
+**Outward signals (the only coupling):**
+- `step_seek_requested = Signal(int)` — emitted with the 0-based execution step
+  index nearest the click/drag-release on the major track.
+- `phase_seek_requested = Signal(int)` — emitted with the 0-based phase index
+  nearest the click/drag-release within the current step's segment.
+
+Drag is debounced/coalesced so a scrub emits on meaningful change (and on
+release), not per pixel.
+
+**Push API (called by the controller):**
+- `rebuild(step_labels: list[str])` — set/refresh the major-tick count and
+  per-tick labels when the protocol structure changes.
+- `set_position(step_index, step_total, phase_index, phase_total)` — move the
+  playhead and (re)draw phase sub-ticks for the current step.
+- `set_running(running: bool)` — toggle the preview-mode visual hint (e.g. a
+  subtle "preview" accent while running); the bar stays interactive regardless.
+
+## Component 2 — Controller wiring (in `views/dock_pane.py`)
+
+No new class. In `PluggableProtocolDockPane`:
+
+1. **Build & place.** In `create_contents`, construct `TimelineBar` and add it to
+   the layout directly under the nav bar, above the tree.
+2. **Intent → model.**
+   - `step_seek_requested(i)` → resolve `row = nth execution frame i` (from
+     `manager.iter_execution_frames()`), then
+     `status_controller.seek_to(row.path, 0)` + `preview_phase(row.path, 0, preview)`.
+     This converges on the *same* path the nav-bar prev/next buttons already use
+     (`_select_step`), so move the tree selection there too for consistency.
+   - `phase_seek_requested(p)` → keep the current step path,
+     `status_controller.seek_to(path, p)` + `preview_phase(path, p, preview)`.
+   - Both are safe while running (model + preview update only) and execution-
+     affecting only when paused — no extra run-state branching needed beyond
+     what `seek_to` already enforces.
+3. **Model → view.** Extend the existing `dispatch="ui"` observers:
+   - on `current_step_path` / `[step_index, step_total, phase_index, phase_total]`
+     change → `timeline.set_position(...)`.
+   - on `manager.rows_changed` → `timeline.rebuild(...)`.
+   - on `running` change → `timeline.set_running(...)`.
+
+### Index ↔ position alignment (must verify in the plan)
+
+The timeline scrubs by linear step index and must use the **same indexing the
+executor uses** when it emits `step_started (row, step_index, step_total)` —
+otherwise the playhead and a scrub target can disagree. The plan must confirm
+that `iter_execution_frames()` enumeration order and the executor's
+`step_index`/`step_total` are the same sequence, and reuse one helper for the
+index→row resolution rather than recomputing it.
+
+## Testing
+
+- **`TimelineBar` unit (Qt, no engine):** construct, `rebuild` with N labels,
+  `set_position`, and assert the emitted signal index for a synthesized click at
+  a known x (major track and phase sub-track). Pure-view, fast.
+- **Controller wiring (integration):** with a small built protocol and a
+  `ProtocolStatusController`, drive `step_seek_requested`/`phase_seek_requested`
+  and assert the model's `current_step_path`/`phase_index` move and a
+  `PROTOCOL_TREE_DISPLAY_STATE` preview is published; assert that while running
+  (not paused) the executor position is unaffected (B1).
+- Place tests per the project's Redis/hardware partitioning; the view test needs
+  neither.
+
+## Out of scope (follow-ups)
+
+- Group bands / a third visual tier.
+- Mid-run execution redirection (B2: auto-pause/seek/resume, or a live executor
+  jump). Dynamic duration loops can't resume mid-phase precisely until #477.
+- Fast-preview throttling beyond a simple drag debounce.

--- a/pluggable_protocol_tree/execution/cursor.py
+++ b/pluggable_protocol_tree/execution/cursor.py
@@ -22,29 +22,43 @@ class ExecutionCursor(HasTraits):
     phase_index = Int(0)
     #: Total phases in the current step (set by the routes handler; 0 if unknown).
     phase_total = Int(0)
+    #: Index of the current frame in execution order — set by the executor as it
+    #: walks frames. Distinguishes repetitions of the same step (same path).
+    frame_index = Int(0)
     #: Pending seek target (step_path, phase_index) or None. Set by the executor's
     #: seek() (GUI thread, while paused); read + cleared on resume.
     resume_target = Any(None)
+    #: Optional exact target frame for a step-rep seek; None for a path seek.
+    resume_frame = Any(None)
 
-    def request_seek(self, step_path, phase_index):
-        """Record a pending seek to ``(step_path, phase_index)`` (0-based phase)."""
+    def request_seek(self, step_path, phase_index, frame_index=None):
+        """Record a pending seek to ``(step_path, phase_index)`` (0-based phase).
+        Pass ``frame_index`` to target a specific repetition (execution frame)
+        of the step rather than its first occurrence."""
         self.resume_target = (tuple(step_path), int(phase_index))
+        self.resume_frame = None if frame_index is None else int(frame_index)
 
     def clear_seek(self):
         self.resume_target = None
+        self.resume_frame = None
 
-    def enter_step(self, step_path, phase_index=0):
+    def enter_step(self, step_path, phase_index=0, frame_index=None):
         """Executor: mark the live step position when entering a frame."""
         self.step_path = tuple(step_path)
         self.phase_index = int(phase_index)
         self.phase_total = 0
+        if frame_index is not None:
+            self.frame_index = int(frame_index)
 
     def decision_at_phase(self, current_phase_index):
         """Routes handler, at a phase pause checkpoint on resume: returns
         ``("continue", phase)`` / ``("jump", phase)`` (same step) /
-        ``("abort", phase)`` (different step)."""
-        return seek_decision(self.resume_target, self.step_path, current_phase_index)
+        ``("abort", phase)`` (different step or repetition frame)."""
+        return seek_decision(self.resume_target, self.step_path, current_phase_index,
+                             target_frame=self.resume_frame,
+                             current_frame_index=self.frame_index)
 
     def frame_for_seek(self, frame_paths):
         """Executor: resolve a pending seek to ``(frame_index, phase)`` or None."""
-        return resolve_seek(frame_paths, self.resume_target)
+        return resolve_seek(frame_paths, self.resume_target,
+                            target_frame=self.resume_frame)

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -194,14 +194,15 @@ class ProtocolExecutor(HasTraits):
         self.pause_event.clear()
         self.signals.protocol_resumed = True
 
-    def seek(self, step_path, phase_index) -> None:
+    def seek(self, step_path, phase_index, frame_index=None) -> None:
         """Record a mid-run resume target (issue #471). Only meaningful while
         paused; ignored otherwise. Qt-free: delegates to the live run's
-        ExecutionCursor."""
+        ExecutionCursor. ``frame_index`` targets a specific repetition frame."""
         if not self.pause_event.is_set():
             return
         if self._active_proto_ctx is not None:
-            self._active_proto_ctx.cursor.request_seek(step_path, phase_index)
+            self._active_proto_ctx.cursor.request_seek(
+                step_path, phase_index, frame_index=frame_index)
 
     def stop(self) -> None:
         """Set stop_event AND clear pause_event so a Stop-while-paused
@@ -360,14 +361,21 @@ class ProtocolExecutor(HasTraits):
                 # Different-step seek redirect at the step boundary (same-step
                 # seeks are handled inside the routes phase loop).
                 resolved = cursor.frame_for_seek(frame_paths)
-                if resolved is not None and tuple(cursor.resume_target[0]) != tuple(row.path):
+                # A step-rep seek (resume_frame set) redirects to a different
+                # frame even within the same path; a path seek redirects only
+                # to a different step.
+                if resolved is not None and (
+                    (cursor.resume_frame is not None and resolved[0] != i)
+                    or (cursor.resume_frame is None
+                        and tuple(cursor.resume_target[0]) != tuple(row.path))
+                ):
                     i, start_phase_index = resolved
                     cursor.clear_seek()
                     step_index = i
                     continue
 
             step_index += 1
-            cursor.enter_step(row.path, start_phase_index)
+            cursor.enter_step(row.path, start_phase_index, frame_index=i)
             self._run_one_frame(handlers, cols, proto_ctx, row, rep_chain,
                                 step_index, len(frames))
             start_phase_index = 0

--- a/pluggable_protocol_tree/execution/seek.py
+++ b/pluggable_protocol_tree/execution/seek.py
@@ -11,14 +11,24 @@ from typing import List, Optional, Tuple
 Path = Tuple[int, ...]
 
 
-def resolve_seek(frame_paths: List[Path], target) -> Optional[Tuple[int, int]]:
+def resolve_seek(frame_paths: List[Path], target,
+                 target_frame: Optional[int] = None) -> Optional[Tuple[int, int]]:
     """Return ``(frame_index, phase_index)`` for ``target`` ((path, phase)), or
     None if target is None or its path is not among ``frame_paths``. The phase
     index is clamped to >= 0 (upper clamping is the phase loop's job — it knows
-    the materialized phase count)."""
+    the materialized phase count).
+
+    ``target_frame`` (set for a step-rep seek) names an exact execution frame:
+    when given and in range it is used directly, so a specific repetition of a
+    step (same path, different frame) can be targeted. Without it, the first
+    frame matching the path is returned (the path-based behaviour)."""
     if target is None:
         return None
     target_path, target_phase = target
+    if target_frame is not None:
+        if 0 <= target_frame < len(frame_paths):
+            return int(target_frame), max(0, int(target_phase))
+        return None
     target_path = tuple(target_path)
     for i, path in enumerate(frame_paths):
         if tuple(path) == target_path:
@@ -26,18 +36,26 @@ def resolve_seek(frame_paths: List[Path], target) -> Optional[Tuple[int, int]]:
     return None
 
 
-def seek_decision(resume_target, current_path: Path, current_phase_index: int):
+def seek_decision(resume_target, current_path: Path, current_phase_index: int,
+                  target_frame: Optional[int] = None,
+                  current_frame_index: Optional[int] = None):
     """Decide what a phase loop should do at its pause checkpoint on resume.
 
     Returns one of:
       ``("continue", current_phase_index)`` — no seek pending,
       ``("jump", target_phase)``           — same step, jump the phase loop,
-      ``("abort", target_phase)``          — different step, unwind to the
+      ``("abort", target_phase)``          — different step (or a different
+                                             repetition frame), unwind to the
                                              frame walk and re-enter the target.
     """
     if resume_target is None:
         return ("continue", current_phase_index)
     target_path, target_phase = resume_target
+    # An exact-frame (step-rep) seek to a different frame must abort even within
+    # the same path, so the frame walk re-enters the chosen repetition.
+    if (target_frame is not None and current_frame_index is not None
+            and target_frame != current_frame_index):
+        return ("abort", int(target_phase))
     if tuple(target_path) == tuple(current_path):
         return ("jump", int(target_phase))
     return ("abort", int(target_phase))

--- a/pluggable_protocol_tree/models/protocol_status.py
+++ b/pluggable_protocol_tree/models/protocol_status.py
@@ -24,6 +24,15 @@ class ProtocolStatusModel(HasTraits):
     phase_total = Int(0)
     repeats_completed = Int(0)
     repeats_total = Int(1)
+    # Per-rep execution-frame position (reps expanded), distinct from the
+    # collapsed step_index/step_total above. Drives the timeline's "show full"
+    # step view, which lays out one cell per frame.
+    frame_index = Int(0)
+    frame_total = Int(0)
+    # Current step's own repetition (1-based) and its total, from the innermost
+    # entry of the executor's rep_chain. 0 when the step does not repeat.
+    step_rep_index = Int(0)
+    step_rep_total = Int(0)
 
     # --- current step identity (single source of truth) ---
     # Path tuple of the step the run is on, SET from the executor's
@@ -65,6 +74,7 @@ class ProtocolStatusModel(HasTraits):
         self.trait_set(
             step_index=0, step_total=0, phase_index=0, phase_total=0,
             repeats_completed=0, repeats_total=1,
+            frame_index=0, frame_total=0, step_rep_index=0, step_rep_total=0,
             recent_step_name="-", next_step_name="-", rep_chain_label="",
             phase_target_s=0.0, running=False, paused=False,
         )
@@ -76,11 +86,13 @@ class ProtocolStatusModel(HasTraits):
         self.protocol_clock.start(now)
 
     def on_step_start(self, now, step_index, step_total, step_path,
-                      recent_name, next_name):
+                      recent_name, next_name, frame_index=0, frame_total=0):
         # SET the position from the executor's authoritative report (never
         # increment) so a mid-run seek can't drift the counter (issue #471).
         self.step_index = int(step_index)
         self.step_total = int(step_total)
+        self.frame_index = int(frame_index)
+        self.frame_total = int(frame_total)
         self.current_step_path = tuple(step_path) if step_path is not None else None
         self.recent_step_name = recent_name
         self.next_step_name = next_name
@@ -168,3 +180,7 @@ class ProtocolStatusModel(HasTraits):
 
     def set_rep_chain(self, label):
         self.rep_chain_label = label
+
+    def set_step_rep(self, index, total):
+        self.step_rep_index = int(index)
+        self.step_rep_total = int(total)

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -322,6 +322,8 @@ class ProtocolStatusController(HasTraits):
                     rep = total
         self.model.frame_index = int(frame_index) + 1
         self.model.set_step_rep(rep, total)
+        self.model.set_rep_chain(
+            self._fmt_chain([("", rep, total)]) if total > 1 else "")
 
     def seek_to_step_rep(self, step_path, rep, rep_total):
         """Seek (while paused) to repetition ``rep`` (1-based) of the step at
@@ -334,6 +336,7 @@ class ProtocolStatusController(HasTraits):
         if self.executor is not None:
             self.executor.seek(tuple(step_path), 0, frame_index=frame_index)
         self.model.set_step_rep(int(rep), int(rep_total))
+        self.model.set_rep_chain(self._fmt_chain([("", int(rep), int(rep_total))]))
 
     @staticmethod
     def _fmt_chain(rep_chain):

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -305,6 +305,24 @@ class ProtocolStatusController(HasTraits):
                     return i
         return None
 
+    def seek_to_frame(self, step_path, frame_index):
+        """Seek (while paused) to an exact execution frame -- used by the
+        full-view step timeline, where each cell is one frame. The executor
+        honours it on resume; the model's frame/step-rep are set optimistically
+        so the view follows the drag immediately."""
+        target = tuple(step_path)
+        if self.executor is not None:
+            self.executor.seek(target, 0, frame_index=int(frame_index))
+        rep = 0
+        total = 0
+        for i, (row, _chain) in enumerate(self.manager.iter_execution_frames()):
+            if tuple(row.path) == target:
+                total += 1
+                if i <= frame_index:
+                    rep = total
+        self.model.frame_index = int(frame_index) + 1
+        self.model.set_step_rep(rep, total)
+
     def seek_to_step_rep(self, step_path, rep, rep_total):
         """Seek (while paused) to repetition ``rep`` (1-based) of the step at
         ``step_path`` -- a specific execution frame. The executor honours it on

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -94,18 +94,26 @@ class ProtocolStatusController(HasTraits):
         # The executor reports one frame per repetition; collapse to distinct
         # steps so the status bar reads "Step 1/1" for a single 8x-repeated
         # step. The rep count is shown separately via step_repetition.
-        row, _frame_index, _frame_total = event.new
+        row, frame_index, frame_total = event.new
         step_index = self._step_index_of(row.path)
         step_total = self._count_steps()
         self.model.on_step_start(
             self.clock(), step_index, step_total, tuple(row.path),
-            row.name, self._next_name(row))
+            row.name, self._next_name(row),
+            frame_index=frame_index, frame_total=frame_total)
         logger.debug(
             f"status: step {step_index}/{step_total} @ {tuple(row.path)} "
             f"({row.name!r})")
 
     def _on_step_repetition(self, event):
-        self.model.set_rep_chain(self._fmt_chain(event.new))
+        chain = event.new
+        self.model.set_rep_chain(self._fmt_chain(chain))
+        # Innermost rep entry is the step's own repetition (outermost-first).
+        if chain:
+            _name, idx, total = chain[-1]
+            self.model.set_step_rep(idx, total)
+        else:
+            self.model.set_step_rep(0, 0)
 
     def _on_phase_started(self, event):
         phase_index, phase_total, phase_duration_s = event.new

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -189,15 +189,18 @@ class ProtocolStatusController(HasTraits):
         return None
 
     @staticmethod
-    def _phases_for(row):
+    def _phases_for(row, n_repeats=None):
         """Materialized phase sequence for a row, mirroring the executor's
         iter_phases call (count/fixed steps). [] on failure. Duration-mode
-        precise phases are deferred (#477)."""
+        precise phases are deferred (#477). Pass ``n_repeats`` to override the
+        row's route_repetitions (e.g. 1 for a single base loop)."""
         try:
             in_duration_mode = (
                 bool(getattr(row, "repeat_duration_controls", False))
                 and float(getattr(row, "repeat_duration", 0.0) or 0.0) > 0
             )
+            reps = (int(getattr(row, "route_repetitions", 1))
+                    if n_repeats is None else int(n_repeats))
             return list(iter_phases(
                 static_electrodes=list(getattr(row, "electrodes", []) or []),
                 routes=list(getattr(row, "routes", []) or []),
@@ -208,7 +211,7 @@ class ProtocolStatusController(HasTraits):
                 repeat_duration_s=(float(getattr(row, "repeat_duration", 0.0))
                                    if in_duration_mode else 0.0),
                 linear_repeats=bool(getattr(row, "linear_repeats", False)),
-                n_repeats=int(getattr(row, "route_repetitions", 1)),
+                n_repeats=reps,
                 step_duration_s=float(getattr(row, "duration_s", 1.0)),
             ))
         except Exception:
@@ -216,6 +219,11 @@ class ProtocolStatusController(HasTraits):
 
     def _phase_total_for(self, row):
         return max(1, len(self._phases_for(row)))
+
+    def _base_phase_total_for(self, row):
+        """Phase count for ONE route loop (n_repeats=1) -- the base loop a
+        route-repeated step cycles through."""
+        return max(1, len(self._phases_for(row, n_repeats=1)))
 
     def preview_phase(self, step_path, phase_index, preview):
         """Publish the selected phase's electrodes to the DV overlay (always)

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -293,6 +293,30 @@ class ProtocolStatusController(HasTraits):
         self.model.seek_phase(
             now, phase0 + 1, phase_total, float(getattr(row, "duration_s", 0.0)))
 
+    def _frame_index_for_rep(self, step_path, rep):
+        """Execution-frame index of the ``rep``-th (1-based) occurrence of the
+        step at ``step_path``, or None if absent."""
+        target = tuple(step_path)
+        seen = 0
+        for i, (row, _chain) in enumerate(self.manager.iter_execution_frames()):
+            if tuple(row.path) == target:
+                seen += 1
+                if seen == int(rep):
+                    return i
+        return None
+
+    def seek_to_step_rep(self, step_path, rep, rep_total):
+        """Seek (while paused) to repetition ``rep`` (1-based) of the step at
+        ``step_path`` -- a specific execution frame. The executor honours it on
+        resume; the model reflects the chosen rep optimistically. No-op if the
+        rep frame is absent."""
+        frame_index = self._frame_index_for_rep(step_path, rep)
+        if frame_index is None:
+            return
+        if self.executor is not None:
+            self.executor.seek(tuple(step_path), 0, frame_index=frame_index)
+        self.model.set_step_rep(int(rep), int(rep_total))
+
     @staticmethod
     def _fmt_chain(rep_chain):
         # Compact "Step Rep i/n" (per repeating level) -- the old

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -91,7 +91,12 @@ class ProtocolStatusController(HasTraits):
         self.model.on_protocol_start(self.clock(), self._count_steps())
 
     def _on_step_started(self, event):
-        row, step_index, step_total = event.new
+        # The executor reports one frame per repetition; collapse to distinct
+        # steps so the status bar reads "Step 1/1" for a single 8x-repeated
+        # step. The rep count is shown separately via step_repetition.
+        row, _frame_index, _frame_total = event.new
+        step_index = self._step_index_of(row.path)
+        step_total = self._count_steps()
         self.model.on_step_start(
             self.clock(), step_index, step_total, tuple(row.path),
             row.name, self._next_name(row))
@@ -131,9 +136,22 @@ class ProtocolStatusController(HasTraits):
 
     # --- helpers (need manager) ---
 
+    def _distinct_steps(self):
+        """Step rows in execution order with repetitions collapsed (one entry
+        per row), so the status bar counts steps -- not per-rep frames."""
+        seen = set()
+        out = []
+        for row in self.manager.iter_execution_steps():
+            key = tuple(row.path)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(row)
+        return out
+
     def _count_steps(self):
         try:
-            return sum(1 for _ in self.manager.iter_execution_steps())
+            return len(self._distinct_steps())
         except Exception:
             return 0
 
@@ -147,9 +165,10 @@ class ProtocolStatusController(HasTraits):
         return "-"
 
     def _step_index_of(self, step_path):
-        """1-based position of step_path in execution order, or 0 if absent."""
+        """1-based position of step_path among the distinct steps, or 0 if
+        absent. Distinct (not per-rep) so a repeated step keeps one index."""
         target = tuple(step_path)
-        for i, row in enumerate(self.manager.iter_execution_steps(), start=1):
+        for i, row in enumerate(self._distinct_steps(), start=1):
             if tuple(row.path) == target:
                 return i
         return 0
@@ -260,8 +279,11 @@ class ProtocolStatusController(HasTraits):
 
     @staticmethod
     def _fmt_chain(rep_chain):
+        # Compact "Step Rep i/n" (per repeating level) -- the old
+        # "rep i/n of 'name'" overflowed the fixed-width status label and
+        # double-counted the step itself in the count beside it.
         if not rep_chain:
             return ""
         return " · ".join(
-            f"rep {idx}/{total} of '{name}'" for name, idx, total in rep_chain
+            f"Step Rep {idx}/{total}" for _name, idx, total in rep_chain
         )

--- a/pluggable_protocol_tree/tests/test_cursor.py
+++ b/pluggable_protocol_tree/tests/test_cursor.py
@@ -39,3 +39,21 @@ def test_frame_for_seek():
     assert c.frame_for_seek([(0,), (1,)]) is None       # no target
     c.request_seek((1,), 5)
     assert c.frame_for_seek([(0,), (1,), (2,)]) == (1, 5)
+
+
+def test_request_seek_with_frame_targets_specific_repetition():
+    c = ExecutionCursor()
+    c.request_seek((1,), 0, frame_index=3)
+    assert c.resume_target == ((1,), 0)
+    assert c.resume_frame == 3
+    # Path (1,) is at frames 1 and 3; the explicit frame wins.
+    assert c.frame_for_seek([(0,), (1,), (2,), (1,)]) == (3, 0)
+    c.clear_seek()
+    assert c.resume_frame is None
+
+
+def test_decision_aborts_for_different_repetition_frame():
+    c = ExecutionCursor()
+    c.enter_step((1,), 0, frame_index=3)
+    c.request_seek((1,), 0, frame_index=5)   # same path, different frame
+    assert c.decision_at_phase(2) == ("abort", 0)

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -97,6 +97,27 @@ def test_step_count_collapses_repetitions():
     assert ctrl.model.step_total == 1
 
 
+def test_frame_index_tracked_alongside_distinct_step():
+    # The per-rep execution frame is kept for the timeline's "show full" view,
+    # separate from the collapsed step counter.
+    ctrl, sigs, clock, rows = _make()
+    sigs.protocol_started = True
+    sigs.step_started = (rows[0], 3, 5)   # executor frame 3 of 5
+    assert ctrl.model.frame_index == 3
+    assert ctrl.model.frame_total == 5
+    assert ctrl.model.step_index == 1     # distinct step still 1
+
+
+def test_step_rep_tracked_from_chain():
+    ctrl, sigs, clock, rows = _make()
+    sigs.step_repetition = [("Wash", 2, 8)]
+    assert ctrl.model.step_rep_index == 2
+    assert ctrl.model.step_rep_total == 8
+    sigs.step_repetition = []             # non-repeating step clears it
+    assert ctrl.model.step_rep_index == 0
+    assert ctrl.model.step_rep_total == 0
+
+
 def test_terminal_signals_reset_trackers():
     # Finished / aborted are the post-protocol teardown: reset to idle.
     for term in ("protocol_finished", "protocol_aborted"):

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -80,9 +80,21 @@ def test_phase_started_and_extended():
 def test_rep_chain_formatting():
     ctrl, sigs, clock, rows = _make()
     sigs.step_repetition = [("Wash", 2, 3)]
-    assert ctrl.model.rep_chain_label == "rep 2/3 of 'Wash'"
+    assert ctrl.model.rep_chain_label == "Step Rep 2/3"
     sigs.step_repetition = []
     assert ctrl.model.rep_chain_label == ""
+
+
+def test_step_count_collapses_repetitions():
+    # One step yielded 3 times (Reps=3) reads as a single step, not 3 -- the
+    # rep progress lives in the separate step_repetition label.
+    shared = _Row("Wash", (0,))
+    ctrl, sigs, clock, rows = _make(rows=[shared, shared, shared])
+    sigs.protocol_started = True
+    assert ctrl.model.step_total == 1
+    sigs.step_started = (shared, 2, 3)   # executor's 2nd of 3 frames
+    assert ctrl.model.step_index == 1    # still the only distinct step
+    assert ctrl.model.step_total == 1
 
 
 def test_terminal_signals_reset_trackers():

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -1576,3 +1576,16 @@ def test_import_into_selected_group_skips_columns_not_in_live_set(qapp,
     assert not hasattr(new_step, "unknown_plugin_col")
 
 
+def test_pane_has_timeline_bar_under_nav_bar(qapp):
+    from pluggable_protocol_tree.builtins.type_column import make_type_column
+    from pluggable_protocol_tree.views.protocol_tree_pane import ProtocolTreePane
+    from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+
+    pane = ProtocolTreePane([make_type_column()])
+    assert isinstance(pane.timeline_bar, TimelineBar)
+
+    layout = pane.layout()
+    nav_idx = layout.indexOf(pane.navigation_bar)
+    timeline_idx = layout.indexOf(pane.timeline_bar)
+    status_idx = layout.indexOf(pane.status_bar)
+    assert nav_idx < timeline_idx < status_idx

--- a/pluggable_protocol_tree/tests/test_seek.py
+++ b/pluggable_protocol_tree/tests/test_seek.py
@@ -25,3 +25,23 @@ def test_seek_decision_jump_same_step():
 
 def test_seek_decision_abort_different_step():
     assert seek_decision(((2,), 1), (1,), 0) == ("abort", 1)
+
+
+def test_resolve_seek_uses_explicit_frame_for_repetition():
+    # Path (1,) appears at frames 1 and 3 (two reps); target_frame picks one.
+    frames = [(0,), (1,), (2,), (1,)]
+    assert resolve_seek(frames, ((1,), 0), target_frame=3) == (3, 0)
+    assert resolve_seek(frames, ((1,), 0)) == (1, 0)   # first match without it
+
+
+def test_resolve_seek_out_of_range_frame_returns_none():
+    assert resolve_seek([(0,), (1,)], ((1,), 0), target_frame=9) is None
+
+
+def test_seek_decision_aborts_for_different_repetition_frame():
+    # Step-rep seek: same path, but a different frame -> abort to re-enter it.
+    assert seek_decision(((1,), 0), (1,), 2,
+                         target_frame=5, current_frame_index=3) == ("abort", 0)
+    # Same frame -> normal same-path phase jump.
+    assert seek_decision(((1,), 4), (1,), 0,
+                         target_frame=3, current_frame_index=3) == ("jump", 4)

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -60,6 +60,14 @@ def test_click_on_phase_track_emits_phase_seek(qapp):
     assert captured == [4]
 
 
+def test_phase_index_at_x_maps_across_width(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 5)  # current step has 5 phases
+    # 5 phases across the usable width -> first is phase 0, last is 4.
+    assert bar._phase_index_at_x(bar._phase_track_rect().left() + 1) == 0
+    assert bar._phase_index_at_x(bar._phase_track_rect().right() - 1) == 4
+
+
 def test_set_running_does_not_break_interaction(qapp):
     bar = _bar(qapp)
     bar.set_position(0, 4, 0, 0)

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -4,7 +4,7 @@ step_seek_requested / phase_seek_requested when the user clicks a track.
 It holds no engine references and performs no seeking itself."""
 
 from pyface.qt.QtCore import QPoint
-from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+from pluggable_protocol_tree.views.timeline_bar import SIDE_MARGIN, TimelineBar
 
 WIDTH = 400
 
@@ -91,3 +91,25 @@ def test_set_running_does_not_break_interaction(qapp):
     r = bar._step_track_rect()
     bar._seek_at_point(QPoint(r.left() + 1, r.center().y()))
     assert captured == [0]
+
+
+def test_group_cells_get_alternating_colors(qapp):
+    bar = TimelineBar()
+    bar.rebuild(["A", "B", "C", "D"], group_keys=[None, (1,), (1,), (2,)])
+    assert bar._cell_colors[0] is None                  # ungrouped step
+    assert bar._cell_colors[1] == bar._cell_colors[2]   # same group -> same colour
+    assert bar._cell_colors[1] != bar._cell_colors[3]   # different group -> different
+
+
+def test_drag_moves_relative_to_current_step(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 0)   # current step index 1 (the drag anchor)
+    captured = []
+    bar.step_seek_requested.connect(captured.append)
+    y = bar._step_track_rect().center().y()
+    seg = bar._usable_width() / bar.step_count
+    bar._begin_drag(QPoint(int(SIDE_MARGIN + 0.5 * seg), y))
+    # Drag right by ~2 cells from the press point -> anchor 1 + 2 = 3,
+    # regardless of which absolute cell the cursor is over.
+    bar._drag_update(QPoint(int(SIDE_MARGIN + 2.5 * seg), y))
+    assert captured[-1] == 3

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -4,7 +4,38 @@ step_seek_requested / phase_seek_requested when the user clicks a track.
 It holds no engine references and performs no seeking itself."""
 
 from pyface.qt.QtCore import QPoint
-from pluggable_protocol_tree.views.timeline_bar import SIDE_MARGIN, TimelineBar
+from pluggable_protocol_tree.views.timeline_bar import (
+    SIDE_MARGIN, TimelineBar, collapse_phase_view,
+)
+
+
+def test_collapse_phase_view_collapses_even_reps():
+    # 12 phases = 3 reps x 4 base phases; at full index 6 we're in rep 2,
+    # base position 2.
+    v = collapse_phase_view(12, 6, 3, show_full=False)
+    assert v["can_collapse"] is True
+    assert v["phase_total"] == 4          # one base loop
+    assert v["phase_index"] == 2          # position within the loop
+    assert v["base_count"] == 4
+    assert v["cur_rep"] == 2
+    assert v["rep_count"] == 3
+
+
+def test_collapse_phase_view_show_full_expands():
+    v = collapse_phase_view(12, 6, 3, show_full=True)
+    assert v["can_collapse"] is True      # controls still apply
+    assert v["phase_total"] == 12         # but every phase is shown
+    assert v["phase_index"] == 6
+    assert v["cur_rep"] == 2
+
+
+def test_collapse_phase_view_no_collapse_when_uneven_or_single_base():
+    # Not divisible by reps -> no collapse (e.g. soft-start ramp phases).
+    assert collapse_phase_view(13, 0, 3, show_full=False)["can_collapse"] is False
+    # Divisible but only 1 base phase per rep -> not worth collapsing.
+    assert collapse_phase_view(3, 0, 3, show_full=False)["can_collapse"] is False
+    # No reps -> no collapse.
+    assert collapse_phase_view(8, 0, 1, show_full=False)["can_collapse"] is False
 
 WIDTH = 400
 

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -46,13 +46,27 @@ def test_click_on_step_track_emits_step_seek(qapp):
 
 def test_phase_track_hidden_without_multiple_phases(qapp):
     bar = _bar(qapp)
+    bar.set_running(True)
     bar.set_position(1, 4, 0, 1)  # phase_total == 1 -> no phase track
     assert bar._phase_track_visible() is False
 
 
+def test_phase_track_hidden_when_not_running(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 5)  # 5 phases, but idle -> phase track hidden
+    assert bar._phase_track_visible() is False
+    captured = []
+    bar.phase_seek_requested.connect(captured.append)
+    r = bar._phase_track_rect()
+    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
+    assert captured == []  # clicks in the phase band don't seek when hidden
+
+
 def test_click_on_phase_track_emits_phase_seek(qapp):
     bar = _bar(qapp)
-    bar.set_position(1, 4, 0, 5)  # current step has 5 phases
+    bar.set_running(True)
+    bar.set_position(1, 4, 0, 5)  # running on a step with 5 phases
+    assert bar._phase_track_visible() is True
     captured = []
     bar.phase_seek_requested.connect(captured.append)
     r = bar._phase_track_rect()

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -1,0 +1,71 @@
+"""TimelineBar is a pure rendering/intent widget: it paints a step track
+(one tick per step) plus a phase track for the current step, and emits
+step_seek_requested / phase_seek_requested when the user clicks a track.
+It holds no engine references and performs no seeking itself."""
+
+from pyface.qt.QtCore import QPoint
+from pluggable_protocol_tree.views.timeline_bar import TimelineBar
+
+WIDTH = 400
+
+
+def _bar(qapp, labels=("S0", "S1", "S2", "S3")):
+    bar = TimelineBar()
+    bar.rebuild(list(labels))
+    bar.resize(WIDTH, bar.height())
+    return bar
+
+
+def test_rebuild_sets_step_count(qapp):
+    bar = _bar(qapp)
+    assert bar.step_count == 4
+
+
+def test_step_index_at_x_maps_across_width(qapp):
+    bar = _bar(qapp)
+    # 4 steps across the usable width -> first quarter is step 0, last is 3.
+    assert bar._step_index_at_x(bar._step_track_rect().left() + 1) == 0
+    assert bar._step_index_at_x(bar._step_track_rect().right() - 1) == 3
+
+
+def test_step_index_at_x_is_clamped(qapp):
+    bar = _bar(qapp)
+    assert bar._step_index_at_x(-50) == 0
+    assert bar._step_index_at_x(WIDTH + 50) == 3
+
+
+def test_click_on_step_track_emits_step_seek(qapp):
+    bar = _bar(qapp)
+    bar.set_position(0, 4, 0, 0)
+    captured = []
+    bar.step_seek_requested.connect(captured.append)
+    r = bar._step_track_rect()
+    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
+    assert captured == [3]
+
+
+def test_phase_track_hidden_without_multiple_phases(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 1)  # phase_total == 1 -> no phase track
+    assert bar._phase_track_visible() is False
+
+
+def test_click_on_phase_track_emits_phase_seek(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 5)  # current step has 5 phases
+    captured = []
+    bar.phase_seek_requested.connect(captured.append)
+    r = bar._phase_track_rect()
+    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
+    assert captured == [4]
+
+
+def test_set_running_does_not_break_interaction(qapp):
+    bar = _bar(qapp)
+    bar.set_position(0, 4, 0, 0)
+    bar.set_running(True)
+    captured = []
+    bar.step_seek_requested.connect(captured.append)
+    r = bar._step_track_rect()
+    bar._seek_at_point(QPoint(r.left() + 1, r.center().y()))
+    assert captured == [0]

--- a/pluggable_protocol_tree/tests/test_timeline_bar.py
+++ b/pluggable_protocol_tree/tests/test_timeline_bar.py
@@ -9,10 +9,9 @@ from pluggable_protocol_tree.views.timeline_bar import (
 )
 
 
-def test_collapse_phase_view_collapses_even_reps():
-    # 12 phases = 3 reps x 4 base phases; at full index 6 we're in rep 2,
-    # base position 2.
-    v = collapse_phase_view(12, 6, 3, show_full=False)
+def test_collapse_phase_view_collapses_with_base_loop():
+    # base loop = 4 phases, 3 reps; at full index 6 we're in rep 2, base pos 2.
+    v = collapse_phase_view(12, 6, 4, 3, show_full=False)
     assert v["can_collapse"] is True
     assert v["phase_total"] == 4          # one base loop
     assert v["phase_index"] == 2          # position within the loop
@@ -21,21 +20,31 @@ def test_collapse_phase_view_collapses_even_reps():
     assert v["rep_count"] == 3
 
 
+def test_collapse_phase_view_handles_uneven_full_count():
+    # Ramp phases make the full count not a multiple of reps (53 != 5*10):
+    # collapse still applies off the real base-loop size.
+    v = collapse_phase_view(53, 7, 5, 10, show_full=False)
+    assert v["can_collapse"] is True
+    assert v["phase_total"] == 5
+    assert v["phase_index"] == 2          # 7 % 5
+    assert v["cur_rep"] == 2              # 7 // 5 + 1
+
+
 def test_collapse_phase_view_show_full_expands():
-    v = collapse_phase_view(12, 6, 3, show_full=True)
+    v = collapse_phase_view(12, 6, 4, 3, show_full=True)
     assert v["can_collapse"] is True      # controls still apply
     assert v["phase_total"] == 12         # but every phase is shown
     assert v["phase_index"] == 6
     assert v["cur_rep"] == 2
 
 
-def test_collapse_phase_view_no_collapse_when_uneven_or_single_base():
-    # Not divisible by reps -> no collapse (e.g. soft-start ramp phases).
-    assert collapse_phase_view(13, 0, 3, show_full=False)["can_collapse"] is False
-    # Divisible but only 1 base phase per rep -> not worth collapsing.
-    assert collapse_phase_view(3, 0, 3, show_full=False)["can_collapse"] is False
+def test_collapse_phase_view_no_collapse_edge_cases():
+    # Base loop of a single phase -> not worth collapsing.
+    assert collapse_phase_view(8, 0, 1, 4, show_full=False)["can_collapse"] is False
     # No reps -> no collapse.
-    assert collapse_phase_view(8, 0, 1, show_full=False)["can_collapse"] is False
+    assert collapse_phase_view(8, 0, 8, 1, show_full=False)["can_collapse"] is False
+    # Fewer phases than one base loop -> no collapse.
+    assert collapse_phase_view(3, 0, 5, 3, show_full=False)["can_collapse"] is False
 
 WIDTH = 400
 
@@ -76,27 +85,24 @@ def test_click_on_step_track_emits_step_seek(qapp):
 
 
 def test_phase_track_hidden_without_multiple_phases(qapp):
+    # Visibility is purely phase_total > 1 now; the controller feeds 0/1 to
+    # hide the track (e.g. idle on a non-repeating step).
     bar = _bar(qapp)
-    bar.set_running(True)
     bar.set_position(1, 4, 0, 1)  # phase_total == 1 -> no phase track
     assert bar._phase_track_visible() is False
-
-
-def test_phase_track_hidden_when_not_running(qapp):
-    bar = _bar(qapp)
-    bar.set_position(1, 4, 0, 5)  # 5 phases, but idle -> phase track hidden
+    bar.set_position(1, 4, 0, 0)  # phase_total == 0 (hidden by controller)
     assert bar._phase_track_visible() is False
-    captured = []
-    bar.phase_seek_requested.connect(captured.append)
-    r = bar._phase_track_rect()
-    bar._seek_at_point(QPoint(r.right() - 1, r.center().y()))
-    assert captured == []  # clicks in the phase band don't seek when hidden
+
+
+def test_phase_track_visible_with_multiple_phases(qapp):
+    bar = _bar(qapp)
+    bar.set_position(1, 4, 0, 5)  # 5 phases handed in -> track shows
+    assert bar._phase_track_visible() is True
 
 
 def test_click_on_phase_track_emits_phase_seek(qapp):
     bar = _bar(qapp)
-    bar.set_running(True)
-    bar.set_position(1, 4, 0, 5)  # running on a step with 5 phases
+    bar.set_position(1, 4, 0, 5)  # step with 5 phases
     assert bar._phase_track_visible() is True
     captured = []
     bar.phase_seek_requested.connect(captured.append)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -372,6 +372,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
             # B1: preview-only while actively running. Move the selection and
             # preview the target; the executor reasserts at the next boundary.
             self._seek_and_preview_step(row)
+            self._refresh_timeline_position()
         else:
             # Paused -> real seek; idle -> selection only (matches nav buttons).
             self._select_step(row)
@@ -388,9 +389,23 @@ class PluggableProtocolDockPane(TraitsDockPane):
             return
         steps = self._pane._navigable_steps()
         cur = self._current_step_in(steps)
-        model = self.status_controller.model if self.status_controller else None
-        phase_index0 = (model.phase_index - 1) if (model and model.phase_index > 0) else 0
-        phase_total = model.phase_total if model else 0
+        sc = self.status_controller
+        phase_index0 = 0
+        phase_total = 0
+        if cur is not None and sc is not None:
+            model = sc.model
+            on_current_step = (
+                model.current_step_path is not None
+                and tuple(model.current_step_path) == tuple(steps[cur].path)
+            )
+            if on_current_step and model.phase_total > 0:
+                # Executing/paused on this step: the model holds the live counts.
+                phase_total = model.phase_total
+                phase_index0 = max(0, model.phase_index - 1)
+            else:
+                # Idle or merely selected: derive the step's phase count so its
+                # phase ticks still show even though no run is driving the model.
+                phase_total = sc._phase_total_for(steps[cur])
         tb.set_position(cur if cur is not None else -1, len(steps),
                         phase_index0, phase_total)
 
@@ -437,6 +452,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
             self._update_phase_nav_buttons()
         else:
             self._pane.select_row(row)
+        # Idle/paused selection isn't a model run-state change, so the model
+        # observers won't fire — move the timeline playhead to match here.
+        self._refresh_timeline_position()
 
     def _current_step_in(self, steps):
         # During a run the nav cursor follows the model's current step (the

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -251,6 +251,12 @@ class PluggableProtocolDockPane(TraitsDockPane):
         nb.btn_first.clicked.connect(self.navigate_to_first_step)
         nb.btn_last.clicked.connect(self.navigate_to_last_step)
 
+        # Timeline seek bar: clicks redirect through the status controller; the
+        # model observers below push the playhead position back.
+        tb = pane.timeline_bar
+        tb.step_seek_requested.connect(self._on_timeline_step_seek)
+        tb.phase_seek_requested.connect(self._on_timeline_phase_seek)
+
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)
         nb.btn_stop.clicked.connect(self.executor.stop)
@@ -261,6 +267,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
         # Legacy protocol_grid parity: the full app opens with one default
         # step when no protocol is loaded (no-op once a protocol is loaded).
         pane._seed_default_step_if_empty()
+
+        # Initial timeline render (structure + position).
+        self._rebuild_timeline()
 
         return pane
 
@@ -332,15 +341,70 @@ class PluggableProtocolDockPane(TraitsDockPane):
     def _on_next_phase(self):
         self._seek_relative_phase(+1)
 
-    def _seek_relative_phase(self, delta):
+    def _seek_to_phase(self, target0):
+        """Seek the current step to absolute 0-based phase ``target0`` and
+        preview it. Shared by the nav-bar prev/next-phase buttons and the
+        timeline's phase track."""
         sc = self.status_controller
         if sc is None or self._current_row is None:
             return
-        target0 = (sc.model.phase_index - 1) + delta   # model phase_index is 1-based
         path = tuple(self._current_row.path)
         sc.seek_to(path, target0)
         sc.preview_phase(path, target0, self._current_run_preview_mode)
         self._update_phase_nav_buttons()
+
+    def _seek_relative_phase(self, delta):
+        sc = self.status_controller
+        if sc is None:
+            return
+        # model phase_index is 1-based; convert to a 0-based absolute target.
+        self._seek_to_phase((sc.model.phase_index - 1) + delta)
+
+    # --- timeline seek bar (view -> controller) ----------------------
+
+    def _on_timeline_step_seek(self, step_index):
+        steps = self._pane._navigable_steps()
+        if not (0 <= step_index < len(steps)):
+            return
+        row = steps[step_index]
+        sc = self.status_controller
+        if sc is not None and sc.model.running and not sc.model.paused:
+            # B1: preview-only while actively running. Move the selection and
+            # preview the target; the executor reasserts at the next boundary.
+            self._pane.select_row(row)
+            self._current_row = row
+            path = tuple(row.path)
+            sc.seek_to(path, 0)
+            sc.preview_phase(path, 0, self._current_run_preview_mode)
+        else:
+            # Paused -> real seek; idle -> selection only (matches nav buttons).
+            self._select_step(row)
+
+    def _on_timeline_phase_seek(self, phase_index):
+        # The bar emits a 0-based phase index, exactly what _seek_to_phase wants.
+        self._seek_to_phase(phase_index)
+
+    # --- timeline seek bar (model -> view) ---------------------------
+
+    def _refresh_timeline_position(self):
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is None:
+            return
+        steps = self._pane._navigable_steps()
+        cur = self._current_step_in(steps)
+        model = self.status_controller.model if self.status_controller else None
+        phase_index0 = (model.phase_index - 1) if (model and model.phase_index > 0) else 0
+        phase_total = model.phase_total if model else 0
+        tb.set_position(cur if cur is not None else -1, len(steps),
+                        phase_index0, phase_total)
+
+    def _rebuild_timeline(self, event=None):
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is None:
+            return
+        steps = self._pane._navigable_steps()
+        tb.rebuild([(row.name or row.dotted_path()) for row in steps])
+        self._refresh_timeline_position()
 
     def _update_phase_nav_buttons(self):
         m = self.status_controller.model if self.status_controller else None
@@ -717,6 +781,10 @@ class PluggableProtocolDockPane(TraitsDockPane):
         """Structural mutation — re-check the baseline path set."""
         self.protocol_state_tracker.on_structure_changed(self.manager)
 
+    @observe("manager.rows_changed", dispatch="ui", post_init=True)
+    def _on_rows_changed_rebuild_timeline(self, event=None):
+        self._rebuild_timeline()
+
     @observe("manager.cell_changed", dispatch="ui")
     def _on_manager_cell_changed(self, event):
         """Cell value edit — incremental dirty update for the one cell."""
@@ -788,12 +856,14 @@ class PluggableProtocolDockPane(TraitsDockPane):
                 row = None
         self._current_row = row
         self._pane.widget.highlight_active_row(row)
+        self._refresh_timeline_position()
 
     ## Observe status bar model changes and modify view accordingly
     @observe("status_controller:model:[step_index, step_total, phase_index, phase_total]", dispatch="ui", post_init=True)
     def _on_counts_changed(self, event=None):
         model = self.status_controller.model
         self._pane.status_bar._refresh_counts(current=model.step_index, total=model.step_total)
+        self._refresh_timeline_position()
 
     @observe("status_controller:model:[repeats_completed, repeats_total]", dispatch="ui", post_init=True)
     def _on_repeats_changed(self, event=None):
@@ -821,6 +891,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
             self._update_protocol_time()  # final freeze-frame (GUI thread)
             if sched.state == STATE_RUNNING:
                 sched.pause()
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is not None:
+            tb.set_running(bool(event.new))
 
 
     ######### Helpers ###################

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -499,10 +499,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
             combo.clear()
             combo.addItems([f"Rep {i}/{rep_count}" for i in range(1, rep_count + 1)])
         combo.setCurrentIndex(max(0, min(rep_count - 1, cur_rep - 1)))
-        # Phase reps can be jumped to; step reps are display-only for now (the
-        # executor seek is path-based, so jumping to a specific step rep needs
-        # executor support). The combo + label hide when showing the full view.
-        combo.setEnabled(context == "phase")
+        # Both phase reps and step reps can be jumped to (while paused). The
+        # combo + label hide when the full timeline is shown.
+        combo.setEnabled(True)
         combo.setVisible(not self._timeline_show_full)
         if label is not None:
             label.setVisible(not self._timeline_show_full)
@@ -512,14 +511,20 @@ class PluggableProtocolDockPane(TraitsDockPane):
         check.blockSignals(False)
 
     def _on_timeline_rep_selected(self, index):
-        # Only phase reps support jumping; keep the current position within the
-        # base loop: index*base + base_index is the absolute phase to seek.
-        if self._timeline_context != "phase":
-            return
-        if not self._timeline_can_collapse or self._timeline_base_count <= 0:
-            return
-        self._seek_to_phase(index * self._timeline_base_count
-                            + self._timeline_base_index)
+        if self._timeline_context == "phase":
+            # Keep the position within the base loop: index*base + base_index is
+            # the absolute phase to seek.
+            if not self._timeline_can_collapse or self._timeline_base_count <= 0:
+                return
+            self._seek_to_phase(index * self._timeline_base_count
+                                + self._timeline_base_index)
+        elif self._timeline_context == "step":
+            row = self._current_step_row()
+            if row is None or self.status_controller is None:
+                return
+            rep_total = max(1, int(getattr(row, "repetitions", 1) or 1))
+            self.status_controller.seek_to_step_rep(
+                tuple(row.path), index + 1, rep_total)
 
     def _on_timeline_show_full_toggled(self, checked):
         # The step track layout (distinct vs per-frame) changes, so rebuild.

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -371,11 +371,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
         if sc is not None and sc.model.running and not sc.model.paused:
             # B1: preview-only while actively running. Move the selection and
             # preview the target; the executor reasserts at the next boundary.
-            self._pane.select_row(row)
-            self._current_row = row
-            path = tuple(row.path)
-            sc.seek_to(path, 0)
-            sc.preview_phase(path, 0, self._current_run_preview_mode)
+            self._seek_and_preview_step(row)
         else:
             # Paused -> real seek; idle -> selection only (matches nav buttons).
             self._select_step(row)
@@ -416,19 +412,31 @@ class PluggableProtocolDockPane(TraitsDockPane):
         self._pane.navigation_bar.set_phase_navigation_enabled(prev_enabled, next_enabled)
 
     # --- step-cursor selection (drives the view + a paused seek) ------
+    def _seek_and_preview_step(self, row):
+        """Move the selection/cursor to ``row`` and preview its first phase
+        (DeviceViewer overlay + hardware unless preview mode). Shared by the
+        timeline's running-preview branch and _select_step's paused branch.
+        seek_to's executor side is paused-guarded, so while actively running
+        this only updates the model + preview and the executor reasserts at
+        the next boundary."""
+        self._pane.select_row(row)
+        self._current_row = row
+        path = tuple(row.path)
+        sc = self.status_controller
+        sc.seek_to(path, 0)
+        sc.preview_phase(path, 0, self._current_run_preview_mode)
+
     @attempt_func_execution_with_error_dialog
     def _select_step(self, row):
         # Move the tree selection (view), then — only while paused — re-seat
         # the model + DV preview to the chosen step. Nav buttons call this; the
         # user expects the DV to follow just as on a direct row click.
-        self._pane.select_row(row)
         sc = self.status_controller
         if sc is not None and sc.model.paused:
-            self._current_row = row
-            path = tuple(row.path)
-            sc.seek_to(path, 0)
-            sc.preview_phase(path, 0, self._current_run_preview_mode)
+            self._seek_and_preview_step(row)
             self._update_phase_nav_buttons()
+        else:
+            self._pane.select_row(row)
 
     def _current_step_in(self, steps):
         # During a run the nav cursor follows the model's current step (the
@@ -879,6 +887,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
         # Lock the tree while a run is in progress (issue #471) and drive the
         # live time-readout poll job off the same running flag.
         self._pane.widget.set_editable(not bool(event.new))
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is not None:
+            tb.set_running(bool(event.new))
         sched = self._protocol_poll_scheduler
         if sched is None:
             return
@@ -891,10 +902,6 @@ class PluggableProtocolDockPane(TraitsDockPane):
             self._update_protocol_time()  # final freeze-frame (GUI thread)
             if sched.state == STATE_RUNNING:
                 sched.pause()
-        tb = getattr(self._pane, "timeline_bar", None)
-        if tb is not None:
-            tb.set_running(bool(event.new))
-
 
     ######### Helpers ###################
     def _clamp_trail_overlay_for_row(self, path, col_id):

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -175,6 +175,8 @@ class PluggableProtocolDockPane(TraitsDockPane):
         self._timeline_base_count = 0
         self._timeline_base_index = 0
         self._timeline_cur_rep = 1
+        self._timeline_context = None
+        self._timeline_step_rows = []
 
         self.status_controller = ProtocolStatusController(
             manager=self.manager,
@@ -378,10 +380,10 @@ class PluggableProtocolDockPane(TraitsDockPane):
     # --- timeline seek bar (view -> controller) ----------------------
 
     def _on_timeline_step_seek(self, step_index):
-        steps = self._pane._navigable_steps()
-        if not (0 <= step_index < len(steps)):
+        rows = self._timeline_step_rows or self._pane._navigable_steps()
+        if not (0 <= step_index < len(rows)):
             return
-        row = steps[step_index]
+        row = rows[step_index]
         sc = self.status_controller
         if sc is not None and sc.model.running and not sc.model.paused:
             # B1: preview-only while actively running. Move the selection and
@@ -403,84 +405,135 @@ class PluggableProtocolDockPane(TraitsDockPane):
 
     # --- timeline seek bar (model -> view) ---------------------------
 
+    def _current_step_row(self):
+        """The distinct current step (drives phase collapse + the rep combo),
+        independent of whether the step track is showing frames."""
+        steps = self._pane._navigable_steps()
+        cur = self._current_step_in(steps)
+        return steps[cur] if cur is not None else None
+
+    def _timeline_active_context(self, row):
+        """Which rep dimension the controls act on for the current step:
+        'phase' while running on a step whose routes repeat (seek supported),
+        else 'step' when the step itself repeats, else None."""
+        if row is None or self.status_controller is None:
+            return None
+        running = bool(self.status_controller.model.running)
+        if running and int(getattr(row, "route_repetitions", 1) or 1) > 1:
+            return "phase"
+        if int(getattr(row, "repetitions", 1) or 1) > 1:
+            return "step"
+        return None
+
     def _refresh_timeline_position(self):
         tb = getattr(self._pane, "timeline_bar", None)
         if tb is None:
             return
-        steps = self._pane._navigable_steps()
-        cur = self._current_step_in(steps)
+        rows = self._timeline_step_rows or self._pane._navigable_steps()
         sc = self.status_controller
+        model = sc.model if sc else None
+        running = bool(model.running) if model else False
+        # Step playhead: the exact execution frame when fully expanded mid-run,
+        # otherwise the step's position in whatever the track is showing.
+        if self._timeline_show_full and running and model and model.frame_index > 0:
+            cur = model.frame_index - 1
+        else:
+            cur = self._current_step_in(rows)
+        # Phase collapse + rep combo are driven by the distinct current step.
+        current_row = self._current_step_row()
         full_count = 0
         full_index = 0
         rep_count = 1
-        if cur is not None and sc is not None:
-            row = steps[cur]
-            model = sc.model
-            on_current_step = (
-                model.current_step_path is not None
-                and tuple(model.current_step_path) == tuple(row.path)
-            )
-            if on_current_step and model.phase_total > 0:
-                # Executing/paused on this step: the model holds the live counts.
+        if current_row is not None and model is not None:
+            on_current = (model.current_step_path is not None
+                          and tuple(model.current_step_path) == tuple(current_row.path))
+            if on_current and model.phase_total > 0:
                 full_count = model.phase_total
                 full_index = max(0, model.phase_index - 1)
             else:
-                # Idle or merely selected: derive the step's phase count so its
-                # phase ticks still show even though no run is driving the model.
-                full_count = sc._phase_total_for(row)
-            rep_count = max(1, int(getattr(row, "route_repetitions", 1) or 1))
+                full_count = sc._phase_total_for(current_row)
+            rep_count = max(1, int(getattr(current_row, "route_repetitions", 1) or 1))
         view = collapse_phase_view(full_count, full_index, rep_count,
                                    self._timeline_show_full)
         self._timeline_can_collapse = view["can_collapse"]
         self._timeline_base_count = view["base_count"]
         self._timeline_base_index = view["base_index"]
         self._timeline_cur_rep = view["cur_rep"]
-        tb.set_position(cur if cur is not None else -1, len(steps),
+        tb.set_position(cur if cur is not None else -1, len(rows),
                         view["phase_index"], view["phase_total"])
-        self._update_timeline_controls(view)
+        self._update_timeline_controls(current_row, view)
 
-    def _update_timeline_controls(self, view):
+    def _update_timeline_controls(self, current_row, view):
         pane = self._pane
         combo = getattr(pane, "timeline_rep_combo", None)
         controls = getattr(pane, "timeline_controls", None)
         check = getattr(pane, "timeline_show_full_check", None)
+        label = getattr(pane, "timeline_rep_label", None)
         if combo is None or controls is None or check is None:
             return
-        running = bool(self.status_controller.model.running) if self.status_controller else False
-        # The phase-rep controls only matter during a run on a collapsible step.
-        controls.setVisible(view["can_collapse"] and running)
-        if not (view["can_collapse"] and running):
+        context = self._timeline_active_context(current_row)
+        self._timeline_context = context
+        model = self.status_controller.model if self.status_controller else None
+        if context == "phase":
+            visible = view["can_collapse"]
+            rep_count = view["rep_count"]
+            cur_rep = view["cur_rep"]
+        elif context == "step":
+            visible = True
+            rep_count = max(1, int(getattr(current_row, "repetitions", 1) or 1))
+            cur_rep = model.step_rep_index if (model and model.step_rep_index > 0) else 1
+        else:
+            visible = False
+            rep_count = 1
+            cur_rep = 1
+        controls.setVisible(visible)
+        if not visible:
             return
-        rep_count = view["rep_count"]
         combo.blockSignals(True)
         if combo.count() != rep_count:
             combo.clear()
             combo.addItems([f"Rep {i}/{rep_count}" for i in range(1, rep_count + 1)])
-        combo.setCurrentIndex(max(0, min(rep_count - 1, view["cur_rep"] - 1)))
+        combo.setCurrentIndex(max(0, min(rep_count - 1, cur_rep - 1)))
+        # Phase reps can be jumped to; step reps are display-only for now (the
+        # executor seek is path-based, so jumping to a specific step rep needs
+        # executor support). The combo + label hide when showing the full view.
+        combo.setEnabled(context == "phase")
+        combo.setVisible(not self._timeline_show_full)
+        if label is not None:
+            label.setVisible(not self._timeline_show_full)
         combo.blockSignals(False)
         check.blockSignals(True)
         check.setChecked(self._timeline_show_full)
         check.blockSignals(False)
 
     def _on_timeline_rep_selected(self, index):
-        # Jump to repetition (index+1), keeping the current position within the
-        # base loop. index*base + base_index is the absolute phase to seek.
+        # Only phase reps support jumping; keep the current position within the
+        # base loop: index*base + base_index is the absolute phase to seek.
+        if self._timeline_context != "phase":
+            return
         if not self._timeline_can_collapse or self._timeline_base_count <= 0:
             return
         self._seek_to_phase(index * self._timeline_base_count
                             + self._timeline_base_index)
 
     def _on_timeline_show_full_toggled(self, checked):
+        # The step track layout (distinct vs per-frame) changes, so rebuild.
         self._timeline_show_full = bool(checked)
-        self._refresh_timeline_position()
+        self._rebuild_timeline()
 
     def _rebuild_timeline(self, event=None):
         tb = getattr(self._pane, "timeline_bar", None)
         if tb is None:
             return
-        steps = self._pane._navigable_steps()
-        labels = [(row.name or row.dotted_path()) for row in steps]
-        group_keys = [self._group_key_for(row) for row in steps]
+        if self._timeline_show_full:
+            # "Show full timeline": one cell per execution frame (every rep of
+            # every step), so step repetitions are visible end to end.
+            rows = [row for row, _chain in self.manager.iter_execution_frames()]
+        else:
+            rows = self._pane._navigable_steps()
+        self._timeline_step_rows = rows
+        labels = [(row.name or row.dotted_path()) for row in rows]
+        group_keys = [self._group_key_for(row) for row in rows]
         tb.rebuild(labels, group_keys)
         self._refresh_timeline_position()
 

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -385,7 +385,16 @@ class PluggableProtocolDockPane(TraitsDockPane):
             return
         row = rows[step_index]
         sc = self.status_controller
-        if sc is not None and sc.model.running and not sc.model.paused:
+        if self._timeline_show_full and sc is not None:
+            # Frames view: the cell index IS the execution-frame index, so seek
+            # to that exact repetition frame (not just its path).
+            self._pane.select_row(row)
+            self._current_row = row
+            path = tuple(row.path)
+            sc.seek_to_frame(path, step_index)
+            sc.preview_phase(path, 0, self._current_run_preview_mode)
+            self._refresh_timeline_position()
+        elif sc is not None and sc.model.running and not sc.model.paused:
             # B1: preview-only while actively running. Move the selection and
             # preview the target; the executor reasserts at the next boundary.
             self._seek_and_preview_step(row)
@@ -469,8 +478,13 @@ class PluggableProtocolDockPane(TraitsDockPane):
         phase_possible = view["can_collapse"]
         self._fill_rep_combo(pane.timeline_phase_rep_combo, pane.timeline_phase_rep_label,
                              phase_possible, view["rep_count"], view["cur_rep"])
-        step_total = (max(1, int(getattr(current_row, "repetitions", 1) or 1))
-                      if current_row is not None else 1)
+        step_reps_attr = (max(1, int(getattr(current_row, "repetitions", 1) or 1))
+                          if current_row is not None else 1)
+        # The running rep count comes from the executor's rep_chain (covers a
+        # repeated GROUP, whose step's own ``repetitions`` is 1); the trait is
+        # the idle fallback for a directly-repeated step.
+        model_total = model.step_rep_total if model else 0
+        step_total = max(step_reps_attr, model_total)
         step_cur = model.step_rep_index if (model and model.step_rep_index > 0) else 1
         step_possible = step_total > 1
         self._fill_rep_combo(pane.timeline_step_rep_combo, pane.timeline_step_rep_label,
@@ -1031,6 +1045,10 @@ class PluggableProtocolDockPane(TraitsDockPane):
     def _on_names_changed(self, event=None):
         model = self.status_controller.model
         self._pane.status_bar._refresh_names(model.recent_step_name, model.next_step_name, model.rep_chain_label)
+        # rep_chain_label changes on every repetition (step or group), so this
+        # reliably advances the Step Rep combo even when no step/phase counter
+        # moved (a no-phase repeated step).
+        self._refresh_timeline_position()
 
     @observe("status_controller:model:running", dispatch="ui", post_init=True)
     def _on_protocol_running_changed(self, event):

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -1015,6 +1015,14 @@ class PluggableProtocolDockPane(TraitsDockPane):
         self._pane.status_bar._refresh_counts(current=model.step_index, total=model.step_total)
         self._refresh_timeline_position()
 
+    @observe("status_controller:model:[frame_index, step_rep_index]", dispatch="ui", post_init=True)
+    def _on_timeline_frame_changed(self, event=None):
+        # A step's repetitions advance the execution frame / step-rep without
+        # changing the distinct step or phase counters, so _on_counts_changed
+        # never fires for them. Refresh here so the Step Rep combo and the
+        # full-view playhead track the running repetition.
+        self._refresh_timeline_position()
+
     @observe("status_controller:model:[repeats_completed, repeats_total]", dispatch="ui", post_init=True)
     def _on_repeats_changed(self, event=None):
         self._pane.status_bar._refresh_repeats(self.status_controller.model.repeats_completed)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -414,12 +414,11 @@ class PluggableProtocolDockPane(TraitsDockPane):
 
     def _timeline_active_context(self, row):
         """Which rep dimension the controls act on for the current step:
-        'phase' while running on a step whose routes repeat (seek supported),
-        else 'step' when the step itself repeats, else None."""
-        if row is None or self.status_controller is None:
+        'phase' when the step's routes repeat (phase seeks are supported, idle
+        or running), else 'step' when the step itself repeats, else None."""
+        if row is None:
             return None
-        running = bool(self.status_controller.model.running)
-        if running and int(getattr(row, "route_repetitions", 1) or 1) > 1:
+        if int(getattr(row, "route_repetitions", 1) or 1) > 1:
             return "phase"
         if int(getattr(row, "repetitions", 1) or 1) > 1:
             return "step"
@@ -444,6 +443,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
         full_count = 0
         full_index = 0
         rep_count = 1
+        base_count = 0
         if current_row is not None and model is not None:
             on_current = (model.current_step_path is not None
                           and tuple(model.current_step_path) == tuple(current_row.path))
@@ -453,14 +453,19 @@ class PluggableProtocolDockPane(TraitsDockPane):
             else:
                 full_count = sc._phase_total_for(current_row)
             rep_count = max(1, int(getattr(current_row, "route_repetitions", 1) or 1))
-        view = collapse_phase_view(full_count, full_index, rep_count,
+            base_count = sc._base_phase_total_for(current_row) if rep_count > 1 else full_count
+        view = collapse_phase_view(full_count, full_index, base_count, rep_count,
                                    self._timeline_show_full)
         self._timeline_can_collapse = view["can_collapse"]
         self._timeline_base_count = view["base_count"]
         self._timeline_base_index = view["base_index"]
         self._timeline_cur_rep = view["cur_rep"]
+        # Show the phase track while running, or idle on a collapsible repeat
+        # step so its base loop + rep controls are visible without running.
+        show_phase = running or view["can_collapse"]
+        phase_total = view["phase_total"] if show_phase else 0
         tb.set_position(cur if cur is not None else -1, len(rows),
-                        view["phase_index"], view["phase_total"])
+                        view["phase_index"], phase_total)
         self._update_timeline_controls(current_row, view)
 
     def _update_timeline_controls(self, current_row, view):

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -417,8 +417,21 @@ class PluggableProtocolDockPane(TraitsDockPane):
         if tb is None:
             return
         steps = self._pane._navigable_steps()
-        tb.rebuild([(row.name or row.dotted_path()) for row in steps])
+        labels = [(row.name or row.dotted_path()) for row in steps]
+        group_keys = [self._group_key_for(row) for row in steps]
+        tb.rebuild(labels, group_keys)
         self._refresh_timeline_position()
+
+    @staticmethod
+    def _group_key_for(row):
+        """Identity of the step's containing group for timeline tinting: the
+        parent group's path, or None for a top-level step (parent is the root
+        group, whose path is empty)."""
+        parent = getattr(row, "parent", None)
+        if parent is None:
+            return None
+        parent_path = tuple(parent.path)
+        return parent_path or None
 
     def _update_phase_nav_buttons(self):
         m = self.status_controller.model if self.status_controller else None

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -50,6 +50,7 @@ from pluggable_protocol_tree.views.protocol_tree_pane import (
     PREVIEW_COMPLETE_TOAST_MS,
 )
 from pluggable_protocol_tree.views.navigation_bar import STATUS_POLL_INTERVAL_MS
+from pluggable_protocol_tree.views.timeline_bar import collapse_phase_view
 from protocol_grid.services.experiment_manager import ExperimentManager
 
 from pluggable_protocol_tree.interfaces.i_column import IColumn
@@ -166,6 +167,15 @@ class PluggableProtocolDockPane(TraitsDockPane):
         # The dock pane is the composition root: it owns the executor, the
         # status controller (executor signals -> status model), the logging
         # controller, and all run control. The pane is a pure view.
+        # Timeline phase-rep collapse state (set before the controller so a
+        # model observer firing on assignment finds it). Collapsed by default:
+        # the phase track shows one base loop and the Rep combo picks the rep.
+        self._timeline_show_full = False
+        self._timeline_can_collapse = False
+        self._timeline_base_count = 0
+        self._timeline_base_index = 0
+        self._timeline_cur_rep = 1
+
         self.status_controller = ProtocolStatusController(
             manager=self.manager,
             executor=self.executor,
@@ -259,6 +269,8 @@ class PluggableProtocolDockPane(TraitsDockPane):
         tb.step_seek_requested.connect(self._on_timeline_step_seek)
         tb.phase_seek_requested.connect(self._on_timeline_phase_seek)
         pane.selection_changed.connect(self._refresh_timeline_position)
+        pane.timeline_rep_combo.currentIndexChanged.connect(self._on_timeline_rep_selected)
+        pane.timeline_show_full_check.toggled.connect(self._on_timeline_show_full_toggled)
 
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)
@@ -381,7 +393,12 @@ class PluggableProtocolDockPane(TraitsDockPane):
             self._select_step(row)
 
     def _on_timeline_phase_seek(self, phase_index):
-        # The bar emits a 0-based phase index, exactly what _seek_to_phase wants.
+        # The bar emits a 0-based phase index within whatever it is showing.
+        # When collapsed, that is an index into the base loop -> map it into the
+        # current repetition; otherwise it is already the absolute phase.
+        if self._timeline_can_collapse and not self._timeline_show_full:
+            phase_index = ((self._timeline_cur_rep - 1) * self._timeline_base_count
+                           + phase_index)
         self._seek_to_phase(phase_index)
 
     # --- timeline seek bar (model -> view) ---------------------------
@@ -393,24 +410,69 @@ class PluggableProtocolDockPane(TraitsDockPane):
         steps = self._pane._navigable_steps()
         cur = self._current_step_in(steps)
         sc = self.status_controller
-        phase_index0 = 0
-        phase_total = 0
+        full_count = 0
+        full_index = 0
+        rep_count = 1
         if cur is not None and sc is not None:
+            row = steps[cur]
             model = sc.model
             on_current_step = (
                 model.current_step_path is not None
-                and tuple(model.current_step_path) == tuple(steps[cur].path)
+                and tuple(model.current_step_path) == tuple(row.path)
             )
             if on_current_step and model.phase_total > 0:
                 # Executing/paused on this step: the model holds the live counts.
-                phase_total = model.phase_total
-                phase_index0 = max(0, model.phase_index - 1)
+                full_count = model.phase_total
+                full_index = max(0, model.phase_index - 1)
             else:
                 # Idle or merely selected: derive the step's phase count so its
                 # phase ticks still show even though no run is driving the model.
-                phase_total = sc._phase_total_for(steps[cur])
+                full_count = sc._phase_total_for(row)
+            rep_count = max(1, int(getattr(row, "route_repetitions", 1) or 1))
+        view = collapse_phase_view(full_count, full_index, rep_count,
+                                   self._timeline_show_full)
+        self._timeline_can_collapse = view["can_collapse"]
+        self._timeline_base_count = view["base_count"]
+        self._timeline_base_index = view["base_index"]
+        self._timeline_cur_rep = view["cur_rep"]
         tb.set_position(cur if cur is not None else -1, len(steps),
-                        phase_index0, phase_total)
+                        view["phase_index"], view["phase_total"])
+        self._update_timeline_controls(view)
+
+    def _update_timeline_controls(self, view):
+        pane = self._pane
+        combo = getattr(pane, "timeline_rep_combo", None)
+        controls = getattr(pane, "timeline_controls", None)
+        check = getattr(pane, "timeline_show_full_check", None)
+        if combo is None or controls is None or check is None:
+            return
+        running = bool(self.status_controller.model.running) if self.status_controller else False
+        # The phase-rep controls only matter during a run on a collapsible step.
+        controls.setVisible(view["can_collapse"] and running)
+        if not (view["can_collapse"] and running):
+            return
+        rep_count = view["rep_count"]
+        combo.blockSignals(True)
+        if combo.count() != rep_count:
+            combo.clear()
+            combo.addItems([f"Rep {i}/{rep_count}" for i in range(1, rep_count + 1)])
+        combo.setCurrentIndex(max(0, min(rep_count - 1, view["cur_rep"] - 1)))
+        combo.blockSignals(False)
+        check.blockSignals(True)
+        check.setChecked(self._timeline_show_full)
+        check.blockSignals(False)
+
+    def _on_timeline_rep_selected(self, index):
+        # Jump to repetition (index+1), keeping the current position within the
+        # base loop. index*base + base_index is the absolute phase to seek.
+        if not self._timeline_can_collapse or self._timeline_base_count <= 0:
+            return
+        self._seek_to_phase(index * self._timeline_base_count
+                            + self._timeline_base_index)
+
+    def _on_timeline_show_full_toggled(self, checked):
+        self._timeline_show_full = bool(checked)
+        self._refresh_timeline_position()
 
     def _rebuild_timeline(self, event=None):
         tb = getattr(self._pane, "timeline_bar", None)
@@ -924,6 +986,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
         tb = getattr(self._pane, "timeline_bar", None)
         if tb is not None:
             tb.set_running(bool(event.new))
+            self._refresh_timeline_position()  # show/hide rep controls
         sched = self._protocol_poll_scheduler
         if sched is None:
             return

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -175,7 +175,6 @@ class PluggableProtocolDockPane(TraitsDockPane):
         self._timeline_base_count = 0
         self._timeline_base_index = 0
         self._timeline_cur_rep = 1
-        self._timeline_context = None
         self._timeline_step_rows = []
 
         self.status_controller = ProtocolStatusController(
@@ -271,7 +270,8 @@ class PluggableProtocolDockPane(TraitsDockPane):
         tb.step_seek_requested.connect(self._on_timeline_step_seek)
         tb.phase_seek_requested.connect(self._on_timeline_phase_seek)
         pane.selection_changed.connect(self._refresh_timeline_position)
-        pane.timeline_rep_combo.currentIndexChanged.connect(self._on_timeline_rep_selected)
+        pane.timeline_step_rep_combo.currentIndexChanged.connect(self._on_timeline_step_rep_selected)
+        pane.timeline_phase_rep_combo.currentIndexChanged.connect(self._on_timeline_phase_rep_selected)
         pane.timeline_show_full_check.toggled.connect(self._on_timeline_show_full_toggled)
 
         nb.btn_play.clicked.connect(self._on_play_clicked)
@@ -412,18 +412,6 @@ class PluggableProtocolDockPane(TraitsDockPane):
         cur = self._current_step_in(steps)
         return steps[cur] if cur is not None else None
 
-    def _timeline_active_context(self, row):
-        """Which rep dimension the controls act on for the current step:
-        'phase' when the step's routes repeat (phase seeks are supported, idle
-        or running), else 'step' when the step itself repeats, else None."""
-        if row is None:
-            return None
-        if int(getattr(row, "route_repetitions", 1) or 1) > 1:
-            return "phase"
-        if int(getattr(row, "repetitions", 1) or 1) > 1:
-            return "step"
-        return None
-
     def _refresh_timeline_position(self):
         tb = getattr(self._pane, "timeline_bar", None)
         if tb is None:
@@ -469,62 +457,57 @@ class PluggableProtocolDockPane(TraitsDockPane):
         self._update_timeline_controls(current_row, view)
 
     def _update_timeline_controls(self, current_row, view):
+        # Two independent selectors, side by side: step reps and phase reps.
+        # Each shows when its dimension applies (a step may have both); the row
+        # is visible if either does. Both hide when the full timeline is shown.
         pane = self._pane
-        combo = getattr(pane, "timeline_rep_combo", None)
         controls = getattr(pane, "timeline_controls", None)
         check = getattr(pane, "timeline_show_full_check", None)
-        label = getattr(pane, "timeline_rep_label", None)
-        if combo is None or controls is None or check is None:
+        if controls is None or check is None:
             return
-        context = self._timeline_active_context(current_row)
-        self._timeline_context = context
         model = self.status_controller.model if self.status_controller else None
-        if context == "phase":
-            visible = view["can_collapse"]
-            rep_count = view["rep_count"]
-            cur_rep = view["cur_rep"]
-        elif context == "step":
-            visible = True
-            rep_count = max(1, int(getattr(current_row, "repetitions", 1) or 1))
-            cur_rep = model.step_rep_index if (model and model.step_rep_index > 0) else 1
-        else:
-            visible = False
-            rep_count = 1
-            cur_rep = 1
-        controls.setVisible(visible)
-        if not visible:
-            return
-        combo.blockSignals(True)
-        if combo.count() != rep_count:
-            combo.clear()
-            combo.addItems([f"Rep {i}/{rep_count}" for i in range(1, rep_count + 1)])
-        combo.setCurrentIndex(max(0, min(rep_count - 1, cur_rep - 1)))
-        # Both phase reps and step reps can be jumped to (while paused). The
-        # combo + label hide when the full timeline is shown.
-        combo.setEnabled(True)
-        combo.setVisible(not self._timeline_show_full)
-        if label is not None:
-            label.setVisible(not self._timeline_show_full)
-        combo.blockSignals(False)
+        phase_possible = view["can_collapse"]
+        self._fill_rep_combo(pane.timeline_phase_rep_combo, pane.timeline_phase_rep_label,
+                             phase_possible, view["rep_count"], view["cur_rep"])
+        step_total = (max(1, int(getattr(current_row, "repetitions", 1) or 1))
+                      if current_row is not None else 1)
+        step_cur = model.step_rep_index if (model and model.step_rep_index > 0) else 1
+        step_possible = step_total > 1
+        self._fill_rep_combo(pane.timeline_step_rep_combo, pane.timeline_step_rep_label,
+                             step_possible, step_total, step_cur)
+        controls.setVisible(phase_possible or step_possible)
         check.blockSignals(True)
         check.setChecked(self._timeline_show_full)
         check.blockSignals(False)
 
-    def _on_timeline_rep_selected(self, index):
-        if self._timeline_context == "phase":
-            # Keep the position within the base loop: index*base + base_index is
-            # the absolute phase to seek.
-            if not self._timeline_can_collapse or self._timeline_base_count <= 0:
-                return
-            self._seek_to_phase(index * self._timeline_base_count
-                                + self._timeline_base_index)
-        elif self._timeline_context == "step":
-            row = self._current_step_row()
-            if row is None or self.status_controller is None:
-                return
-            rep_total = max(1, int(getattr(row, "repetitions", 1) or 1))
-            self.status_controller.seek_to_step_rep(
-                tuple(row.path), index + 1, rep_total)
+    def _fill_rep_combo(self, combo, label, possible, rep_count, cur_rep):
+        show = possible and not self._timeline_show_full
+        combo.setVisible(show)
+        label.setVisible(show)
+        if not show:
+            return
+        combo.blockSignals(True)
+        if combo.count() != rep_count:
+            combo.clear()
+            combo.addItems([f"{i}/{rep_count}" for i in range(1, rep_count + 1)])
+        combo.setCurrentIndex(max(0, min(rep_count - 1, cur_rep - 1)))
+        combo.blockSignals(False)
+
+    def _on_timeline_phase_rep_selected(self, index):
+        # Keep the position within the base loop: index*base + base_index is the
+        # absolute phase to seek.
+        if not self._timeline_can_collapse or self._timeline_base_count <= 0:
+            return
+        self._seek_to_phase(index * self._timeline_base_count
+                            + self._timeline_base_index)
+
+    def _on_timeline_step_rep_selected(self, index):
+        row = self._current_step_row()
+        if row is None or self.status_controller is None:
+            return
+        rep_total = max(1, int(getattr(row, "repetitions", 1) or 1))
+        self.status_controller.seek_to_step_rep(
+            tuple(row.path), index + 1, rep_total)
 
     def _on_timeline_show_full_toggled(self, checked):
         # The step track layout (distinct vs per-frame) changes, so rebuild.

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -252,10 +252,13 @@ class PluggableProtocolDockPane(TraitsDockPane):
         nb.btn_last.clicked.connect(self.navigate_to_last_step)
 
         # Timeline seek bar: clicks redirect through the status controller; the
-        # model observers below push the playhead position back.
+        # model observers below push the playhead position back. Also follow
+        # direct tree selection moves (clicking a row in the tree) so the
+        # playhead reflects the latest selected step when idle.
         tb = pane.timeline_bar
         tb.step_seek_requested.connect(self._on_timeline_step_seek)
         tb.phase_seek_requested.connect(self._on_timeline_phase_seek)
+        pane.selection_changed.connect(self._refresh_timeline_position)
 
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -514,14 +514,22 @@ class PluggableProtocolDockPane(TraitsDockPane):
             return
         self._seek_to_phase(index * self._timeline_base_count
                             + self._timeline_base_index)
+        # Refresh the status bar's phase readout now, not on the next play.
+        self._update_protocol_time()
 
     def _on_timeline_step_rep_selected(self, index):
         row = self._current_step_row()
-        if row is None or self.status_controller is None:
+        sc = self.status_controller
+        if row is None or sc is None:
             return
-        rep_total = max(1, int(getattr(row, "repetitions", 1) or 1))
-        self.status_controller.seek_to_step_rep(
-            tuple(row.path), index + 1, rep_total)
+        # Cover a repeated group (the step's own ``repetitions`` is 1) by using
+        # the running rep total too -- same source the combo was filled from.
+        rep_total = max(int(getattr(row, "repetitions", 1) or 1),
+                        int(sc.model.step_rep_total or 0))
+        sc.seek_to_step_rep(tuple(row.path), index + 1, rep_total)
+        # The Step Rep status label follows rep_chain_label (set by the seek);
+        # refresh the time readouts now too rather than waiting for play.
+        self._update_protocol_time()
 
     def _on_timeline_show_full_toggled(self, checked):
         # The step track layout (distinct vs per-frame) changes, so rebuild.

--- a/pluggable_protocol_tree/views/navigation_bar.py
+++ b/pluggable_protocol_tree/views/navigation_bar.py
@@ -464,7 +464,7 @@ class StatusBar(QScrollArea):
         self.lbl_step_progress.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.lbl_step_repetition = QLabel("Repetition 0/0")
-        self.lbl_step_repetition.setFixedWidth(100)
+        self.lbl_step_repetition.setFixedWidth(120)
         self.lbl_step_repetition.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         # Recent / next step labels: fixed width truncates long step

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -22,8 +22,8 @@ from pyface.qt.QtCore import (
 )
 from pyface.qt.QtGui import QFont
 from pyface.qt.QtWidgets import (
-    QApplication, QFileDialog, QProgressDialog, QToolButton, QVBoxLayout,
-    QWidget,
+    QApplication, QCheckBox, QComboBox, QFileDialog, QHBoxLayout, QLabel,
+    QProgressDialog, QToolButton, QVBoxLayout, QWidget,
 )
 
 from microdrop_application.dialogs.pyface_wrapper import (
@@ -164,6 +164,7 @@ class ProtocolTreePane(QWidget):
         self._build_status_bar()
         self._build_navigation_bar()
         self.timeline_bar = TimelineBar()
+        self.timeline_controls = self._build_timeline_controls()
         self._build_experiment_bar()
 
         # Quick-actions toolbar (bar + controller). Both are None when no
@@ -222,6 +223,26 @@ class ProtocolTreePane(QWidget):
     def _build_navigation_bar(self):
         self.navigation_bar = NavigationBar()
 
+    def _build_timeline_controls(self):
+        """Rep selector + 'show full timeline' toggle shown beneath the
+        timeline when the current step has phase repetitions. The dock-pane
+        controller populates, shows/hides, and wires these."""
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(8, 0, 8, 0)
+        layout.setSpacing(6)
+        self.timeline_rep_combo = QComboBox()
+        self.timeline_rep_combo.setToolTip("Jump to a repetition")
+        self.timeline_show_full_check = QCheckBox("Show full timeline")
+        self.timeline_show_full_check.setToolTip(
+            "Show every phase across all repetitions instead of one base loop")
+        layout.addWidget(QLabel("Rep"))
+        layout.addWidget(self.timeline_rep_combo)
+        layout.addWidget(self.timeline_show_full_check)
+        layout.addStretch()
+        row.setVisible(False)
+        return row
+
     def _build_experiment_bar(self):
         icon_font = QFont(ICON_FONT_FAMILY)
         icon_font.setPixelSize(20)
@@ -254,6 +275,7 @@ class ProtocolTreePane(QWidget):
         layout.setSpacing(0)
         layout.addWidget(self.navigation_bar)
         layout.addWidget(self.timeline_bar)
+        layout.addWidget(self.timeline_controls)
         layout.addWidget(self.status_bar)
         layout.addWidget(make_separator())
         layout.addWidget(self.widget)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -233,10 +233,12 @@ class ProtocolTreePane(QWidget):
         layout.setSpacing(6)
         self.timeline_rep_combo = QComboBox()
         self.timeline_rep_combo.setToolTip("Jump to a repetition")
+        self.timeline_rep_label = QLabel("Rep")
         self.timeline_show_full_check = QCheckBox("Show full timeline")
         self.timeline_show_full_check.setToolTip(
-            "Show every phase across all repetitions instead of one base loop")
-        layout.addWidget(QLabel("Rep"))
+            "Show every phase/step across all repetitions instead of a "
+            "collapsed base loop")
+        layout.addWidget(self.timeline_rep_label)
         layout.addWidget(self.timeline_rep_combo)
         layout.addWidget(self.timeline_show_full_check)
         layout.addStretch()

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -224,22 +224,27 @@ class ProtocolTreePane(QWidget):
         self.navigation_bar = NavigationBar()
 
     def _build_timeline_controls(self):
-        """Rep selector + 'show full timeline' toggle shown beneath the
-        timeline when the current step has phase repetitions. The dock-pane
-        controller populates, shows/hides, and wires these."""
+        """Step-rep and phase-rep selectors (side by side) + a 'show full
+        timeline' toggle, shown beneath the timeline when the current step has
+        repetitions. The dock-pane controller populates, shows/hides, wires."""
         row = QWidget()
         layout = QHBoxLayout(row)
         layout.setContentsMargins(8, 0, 8, 0)
         layout.setSpacing(6)
-        self.timeline_rep_combo = QComboBox()
-        self.timeline_rep_combo.setToolTip("Jump to a repetition")
-        self.timeline_rep_label = QLabel("Rep")
+        self.timeline_step_rep_label = QLabel("Step Rep")
+        self.timeline_step_rep_combo = QComboBox()
+        self.timeline_step_rep_combo.setToolTip("Jump to a step repetition")
+        self.timeline_phase_rep_label = QLabel("Phase Rep")
+        self.timeline_phase_rep_combo = QComboBox()
+        self.timeline_phase_rep_combo.setToolTip("Jump to a phase repetition")
         self.timeline_show_full_check = QCheckBox("Show full timeline")
         self.timeline_show_full_check.setToolTip(
             "Show every phase/step across all repetitions instead of a "
             "collapsed base loop")
-        layout.addWidget(self.timeline_rep_label)
-        layout.addWidget(self.timeline_rep_combo)
+        layout.addWidget(self.timeline_step_rep_label)
+        layout.addWidget(self.timeline_step_rep_combo)
+        layout.addWidget(self.timeline_phase_rep_label)
+        layout.addWidget(self.timeline_phase_rep_combo)
         layout.addWidget(self.timeline_show_full_check)
         layout.addStretch()
         row.setVisible(False)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -55,6 +55,7 @@ from pluggable_protocol_tree.views.protocol_validator_presenter import (
 from pluggable_protocol_tree.views.navigation_bar import (
     NavigationBar, StatusBar, make_separator,
 )
+from pluggable_protocol_tree.views.timeline_bar import TimelineBar
 from pluggable_protocol_tree.views.quick_action_bar import (
     QuickActionBar, QuickActionsController,
 )
@@ -162,6 +163,7 @@ class ProtocolTreePane(QWidget):
 
         self._build_status_bar()
         self._build_navigation_bar()
+        self.timeline_bar = TimelineBar()
         self._build_experiment_bar()
 
         # Quick-actions toolbar (bar + controller). Both are None when no
@@ -251,6 +253,7 @@ class ProtocolTreePane(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
         layout.addWidget(self.navigation_bar)
+        layout.addWidget(self.timeline_bar)
         layout.addWidget(self.status_bar)
         layout.addWidget(make_separator())
         layout.addWidget(self.widget)

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -11,7 +11,7 @@ re-applies theme colours on colorSchemeChanged (deferred one event-loop
 tick, since is_dark_mode() can be briefly stale at signal time).
 """
 
-from pyface.qt.QtCore import Qt, QRect, QTimer, Signal
+from pyface.qt.QtCore import Qt, QPoint, QRect, QTimer, Signal
 from pyface.qt.QtGui import QColor, QPainter, QPen
 from pyface.qt.QtWidgets import QApplication, QSizePolicy, QWidget
 
@@ -160,7 +160,12 @@ class TimelineBar(QWidget):
             head_x = self._tick_center_x(position, count)
             head_color = colors["running_head"] if self._running else colors["head"]
             painter.setPen(QPen(QColor(head_color), 3))
-            painter.drawLine(head_x, rect.top() - 2, head_x, rect.bottom() + 2)
+            painter.drawLine(head_x, rect.top() - 3, head_x, rect.bottom() + 3)
+            # Filled marker so the current tick clearly reads as the playhead,
+            # not just a slightly-taller tick among its neighbours.
+            painter.setBrush(QColor(head_color))
+            painter.drawEllipse(QPoint(head_x, rect.center().y()), 4, 4)
+            painter.setBrush(Qt.NoBrush)
 
     def paintEvent(self, event):
         if self.step_count <= 0:

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -40,12 +40,13 @@ GROUP_TINT_ALPHA = 60
 DRAG_THROTTLE_MS = 75
 
 
-def collapse_phase_view(full_count, full_index, rep_count, show_full):
+def collapse_phase_view(full_count, full_index, base_count, rep_count, show_full):
     """Collapse route-repeat phases to one base loop + a repetition number.
 
-    Given a step's full phase count and 0-based index plus its phase-rep count,
-    decide whether the phases collapse to a single base loop (they do only when
-    the count divides evenly into >= 2 base phases per rep). Returns a dict:
+    ``base_count`` is the size of one route loop (computed once with
+    n_repeats=1, so soft-start/trail ramps are handled rather than assuming the
+    full count divides evenly). Collapsing applies when the step repeats
+    (rep_count > 1) and the base loop has >= 2 phases. Returns a dict:
       phase_total / phase_index -- what to feed TimelineBar.set_position
       can_collapse              -- whether the rep controls apply at all
       base_count / base_index   -- one base loop's size and the position in it
@@ -54,14 +55,12 @@ def collapse_phase_view(full_count, full_index, rep_count, show_full):
     every rep is shown at once.
     """
     rep_count = max(1, int(rep_count))
-    can_collapse = (rep_count > 1 and full_count > 0
-                    and full_count % rep_count == 0
-                    and full_count // rep_count >= 2)
+    base_count = int(base_count)
+    can_collapse = rep_count > 1 and base_count >= 2 and full_count >= base_count
     if not can_collapse:
         return dict(phase_total=full_count, phase_index=full_index,
                     can_collapse=False, base_count=full_count,
                     base_index=full_index, cur_rep=1, rep_count=rep_count)
-    base_count = full_count // rep_count
     base_index = full_index % base_count
     cur_rep = min(rep_count, full_index // base_count + 1)
     collapsed = not show_full
@@ -161,9 +160,10 @@ class TimelineBar(QWidget):
                      self._usable_width(), PHASE_TRACK_BOTTOM - PHASE_TRACK_TOP)
 
     def _phase_track_visible(self):
-        # Phase scrubbing only makes sense during a run (incl. paused); when
-        # idle the phase track is hidden even on a multi-phase step.
-        return self._running and self._phase_total > 1
+        # Visibility policy lives in the controller (it knows run state + reps);
+        # the widget simply shows the phase track whenever it is given >1 phase.
+        # The controller feeds phase_total=0 when the track should be hidden.
+        return self._phase_total > 1
 
     def _index_at_x(self, x, count):
         if count <= 0:

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -35,6 +35,10 @@ PHASE_TRACK_BOTTOM = 29
 GROUP_PALETTE = ("#4F9DDE", "#E0A23B", "#5FBF77", "#C56BD6", "#E06C75", "#46B5A8")
 GROUP_TINT_ALPHA = 60
 
+# Minimum gap between drag-seek emits, so a fast scrub steps through cells at a
+# steady rate instead of firing a burst that visually skips steps/phases.
+DRAG_THROTTLE_MS = 75
+
 
 class TimelineBar(QWidget):
     step_seek_requested = Signal(int)
@@ -62,7 +66,12 @@ class TimelineBar(QWidget):
         self._drag_press_x = 0
         self._drag_anchor_index = 0
         self._drag_moved = False
-        self._drag_last_target = None
+        self._pending_target = None
+        self._emitted_target = None
+        self._drag_throttle = QTimer(self)
+        self._drag_throttle.setSingleShot(True)
+        self._drag_throttle.setInterval(DRAG_THROTTLE_MS)
+        self._drag_throttle.timeout.connect(self._on_throttle_timeout)
 
         QApplication.styleHints().colorSchemeChanged.connect(
             self._on_color_scheme_changed,
@@ -166,6 +175,12 @@ class TimelineBar(QWidget):
             if not self._drag_moved:
                 # A press with no drag is a plain click: jump to that cell.
                 self._seek_at_point(self._event_point(event))
+            else:
+                # Flush the final drag position immediately on release.
+                self._drag_throttle.stop()
+                if (self._pending_target is not None
+                        and self._pending_target != self._emitted_target):
+                    self._emit_target(self._pending_target)
             self._drag_track = None
         super().mouseReleaseEvent(event)
 
@@ -183,7 +198,8 @@ class TimelineBar(QWidget):
             return
         self._drag_press_x = point.x()
         self._drag_moved = False
-        self._drag_last_target = None
+        self._pending_target = None
+        self._emitted_target = None
 
     def _drag_update(self, point):
         count = self._phase_total if self._drag_track == "phase" else self.step_count
@@ -195,9 +211,24 @@ class TimelineBar(QWidget):
             self._drag_moved = True
         anchor = self._drag_anchor_index if self._drag_anchor_index >= 0 else 0
         target = max(0, min(count - 1, anchor + delta))
-        if target == self._drag_last_target:
-            return
-        self._drag_last_target = target
+        self._request_seek(target)
+
+    def _request_seek(self, target):
+        # Throttle: emit the first change immediately (responsive), then at most
+        # one emit per DRAG_THROTTLE_MS while the drag keeps changing.
+        self._pending_target = target
+        if not self._drag_throttle.isActive():
+            self._emit_target(target)
+            self._drag_throttle.start()
+
+    def _on_throttle_timeout(self):
+        if (self._pending_target is not None
+                and self._pending_target != self._emitted_target):
+            self._emit_target(self._pending_target)
+            self._drag_throttle.start()   # keep pacing while the drag advances
+
+    def _emit_target(self, target):
+        self._emitted_target = target
         if self._drag_track == "phase":
             self.phase_seek_requested.emit(target)
         else:

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -11,7 +11,7 @@ re-applies theme colours on colorSchemeChanged (deferred one event-loop
 tick, since is_dark_mode() can be briefly stale at signal time).
 """
 
-from pyface.qt.QtCore import Qt, QPoint, QRect, QTimer, Signal
+from pyface.qt.QtCore import Qt, QRect, QTimer, Signal
 from pyface.qt.QtGui import QColor, QPainter, QPen
 from pyface.qt.QtWidgets import QApplication, QSizePolicy, QWidget
 
@@ -144,27 +144,28 @@ class TimelineBar(QWidget):
 
     # --- paint ------------------------------------------------------
 
-    def _tick_center_x(self, index, count):
-        seg = self._usable_width() / max(1, count)
-        return int(SIDE_MARGIN + (index + 0.5) * seg)
-
     def _paint_track(self, painter, rect, count, position, colors):
+        # Video-timeline look: a track bar divided into one cell per item by
+        # thin separators, with the current item drawn as a filled, outlined
+        # box (the "you are here" cell) rather than a single tick.
+        seg = self._usable_width() / max(1, count)
         painter.setPen(QPen(QColor(colors["track"]), 2))
         mid_y = rect.center().y()
         painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
         painter.setPen(QPen(QColor(colors["tick"]), 1))
-        for i in range(count):
-            x = self._tick_center_x(i, count)
+        for i in range(count + 1):
+            x = int(SIDE_MARGIN + i * seg)
             painter.drawLine(x, rect.top(), x, rect.bottom())
         if 0 <= position < count:
-            head_x = self._tick_center_x(position, count)
+            left = int(SIDE_MARGIN + position * seg)
+            right = int(SIDE_MARGIN + (position + 1) * seg)
             head_color = colors["running_head"] if self._running else colors["head"]
-            painter.setPen(QPen(QColor(head_color), 3))
-            painter.drawLine(head_x, rect.top() - 3, head_x, rect.bottom() + 3)
-            # Filled marker so the current tick clearly reads as the playhead,
-            # not just a slightly-taller tick among its neighbours.
-            painter.setBrush(QColor(head_color))
-            painter.drawEllipse(QPoint(head_x, rect.center().y()), 4, 4)
+            fill = QColor(head_color)
+            fill.setAlpha(90)
+            painter.setBrush(fill)
+            painter.setPen(QPen(QColor(head_color), 2))
+            painter.drawRoundedRect(
+                QRect(left, rect.top(), max(1, right - left), rect.height()), 3, 3)
             painter.setBrush(Qt.NoBrush)
 
     def paintEvent(self, event):

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -1,0 +1,176 @@
+"""TimelineBar — a video-style seek strip for the pluggable protocol tree.
+
+Pure view: it paints a step track (one tick per navigable step) with a
+playhead, and — only when the current step has more than one phase — a
+secondary phase track beneath it. Clicking either track emits an intent
+signal; the dock-pane controller translates that into a status-controller
+seek. The widget holds no engine references and never seeks itself.
+
+Mirrors NavigationBar's conventions: hugs its height (Expanding/Fixed),
+re-applies theme colours on colorSchemeChanged (deferred one event-loop
+tick, since is_dark_mode() can be briefly stale at signal time).
+"""
+
+from pyface.qt.QtCore import Qt, QRect, QTimer, Signal
+from pyface.qt.QtGui import QColor, QPainter, QPen
+from pyface.qt.QtWidgets import QApplication, QSizePolicy, QWidget
+
+from microdrop_style.colors import BLACK, GREY, SECONDARY_SHADE, WHITE
+from microdrop_style.helpers import is_dark_mode
+
+# Layout geometry (px). The widget is a fixed-height strip; the step track
+# sits on top, the phase track (shown only for multi-phase current steps)
+# directly below it.
+SIDE_MARGIN = 8
+BAR_HEIGHT = 34
+STEP_TRACK_TOP = 6
+STEP_TRACK_BOTTOM = 18
+PHASE_TRACK_TOP = 21
+PHASE_TRACK_BOTTOM = 29
+
+
+class TimelineBar(QWidget):
+    step_seek_requested = Signal(int)
+    phase_seek_requested = Signal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self.setFixedHeight(BAR_HEIGHT)
+        self.setMouseTracking(True)
+
+        self.step_count = 0
+        self._step_labels = []
+        self._step_index = -1
+        self._phase_index = 0
+        self._phase_total = 0
+        self._running = False
+
+        QApplication.styleHints().colorSchemeChanged.connect(
+            self._on_color_scheme_changed,
+        )
+
+    # --- push API (driven by the dock-pane controller) ---------------
+
+    def rebuild(self, step_labels):
+        self._step_labels = list(step_labels)
+        self.step_count = len(self._step_labels)
+        self.update()
+
+    def set_position(self, step_index, step_total, phase_index, phase_total):
+        # step_total is accepted for API symmetry with the status bar, but the
+        # tick count comes from rebuild()'s label list; trust step_count.
+        self._step_index = step_index
+        self._phase_index = phase_index
+        self._phase_total = phase_total
+        self.setToolTip(self._current_label())
+        self.update()
+
+    def set_running(self, running):
+        self._running = bool(running)
+        self.update()
+
+    # --- geometry / hit testing --------------------------------------
+
+    def _usable_width(self):
+        return max(1, self.width() - 2 * SIDE_MARGIN)
+
+    def _step_track_rect(self):
+        return QRect(SIDE_MARGIN, STEP_TRACK_TOP,
+                     self._usable_width(), STEP_TRACK_BOTTOM - STEP_TRACK_TOP)
+
+    def _phase_track_rect(self):
+        return QRect(SIDE_MARGIN, PHASE_TRACK_TOP,
+                     self._usable_width(), PHASE_TRACK_BOTTOM - PHASE_TRACK_TOP)
+
+    def _phase_track_visible(self):
+        return self._phase_total > 1
+
+    def _index_at_x(self, x, count):
+        if count <= 0:
+            return 0
+        seg = self._usable_width() / count
+        idx = int((x - SIDE_MARGIN) / seg)
+        return max(0, min(count - 1, idx))
+
+    def _step_index_at_x(self, x):
+        return self._index_at_x(x, self.step_count)
+
+    def _phase_index_at_x(self, x):
+        return self._index_at_x(x, self._phase_total)
+
+    def _seek_at_point(self, point):
+        if self._phase_track_visible() and self._phase_track_rect().contains(point):
+            self.phase_seek_requested.emit(self._phase_index_at_x(point.x()))
+        elif self._step_track_rect().contains(point):
+            self.step_seek_requested.emit(self._step_index_at_x(point.x()))
+
+    # --- mouse ------------------------------------------------------
+
+    def _event_point(self, event):
+        # PySide6: QMouseEvent.position() returns QPointF; older shims use pos().
+        if hasattr(event, "position"):
+            return event.position().toPoint()
+        return event.pos()
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.LeftButton:
+            self._seek_at_point(self._event_point(event))
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        # Scrub: while the left button is held, keep emitting as the pointer
+        # crosses ticks. Qt coalesces move events, so this is not per-pixel.
+        if event.buttons() & Qt.LeftButton:
+            self._seek_at_point(self._event_point(event))
+        super().mouseMoveEvent(event)
+
+    # --- labels / theme ---------------------------------------------
+
+    def _current_label(self):
+        if 0 <= self._step_index < len(self._step_labels):
+            return self._step_labels[self._step_index]
+        return ""
+
+    def _on_color_scheme_changed(self, *_):
+        QTimer.singleShot(0, self.update)
+
+    def _colors(self):
+        if is_dark_mode():
+            return dict(track=GREY["dark"], tick=GREY["lighter"], text=WHITE,
+                        head=SECONDARY_SHADE[300])
+        return dict(track=GREY["light"], tick=GREY["dark"], text=BLACK,
+                    head=SECONDARY_SHADE[700])
+
+    # --- paint ------------------------------------------------------
+
+    def _tick_center_x(self, index, count):
+        seg = self._usable_width() / max(1, count)
+        return int(SIDE_MARGIN + (index + 0.5) * seg)
+
+    def _paint_track(self, painter, rect, count, position, colors):
+        painter.setPen(QPen(QColor(colors["track"]), 2))
+        mid_y = rect.center().y()
+        painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
+        painter.setPen(QPen(QColor(colors["tick"]), 1))
+        for i in range(count):
+            x = self._tick_center_x(i, count)
+            painter.drawLine(x, rect.top(), x, rect.bottom())
+        if 0 <= position < count:
+            head_x = self._tick_center_x(position, count)
+            head_color = SECONDARY_SHADE[300] if self._running else colors["head"]
+            painter.setPen(QPen(QColor(head_color), 3))
+            painter.drawLine(head_x, rect.top() - 2, head_x, rect.bottom() + 2)
+
+    def paintEvent(self, event):
+        if self.step_count <= 0:
+            return
+        colors = self._colors()
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        self._paint_track(painter, self._step_track_rect(),
+                          self.step_count, self._step_index, colors)
+        if self._phase_track_visible():
+            self._paint_track(painter, self._phase_track_rect(),
+                              self._phase_total, self._phase_index, colors)
+        painter.end()

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -1,8 +1,9 @@
 """TimelineBar — a video-style seek strip for the pluggable protocol tree.
 
-Pure view: it paints a step track (one tick per navigable step) with a
-playhead, and — only when the current step has more than one phase — a
-secondary phase track beneath it. Clicking either track emits an intent
+Pure view: it paints a step track (one cell per navigable step) with the
+current step highlighted, and — only while a protocol is running and the
+current step has more than one phase — a secondary phase track beneath
+it. Clicking either track emits an intent
 signal; the dock-pane controller translates that into a status-controller
 seek. The widget holds no engine references and never seeks itself.
 
@@ -84,7 +85,9 @@ class TimelineBar(QWidget):
                      self._usable_width(), PHASE_TRACK_BOTTOM - PHASE_TRACK_TOP)
 
     def _phase_track_visible(self):
-        return self._phase_total > 1
+        # Phase scrubbing only makes sense during a run (incl. paused); when
+        # idle the phase track is hidden even on a multi-phase step.
+        return self._running and self._phase_total > 1
 
     def _index_at_x(self, x, count):
         if count <= 0:

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -29,6 +29,12 @@ STEP_TRACK_BOTTOM = 18
 PHASE_TRACK_TOP = 21
 PHASE_TRACK_BOTTOM = 29
 
+# Translucent categorical tints used to band steps by their containing group,
+# so grouped steps are identifiable at a glance. Cycled in group order; steps
+# not in any group get no tint.
+GROUP_PALETTE = ("#4F9DDE", "#E0A23B", "#5FBF77", "#C56BD6", "#E06C75", "#46B5A8")
+GROUP_TINT_ALPHA = 60
+
 
 class TimelineBar(QWidget):
     step_seek_requested = Signal(int)
@@ -46,6 +52,17 @@ class TimelineBar(QWidget):
         self._phase_index = 0
         self._phase_total = 0
         self._running = False
+        self._cell_colors = []
+
+        # Relative-drag state: a press anchors at the current playhead, and a
+        # drag moves it by the number of cells the pointer travels -- so
+        # dragging left/right nudges the position rather than jumping to the
+        # cell under the cursor. A press with no drag is a plain click (jump).
+        self._drag_track = None
+        self._drag_press_x = 0
+        self._drag_anchor_index = 0
+        self._drag_moved = False
+        self._drag_last_target = None
 
         QApplication.styleHints().colorSchemeChanged.connect(
             self._on_color_scheme_changed,
@@ -53,10 +70,28 @@ class TimelineBar(QWidget):
 
     # --- push API (driven by the dock-pane controller) ---------------
 
-    def rebuild(self, step_labels):
+    def rebuild(self, step_labels, group_keys=None):
         self._step_labels = list(step_labels)
         self.step_count = len(self._step_labels)
+        self._cell_colors = self._compute_cell_colors(group_keys)
         self.update()
+
+    def _compute_cell_colors(self, group_keys):
+        """Map each step to a group tint colour (or None). Distinct group keys
+        get successive palette colours in order of first appearance; steps with
+        a None key (not in a group) get no tint."""
+        if not group_keys:
+            return [None] * self.step_count
+        order = {}
+        out = []
+        for key in group_keys:
+            if key is None:
+                out.append(None)
+                continue
+            if key not in order:
+                order[key] = len(order)
+            out.append(GROUP_PALETTE[order[key] % len(GROUP_PALETTE)])
+        return out
 
     def set_position(self, step_index, step_total, phase_index, phase_total):
         # step_total is accepted for API symmetry with the status bar, but the
@@ -118,15 +153,55 @@ class TimelineBar(QWidget):
 
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
-            self._seek_at_point(self._event_point(event))
+            self._begin_drag(self._event_point(event))
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
-        # Scrub: while the left button is held, keep emitting as the pointer
-        # crosses ticks. Qt coalesces move events, so this is not per-pixel.
-        if event.buttons() & Qt.LeftButton:
-            self._seek_at_point(self._event_point(event))
+        if (event.buttons() & Qt.LeftButton) and self._drag_track is not None:
+            self._drag_update(self._event_point(event))
         super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if event.button() == Qt.LeftButton and self._drag_track is not None:
+            if not self._drag_moved:
+                # A press with no drag is a plain click: jump to that cell.
+                self._seek_at_point(self._event_point(event))
+            self._drag_track = None
+        super().mouseReleaseEvent(event)
+
+    def _begin_drag(self, point):
+        # Anchor at the *current* playhead so a drag nudges from where the
+        # position is, not from where the cursor landed.
+        if self._phase_track_visible() and self._phase_track_rect().contains(point):
+            self._drag_track = "phase"
+            self._drag_anchor_index = self._phase_index
+        elif self._step_track_rect().contains(point):
+            self._drag_track = "step"
+            self._drag_anchor_index = self._step_index
+        else:
+            self._drag_track = None
+            return
+        self._drag_press_x = point.x()
+        self._drag_moved = False
+        self._drag_last_target = None
+
+    def _drag_update(self, point):
+        count = self._phase_total if self._drag_track == "phase" else self.step_count
+        if count <= 0:
+            return
+        seg = self._usable_width() / count
+        delta = int(round((point.x() - self._drag_press_x) / seg))
+        if delta != 0:
+            self._drag_moved = True
+        anchor = self._drag_anchor_index if self._drag_anchor_index >= 0 else 0
+        target = max(0, min(count - 1, anchor + delta))
+        if target == self._drag_last_target:
+            return
+        self._drag_last_target = target
+        if self._drag_track == "phase":
+            self.phase_seek_requested.emit(target)
+        else:
+            self.step_seek_requested.emit(target)
 
     # --- labels / theme ---------------------------------------------
 
@@ -147,11 +222,25 @@ class TimelineBar(QWidget):
 
     # --- paint ------------------------------------------------------
 
-    def _paint_track(self, painter, rect, count, position, colors):
+    def _paint_track(self, painter, rect, count, position, colors, cell_colors=None):
         # Video-timeline look: a track bar divided into one cell per item by
         # thin separators, with the current item drawn as a filled, outlined
         # box (the "you are here" cell) rather than a single tick.
         seg = self._usable_width() / max(1, count)
+        # Group tint bands (step track only): shade each cell by its group so
+        # grouped steps are identifiable at a glance.
+        if cell_colors:
+            for i in range(count):
+                hexc = cell_colors[i] if i < len(cell_colors) else None
+                if hexc is None:
+                    continue
+                left = int(SIDE_MARGIN + i * seg)
+                right = int(SIDE_MARGIN + (i + 1) * seg)
+                tint = QColor(hexc)
+                tint.setAlpha(GROUP_TINT_ALPHA)
+                painter.fillRect(
+                    QRect(left, rect.top(), max(1, right - left), rect.height()),
+                    tint)
         painter.setPen(QPen(QColor(colors["track"]), 2))
         mid_y = rect.center().y()
         painter.drawLine(rect.left(), mid_y, rect.right(), mid_y)
@@ -178,7 +267,8 @@ class TimelineBar(QWidget):
         painter = QPainter(self)
         painter.setRenderHint(QPainter.Antialiasing)
         self._paint_track(painter, self._step_track_rect(),
-                          self.step_count, self._step_index, colors)
+                          self.step_count, self._step_index, colors,
+                          cell_colors=self._cell_colors)
         if self._phase_track_visible():
             self._paint_track(painter, self._phase_track_rect(),
                               self._phase_total, self._phase_index, colors)

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -40,6 +40,38 @@ GROUP_TINT_ALPHA = 60
 DRAG_THROTTLE_MS = 75
 
 
+def collapse_phase_view(full_count, full_index, rep_count, show_full):
+    """Collapse route-repeat phases to one base loop + a repetition number.
+
+    Given a step's full phase count and 0-based index plus its phase-rep count,
+    decide whether the phases collapse to a single base loop (they do only when
+    the count divides evenly into >= 2 base phases per rep). Returns a dict:
+      phase_total / phase_index -- what to feed TimelineBar.set_position
+      can_collapse              -- whether the rep controls apply at all
+      base_count / base_index   -- one base loop's size and the position in it
+      cur_rep / rep_count       -- 1-based current rep and the total
+    ``show_full`` keeps can_collapse True but expands the displayed phases so
+    every rep is shown at once.
+    """
+    rep_count = max(1, int(rep_count))
+    can_collapse = (rep_count > 1 and full_count > 0
+                    and full_count % rep_count == 0
+                    and full_count // rep_count >= 2)
+    if not can_collapse:
+        return dict(phase_total=full_count, phase_index=full_index,
+                    can_collapse=False, base_count=full_count,
+                    base_index=full_index, cur_rep=1, rep_count=rep_count)
+    base_count = full_count // rep_count
+    base_index = full_index % base_count
+    cur_rep = min(rep_count, full_index // base_count + 1)
+    collapsed = not show_full
+    return dict(
+        phase_total=base_count if collapsed else full_count,
+        phase_index=base_index if collapsed else full_index,
+        can_collapse=True, base_count=base_count, base_index=base_index,
+        cur_rep=cur_rep, rep_count=rep_count)
+
+
 class TimelineBar(QWidget):
     step_seek_requested = Signal(int)
     phase_seek_requested = Signal(int)

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -15,7 +15,7 @@ from pyface.qt.QtCore import Qt, QRect, QTimer, Signal
 from pyface.qt.QtGui import QColor, QPainter, QPen
 from pyface.qt.QtWidgets import QApplication, QSizePolicy, QWidget
 
-from microdrop_style.colors import BLACK, GREY, SECONDARY_SHADE, WHITE
+from microdrop_style.colors import GREY, SECONDARY_SHADE
 from microdrop_style.helpers import is_dark_mode
 
 # Layout geometry (px). The widget is a fixed-height strip; the step track
@@ -137,10 +137,10 @@ class TimelineBar(QWidget):
 
     def _colors(self):
         if is_dark_mode():
-            return dict(track=GREY["dark"], tick=GREY["lighter"], text=WHITE,
-                        head=SECONDARY_SHADE[300])
-        return dict(track=GREY["light"], tick=GREY["dark"], text=BLACK,
-                    head=SECONDARY_SHADE[700])
+            return dict(track=GREY["dark"], tick=GREY["lighter"],
+                        head=SECONDARY_SHADE[300], running_head=SECONDARY_SHADE[100])
+        return dict(track=GREY["light"], tick=GREY["dark"],
+                    head=SECONDARY_SHADE[700], running_head=SECONDARY_SHADE[900])
 
     # --- paint ------------------------------------------------------
 
@@ -158,7 +158,7 @@ class TimelineBar(QWidget):
             painter.drawLine(x, rect.top(), x, rect.bottom())
         if 0 <= position < count:
             head_x = self._tick_center_x(position, count)
-            head_color = SECONDARY_SHADE[300] if self._running else colors["head"]
+            head_color = colors["running_head"] if self._running else colors["head"]
             painter.setPen(QPen(QColor(head_color), 3))
             painter.drawLine(head_x, rect.top() - 2, head_x, rect.bottom() + 2)
 


### PR DESCRIPTION
## Summary

Adds a video-style **timeline seek bar** to the pluggable protocol tree (a sub-widget under the nav bar) for scrubbing steps and phases, plus repetition handling (collapse to a base loop + jumpable rep selectors). Built as a pure view driven by the existing `ProtocolStatusController` / `ProtocolStatusModel`; one delicate change to the execution engine enables jumping to a specific repetition.

Design + plan: `docs/superpowers/specs/2026-06-18-protocol-timeline-seek-bar-design.md`, `docs/superpowers/plans/2026-06-18-protocol-timeline-seek-bar.md`.

## What it does

- **Step + phase scrubbing.** Horizontal track with one cell per step; the current cell is highlighted (video-scrubber box). A secondary **phase track** appears while running (or idle on a collapsible repeat step). Click to jump; **relative drag** nudges the playhead by drag direction (throttled so a fast scrub doesn't skip).
- **Group tint bands.** Steps are shaded by their containing group (cycled palette) so grouped steps are identifiable.
- **Repetition collapse + selectors.** When a step's routes repeat, the phase track collapses to one **base loop** (size from `iter_phases(n_repeats=1)`, so uneven/ramped counts work) with a **Phase Rep** combo. A **Step Rep** combo handles the step's own repetitions (and repeated groups). The two selectors sit side by side; **Show full timeline** expands to every phase/frame.
- **Jump to a repetition.** Both combos seek to a chosen rep while paused (executor honours it on resume). Phase reps jump within the step; step reps required threading an exact **frame index** through the seek (see below). The status bar's "Step Rep n/N" / "Phase n/N" updates immediately on a paused rep change.
- **Follows tree selection** and live execution (step/phase/rep advance).

## Notable / risk areas for review

- **Execution engine (`execution/seek.py`, `cursor.py`, `executor.py`).** The seek target gained an optional exact **frame index** so a specific repetition (same path, different frame) can be targeted. `resolve_seek`/`seek_decision` use it; the step-boundary redirect is gated on it so the existing **path-based** seek behaviour is unchanged (a phase seek on a repeated step still doesn't jump to rep 1). Backward compatible — new params default to `None`. Unit-tested in `test_seek.py` / `test_cursor.py`.
- **Status-bar repetition counting (`protocol_status_controller.py`, `navigation_bar.py`).** Separate, pre-existing-ish fix bundled here: the status bar now counts **distinct steps** (a single 8×-repeated step reads "Step 1/1", not "Step 1/8…8/8") and the rep label is compact ("Step Rep 2/8"). If you'd prefer this split out, say so.
- **Phase-track visibility policy** moved from the widget into the controller (it feeds `phase_total=0` to hide), enabling idle visibility for repeat steps.

## Testing

Unit tests added/updated for the pure parts: `test_timeline_bar.py` (widget geometry, drag, group colours, `collapse_phase_view`), `test_seek.py`, `test_cursor.py`, `test_protocol_status_controller.py`. The dock-pane wiring and GUI behaviour were verified manually (full pane construction needs the Envisage task/window). Run:

```bash
# from microdrop-py/src
pixi run python -m pytest pluggable_protocol_tree/tests/test_timeline_bar.py \
  pluggable_protocol_tree/tests/test_seek.py \
  pluggable_protocol_tree/tests/test_cursor.py \
  pluggable_protocol_tree/tests/test_protocol_status_controller.py \
  pluggable_protocol_tree/tests/test_protocol_tree_pane.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)