### PR TITLE
feat(volume-threshold): Rewind recovery action

### DIFF
--- a/volume_threshold_protocol_controls/consts.py
+++ b/volume_threshold_protocol_controls/consts.py
@@ -17,3 +17,8 @@ PHASE_POLL_TIMEOUT_S = 2.0
 # Polling interval while monitoring CAPACITANCE_UPDATED during a phase.
 # Lets the handler re-check stop_event between samples.
 CAP_POLL_TIMEOUT_S = 1.0
+
+# How long the Rewind action waits for the droplet check (DROPLETS_DETECTED)
+# to come back before giving up and showing the "couldn't locate" notice.
+# Matches DropletCheckHandler's default ack window.
+REWIND_DROPLET_CHECK_TIMEOUT_S = 12.0

--- a/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
+++ b/volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py
@@ -65,12 +65,17 @@ from logger.logger_service import get_logger
 
 from microdrop_application.helpers import get_microdrop_redis_globals_manager
 
-from dropbot_controller.consts import CAPACITANCE_UPDATED
+from dropbot_controller.consts import (
+    CAPACITANCE_UPDATED, DETECT_DROPLETS, DROPLETS_DETECTED,
+)
 from electrode_controller.consts import ELECTRODES_STATE_CHANGE
 
+from microdrop_application.dialogs.pyface_wrapper import information
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from pluggable_protocol_tree.builtins.routes_column import (
     PHASE_HOLD_REQUESTED_KEY,
 )
+from pluggable_protocol_tree.consts import ELECTRODE_TO_CHANNEL_KEY
 from pluggable_protocol_tree.models.column import (
     BaseColumnHandler, BaseColumnModel, Column,
 )
@@ -80,9 +85,11 @@ from pluggable_protocol_tree.views.columns.spinbox import (
 
 from ..consts import (
     CAP_POLL_TIMEOUT_S, PHASE_POLL_TIMEOUT_S,
+    REWIND_DROPLET_CHECK_TIMEOUT_S,
     VOLUME_THRESHOLD_COL_ID, VOLUME_THRESHOLD_COL_NAME,
     VOLUME_THRESHOLD_DEFAULT,
 )
+from ..rewind import rewind_target_phase, route_channels, step_route_phases
 from ..views.recovery_dialog import show_volume_threshold_recovery_dialog
 
 from microdrop_utils.ureg_helpers import ureg
@@ -184,7 +191,9 @@ class VolumeThresholdHandler(BaseColumnHandler):
     """
 
     priority = 30
-    wait_for_topics = [ELECTRODES_STATE_CHANGE, CAPACITANCE_UPDATED]
+    # DROPLETS_DETECTED opens a mailbox for the Rewind action's droplet check.
+    wait_for_topics = [ELECTRODES_STATE_CHANGE, CAPACITANCE_UPDATED,
+                       DROPLETS_DETECTED]
 
     def on_pre_step(self, row, ctx):
         """Hook into RoutesHandler's generic phase-hold mechanism.
@@ -390,6 +399,11 @@ class VolumeThresholdHandler(BaseColumnHandler):
             if action == "proceed":
                 ctx.phase_advance_event.set()
                 return percent
+            if action == "rewind":
+                # Droplet-check the route, infer the droplet's phase, and seek
+                # back there (auto-continue) -- or notice + stay paused.
+                self._rewind_to_droplet(ctx, row)
+                return percent
 
             # "retry": apply the new coverage + extension and keep monitoring.
             percent = int(decision.get("new_percent", percent))
@@ -398,6 +412,64 @@ class VolumeThresholdHandler(BaseColumnHandler):
                 actuated_area)
             extend_s = float(decision.get("extend_s", 0.0) or 0.0)
             deadline = time.monotonic() + max(extend_s, 0.0)
+
+    def _rewind_to_droplet(self, ctx, row):
+        """Droplet-check the step's route channels, infer the phase the droplet
+        is at, and seek execution back there so the run continues from it. If
+        the droplet can't be located unambiguously, show a notice and leave the
+        run paused for the operator to decide.
+
+        Uses the proven paused-seek flow (pause -> cursor.request_seek ->
+        resume): RoutesHandler honours the same-step jump on resume. Scoped to
+        static steps -- the dialog hides Rewind in duration mode."""
+        # Keep the run paused while we probe + seek (prompt_gui auto-resumed
+        # when the dialog returned).
+        ctx.protocol.pause()
+        e2c = ctx.protocol.scratch.get(ELECTRODE_TO_CHANNEL_KEY, {}) or {}
+        channels = route_channels(row, e2c)
+        target = None
+        if channels:
+            detected = self._droplet_check(ctx, channels)
+            if detected is not None:
+                target = rewind_target_phase(step_route_phases(row), e2c, detected)
+
+        if target is None:
+            ctx.prompt_gui(lambda: information(
+                None,
+                "Could not locate the droplet on this step's route, so the run "
+                "was not rewound. Resume from the toolbar or choose another "
+                "action.",
+                title="Rewind"))
+            ctx.protocol.pause()      # prompt_gui auto-resumes; stay paused
+            return
+
+        logger.info(f"volume_threshold rewind: seeking to phase {target} of "
+                    f"step {tuple(row.path)}")
+        ctx.protocol.cursor.request_seek(tuple(row.path), int(target))
+        ctx.protocol.resume()         # auto-continue from the located phase
+
+    def _droplet_check(self, ctx, channels):
+        """Request a droplet check across ``channels`` and return the channels
+        with liquid, or None on failure / timeout. Mirrors DropletCheckHandler's
+        request/await pattern."""
+        try:
+            _drain_stale(ctx, DROPLETS_DETECTED)
+            publish_message(topic=DETECT_DROPLETS, message=_json.dumps(channels))
+            raw = ctx.wait_for(DROPLETS_DETECTED,
+                               timeout=REWIND_DROPLET_CHECK_TIMEOUT_S)
+            ack = _json.loads(raw)
+            if not ack.get("success", False):
+                logger.warning("volume_threshold rewind: droplet check "
+                               f"failed: {ack.get('error')}")
+                return None
+            return [int(c) for c in ack.get("detected_channels", [])]
+        except TimeoutError:
+            logger.warning("volume_threshold rewind: droplet check timed out")
+            return None
+        except Exception as e:
+            logger.warning(f"volume_threshold rewind: droplet check error: {e}",
+                           exc_info=True)
+            return None
 
     @staticmethod
     def _monitor_until_threshold(ctx, target, deadline):

--- a/volume_threshold_protocol_controls/rewind.py
+++ b/volume_threshold_protocol_controls/rewind.py
@@ -1,0 +1,81 @@
+"""Pure helpers for the volume-threshold "Rewind" action.
+
+Rewind runs a droplet check across the step's route channels, infers which
+phase the droplet is currently sitting at, and seeks execution back to that
+phase. These functions are Qt-free, IO-free, and thread-free so they unit-test
+without the executor or a DropBot:
+
+  * ``step_route_phases`` rebuilds the step's phase list (one pass, static mode)
+    the same way RoutesHandler does.
+  * ``route_channels`` lists the channels the droplet check should sample.
+  * ``rewind_target_phase`` maps the detected channels back to a single phase
+    index (the droplet's leading-edge phase), or None when the result is
+    absent / off-route / ambiguous.
+"""
+
+from typing import List, Optional, Set
+
+from pluggable_protocol_tree.services.phase_math import iter_phases
+
+
+def step_route_phases(row) -> List[Set[str]]:
+    """Ordered electrode-id sets for ONE pass of the step's routes.
+
+    Mirrors RoutesHandler's static-mode ``iter_phases`` call (Rewind is scoped
+    to non-duration steps, so ``repeat_duration_s=0``)."""
+    return list(iter_phases(
+        static_electrodes=list(getattr(row, "electrodes", []) or []),
+        routes=list(getattr(row, "routes", []) or []),
+        trail_length=int(getattr(row, "trail_length", 1)),
+        trail_overlay=int(getattr(row, "trail_overlay", 0)),
+        soft_start=bool(getattr(row, "soft_start", False)),
+        soft_end=bool(getattr(row, "soft_end", False)),
+        repeat_duration_s=0.0,
+        linear_repeats=bool(getattr(row, "linear_repeats", False)),
+        n_repeats=int(getattr(row, "route_repetitions", 1)),
+        step_duration_s=float(getattr(row, "duration_s", 1.0)),
+    ))
+
+
+def route_channels(row, electrode_to_channel) -> List[int]:
+    """Sorted unique channels touched by the step's routes -- the set the
+    droplet check actuates to find where the droplet is. Electrode IDs with no
+    channel mapping are dropped."""
+    chans = set()
+    for route in (getattr(row, "routes", []) or []):
+        for eid in route:
+            ch = electrode_to_channel.get(eid)
+            if ch is not None:
+                chans.add(int(ch))
+    return sorted(chans)
+
+
+def rewind_target_phase(phases, electrode_to_channel,
+                        detected_channels) -> Optional[int]:
+    """Phase index to rewind to, or None.
+
+    ``phases`` is the ordered list of electrode-id sets (``step_route_phases``).
+    Each detected channel is translated back to the route and resolved to the
+    phase where it FIRST appears -- its leading-edge phase (for ``trail_length``
+    1 this is just the phase that actuates it). Returns that index only when all
+    on-route detected channels resolve to a SINGLE phase; returns None when no
+    detected channel lies on the route, or they map to more than one phase
+    (ambiguous -- the caller shows a notice and does not rewind)."""
+    detected = {int(c) for c in detected_channels}
+    if not detected:
+        return None
+    chan_phases = [
+        {int(electrode_to_channel[e]) for e in ph if e in electrode_to_channel}
+        for ph in phases
+    ]
+    targets = set()
+    for channel in detected:
+        if not any(channel in cp for cp in chan_phases):
+            continue  # not on this route -> ignore
+        for index, cp in enumerate(chan_phases):
+            if channel in cp and (index == 0 or channel not in chan_phases[index - 1]):
+                targets.add(index)
+                break
+    if len(targets) != 1:
+        return None
+    return next(iter(targets))

--- a/volume_threshold_protocol_controls/rewind.py
+++ b/volume_threshold_protocol_controls/rewind.py
@@ -57,10 +57,11 @@ def rewind_target_phase(phases, electrode_to_channel,
     ``phases`` is the ordered list of electrode-id sets (``step_route_phases``).
     Each detected channel is translated back to the route and resolved to the
     phase where it FIRST appears -- its leading-edge phase (for ``trail_length``
-    1 this is just the phase that actuates it). Returns that index only when all
-    on-route detected channels resolve to a SINGLE phase; returns None when no
-    detected channel lies on the route, or they map to more than one phase
-    (ambiguous -- the caller shows a notice and does not rewind)."""
+    1 this is just the phase that actuates it). A droplet commonly spans several
+    electrodes, so multiple channels light up; rewind to the FURTHEST one along
+    the route -- the droplet's leading edge -- so the run resumes from where the
+    droplet actually reached. Returns None only when no detected channel lies on
+    this route (the caller shows a notice and does not rewind)."""
     detected = {int(c) for c in detected_channels}
     if not detected:
         return None
@@ -76,6 +77,6 @@ def rewind_target_phase(phases, electrode_to_channel,
             if channel in cp and (index == 0 or channel not in chan_phases[index - 1]):
                 targets.add(index)
                 break
-    if len(targets) != 1:
+    if not targets:
         return None
-    return next(iter(targets))
+    return max(targets)

--- a/volume_threshold_protocol_controls/tests/test_rewind.py
+++ b/volume_threshold_protocol_controls/tests/test_rewind.py
@@ -46,8 +46,11 @@ def test_off_route_only_returns_none():
     assert rewind_target_phase(_PHASES_T1, E2C, [99]) is None
 
 
-def test_multiple_distinct_on_route_channels_are_ambiguous():
-    assert rewind_target_phase(_PHASES_T1, E2C, [11, 13]) is None
+def test_multiple_channels_rewind_to_furthest_leading_edge():
+    # A droplet spanning electrodes lights up several channels; rewind to the
+    # furthest one along the route (channel 13 -> phase 3), its leading edge.
+    assert rewind_target_phase(_PHASES_T1, E2C, [11, 13]) == 3
+    assert rewind_target_phase(_PHASES_T1, E2C, [10, 11, 12]) == 2
 
 
 def test_leading_edge_with_trail_window():

--- a/volume_threshold_protocol_controls/tests/test_rewind.py
+++ b/volume_threshold_protocol_controls/tests/test_rewind.py
@@ -1,0 +1,81 @@
+"""Unit tests for the pure Rewind helpers (no Qt, executor, or DropBot)."""
+
+from types import SimpleNamespace
+
+from volume_threshold_protocol_controls.rewind import (
+    rewind_target_phase, route_channels, step_route_phases,
+)
+
+
+# Electrode IDs "e0".."e3" map to channels 10..13.
+E2C = {"e0": 10, "e1": 11, "e2": 12, "e3": 13}
+
+
+def _row(routes=None, electrodes=None, **kw):
+    return SimpleNamespace(
+        routes=routes or [], electrodes=electrodes or [],
+        trail_length=kw.get("trail_length", 1),
+        trail_overlay=kw.get("trail_overlay", 0),
+        soft_start=False, soft_end=False, repeat_duration=0.0,
+        repeat_duration_controls=False, linear_repeats=False,
+        route_repetitions=kw.get("route_repetitions", 1),
+        duration_s=1.0,
+    )
+
+
+# --- rewind_target_phase (pure mapping) -----------------------------------
+
+# trail_length=1: phase P actuates exactly route[P].
+_PHASES_T1 = [{"e0"}, {"e1"}, {"e2"}, {"e3"}]
+
+
+def test_single_on_route_channel_maps_to_its_phase():
+    assert rewind_target_phase(_PHASES_T1, E2C, [12]) == 2
+
+
+def test_off_route_channels_are_ignored():
+    # 99 isn't on the route; 11 is -> phase 1.
+    assert rewind_target_phase(_PHASES_T1, E2C, [99, 11]) == 1
+
+
+def test_no_droplet_returns_none():
+    assert rewind_target_phase(_PHASES_T1, E2C, []) is None
+
+
+def test_off_route_only_returns_none():
+    assert rewind_target_phase(_PHASES_T1, E2C, [99]) is None
+
+
+def test_multiple_distinct_on_route_channels_are_ambiguous():
+    assert rewind_target_phase(_PHASES_T1, E2C, [11, 13]) is None
+
+
+def test_leading_edge_with_trail_window():
+    # With a trail window a channel spans two phases; rewind to where it FIRST
+    # appears (its leading edge). e2 (=channel 12) is in phases 2 and 3, so the
+    # leading-edge phase is 2.
+    phases = [{"e0"}, {"e0", "e1"}, {"e1", "e2"}, {"e2", "e3"}]
+    assert rewind_target_phase(phases, E2C, [12]) == 2
+
+
+# --- route_channels -------------------------------------------------------
+
+def test_route_channels_collects_all_route_electrodes():
+    row = _row(routes=[["e0", "e1", "e2"]])
+    assert route_channels(row, E2C) == [10, 11, 12]
+
+
+def test_route_channels_drops_unmapped_electrodes():
+    row = _row(routes=[["e0", "eX", "e3"]])
+    assert route_channels(row, E2C) == [10, 13]
+
+
+# --- step_route_phases (integration with iter_phases) ---------------------
+
+def test_step_route_phases_one_pass_trail1():
+    # A single 4-electrode route, trail_length=1 -> 4 phases, each one electrode.
+    row = _row(routes=[["e0", "e1", "e2", "e3"]])
+    phases = step_route_phases(row)
+    assert len(phases) == 4
+    assert phases[0] == {"e0"}
+    assert phases[3] == {"e3"}

--- a/volume_threshold_protocol_controls/views/recovery_dialog.py
+++ b/volume_threshold_protocol_controls/views/recovery_dialog.py
@@ -10,6 +10,10 @@ out:
     the protocol continue (the troubleshooting escape hatch).
   * **Pause Protocol** — pause the run (the operator resumes it later from
     the toolbar) instead of aborting.
+  * **Rewind** (static steps only) — locate the droplet via a droplet check
+    across the route channels and rewind execution to that phase, then
+    continue. The dialog only returns the intent; the locating + seek happen
+    at the call site (it has no route/phase context).
 
 This module is pure Qt widget code: ``show_volume_threshold_recovery_dialog``
 builds a modal dialog, ``exec()``s it, and returns a plain decision dict.
@@ -22,6 +26,7 @@ Decision dict shapes:
      "count_toward_duration": bool}   # last key only in duration mode
     {"action": "proceed"}
     {"action": "pause"}
+    {"action": "rewind"}              # only offered when not duration_mode
 
 ``count_toward_duration`` (duration-looping steps only): when True the extra
 time is charged against the loop's duration budget (the run still ends on
@@ -110,6 +115,17 @@ class _RecoveryDialog(QDialog):
         buttons = QHBoxLayout()
         buttons.addWidget(retry_btn)
         buttons.addWidget(proceed_btn)
+        # Rewind locates the droplet (droplet check across the route channels)
+        # and rewinds to that phase, then continues. Only offered for static
+        # steps; a duration-mode step's phase loop can't honour a same-step
+        # rewind yet, so the button is hidden there.
+        if not duration_mode:
+            rewind_btn = QPushButton("Rewind")
+            rewind_btn.setToolTip(
+                "Find the droplet (droplet check across the route) and rewind "
+                "to that phase, then continue.")
+            rewind_btn.clicked.connect(lambda: self._choose("rewind"))
+            buttons.addWidget(rewind_btn)
         buttons.addStretch(1)
         buttons.addWidget(pause_btn)
         layout.addLayout(buttons)


### PR DESCRIPTION
## Summary

Adds a **Rewind** recovery action for volume-threshold protocol steps. When a step misses the volume threshold, the recovery dialog now offers a *Rewind* button (static steps only — hidden in duration mode). On rewind, the handler runs a droplet check across the step's route channels, infers the phase the droplet has reached (its leading edge), seeks execution back to that phase, and auto-continues.

## Changes

- **`recovery_dialog.py`** — conditional *Rewind* button → `{"action": "rewind"}`.
- **`rewind.py`** — pure helpers (`step_route_phases`, `route_channels`, `rewind_target_phase`) with unit tests in `tests/test_rewind.py`.
- **`volume_threshold_column.py` / `consts.py`** — `VolumeThresholdHandler` rewind branch reuses the droplet-check request/await (`DETECT_DROPLETS` / `DROPLETS_DETECTED`) and the existing paused-seek flow (pause → `cursor.request_seek` → resume).

## Behavior notes

- A droplet spans several electrodes, so the droplet check commonly returns multiple on-route channels. Rather than bailing on a multi-channel hit, rewind targets the **furthest** matched channel along the route — the droplet's leading edge — so the run resumes from where the droplet actually reached.
- If the droplet can't be located unambiguously (none / off-route), a notice is shown and the run is left paused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)