### PR TITLE
PPT: Guaranteed-loop duration mode with unique-phase navigation (#477)

### DIFF
--- a/docs/superpowers/plans/2026-06-22-477-guaranteed-loop-duration-mode.md
+++ b/docs/superpowers/plans/2026-06-22-477-guaranteed-loop-duration-mode.md
@@ -1,0 +1,668 @@
+# Guaranteed-loop Duration Mode with Unique-Phase Navigation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** For route-rep-by-time (duration-mode) steps, keep looping only while a full loop is *guaranteed* to finish within the user-set rep time, then idle; let the operator toggle the loop's unique phases while paused and resume from there; warn on mid-loop-expiry and on leaving the idle phase.
+
+**Architecture:** The dynamic duration loop (`RoutesHandler._run_dynamic_duration_loop`) is changed to (a) gate each loop on raw wall-clock elapsed plus the worst-case loop time, (b) enter an explicit electrodes-off idle phase when no further loop fits, (c) re-enter at the cursor's phase index after a paused seek (closing the #477 gap), and (d) raise a mid-loop-expiry dialog on resume. The phase timeline bar shows the loop's unique phases plus one dark-yellow idle cell; navigating away from idle raises a warning on the GUI side.
+
+**Tech Stack:** Python 3, Traits/TraitsUI, PySide6/Qt, pytest. Run Python/pytest via `pixi run` (see `reference_pixi_python_invocation`).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-22-477-guaranteed-loop-duration-mode-design.md`. Every task implicitly includes its requirements.
+- Scope is the **dynamic** duration loop only (`in_duration_mode and phase_hold`). Count-mode and static-duration paths are untouched except for the shared idle-cell rendering and warnings.
+- `raw_elapsed = monotonic() - step_start` — **includes pauses and holds; never pause-aware, never extension-credited.**
+- `phase_dwell = row.duration_s`; `worst_loop = cycle_len * phase_dwell`; `budget = row.repeat_duration`.
+- Use f-strings for all logging/messages. Use `microdrop_application.dialogs.pyface_wrapper` for all dialogs (returns pyface `YES`/`NO`). No cross-plugin class imports.
+- Voltage/frequency are ints elsewhere — not relevant here; durations are floats (seconds).
+
+---
+
+### Task 1: Pure duration-loop decision helpers
+
+**Files:**
+- Modify: `pluggable_protocol_tree/services/phase_math.py` (append helpers near `duration_loop_parts`, line ~136–179)
+- Test: `pluggable_protocol_tree/tests/test_phase_math.py` (add cases; create if absent)
+
+**Interfaces:**
+- Consumes: `duration_loop_parts(...)` (existing).
+- Produces:
+  - `unit_cycle_len(static_electrodes, routes, *, trail_length=1, trail_overlay=0, soft_start=False) -> int`
+  - `another_loop_fits(raw_elapsed: float, cycle_len: int, phase_dwell: float, budget: float) -> bool`
+  - `loop_completion_fits(raw_elapsed: float, phase_in_cycle: int, cycle_len: int, phase_dwell: float, budget: float) -> bool`
+  - `idle_cell_index(cycle_len: int) -> int`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# pluggable_protocol_tree/tests/test_phase_math.py  (add to file)
+from pluggable_protocol_tree.services.phase_math import (
+    unit_cycle_len, another_loop_fits, loop_completion_fits, idle_cell_index,
+)
+
+def test_unit_cycle_len_loop_route():
+    # one loop route a-b-c-d, trail_length 1 -> 4 windows in the unit cycle
+    n = unit_cycle_len([], [["a", "b", "c", "d"]], trail_length=1, trail_overlay=0)
+    assert n == 4
+
+def test_unit_cycle_len_static_only_is_one():
+    assert unit_cycle_len(["a", "b"], []) == 1
+
+def test_another_loop_fits_boundary():
+    # cycle_len 4 * dwell 2.0 = 8.0 worst loop; budget 20
+    assert another_loop_fits(raw_elapsed=12.0, cycle_len=4, phase_dwell=2.0, budget=20.0) is True   # 12+8=20 exact fit
+    assert another_loop_fits(raw_elapsed=12.001, cycle_len=4, phase_dwell=2.0, budget=20.0) is False
+    assert another_loop_fits(raw_elapsed=0.0, cycle_len=0, phase_dwell=2.0, budget=20.0) is False    # no phases -> never
+
+def test_loop_completion_fits_from_mid_cycle():
+    # from phase k=1 of a 4-phase loop, 3 phases remain * 2.0 = 6.0
+    assert loop_completion_fits(raw_elapsed=14.0, phase_in_cycle=1, cycle_len=4, phase_dwell=2.0, budget=20.0) is True  # 14+6=20
+    assert loop_completion_fits(raw_elapsed=14.5, phase_in_cycle=1, cycle_len=4, phase_dwell=2.0, budget=20.0) is False
+
+def test_idle_cell_index_is_cycle_len():
+    assert idle_cell_index(4) == 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_phase_math.py -k "loop or idle or unit_cycle_len" -v`
+Expected: FAIL with `ImportError`/`AttributeError` (helpers not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+```python
+# pluggable_protocol_tree/services/phase_math.py  (append after duration_loop_parts)
+def unit_cycle_len(static_electrodes, routes, *, trail_length=1,
+                   trail_overlay=0, soft_start=False) -> int:
+    """Number of phases in one unit loop (the unique, navigable phases)."""
+    _ramp, unit_cycle, _ret = duration_loop_parts(
+        static_electrodes, routes, trail_length=trail_length,
+        trail_overlay=trail_overlay, soft_start=soft_start)
+    return len(unit_cycle)
+
+
+def another_loop_fits(raw_elapsed: float, cycle_len: int,
+                      phase_dwell: float, budget: float) -> bool:
+    """True if a FULL fresh loop is guaranteed to finish within budget.
+
+    Worst case assumes every phase runs its full ``phase_dwell`` (the
+    volume-threshold timeout equals the duration-column value). Uses raw
+    wall-clock elapsed (pauses/holds already spent count against budget)."""
+    if cycle_len <= 0:
+        return False
+    return raw_elapsed + cycle_len * phase_dwell <= budget
+
+
+def loop_completion_fits(raw_elapsed: float, phase_in_cycle: int,
+                         cycle_len: int, phase_dwell: float,
+                         budget: float) -> bool:
+    """True if finishing the CURRENT loop from ``phase_in_cycle`` (0-based)
+    back to the start still fits the budget. Used for the mid-loop-expiry
+    check on resume after a seek."""
+    remaining = max(0, cycle_len - phase_in_cycle)
+    return raw_elapsed + remaining * phase_dwell <= budget
+
+
+def idle_cell_index(cycle_len: int) -> int:
+    """0-based index of the trailing idle cell on the phase bar
+    (the bar shows ``cycle_len`` unique phases + this idle cell)."""
+    return cycle_len
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_phase_math.py -k "loop or idle or unit_cycle_len" -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/services/phase_math.py pluggable_protocol_tree/tests/test_phase_math.py
+git commit -m "feat(#477): pure duration-loop gate + idle-cell helpers"
+```
+
+---
+
+### Task 2: Status model — dynamic-loop unique-phase + idle state
+
+**Files:**
+- Modify: `pluggable_protocol_tree/models/protocol_status.py` (add fields + methods; reset at line 74–80)
+- Test: `pluggable_protocol_tree/tests/test_protocol_status_model.py` (add cases; create if absent)
+
+**Interfaces:**
+- Produces (on `ProtocolStatusModel`):
+  - field `dyn_idle = Bool(False)` — True while the running step is parked in its idle phase.
+  - `on_dyn_phase(now, cycle_pos, cycle_len, phase_target_s)` — cycle_pos is 1-based within the unit loop.
+  - `on_dyn_idle(now, cycle_len)` — park on the idle cell.
+- Consumes: nothing new.
+
+Note: the bar shows `cycle_len + 1` cells (unique phases + idle). `phase_total` therefore holds `cycle_len + 1`; the idle cell is the last one (`phase_index == cycle_len + 1`, 1-based).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# pluggable_protocol_tree/tests/test_protocol_status_model.py  (add)
+from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
+
+def test_on_dyn_phase_sets_unique_phase_plus_idle_total():
+    m = ProtocolStatusModel()
+    m.on_dyn_phase(now=0.0, cycle_pos=2, cycle_len=4, phase_target_s=2.0)
+    assert m.phase_index == 2
+    assert m.phase_total == 5          # 4 unique + 1 idle cell
+    assert m.dyn_idle is False
+
+def test_on_dyn_idle_parks_on_idle_cell():
+    m = ProtocolStatusModel()
+    m.on_dyn_idle(now=0.0, cycle_len=4)
+    assert m.phase_index == 5          # idle cell is the last (1-based)
+    assert m.phase_total == 5
+    assert m.dyn_idle is True
+
+def test_reset_clears_dyn_idle():
+    m = ProtocolStatusModel()
+    m.on_dyn_idle(now=0.0, cycle_len=4)
+    m.reset()
+    assert m.dyn_idle is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_model.py -k dyn -v`
+Expected: FAIL (`AttributeError: dyn_idle` / methods missing).
+
+- [ ] **Step 3: Implement**
+
+```python
+# protocol_status.py — add field next to run state (after line 53 `paused = Bool(False)`)
+    # True while a dynamic duration-mode step is parked in its idle phase
+    # (the trailing dark-yellow cell). Drives the leaving-idle warning (#477).
+    dyn_idle = Bool(False)
+```
+
+```python
+# protocol_status.py — in reset(), add dyn_idle=False to the trait_set(...) call (line 74-80)
+            phase_target_s=0.0, running=False, paused=False, dyn_idle=False,
+```
+
+```python
+# protocol_status.py — add methods after on_phase_start (line ~116)
+    def on_dyn_phase(self, now, cycle_pos, cycle_len, phase_target_s):
+        """Dynamic duration loop: park the bar on unique phase ``cycle_pos``
+        (1-based) of a ``cycle_len``-phase loop. phase_total carries the extra
+        trailing idle cell so the bar renders cycle_len + 1 cells (#477)."""
+        self.dyn_idle = False
+        self.on_phase_start(now, cycle_pos, cycle_len + 1, phase_target_s)
+
+    def on_dyn_idle(self, now, cycle_len):
+        """Dynamic duration loop: park on the trailing idle cell (electrodes
+        off). The idle cell is the last of cycle_len + 1 cells (#477)."""
+        self.on_phase_start(now, cycle_len + 1, cycle_len + 1, 0.0)
+        self.dyn_idle = True
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_model.py -k dyn -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/models/protocol_status.py pluggable_protocol_tree/tests/test_protocol_status_model.py
+git commit -m "feat(#477): status model unique-phase + idle state for dynamic loops"
+```
+
+---
+
+### Task 3: ExecutorSignals + controller wiring for dynamic phase/idle
+
+**Files:**
+- Modify: `pluggable_protocol_tree/execution/signals.py` (add two Events near `phase_started`, line ~52–58)
+- Modify: `pluggable_protocol_tree/services/protocol_status_controller.py` (observe them, near `_on_phase_started` line ~119–125)
+- Test: `pluggable_protocol_tree/tests/test_protocol_status_controller.py` (add cases)
+
+**Interfaces:**
+- Produces on `ExecutorSignals`:
+  - `dyn_phase_started = Event` — payload `(cycle_pos:int, cycle_len:int, phase_dwell:float)`
+  - `dyn_idle_entered = Event` — payload `cycle_len:int`
+- Consumes: `ProtocolStatusModel.on_dyn_phase`, `on_dyn_idle` (Task 2).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# test_protocol_status_controller.py  (add)
+def test_dyn_phase_and_idle_signals_update_model(make_controller):
+    # make_controller: existing fixture returning (controller, signals) with a
+    # fake clock; mirror the existing phase_started test in this file.
+    ctrl, signals = make_controller()
+    signals.dyn_phase_started = (2, 4, 2.0)
+    assert ctrl.model.phase_index == 2
+    assert ctrl.model.phase_total == 5
+    assert ctrl.model.dyn_idle is False
+    signals.dyn_idle_entered = 4
+    assert ctrl.model.dyn_idle is True
+    assert ctrl.model.phase_index == 5
+```
+
+If no `make_controller` fixture exists, construct the controller as the existing `_on_phase_started` test does in this file (match its setup exactly).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_controller.py -k dyn -v`
+Expected: FAIL (Event attrs / handlers missing).
+
+- [ ] **Step 3: Implement signals + handlers**
+
+```python
+# execution/signals.py — add near phase_started / phase_extended
+    #: Dynamic duration loop: (cycle_pos 1-based, cycle_len, phase_dwell_s).
+    dyn_phase_started = Event()
+    #: Dynamic duration loop entered its idle phase; payload = cycle_len.
+    dyn_idle_entered = Event()
+```
+
+```python
+# services/protocol_status_controller.py — add observers next to _on_phase_started
+    @observe("signals:dyn_phase_started")
+    def _on_dyn_phase_started(self, event):
+        cycle_pos, cycle_len, phase_dwell = event.new
+        self.model.on_dyn_phase(self.clock(), cycle_pos, cycle_len, phase_dwell)
+
+    @observe("signals:dyn_idle_entered")
+    def _on_dyn_idle_entered(self, event):
+        self.model.on_dyn_idle(self.clock(), int(event.new))
+```
+
+(Match the existing observer style in this file — it already uses `@observe("signals:...")` with `self.clock()`; confirm the exact decorator/clock accessor against `_on_phase_started` at lines 119–125 and copy it.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_protocol_status_controller.py -k dyn -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/execution/signals.py pluggable_protocol_tree/services/protocol_status_controller.py pluggable_protocol_tree/tests/test_protocol_status_controller.py
+git commit -m "feat(#477): executor signals + controller wiring for dynamic phase/idle"
+```
+
+---
+
+### Task 4: Dynamic loop — raw-elapsed guaranteed-loop gate, explicit idle, seek re-entry, mid-loop-expiry
+
+**Files:**
+- Modify: `pluggable_protocol_tree/builtins/routes_column.py` — `_run_dynamic_duration_loop` (lines 263–349)
+- Test: `pluggable_protocol_tree/tests/test_routes_dynamic_loop.py` (create) — pure-logic seams only
+
+**Interfaces:**
+- Consumes: `another_loop_fits`, `loop_completion_fits`, `idle_cell_index`, `unit_cycle_len` (Task 1); `ctx.protocol.cursor` (`phase_index`, `resume_target`, `clear_seek`, `decision_at_phase`); `signals.dyn_phase_started`, `signals.dyn_idle_entered` (Task 3); `ctx.prompt_gui` (existing, returns the dialog result on the worker thread).
+- Produces: revised `_run_dynamic_duration_loop` behavior. A new module-level pure helper `dyn_resume_start(cursor_phase_index, cycle_len) -> tuple[int, bool]` → `(start_phase_in_cycle, start_idle)`.
+
+**Behavior to implement (replace the body from line 297 onward):**
+
+1. `cycle_len = len(unit_cycle)`; `worst = cycle_len * per_phase_dwell` (== existing `cycle_full_time`).
+2. `step_start = _monotonic()`; `raw_elapsed = lambda: _monotonic() - step_start` (NO extension subtraction — drop `_budget_elapsed`).
+3. Resume position from cursor: `start_k, start_idle = dyn_resume_start(int(ctx.protocol.cursor.phase_index), cycle_len)`.
+4. **Mid-loop-expiry** (only when re-entering at `start_k > 0` from a seek, i.e. `resume_target` was set, and NOT coming from idle): if `not loop_completion_fits(raw_elapsed(), start_k, cycle_len, per_phase_dwell, budget)`, call `ctx.prompt_gui(...)`. On YES → run `start_k..end` then advance to next step (set `ctx.step_phases_done_event`/return after the partial loop, skipping the gate). On NO → `ctx.pause()` and return to the pause checkpoint (do not run).
+5. Emit each phase via `_run` AND `signals.dyn_phase_started = (cycle_pos, cycle_len, per_phase_dwell)` where `cycle_pos` is 1-based position within the unit cycle.
+6. **Gate** at each loop boundary: `if another_loop_fits(raw_elapsed(), cycle_len, per_phase_dwell, budget): run a full loop; else: break to idle`.
+7. **Idle**: publish electrodes-off once (`electrode_state_change_publisher.publish(actuated_channels=[])` unless `preview_mode`), `signals.dyn_idle_entered = cycle_len`, then `_cooperative_sleep` until `raw_elapsed() >= budget` OR a seek arrives (`ctx.protocol.cursor.resume_target is not None`); if a seek arrives, loop back so the executor's pause/seek path re-enters this step.
+
+A unit-testable seam (`dyn_resume_start`) is the only pure logic added here; the threaded loop itself is verified manually (Step 6).
+
+- [ ] **Step 1: Write the failing test for the pure seam**
+
+```python
+# pluggable_protocol_tree/tests/test_routes_dynamic_loop.py (create)
+from pluggable_protocol_tree.builtins.routes_column import dyn_resume_start
+
+def test_dyn_resume_start_normal_phase():
+    assert dyn_resume_start(0, 4) == (0, False)
+    assert dyn_resume_start(2, 4) == (2, False)
+
+def test_dyn_resume_start_idle_cell():
+    # cursor index == cycle_len -> idle cell
+    assert dyn_resume_start(4, 4) == (0, True)
+
+def test_dyn_resume_start_clamps_out_of_range():
+    assert dyn_resume_start(9, 4) == (0, True)   # >= cycle_len clamps to idle
+    assert dyn_resume_start(-1, 4) == (0, False)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_routes_dynamic_loop.py -v`
+Expected: FAIL (`ImportError: dyn_resume_start`).
+
+- [ ] **Step 3: Add the pure seam**
+
+```python
+# routes_column.py — module level (near other helpers, above RoutesHandler)
+def dyn_resume_start(cursor_phase_index: int, cycle_len: int):
+    """Resolve a paused-seek cursor phase to a dynamic-loop start.
+
+    Returns (start_phase_in_cycle, start_idle). cursor_phase_index is the
+    0-based unique-phase the operator toggled to; an index at/over cycle_len
+    is the trailing idle cell. Negative clamps to phase 0 (#477)."""
+    if cycle_len <= 0:
+        return 0, False
+    if cursor_phase_index >= cycle_len:
+        return 0, True
+    return max(0, int(cursor_phase_index)), False
+```
+
+- [ ] **Step 4: Run to verify the seam passes**
+
+Run: `pixi run pytest pluggable_protocol_tree/tests/test_routes_dynamic_loop.py -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Rewrite `_run_dynamic_duration_loop` body**
+
+Replace lines 297–349 with the logic below (keep the `ramp_up, unit_cycle, return_phase = duration_loop_parts(...)` block above it). Imports needed at top of file (verify present): `from electrode_controller.consts import electrode_state_change_publisher` (already imported), `another_loop_fits, loop_completion_fits` from `phase_math`.
+
+```python
+        cycle_len = len(unit_cycle)
+        worst_loop = cycle_len * per_phase_dwell
+        step_start = _monotonic()
+        running_idx = 0
+
+        def raw_elapsed():
+            # RAW wall-clock since step start: pauses and holds count against
+            # the budget (NOT pause-aware, NOT extension-credited) — #477.
+            return _monotonic() - step_start
+
+        cursor = ctx.protocol.cursor
+        start_k, start_idle = dyn_resume_start(int(cursor.phase_index), cycle_len)
+        came_from_seek = cursor.resume_target is not None
+        cursor.clear_seek()
+
+        def _run_cycle_phase(phase, cycle_pos):
+            nonlocal running_idx
+            running_idx += 1
+            if signals is not None:
+                signals.dyn_phase_started = (cycle_pos + 1, cycle_len, per_phase_dwell)
+            return self._run_phase(
+                phase, ctx=ctx, mapping=mapping, static_routes=static_routes,
+                step_uuid=step_uuid, step_label=step_label,
+                preview_mode=preview_mode, per_phase_dwell=per_phase_dwell,
+                stop_event=stop_event, pause_event=pause_event,
+                signals=signals, phase_index=cycle_pos + 1, phase_total=cycle_len + 1,
+                hold_for_buffer=True, honor_pause=False)
+
+        def _go_idle():
+            if not preview_mode:
+                electrode_state_change_publisher.publish(actuated_channels=[])
+            if signals is not None:
+                signals.dyn_idle_entered = cycle_len
+            while not stop_event.is_set() and raw_elapsed() < budget:
+                if cursor.resume_target is not None:
+                    return  # operator toggled away from idle -> let executor re-enter
+                _cooperative_sleep(min(0.1, budget - raw_elapsed()),
+                                   stop_event, pause_event,
+                                   seek_pending=lambda: cursor.resume_target is not None)
+
+        # Soft-start ramp only on a fresh (non-seek) entry.
+        if not came_from_seek and not start_idle:
+            for phase in ramp_up:
+                if not _run_cycle_phase(phase, 0):
+                    return
+
+        # Mid-loop-expiry guard: re-entry partway through the loop where
+        # finishing won't fit the budget (operator toggled to a bad spot).
+        if came_from_seek and not start_idle and start_k > 0 \
+                and not loop_completion_fits(raw_elapsed(), start_k, cycle_len,
+                                             per_phase_dwell, budget):
+            proceed = ctx.prompt_gui(lambda: _confirm_finish_loop_over_budget())
+            if not proceed:
+                ctx.pause()
+                return
+            # Run the partial loop to its end, then advance to next step.
+            for i in range(start_k, cycle_len):
+                if not _run_cycle_phase(unit_cycle[i], i):
+                    return
+            ctx.step_phases_done_event.set()
+            return
+
+        if start_idle:
+            _go_idle()
+            return
+
+        # First (possibly partial) loop from start_k, then full loops while
+        # another guaranteed loop fits; otherwise idle.
+        i = start_k
+        while not stop_event.is_set():
+            while i < cycle_len:
+                if not _run_cycle_phase(unit_cycle[i], i):
+                    return
+                i += 1
+            i = 0
+            if not another_loop_fits(raw_elapsed(), cycle_len, per_phase_dwell, budget):
+                break
+        if not stop_event.is_set():
+            _go_idle()
+```
+
+Where `_confirm_finish_loop_over_budget` is a small helper added to the module:
+
+```python
+# routes_column.py — module level
+def _confirm_finish_loop_over_budget():
+    from microdrop_application.dialogs.pyface_wrapper import confirm, YES
+    return confirm(
+        None,
+        "The set route-rep time is up, but the current loop is not back at its "
+        "start position. Finish this loop (electrodes return to start) and then "
+        "move to the next step?",
+        title="Loop needs more time",
+        cancel=False,
+    ) == YES
+```
+
+Note: drop the old `_budget_elapsed`, the old `cycle_full_time` gate (lines 327–340), the old `return_phase` tail (342–343), and the old credit-back remainder sleep (345–349) — superseded by `_go_idle()` and the guaranteed-loop gate. The loop now always ends back at the unit-cycle start, so the separate `return_phase` is unnecessary (the next loop's phase 0 IS the return).
+
+- [ ] **Step 6: Manual verification (threaded loop)**
+
+The dynamic loop runs on a worker thread under volume-threshold; verify in the app, not pytest:
+1. Build a duration-mode loop step (`repeat_duration_controls` on, `repeat_duration` set, a volume-threshold column present), e.g. 4-phase loop, `duration_s=2`, `repeat_duration=20`.
+2. Run it: confirm it loops and, when fewer than `4*2=8 s` remain, enters idle (electrodes off) until 20 s, then advances.
+3. Pause mid-step, toggle to phase 2 on the bar, resume → it continues from phase 2 and completes the loop.
+4. Pause near the end, toggle to a late phase so finishing won't fit → on resume the "Loop needs more time" dialog appears; YES finishes the loop then next step; NO leaves it paused.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pluggable_protocol_tree/builtins/routes_column.py pluggable_protocol_tree/tests/test_routes_dynamic_loop.py
+git commit -m "feat(#477): guaranteed-loop gate, idle phase, seek re-entry, mid-loop-expiry"
+```
+
+---
+
+### Task 5: Make the phase bar show unique phases + idle during the dynamic loop
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/dock_pane.py` — `_refresh_timeline_position` (lines 425–467) and `_update_phase_nav_buttons` (567–574)
+- Modify: `pluggable_protocol_tree/views/timeline_bar.py` — idle-cell color (`_colors` 279–284, `_paint_track` 288–324, `set_position` 136–143)
+
+**Interfaces:**
+- Consumes: `status_controller.model.phase_total`, `phase_index`, `dyn_idle` (Tasks 2–3).
+- Produces: `TimelineBar.set_idle_cell(index_or_None)` — paints that cell dark yellow regardless of playhead.
+
+Today the dynamic loop emitted `phase_total = 0`, hiding the phase track. Task 4 now emits `phase_total = cycle_len + 1` via the status model, so the existing `_refresh_timeline_position` will show the track (it requires `> 1`). This task adds the **idle-cell color** and ensures the idle cell is reachable by the nav buttons.
+
+- [ ] **Step 1: Add the idle-cell color + setter to TimelineBar**
+
+```python
+# timeline_bar.py — in _colors(), add an "idle" key to both branches
+# dark:  idle=QColor("#9a7d0a")   light: idle=QColor("#b8860b")  (dark yellow / dark goldenrod)
+```
+Concretely:
+```python
+    def _colors(self):
+        if is_dark_mode():
+            return dict(track=GREY["dark"], tick=GREY["lighter"],
+                        head=SECONDARY_SHADE[300], running_head=SECONDARY_SHADE[100],
+                        idle="#9a7d0a")
+        return dict(track=GREY["light"], tick=GREY["dark"],
+                    head=SECONDARY_SHADE[700], running_head=SECONDARY_SHADE[900],
+                    idle="#b8860b")
+```
+
+```python
+# timeline_bar.py — add an _idle_cell attribute (init in __init__ near other state, default None)
+        self._idle_cell = None
+
+    def set_idle_cell(self, index):
+        """Index of the dark-yellow idle cell on the phase track, or None."""
+        if self._idle_cell != index:
+            self._idle_cell = index
+            self.update()
+```
+
+```python
+# timeline_bar.py — in _paint_track, BEFORE the current-position box (line ~314),
+# fill the idle cell when this is the phase track. Pass an `idle_cell` arg through
+# from paintEvent for the phase track only.
+        if idle_cell is not None and 0 <= idle_cell < count:
+            left = int(SIDE_MARGIN + idle_cell * seg)
+            right = int(SIDE_MARGIN + (idle_cell + 1) * seg)
+            idle_fill = QColor(colors["idle"]); idle_fill.setAlpha(120)
+            painter.fillRect(QRect(left, rect.top(), max(1, right - left),
+                                   rect.height()), idle_fill)
+```
+Update `_paint_track` signature to `(..., cell_colors=None, idle_cell=None)` and pass `idle_cell=self._idle_cell` only for the phase-track call in `paintEvent` (line 335–337); the step-track call passes nothing (defaults None).
+
+- [ ] **Step 2: Drive the idle cell + show the track from the dock pane**
+
+In `_refresh_timeline_position` (dock_pane.py 425–467), after computing the phase track position, set the idle cell when the running step is a dynamic duration step:
+
+```python
+        # Dynamic duration step: the last phase cell is the idle phase (#477).
+        m = self.status_controller.model
+        tb = getattr(self._pane, "timeline_bar", None)
+        if tb is not None:
+            if m.running and m.phase_total > 1 and self._current_row is not None \
+                    and bool(getattr(self._current_row, "repeat_duration_controls", False)):
+                tb.set_idle_cell(m.phase_total - 1)
+            else:
+                tb.set_idle_cell(None)
+```
+Place this where `set_position(...)`/`show_phase` is decided (around line 463–464). Ensure `show_phase` becomes True for the dynamic loop now that `phase_total > 1` (it keys off `running or view["can_collapse"]`, so running already satisfies it — confirm no explicit `phase_total=0` override remains for this path).
+
+- [ ] **Step 3: Allow navigating onto the idle cell**
+
+In `_update_phase_nav_buttons` (dock_pane.py 567–574), the next-phase button currently disables at `phase_index >= phase_total`. Since the idle cell IS `phase_total`, leave as-is (idle is the last index, reachable). Confirm `prev_enabled = m.phase_index > 1` and `next_enabled = 0 < m.phase_index < m.phase_total` still let the user land on and leave the idle cell (idle index == phase_total, so `next_enabled` is False at idle — correct; `prev` leaves it). No code change expected; add a comment noting the idle cell is index `phase_total`.
+
+- [ ] **Step 4: Manual verification**
+
+Run a dynamic duration step; confirm the phase bar shows `cycle_len + 1` cells, the last one tinted dark yellow, the playhead advancing through the unique phases and parking on the idle cell during idle.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/timeline_bar.py pluggable_protocol_tree/views/dock_pane.py
+git commit -m "feat(#477): phase bar shows unique phases + dark-yellow idle cell"
+```
+
+---
+
+### Task 6: Leaving-idle warning (GUI-side, pre-seek)
+
+**Files:**
+- Modify: `pluggable_protocol_tree/views/dock_pane.py` — `_seek_to_phase` (lines 362–372)
+- Test: covered by manual verification (the guard is a dialog around a Qt seek).
+
+**Interfaces:**
+- Consumes: `status_controller.model.dyn_idle` (Task 2), `pyface_wrapper.confirm`/`YES`.
+
+- [ ] **Step 1: Add the warning to `_seek_to_phase`**
+
+```python
+# dock_pane.py — top of _seek_to_phase, before sc.seek_to(...)
+        sc = self.status_controller
+        if sc is None or self._current_row is None:
+            return
+        # Leaving the idle phase mid-run: warn before toggling back to a real
+        # phase — there may not be time to complete a full loop, so resuming
+        # could strand electrodes mid-loop (#477).
+        idle_index = sc.model.phase_total - 1
+        if sc.model.dyn_idle and target0 != idle_index:
+            from microdrop_application.dialogs.pyface_wrapper import confirm, YES
+            if confirm(
+                None,
+                "This step has already reached its idle phase. Toggling back to "
+                "a phase may leave the electrodes mid-loop (not at the start "
+                "position) if there isn't time to finish a full loop. Continue?",
+                title="Already idle",
+                cancel=False,
+            ) != YES:
+                return
+        path = tuple(self._current_row.path)
+        sc.seek_to(path, target0)
+        sc.preview_phase(path, target0, self._current_run_preview_mode)
+        self._update_phase_nav_buttons()
+```
+
+(This replaces the current 6-line body; the `sc`/`_current_row` guard is preserved at the top.)
+
+- [ ] **Step 2: Manual verification**
+
+Reach idle on a dynamic duration step, pause, click an earlier phase on the bar → the "Already idle" dialog appears; Cancel keeps idle; OK seeks and (on resume) runs the loop from there and returns to idle.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pluggable_protocol_tree/views/dock_pane.py
+git commit -m "feat(#477): warn before leaving the idle phase"
+```
+
+---
+
+### Task 7: Cap per-phase hold at duration_s (worst-case guarantee)
+
+**Files:**
+- Modify: `volume_threshold_protocol_controls/protocol_columns/volume_threshold_column.py` (the hold/extend path; confirm against `ctx.note_phase_extension` call site ~line 387)
+- Test: manual + existing volume-threshold tests must still pass.
+
+**Interfaces:**
+- Consumes: `row.duration_s`. Ensures a phase never holds beyond `duration_s`, so `worst_loop = cycle_len * duration_s` is a true bound (spec §10).
+
+- [ ] **Step 1: Audit the hold**
+
+Read the volume-threshold hold/extend logic. Per the product decision, the threshold per-phase timeout equals the duration-column value (`duration_s`). Confirm the post-dwell hold (`hold_for_buffer` in `routes_column._run_phase`, lines 236–260) plus any threshold extension cannot keep a phase active longer than `duration_s`. If an explicit timeout field exists, set/clamp it to `duration_s`.
+
+- [ ] **Step 2: Apply the cap (if needed)**
+
+If the hold can exceed `duration_s`, clamp the wait to `max(0, duration_s - already_elapsed_in_phase)` at the hold site. Show the exact change in the PR; if the audit shows the hold already caps at `duration_s`, record that finding in the commit message and skip the code change.
+
+- [ ] **Step 3: Run existing volume-threshold tests**
+
+Run: `pixi run pytest volume_threshold_protocol_controls/tests/ -v`
+Expected: PASS (no regressions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add volume_threshold_protocol_controls/
+git commit -m "fix(#477): cap per-phase hold at duration_s for the worst-case loop bound"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 guaranteed-loop gate + idle → Task 1 (`another_loop_fits`) + Task 4 (gate + `_go_idle`). ✓
+- §4 unique phases + dark-yellow idle cell → Task 2/3 (model+signals) + Task 5 (rendering). ✓
+- §5 seek re-entry into the dynamic loop → Task 4 (`dyn_resume_start`, start_k loop). ✓
+- §6a mid-loop-expiry warning → Task 4 (`loop_completion_fits` + `ctx.prompt_gui`). ✓
+- §6b leaving-idle warning → Task 6. ✓
+- §10 hold cap → Task 7. ✓
+- §7 removed items (no time scrubbing/axis/record/spinbox) → nothing added for them. ✓
+
+**Placeholder scan:** Task 7 Step 2 is conditional ("if needed") by design — it carries an explicit audit-then-act instruction and a definite fallback (record the finding), not a vague TODO. All other steps carry concrete code/commands.
+
+**Type consistency:** `dyn_resume_start(idx, cycle_len) -> (int, bool)`, `another_loop_fits`/`loop_completion_fits` signatures, `on_dyn_phase(now, cycle_pos, cycle_len, phase_target_s)` and `on_dyn_idle(now, cycle_len)`, signals `dyn_phase_started=(cycle_pos, cycle_len, dwell)` / `dyn_idle_entered=cycle_len`, and `set_idle_cell(index)` are used consistently across Tasks 1–6.
+
+**Note on testing:** the threaded dynamic loop and Qt painting are verified manually (Tasks 4–6) per project norms; pure logic (Tasks 1–3, and the `dyn_resume_start` seam in Task 4) is unit-tested.

--- a/docs/superpowers/specs/2026-06-22-477-guaranteed-loop-duration-mode-design.md
+++ b/docs/superpowers/specs/2026-06-22-477-guaranteed-loop-duration-mode-design.md
@@ -1,0 +1,178 @@
+# Guaranteed-loop duration mode with unique-phase navigation (#477)
+
+**Issue:** [#477](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/477) — Precise phase-granular resume for duration-mode steps (follow-up to #471).
+**Date:** 2026-06-22
+**Status:** Design approved; ready for implementation plan.
+
+> **Direction change vs. the issue text.** Issue #477 proposed resolving a *phase index*
+> for duration-mode resume. This spec supersedes that with a simpler model: keep the loop
+> running only while a full loop is *guaranteed* to finish within the user-set rep time,
+> then idle; let the operator toggle the loop's unique phases while paused and resume from
+> there; and warn (rather than silently misbehave) when navigation would strand the run
+> mid-loop. There is **no** time-domain scrubbing, no time axis, and no per-phase actual-
+> duration recording.
+
+---
+
+## 1. Scope
+
+Applies only to **route-rep-by-time (duration-mode) steps** — rows where
+`repeat_duration_controls is True and repeat_duration > 0`. Within those, the work targets the
+**dynamic loop** `RoutesHandler._run_dynamic_duration_loop`
+(`builtins/routes_column.py:263–349`), which runs when `in_duration_mode and phase_hold`
+(the volume-threshold path; `phase_hold = ctx.scratch.get(PHASE_HOLD_REQUESTED_KEY)`).
+
+Out of scope / unchanged:
+- Count-mode steps (discrete materialized phases) keep their current phase bar and navigation.
+- Duration-mode steps **without** volume-threshold (the static `iter_phases` path with a
+  trailing hold-pad, `routes_column.py:393–461`) already precompute their loop count and
+  idle pad and already honor the seek cursor; they get only the shared idle-cell rendering
+  and the two warning dialogs (§5) for consistency, no loop-gate surgery.
+
+## 2. Definitions
+
+For a duration-mode dynamic step:
+
+| Symbol | Meaning | Source |
+|---|---|---|
+| `cycle_len` | number of phases in one unit loop (the unique phases) | `len(unit_cycle)` from `duration_loop_parts(...)` (`phase_math.py:136–179`) |
+| `phase_dwell` | per-phase dwell / max hold, seconds | `row.duration_s` |
+| `worst_loop` | worst-case time for one full loop | `cycle_len * phase_dwell` |
+| `budget` | the user-set rep time | `row.repeat_duration` |
+| `raw_elapsed()` | wall-clock since step start | `monotonic() - step_start`, **including pauses and holds; NOT pause-aware and NOT extension-credited** |
+
+`phase_dwell` is also the per-phase volume-threshold hold timeout (per product decision: the
+threshold timeout equals the duration-column value). Therefore each phase takes **at most**
+`phase_dwell`, which makes `worst_loop` a true upper bound on a full loop.
+
+## 3. Loop-continuation gate (core behavior change)
+
+In `_run_dynamic_duration_loop`, the decision to run another loop happens at each **loop
+boundary** (the moment execution is back at the loop's start position):
+
+```
+if raw_elapsed() + worst_loop <= budget:
+    run another full loop
+else:
+    enter idle
+```
+
+- Because every phase ≤ `phase_dwell`, any loop admitted by the gate is *guaranteed* to
+  complete within `budget`. The run never starts a loop it cannot finish.
+- This replaces today's continuation check
+  (`_budget_elapsed() + cycle_full_time <= budget`, `routes_column.py:327–340`), which used
+  `_budget_elapsed() = monotonic - step_start - phase_extension_total` (pause/extension
+  credit-back). The new gate uses **raw elapsed** — pauses and holds count against the budget.
+- `cycle_full_time` in today's code already equals `cycle_len * phase_dwell = worst_loop`; the
+  change is dropping the credit-back term, plus moving the idle decision to the loop boundary.
+
+### Idle
+When the gate fails, the step enters **idle**:
+- Electrodes **off** (publish an empty actuation set, preview-gated like other hardware
+  publishes).
+- Cooperative-sleep (stop/pause-aware) until `raw_elapsed() >= budget`, then the step ends and
+  the executor advances to the next step.
+- Idle is a real, navigable position on the phase bar (§4).
+
+## 4. Phase bar: unique phases + idle cell
+
+Today the dynamic loop emits `phase_total = 0`, which hides the phase track
+(`timeline_bar._phase_track_visible` requires `> 1`). Instead:
+
+- Feed the bar `phase_total = cycle_len + 1` — the `cycle_len` unique phases plus a single
+  trailing **idle** cell — and a playhead at the current unit-cycle index (or the idle cell
+  when idle). Source the count/position from the running loop via the status model
+  (`models/protocol_status.py`) and `_refresh_timeline_position` (`dock_pane.py:425–467`).
+- The trailing idle cell renders in **dark yellow** (new color key in `timeline_bar.py`’s
+  color set, applied via the existing `cell_colors` channel in `_paint_track`,
+  `timeline_bar.py:288–324`).
+- Count-mode steps are unaffected.
+
+Navigation maps a clicked/▶◀ cell to a unique-phase index `k` (or the idle cell). The three
+existing input paths (`timeline_bar.phase_seek_requested`, nav-bar prev/next-phase buttons,
+phase-rep combo) funnel through `dock_pane._seek_to_phase(target0)`
+(`dock_pane.py:362–372`) as today.
+
+## 5. Seek re-entry into the dynamic loop (closes the #477 gap)
+
+Currently `_run_dynamic_duration_loop` always starts `running_idx = 0` and ignores
+`cursor.phase_index`, so a phase-seek re-enters at phase 1 (`routes_column.py:299`). Change:
+
+- `_run_dynamic_duration_loop` reads `cursor.phase_index` on entry and resumes the loop at
+  `unit_cycle[k]`, running phases `k…cycle_len-1` to complete the loop back to start, then
+  evaluates the gate (§3).
+- The seek plumbing is unchanged: `executor.seek` → `cursor.request_seek` →
+  `cursor.frame_for_seek` / `decision_at_phase` (`cursor.py`, `seek.py`,
+  `protocol_status_controller.seek_to`). Only the dynamic loop's *consumption* of the cursor
+  phase index is new.
+- A pure helper resolves a unique-phase index `k` to its `unit_cycle` position (and back),
+  unit-tested independently.
+
+## 6. Warning dialogs
+
+Both use the project dialog wrapper (`microdrop_application.dialogs.pyface_wrapper`), returning
+pyface YES/NO directly. Both are triggered on the GUI thread from the navigation/resume flow.
+
+### (a) Mid-loop-expiry warning
+On **resume** after the operator navigated to phase `k`, if completing the loop from `k` would
+exceed the budget:
+
+```
+remaining_to_loop_end = (cycle_len - k) * phase_dwell
+if raw_elapsed() + remaining_to_loop_end > budget:  # won't fit
+    warn("We need more time to reach the loop's end point.")
+```
+
+- **OK / Yes** → run `k…end` ignoring the budget, then advance to the next step (the intended
+  time is up; do not start another loop).
+- **No / Cancel** → leave the protocol paused so the operator can toggle to a safe phase, stop,
+  or otherwise decide. The step is not advanced and no loop is run.
+
+### (b) Leaving-idle warning
+Once the step has reached **idle**, if the operator navigates back to a real phase `k`:
+
+- Warn first: "We've already reached the idle phase. Toggling phases may leave the electrodes
+  in a non-start position mid-loop, because there may not be time to complete a full loop."
+- **OK / Yes** → run the loop from `k`; on completion (back at start), return to idle.
+- **No / Cancel** → stay idle; no navigation applied.
+
+When both conditions apply (navigating away from idle *and* the loop won't fit), warning (b) is
+shown; an OK there proceeds under warning (a)'s "run to loop end, then next step" semantics.
+
+## 7. What is explicitly NOT in this design
+
+Removed relative to the earlier time-domain brainstorm:
+- No time scrubbing / moving the playhead forward or backward in time.
+- No "time increment" float spin box in the timeline controls.
+- No `phase_finished` signal or per-phase actual-duration record.
+- No proportional time-axis rendering (the bar stays discrete unique-phase cells + idle).
+- No standalone auto-overrun pause; the loop-gate (§3) plus mid-loop-expiry warning (§6a)
+  cover overrun.
+
+## 8. Components touched
+
+| Area | File(s) | Change |
+|---|---|---|
+| Loop gate + idle + seek re-entry | `builtins/routes_column.py` (`_run_dynamic_duration_loop`, `_run_phase`) | raw-elapsed guaranteed-loop gate; idle-on-fail; read `cursor.phase_index`; cap phase hold at `phase_dwell` |
+| Unique-phase + idle resolution | `services/phase_math.py` | pure helper: unit-cycle length, `k → unit_cycle` position, idle-cell index |
+| Bar state during dynamic loop | `models/protocol_status.py`, `services/protocol_status_controller.py`, `views/dock_pane.py` (`_refresh_timeline_position`) | emit `cycle_len + 1` and current cell instead of `phase_total = 0` |
+| Idle cell color | `views/timeline_bar.py` | dark-yellow idle cell via `cell_colors` |
+| Warnings | `views/dock_pane.py` (navigation/resume handlers) | mid-loop-expiry + leaving-idle dialogs |
+
+## 9. Testing
+
+Pure-unit coverage (no Redis/hardware):
+- Loop-continuation gate: `raw_elapsed + worst_loop <= budget` boundary cases (exact fit,
+  just-over, idle-from-start when budget < worst_loop).
+- Mid-loop-expiry predicate: `(cycle_len - k) * phase_dwell` vs. remaining budget across `k`.
+- Seek re-entry: `k → unit_cycle` position resolution, including `k = 0`, `k = cycle_len-1`,
+  and the idle cell.
+- Idle entry/exit transitions on the status model.
+
+## 10. Open implementation note
+
+For the worst-case bound to hold, the dynamic loop must treat `duration_s` as the per-phase
+hold ceiling. If the current volume-threshold hold logic
+(`volume_threshold_protocol_controls`, `ctx.note_phase_extension`,
+`StepContext` phase-buffer) can extend a phase beyond `duration_s`, the implementation must cap
+it (or surface the discrepancy). Confirm during implementation.

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -340,10 +340,28 @@ class RoutesHandler(BaseColumnHandler):
             # the budget (NOT pause-aware, NOT extension-credited) — #477.
             return _monotonic() - step_start
 
+        # Resolve the resume phase (#477 review fix). A SAME-STEP seek leaves
+        # cursor.phase_index at 0 — the real target lives in resume_target,
+        # recovered via decision_at_phase exactly like the static phase loop.
+        # A DIFFERENT-STEP seek is pre-resolved by the executor into
+        # cursor.phase_index with resume_target already cleared. A fresh entry
+        # is phase_index 0 with no resume_target.
         cursor = ctx.protocol.cursor
-        start_k, start_idle = dyn_resume_start(int(cursor.phase_index), cycle_len)
-        came_from_seek = cursor.resume_target is not None
-        cursor.clear_seek()
+        if cursor.resume_target is not None:
+            action, target_phase = cursor.decision_at_phase(0)
+            if action == "abort":
+                # Different step/frame: unwind so the executor's frame walk
+                # re-enters the correct target.
+                ctx.step_phases_done_event.set()
+                return
+            # ("jump", target_phase): same-step seek — consume it here.
+            seek_phase = int(target_phase)
+            came_from_seek = True
+            cursor.clear_seek()
+        else:
+            seek_phase = int(cursor.phase_index)
+            came_from_seek = seek_phase > 0
+        start_k, start_idle = dyn_resume_start(seek_phase, cycle_len)
 
         def _run_cycle_phase(phase, cycle_pos):
             nonlocal running_idx
@@ -413,8 +431,8 @@ class RoutesHandler(BaseColumnHandler):
                     return
                 i += 1
             i = 0
-            if not another_loop_fits(raw_elapsed(), cycle_len, per_phase_dwell,
-                                     budget):
+            if per_phase_dwell <= 0 or not another_loop_fits(
+                    raw_elapsed(), cycle_len, per_phase_dwell, budget):
                 break
         if not stop_event.is_set():
             _go_idle()

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -378,7 +378,7 @@ class RoutesHandler(BaseColumnHandler):
         else:
             seek_phase = int(cursor.phase_index)
             came_from_seek = seek_phase > 0
-        start_k, start_idle = dyn_resume_start(seek_phase, cycle_len)
+        _, start_idle = dyn_resume_start(seek_phase, cycle_len)
 
         def _run_cycle_phase(phase, cycle_pos):
             nonlocal running_idx
@@ -414,36 +414,69 @@ class RoutesHandler(BaseColumnHandler):
                     min(0.1, budget - raw_elapsed()), stop_event, pause_event,
                     seek_pending=lambda: cursor.resume_target is not None)
 
+        def _resume_at(target):
+            """Resolve a (just-cleared) same-step seek to phase ``target`` to
+            the loop index to run from, or None when the step finishes here.
+
+            ``target`` >= cycle_len is the idle cell -> idle to the budget. A
+            mid-loop target that can no longer finish within the budget prompts
+            the operator (finish-then-advance vs stay paused) — the same rule a
+            fresh seek-resume uses. A fresh non-seek entry passes 0 and just
+            runs from the loop start."""
+            k = max(0, int(target))
+            if k >= cycle_len:
+                _go_idle()
+                return None
+            if k > 0 and not loop_completion_fits(
+                    raw_elapsed(), k, cycle_len, per_phase_dwell, budget):
+                if ctx.prompt_gui(lambda: _confirm_finish_loop_over_budget()):
+                    # Finish this loop (back to start), then advance.
+                    for j in range(k, cycle_len):
+                        if not _run_cycle_phase(unit_cycle[j], j):
+                            return None
+                    ctx.step_phases_done_event.set()
+                    return None
+                # Declined: stay paused on this step at k. A plain resume runs
+                # from k; a re-toggle is picked up by the loop's seek checkpoint.
+                ctx.protocol.pause()
+            return k
+
         # Soft-start ramp only on a fresh (non-seek) entry that isn't idle.
         if not came_from_seek and not start_idle:
             for phase in ramp_up:
                 if not _run_cycle_phase(phase, 0):
                     return
 
-        # Mid-loop-expiry guard: a seek re-entry partway through the loop where
-        # finishing won't fit the budget (operator toggled to a bad spot).
-        if came_from_seek and not start_idle and start_k > 0 \
-                and not loop_completion_fits(raw_elapsed(), start_k, cycle_len,
-                                             per_phase_dwell, budget):
-            if not ctx.prompt_gui(lambda: _confirm_finish_loop_over_budget()):
-                ctx.protocol.pause()
-                return
-            # Run the partial loop to its end, then advance to the next step.
-            for i in range(start_k, cycle_len):
-                if not _run_cycle_phase(unit_cycle[i], i):
-                    return
-            ctx.step_phases_done_event.set()
+        # Resolve the entry position (idle / over-budget prompt / run-from-k);
+        # for a fresh entry this is just phase 0.
+        i = _resume_at(seek_phase)
+        if i is None:
             return
 
-        if start_idle:
-            _go_idle()
-            return
-
-        # First (possibly partial) loop from start_k, then full loops while
-        # another guaranteed loop fits; otherwise idle.
-        i = start_k
+        # Run full unit cycles while another guaranteed loop still fits. The
+        # in-loop pause + seek checkpoint repositions a mid-loop toggle IN PLACE
+        # (mirrors the static phase loop): without it a pending seek would leave
+        # resume_target stuck, collapsing every remaining dwell to ~0 (strobing
+        # the rest of the cycle) and skipping idle, so the step would race to
+        # the next one (#477).
         while not stop_event.is_set():
             while i < cycle_len:
+                if pause_event.is_set():
+                    pause_event.wait_cleared()
+                    if stop_event.is_set():
+                        return
+                if cursor.resume_target is not None:
+                    action, target_phase = cursor.decision_at_phase(i)
+                    if action == "abort":
+                        # Different step: unwind; the executor re-enters the
+                        # target step (leave resume_target set).
+                        ctx.step_phases_done_event.set()
+                        return
+                    cursor.clear_seek()
+                    i = _resume_at(int(target_phase))
+                    if i is None:
+                        return
+                    continue
                 if not _run_cycle_phase(unit_cycle[i], i):
                     return
                 i += 1

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -117,6 +117,35 @@ def _confirm_finish_loop_over_budget():
     ) == YES
 
 
+def _prompt_time_expired():
+    """Operator prompt when the route-rep duration expires before the step has
+    finished and the electrodes are NOT back at their start position (#477
+    follow-up). Three choices, returned as a string:
+
+      'finish' -> run the rest (complete the loop / remaining phases) so the
+                  electrodes return to start, then advance to the next step,
+      'next'   -> skip the rest of this step and advance to the next step now,
+      'paused' -> stay paused on this step so the operator decides.
+    """
+    from microdrop_application.dialogs.pyface_wrapper import confirm, YES, NO
+    result = confirm(
+        None,
+        "The route-rep duration time has expired, but this step has not "
+        "finished and the electrodes are not back at their start position.\n\n"
+        "What would you like to do?",
+        title="Route-rep time expired",
+        cancel=True,
+        yes_label="Complete loop, then next step",
+        no_label="Skip to next step now",
+        cancel_label="Stay paused",
+    )
+    if result == YES:
+        return "finish"
+    if result == NO:
+        return "next"
+    return "paused"
+
+
 class RoutesColumnModel(BaseColumnModel):
     """List[List[str]] trait. Default = empty list."""
     def trait_for_row(self):
@@ -409,6 +438,11 @@ class RoutesHandler(BaseColumnHandler):
             # Explicit idle: electrodes off once, then hold to the budget. A
             # seek (operator toggled away from idle) returns so the executor's
             # pause/seek path re-enters this step.
+            idle_for = max(0.0, budget - raw_elapsed())
+            logger.info(
+                f"[dyn-loop] entering IDLE (electrodes off): elapsed="
+                f"{raw_elapsed():.2f}s of rep-duration budget {budget:.2f}s "
+                f"-> idle for ~{idle_for:.2f}s until the budget elapses")
             if not preview_mode:
                 electrode_state_change_publisher.publish(actuated_channels=[])
             if signals is not None:
@@ -465,6 +499,7 @@ class RoutesHandler(BaseColumnHandler):
         # resume_target stuck, collapsing every remaining dwell to ~0 (strobing
         # the rest of the cycle) and skipping idle, so the step would race to
         # the next one (#477).
+        overrun_prompted = False
         while not stop_event.is_set():
             while i < cycle_len:
                 if pause_event.is_set():
@@ -486,9 +521,40 @@ class RoutesHandler(BaseColumnHandler):
                 if not _run_cycle_phase(unit_cycle[i], i):
                     return
                 i += 1
+                # Overrun guard (#477 follow-up): the rep-duration budget ran
+                # out MID-loop (electrodes not back at start) — e.g. a phase
+                # held past its dwell, or the budget was too short for even one
+                # full loop (the first loop runs unconditionally). Ask the
+                # operator once per step what to do. Skipped in preview (a
+                # visual dry-run shouldn't block on a dialog).
+                if (not preview_mode and not overrun_prompted and budget > 0
+                        and i < cycle_len and raw_elapsed() >= budget):
+                    overrun_prompted = True
+                    decision = ctx.prompt_gui(_prompt_time_expired) or "finish"
+                    if decision == "next":
+                        ctx.step_phases_done_event.set()
+                        return
+                    if decision == "paused":
+                        ctx.protocol.pause()
+                    # 'finish' (or an external resume): fall through and run the
+                    # rest of the loop back to start; the loop gate below is now
+                    # over budget, so the next stop is idle (which exits at once)
+                    # then advance. No re-prompt — overrun_prompted stays set.
             i = 0
-            if per_phase_dwell <= 0 or not another_loop_fits(
-                    raw_elapsed(), cycle_len, per_phase_dwell, budget):
+            elapsed = raw_elapsed()
+            worst_loop = cycle_len * per_phase_dwell
+            fits = per_phase_dwell > 0 and another_loop_fits(
+                elapsed, cycle_len, per_phase_dwell, budget)
+            # Explain the keep-looping-vs-idle decision so the operator can see
+            # how the dynamic loop is spending the rep-duration budget (#477).
+            logger.info(
+                f"[dyn-loop] end of loop: elapsed={elapsed:.2f}s, "
+                f"worst-case loop time={worst_loop:.2f}s "
+                f"({cycle_len} phases x {per_phase_dwell:.2f}s), "
+                f"available={max(0.0, budget - elapsed):.2f}s, "
+                f"rep-duration budget={budget:.2f}s -> "
+                f"{'run another loop' if fits else 'stop looping, go idle'}")
+            if not fits:
                 break
         if not stop_event.is_set():
             _go_idle()
@@ -519,6 +585,9 @@ class RoutesHandler(BaseColumnHandler):
             bool(getattr(row, "repeat_duration_controls", False))
             and float(getattr(row, "repeat_duration", 0.0) or 0.0) > 0
         )
+        # Rep-duration budget (seconds); 0 in count mode. Shared by the dynamic
+        # loop and the static path's overrun guard.
+        budget = float(getattr(row, "repeat_duration", 0.0) or 0.0)
 
         signals = getattr(ctx.protocol, "signals", None)
         # Generic opt-in: a sibling column (e.g. volume threshold) requested in
@@ -533,8 +602,7 @@ class RoutesHandler(BaseColumnHandler):
                 step_uuid=step_uuid, step_label=step_label,
                 preview_mode=preview_mode, per_phase_dwell=per_phase_dwell,
                 stop_event=stop_event, pause_event=pause_event,
-                signals=signals,
-                budget=float(getattr(row, "repeat_duration", 0.0) or 0.0))
+                signals=signals, budget=budget)
         else:
             phases = list(iter_phases(
                 static_electrodes=list(getattr(row, "electrodes", []) or []),
@@ -556,6 +624,11 @@ class RoutesHandler(BaseColumnHandler):
             # a different-step seek). Clamp into range.
             phase_i = max(0, min(int(cursor.phase_index), max(0, total_phases - 1)))
             seek_abort = False
+            # Raw wall-clock origin for the duration-mode overrun guard below
+            # (same RAW accounting as the dynamic loop: pauses/holds count).
+            step_start = _monotonic()
+            overrun_prompted = False
+            skip_to_next = False
             while phase_i < total_phases:
                 if stop_event.is_set():
                     break
@@ -588,6 +661,25 @@ class RoutesHandler(BaseColumnHandler):
                         hold_for_buffer=phase_hold, honor_pause=False):
                     break
                 phase_i += 1
+                # Overrun guard (#477 follow-up): duration mode with the budget
+                # used up before the phases finished (e.g. the budget is shorter
+                # than one full set of phases). Ask the operator once. Skipped in
+                # preview (a visual dry-run shouldn't block on a dialog).
+                # ``phase_i < total_phases - 1``: iter_phases appends a trailing
+                # return-to-start phase, so when only THAT phase remains the step
+                # is completing normally (it ends back at start) — not an
+                # overrun. Only prompt while a real move phase still remains.
+                if (in_duration_mode and not preview_mode and budget > 0
+                        and not overrun_prompted and phase_i < total_phases - 1
+                        and _monotonic() - step_start >= budget):
+                    overrun_prompted = True
+                    decision = ctx.prompt_gui(_prompt_time_expired) or "finish"
+                    if decision == "next":
+                        skip_to_next = True
+                        break
+                    if decision == "paused":
+                        ctx.protocol.pause()
+                    # 'finish'/external resume: keep running the remaining phases.
             if seek_abort:
                 # Leave resume_target set; the executor re-enters the target step.
                 ctx.step_phases_done_event.set()
@@ -596,8 +688,10 @@ class RoutesHandler(BaseColumnHandler):
             # phase's electrodes (no new publish) for the exact leftover so
             # total step time lands on the budget precisely. Based on the
             # ACTUAL emitted phase count so it accounts for loop cycles,
-            # ramps, and routes.
-            if in_duration_mode and not stop_event.is_set():
+            # ramps, and routes. Skipped when the budget already overran
+            # (skip-to-next, or the operator let it finish past the budget).
+            if (in_duration_mode and not stop_event.is_set()
+                    and not overrun_prompted and not skip_to_next):
                 pad = max(0.0, float(getattr(row, "repeat_duration", 0.0))
                               - len(phases) * per_phase_dwell)
                 if pad > 0:

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -48,7 +48,7 @@ from pluggable_protocol_tree.models.display_state import (
     ProtocolTreeDisplayMessage,
 )
 from pluggable_protocol_tree.services.phase_math import (
-    duration_loop_parts, iter_phases,
+    another_loop_fits, duration_loop_parts, iter_phases, loop_completion_fits,
 )
 from pluggable_protocol_tree.views.columns.base import BaseColumnView
 
@@ -87,6 +87,34 @@ _HOLD_GRACE_S = 0.5
 # replaced with a deterministic fake clock in tests. Production uses
 # time.monotonic unchanged.
 _monotonic = time.monotonic
+
+
+def dyn_resume_start(cursor_phase_index: int, cycle_len: int):
+    """Resolve a paused-seek cursor phase to a dynamic-loop start.
+
+    Returns (start_phase_in_cycle, start_idle). cursor_phase_index is the
+    0-based unique-phase the operator toggled to; an index at/over cycle_len
+    is the trailing idle cell. Negative clamps to phase 0 (#477)."""
+    if cycle_len <= 0:
+        return 0, False
+    if cursor_phase_index >= cycle_len:
+        return 0, True
+    return max(0, int(cursor_phase_index)), False
+
+
+def _confirm_finish_loop_over_budget():
+    """Operator prompt when a seek-resume lands partway through a loop that
+    can no longer finish within the route-rep budget (#477). Returns True to
+    finish the loop and advance, False to leave the run paused."""
+    from microdrop_application.dialogs.pyface_wrapper import confirm, YES
+    return confirm(
+        None,
+        "The set route-rep time is up, but the current loop is not back at its "
+        "start position. Finish this loop (electrodes return to start) and then "
+        "move to the next step?",
+        title="Loop needs more time",
+        cancel=False,
+    ) == YES
 
 
 class RoutesColumnModel(BaseColumnModel):
@@ -264,26 +292,33 @@ class RoutesHandler(BaseColumnHandler):
                                    step_uuid, step_label, preview_mode,
                                    per_phase_dwell, stop_event, pause_event,
                                    signals, budget):
-        """Duration mode + a phase-hold hook: loop the unit cycle as long as
-        another FULL-duration cycle still fits the budget, then close with
-        the return-to-start phase and idle any sub-cycle remainder.
+        """Duration mode + a phase-hold hook: run full unit cycles while a
+        guaranteed FULL loop still fits the RAW wall-clock budget, then enter
+        an explicit idle phase (electrodes off) until the budget elapses.
+
+        Budget accounting is RAW wall-clock since step start (#477): pauses
+        and holds count against the budget — there is no extension credit-back.
+        At each loop boundary ``another_loop_fits`` gates whether one more
+        worst-case loop (every phase at ``per_phase_dwell``) finishes in time;
+        when it won't, the loop closes back at the unit-cycle start and idles.
+        Because every loop ends at phase 0, there is no separate return phase —
+        the next loop's phase 0 IS the return.
 
         A hook column (e.g. volume threshold) cuts each phase short via
         phase_advance_event, so wall-clock elapses slower than
-        ``per_phase_dwell`` would predict and more cycles fit -> the freed
-        time becomes more loops, not idle. The soft-end ramp-down is
-        intentionally absent (duration_loop_parts does not produce it):
-        reaching the hook's advance condition guarantees droplet position.
-        The phase index is a running counter with total 0 (unknown while
-        looping) so the status bar shows the advancing phase number.
+        ``per_phase_dwell`` predicts and more loops fit. The phase index is a
+        running counter with total 0 (unknown while looping) so the status bar
+        shows the advancing phase number.
 
-        Operator-requested phase extensions (the recovery dialog's "extend by
-        X") are CREDITED BACK to the budget: they add to the step's total
-        time rather than displacing later cycles. A 1000s budget with a 30s
-        stuck-phase extension therefore runs ~1030s total, keeping the full
-        1000s of cycling. ``ctx.phase_extension_total()`` accumulates those
-        extensions; ``_budget_elapsed`` subtracts them from wall-clock."""
-        ramp_up, unit_cycle, return_phase = duration_loop_parts(
+        Seek re-entry: on a paused seek the cursor's phase resolves via
+        ``dyn_resume_start`` to a start phase or the idle cell. If the seek
+        lands partway through a loop that can no longer finish in budget, the
+        operator is prompted (``_confirm_finish_loop_over_budget``): YES runs
+        the partial loop to its end then advances; NO pauses."""
+        # return_phase is unused now: every loop closes back at the unit-cycle
+        # start (the next loop's phase 0 IS the return), and idle replaces the
+        # old soft-end remainder (#477).
+        ramp_up, unit_cycle, _return_phase = duration_loop_parts(
             static_electrodes=list(getattr(row, "electrodes", []) or []),
             routes=list(getattr(row, "routes", []) or []),
             trail_length=int(getattr(row, "trail_length", 1)),
@@ -294,59 +329,95 @@ class RoutesHandler(BaseColumnHandler):
         # is None; the loop below repeats that static actuation across the
         # budget (holding the droplet, re-checking the threshold each dwell)
         # rather than yielding it once. Intentional for VT static-merge steps.
-        cycle_full_time = len(unit_cycle) * per_phase_dwell
+        # cycle_len phases at per_phase_dwell each = one worst-case loop; the
+        # guaranteed-loop gate (another_loop_fits) computes that bound itself.
+        cycle_len = len(unit_cycle)
         step_start = _monotonic()
         running_idx = 0
 
-        def _budget_elapsed():
-            # Wall-clock since step start MINUS operator-requested phase
-            # extensions, so those add to the total run time rather than
-            # eating into the duration budget.
-            return _monotonic() - step_start - ctx.phase_extension_total()
+        def raw_elapsed():
+            # RAW wall-clock since step start: pauses and holds count against
+            # the budget (NOT pause-aware, NOT extension-credited) — #477.
+            return _monotonic() - step_start
 
-        def _run(phase):
+        cursor = ctx.protocol.cursor
+        start_k, start_idle = dyn_resume_start(int(cursor.phase_index), cycle_len)
+        came_from_seek = cursor.resume_target is not None
+        cursor.clear_seek()
+
+        def _run_cycle_phase(phase, cycle_pos):
             nonlocal running_idx
             running_idx += 1
+            if signals is not None:
+                signals.dyn_phase_started = (cycle_pos + 1, cycle_len,
+                                             per_phase_dwell)
             # hold_for_buffer=True: this loop only runs when a column requested
             # the phase-hold hook, so honour the same post-dwell hold/dialog as
-            # the static path. A phase whose hook advances early is still cut
-            # short by phase_advance_event (so cycles keep fitting the budget);
-            # only a held phase can extend / open the dialog.
+            # the static path. honor_pause=False: this loop owns the pause/seek
+            # checkpoints (the executor re-enters the step on a seek).
             return self._run_phase(
                 phase, ctx=ctx, mapping=mapping, static_routes=static_routes,
                 step_uuid=step_uuid, step_label=step_label,
                 preview_mode=preview_mode, per_phase_dwell=per_phase_dwell,
                 stop_event=stop_event, pause_event=pause_event,
-                signals=signals, phase_index=running_idx, phase_total=0,
-                hold_for_buffer=True)
+                signals=signals, phase_index=cycle_pos + 1,
+                phase_total=cycle_len + 1, hold_for_buffer=True,
+                honor_pause=False)
 
-        for phase in ramp_up:
-            if not _run(phase):
-                return
+        def _go_idle():
+            # Explicit idle: electrodes off once, then hold to the budget. A
+            # seek (operator toggled away from idle) returns so the executor's
+            # pause/seek path re-enters this step.
+            if not preview_mode:
+                electrode_state_change_publisher.publish(actuated_channels=[])
+            if signals is not None:
+                signals.dyn_idle_entered = cycle_len
+            while not stop_event.is_set() and raw_elapsed() < budget:
+                if cursor.resume_target is not None:
+                    return
+                _cooperative_sleep(
+                    min(0.1, budget - raw_elapsed()), stop_event, pause_event,
+                    seek_pending=lambda: cursor.resume_target is not None)
 
-        while not stop_event.is_set():
-            # Only add a cycle if there's room for a COMPLETE one at full
-            # per-phase dwell. cycle_full_time <= 0 (degenerate 0-dwell
-            # config) would never gate, so run a single cycle and stop.
-            if cycle_full_time <= 0:
-                for phase in unit_cycle:
-                    if not _run(phase):
-                        return
-                break
-            if _budget_elapsed() + cycle_full_time > budget:
-                break
-            for phase in unit_cycle:
-                if not _run(phase):
+        # Soft-start ramp only on a fresh (non-seek) entry that isn't idle.
+        if not came_from_seek and not start_idle:
+            for phase in ramp_up:
+                if not _run_cycle_phase(phase, 0):
                     return
 
-        if return_phase is not None and not stop_event.is_set():
-            _run(return_phase)
+        # Mid-loop-expiry guard: a seek re-entry partway through the loop where
+        # finishing won't fit the budget (operator toggled to a bad spot).
+        if came_from_seek and not start_idle and start_k > 0 \
+                and not loop_completion_fits(raw_elapsed(), start_k, cycle_len,
+                                             per_phase_dwell, budget):
+            if not ctx.prompt_gui(lambda: _confirm_finish_loop_over_budget()):
+                ctx.protocol.pause()
+                return
+            # Run the partial loop to its end, then advance to the next step.
+            for i in range(start_k, cycle_len):
+                if not _run_cycle_phase(unit_cycle[i], i):
+                    return
+            ctx.step_phases_done_event.set()
+            return
 
-        remaining = budget - _budget_elapsed()
-        if remaining > 0 and not stop_event.is_set():
-            _cooperative_sleep(
-                remaining, stop_event, pause_event,
-                seek_pending=lambda: ctx.protocol.cursor.resume_target is not None)
+        if start_idle:
+            _go_idle()
+            return
+
+        # First (possibly partial) loop from start_k, then full loops while
+        # another guaranteed loop fits; otherwise idle.
+        i = start_k
+        while not stop_event.is_set():
+            while i < cycle_len:
+                if not _run_cycle_phase(unit_cycle[i], i):
+                    return
+                i += 1
+            i = 0
+            if not another_loop_fits(raw_elapsed(), cycle_len, per_phase_dwell,
+                                     budget):
+                break
+        if not stop_event.is_set():
+            _go_idle()
 
     def on_step(self, row, ctx):
         mapping = ctx.protocol.scratch.get(ELECTRODE_TO_CHANNEL_KEY, {})

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -51,6 +51,7 @@ from pluggable_protocol_tree.services.phase_math import (
     another_loop_fits, duration_loop_parts, iter_phases, loop_completion_fits,
 )
 from pluggable_protocol_tree.views.columns.base import BaseColumnView
+from microdrop_application.dialogs.pyface_wrapper import confirm, YES, NO
 
 
 logger = logging.getLogger(__name__)
@@ -127,17 +128,19 @@ def _prompt_time_expired():
       'next'   -> skip the rest of this step and advance to the next step now,
       'paused' -> stay paused on this step so the operator decides.
     """
-    from microdrop_application.dialogs.pyface_wrapper import confirm, YES, NO
     result = confirm(
         None,
         "The route-rep duration time has expired, but this step has not "
-        "finished and the electrodes are not back at their start position.\n\n"
-        "What would you like to do?",
+        "finished and the electrodes are not back at their start position.<br><br>"
+        "What would you like to do?<br><br>"
+        "<b> Pause </b> and decide next step manually; <br><br>"
+        "<b> Skip </b> to next step; <br> <br>"
+        "<b> Complete </b>: Complete rest of loop then proceed to next step. <br><br>",
         title="Route-rep time expired",
         cancel=True,
-        yes_label="Complete loop, then next step",
-        no_label="Skip to next step now",
-        cancel_label="Stay paused",
+        yes_label="Complete",
+        no_label="Skip",
+        cancel_label="Pause",
     )
     if result == YES:
         return "finish"

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -336,7 +336,10 @@ class RoutesHandler(BaseColumnHandler):
                 if time_expired is not None and time_expired():
                     break
                 if pause_event.is_set():
-                    pause_event.wait_cleared()
+                    # Poll so a budget expiry DURING the hold-pause wakes us;
+                    # the top-of-loop time_expired check then breaks the hold so
+                    # the caller can raise the overrun prompt while paused.
+                    _wait_through_pause(pause_event, stop_event, time_expired)
                     grace_deadline = time.monotonic() + _HOLD_GRACE_S
                     continue
                 extra = _take_and_emit()
@@ -532,7 +535,12 @@ class RoutesHandler(BaseColumnHandler):
         while not stop_event.is_set():
             while i < cycle_len:
                 if pause_event.is_set():
-                    pause_event.wait_cleared()
+                    # Poll the budget so an expiry during a between-phase pause
+                    # is noticed: on wake the next phase's dwell breaks at once
+                    # (over budget) and the post-phase overrun check prompts.
+                    _wait_through_pause(
+                        pause_event, stop_event,
+                        lambda: not overrun_prompted and raw_elapsed() >= budget)
                     if stop_event.is_set():
                         return
                 if cursor.resume_target is not None:
@@ -658,14 +666,35 @@ class RoutesHandler(BaseColumnHandler):
             step_start = _monotonic()
             overrun_prompted = False
             skip_to_next = False
+            # The loop-origin phase for the "complete loop" overrun choice: it
+            # lets us stop as soon as the droplet is back at start instead of
+            # running ALL the remaining predetermined reps (#477 follow-up).
+            # Same origin the dynamic loop uses (zipped first window + static).
+            _dlp_ramp, _dlp_cycle, _dlp_ret = duration_loop_parts(
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)))
+            start_set = _dlp_cycle[0] if _dlp_cycle else None
+            finish_to_start = False
+            # Budget-expiry predicate: lets a paused/dwelling phase wake the
+            # instant the rep budget is crossed (so the prompt shows even while
+            # paused). Disabled once prompted so the loop-completion phases dwell
+            # normally. None in count mode (no budget).
+            time_expired = (
+                (lambda: not overrun_prompted
+                 and (_monotonic() - step_start) >= budget)
+                if (in_duration_mode and budget > 0) else None)
             while phase_i < total_phases:
                 if stop_event.is_set():
                     break
                 cursor.phase_index = phase_i
                 # Pause checkpoint (this loop owns it; _run_phase is called with
-                # honor_pause=False so it won't block again at its top).
+                # honor_pause=False so it won't block again at its top). Poll the
+                # budget so an expiry during a between-phase pause is noticed.
                 if pause_event.is_set():
-                    pause_event.wait_cleared()
+                    _wait_through_pause(pause_event, stop_event, time_expired)
                     if stop_event.is_set():
                         break
                 # Honor a pending seek whenever one is set -- covers a pause that
@@ -687,9 +716,15 @@ class RoutesHandler(BaseColumnHandler):
                         per_phase_dwell=per_phase_dwell, stop_event=stop_event,
                         pause_event=pause_event, signals=signals,
                         phase_index=phase_i + 1, phase_total=total_phases,
-                        hold_for_buffer=phase_hold, honor_pause=False):
+                        hold_for_buffer=phase_hold, honor_pause=False,
+                        time_expired=time_expired):
                     break
                 phase_i += 1
+                # "Complete loop" choice: stop the instant the droplet is back at
+                # the loop origin — don't run the remaining predetermined reps.
+                if (finish_to_start and start_set is not None
+                        and phases[phase_i - 1] == start_set):
+                    break
                 # Overrun guard (#477 follow-up): duration mode with the budget
                 # used up before the phases finished (e.g. the budget is shorter
                 # than one full set of phases). Ask the operator once. Skipped in
@@ -708,7 +743,14 @@ class RoutesHandler(BaseColumnHandler):
                         break
                     if decision == "paused":
                         ctx.protocol.pause()
-                    # 'finish'/external resume: keep running the remaining phases.
+                    elif decision == "finish":
+                        # Run only until the droplet is back at the loop origin,
+                        # then advance — NOT all the remaining reps. If it is
+                        # already there, advance now.
+                        if start_set is not None and phases[phase_i - 1] == start_set:
+                            skip_to_next = True
+                            break
+                        finish_to_start = True
             if seek_abort:
                 # Leave resume_target set; the executor re-enters the target step.
                 ctx.step_phases_done_event.set()
@@ -736,6 +778,19 @@ class RoutesHandler(BaseColumnHandler):
         # wait_for(ELECTRODES_STATE_CHANGE) for a next phase that will never
         # come would block the bucket's ThreadPoolExecutor indefinitely.
         ctx.step_phases_done_event.set()
+
+
+def _wait_through_pause(pause_event, stop_event, time_expired=None) -> None:
+    """Block while ``pause_event`` is set, polling each slice so a Stop or a
+    rep-duration budget expiry (``time_expired``) is noticed DURING the pause
+    rather than only when the operator resumes (#477 follow-up). Returns once
+    unpaused, on stop, or on time_expired — the caller re-checks those. Does
+    NOT itself clear the pause."""
+    while pause_event is not None and pause_event.is_set():
+        if pause_event.wait_cleared(timeout=_SLICE_S):
+            return                       # resumed
+        if stop_event.is_set() or (time_expired is not None and time_expired()):
+            return                       # caller re-checks stop / budget
 
 
 def _cooperative_sleep(seconds: float, stop_event, pause_event=None,
@@ -773,11 +828,14 @@ def _cooperative_sleep(seconds: float, stop_event, pause_event=None,
         if time_expired is not None and time_expired():
             return
         if pause_event is not None and pause_event.is_set():
-            pause_event.wait_cleared()
+            # Poll (not a blind block) so a budget expiry that lands DURING the
+            # pause wakes us — the top-of-loop time_expired check then returns,
+            # letting the caller raise the overrun prompt while still paused.
+            _wait_through_pause(pause_event, stop_event, time_expired)
             if stop_event.is_set():
                 return
-            # Re-check stop/seek/advance at the top before consuming more
-            # dwell; the resume may have a seek queued behind it.
+            # Re-check stop/seek/advance/time_expired at the top before consuming
+            # more dwell; the resume may have a seek queued behind it.
             continue
         if buffer_provider is not None:
             remaining += buffer_provider()

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -187,7 +187,7 @@ class RoutesHandler(BaseColumnHandler):
                    step_label, preview_mode, per_phase_dwell, stop_event,
                    pause_event, signals, phase_index, phase_total,
                    hold_for_buffer=False, honor_pause=True,
-                   emit_phase_started=True):
+                   emit_phase_started=True, time_expired=None):
         """Run ONE phase: clear the early-advance event, honour stop/pause,
         publish display (+ hardware when not preview), wait the ack, and
         dwell (cut short by phase_advance_event). Returns False if a Stop
@@ -206,6 +206,13 @@ class RoutesHandler(BaseColumnHandler):
         ``dyn_phase_started`` (which drives the model AND sets dyn_loop_active);
         it passes False here so the generic ``phase_started`` — whose handler
         clears dyn_loop_active — doesn't immediately undo that flag (#477).
+
+        ``time_expired`` (optional zero-arg predicate): polled each slice during
+        the dwell AND the post-dwell hold; when it returns True the phase ends
+        at once. The dynamic duration loop passes it so a phase held open by
+        volume threshold (a stuck droplet) still yields the instant the rep-
+        duration budget is crossed, letting the caller raise the overrun prompt
+        rather than waiting for the hold to end on its own (#477 follow-up).
         """
         # Fresh slate: a handler set in phase N-1 must NOT carry over into
         # phase N. Cleared before the stop/pause checks so a stale set
@@ -285,7 +292,8 @@ class RoutesHandler(BaseColumnHandler):
 
         _cooperative_sleep(per_phase_dwell, stop_event, pause_event,
                            phase_advance_event=ctx.phase_advance_event,
-                           seek_pending=_seek_pending)
+                           seek_pending=_seek_pending,
+                           time_expired=time_expired)
 
         # Consume any phase-time buffer a sibling column added (only relevant
         # when this step opted into holding — see below) and tell the status
@@ -322,6 +330,11 @@ class RoutesHandler(BaseColumnHandler):
                    and not ctx.phase_advance_event.is_set()):
                 if _seek_pending():
                     break
+                # Rep-duration budget crossed while holding (e.g. a stuck
+                # droplet held open by volume threshold): stop holding so the
+                # caller can raise the overrun prompt (#477 follow-up).
+                if time_expired is not None and time_expired():
+                    break
                 if pause_event.is_set():
                     pause_event.wait_cleared()
                     grace_deadline = time.monotonic() + _HOLD_GRACE_S
@@ -332,7 +345,8 @@ class RoutesHandler(BaseColumnHandler):
                         extra, stop_event, pause_event,
                         phase_advance_event=ctx.phase_advance_event,
                         buffer_provider=_take_and_emit,
-                        seek_pending=_seek_pending)
+                        seek_pending=_seek_pending,
+                        time_expired=time_expired)
                     grace_deadline = time.monotonic() + _HOLD_GRACE_S
                     continue
                 if time.monotonic() >= grace_deadline:
@@ -386,6 +400,12 @@ class RoutesHandler(BaseColumnHandler):
         cycle_len = len(unit_cycle)
         step_start = _monotonic()
         running_idx = 0
+        # Set once the time-expired prompt has been shown for this step (or the
+        # operator chose to finish the loop): it both suppresses re-prompting and
+        # disables the mid-phase budget wake, so the loop-completion phases dwell
+        # NORMALLY (the droplet must physically return to start) instead of
+        # strobing once we are knowingly over budget.
+        overrun_prompted = False
 
         def raw_elapsed():
             # RAW wall-clock since step start: pauses and holds count against
@@ -415,12 +435,21 @@ class RoutesHandler(BaseColumnHandler):
             came_from_seek = seek_phase > 0
         _, start_idle = dyn_resume_start(seek_phase, cycle_len)
 
-        def _run_cycle_phase(phase, cycle_pos):
+        def _run_cycle_phase(phase, cycle_pos, guard_budget=False):
             nonlocal running_idx
             running_idx += 1
             if signals is not None:
                 signals.dyn_phase_started = (cycle_pos + 1, cycle_len,
                                              per_phase_dwell)
+            # guard_budget: only the main active-loop phases pass True. It wakes
+            # the dwell/hold the instant the RAW budget is crossed (within a
+            # slice) so the overrun prompt fires even while a phase is held open
+            # by volume threshold (a stuck droplet). Gated on not-yet-prompted so
+            # the loop-completion phases (post-prompt) dwell normally. The
+            # ramp-up and seek-resume finishes pass False (never break early).
+            time_expired = (
+                (lambda: not overrun_prompted and raw_elapsed() >= budget)
+                if (guard_budget and budget > 0) else None)
             # hold_for_buffer=True: this loop only runs when a column requested
             # the phase-hold hook, so honour the same post-dwell hold/dialog as
             # the static path. honor_pause=False: this loop owns the pause/seek
@@ -432,7 +461,8 @@ class RoutesHandler(BaseColumnHandler):
                 stop_event=stop_event, pause_event=pause_event,
                 signals=signals, phase_index=cycle_pos + 1,
                 phase_total=cycle_len + 1, hold_for_buffer=True,
-                honor_pause=False, emit_phase_started=False)
+                honor_pause=False, emit_phase_started=False,
+                time_expired=time_expired)
 
         def _go_idle():
             # Explicit idle: electrodes off once, then hold to the budget. A
@@ -499,7 +529,6 @@ class RoutesHandler(BaseColumnHandler):
         # resume_target stuck, collapsing every remaining dwell to ~0 (strobing
         # the rest of the cycle) and skipping idle, so the step would race to
         # the next one (#477).
-        overrun_prompted = False
         while not stop_event.is_set():
             while i < cycle_len:
                 if pause_event.is_set():
@@ -518,7 +547,7 @@ class RoutesHandler(BaseColumnHandler):
                     if i is None:
                         return
                     continue
-                if not _run_cycle_phase(unit_cycle[i], i):
+                if not _run_cycle_phase(unit_cycle[i], i, guard_budget=True):
                     return
                 i += 1
                 # Overrun guard (#477 follow-up): the rep-duration budget ran
@@ -711,7 +740,7 @@ class RoutesHandler(BaseColumnHandler):
 
 def _cooperative_sleep(seconds: float, stop_event, pause_event=None,
                        phase_advance_event=None, buffer_provider=None,
-                       seek_pending=None) -> None:
+                       seek_pending=None, time_expired=None) -> None:
     """Sleep for ``seconds``, waking every _SLICE_S to check stop_event
     (and pause_event if provided). Used so a Stop or Pause press lands
     within ~50ms even mid-dwell. On pause: block in
@@ -724,6 +753,11 @@ def _cooperative_sleep(seconds: float, stop_event, pause_event=None,
     that returns seconds to ADD to the remaining dwell. Lets a sibling
     column extend the phase mid-dwell via
     ``StepContext.add_time_buffer_to_current_phase`` without restarting it.
+
+    ``time_expired`` (optional): a zero-arg predicate polled each slice;
+    returns early (cuts the dwell short) the first time it is True. Used by
+    the dynamic duration loop to yield the instant the rep-duration budget
+    is crossed, even mid-dwell/hold (#477 follow-up).
     """
     remaining = seconds
     while remaining > 0:
@@ -735,6 +769,8 @@ def _cooperative_sleep(seconds: float, stop_event, pause_event=None,
         # step/phase) must abort the leftover dwell on resume — otherwise the
         # old step's remaining time runs before the redirect (#471).
         if seek_pending is not None and seek_pending():
+            return
+        if time_expired is not None and time_expired():
             return
         if pause_event is not None and pause_event.is_set():
             pause_event.wait_cleared()

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -157,7 +157,8 @@ class RoutesHandler(BaseColumnHandler):
     def _run_phase(self, phase, *, ctx, mapping, static_routes, step_uuid,
                    step_label, preview_mode, per_phase_dwell, stop_event,
                    pause_event, signals, phase_index, phase_total,
-                   hold_for_buffer=False, honor_pause=True):
+                   hold_for_buffer=False, honor_pause=True,
+                   emit_phase_started=True):
         """Run ONE phase: clear the early-advance event, honour stop/pause,
         publish display (+ hardware when not preview), wait the ack, and
         dwell (cut short by phase_advance_event). Returns False if a Stop
@@ -171,6 +172,11 @@ class RoutesHandler(BaseColumnHandler):
         columns a grace window to extend THIS phase (see the post-dwell hold
         below). Used for volume-threshold steps so a missed threshold can
         hold the phase open rather than advancing on schedule.
+
+        ``emit_phase_started``: the dynamic duration loop already emits its own
+        ``dyn_phase_started`` (which drives the model AND sets dyn_loop_active);
+        it passes False here so the generic ``phase_started`` — whose handler
+        clears dyn_loop_active — doesn't immediately undo that flag (#477).
         """
         # Fresh slate: a handler set in phase N-1 must NOT carry over into
         # phase N. Cleared before the stop/pause checks so a stale set
@@ -212,7 +218,7 @@ class RoutesHandler(BaseColumnHandler):
                     f"actuation channel skipped"
                 )
 
-        if signals is not None:
+        if signals is not None and emit_phase_started:
             signals.phase_started = (
                 phase_index, phase_total, per_phase_dwell,
             )
@@ -397,7 +403,7 @@ class RoutesHandler(BaseColumnHandler):
                 stop_event=stop_event, pause_event=pause_event,
                 signals=signals, phase_index=cycle_pos + 1,
                 phase_total=cycle_len + 1, hold_for_buffer=True,
-                honor_pause=False)
+                honor_pause=False, emit_phase_started=False)
 
         def _go_idle():
             # Explicit idle: electrodes off once, then hold to the budget. A

--- a/pluggable_protocol_tree/builtins/routes_column.py
+++ b/pluggable_protocol_tree/builtins/routes_column.py
@@ -195,6 +195,14 @@ class RoutesHandler(BaseColumnHandler):
             if stop_event.is_set():
                 return False
 
+        # Phase wall-clock origin: used to cap the post-dwell automatic grace
+        # so a single phase's nominal dwell + grace never exceeds
+        # per_phase_dwell, keeping worst_loop = cycle_len * per_phase_dwell a
+        # TRUE upper bound for the dynamic duration loop (#477 §10). Deliberate
+        # operator holds (pause / buffer extension) refresh past this cap and
+        # are credited back to the budget separately — they are not bounded here.
+        phase_start = time.monotonic()
+
         electrodes = sorted(phase)
         channels = sorted(mapping[e] for e in electrodes if e in mapping)
         for e in electrodes:
@@ -265,7 +273,16 @@ class RoutesHandler(BaseColumnHandler):
         # (dialog up) we refresh the grace each loop so a deliberate operator
         # never triggers an early advance.
         if hold_for_buffer and not preview_mode:
-            grace_deadline = time.monotonic() + _HOLD_GRACE_S
+            # Cap the AUTOMATIC grace so dwell + grace <= per_phase_dwell: the
+            # threshold timeout equals the duration-column value, so a phase
+            # that never reaches threshold must still end by per_phase_dwell
+            # (#477 §10). Once the dwell has already consumed per_phase_dwell,
+            # this cap is the phase start + dwell <= now, so the loop breaks at
+            # once and adds nothing. A non-zero gap (e.g. the dwell ended early
+            # on a stale advance) still gets the bounded grace. Deliberate
+            # operator holds below (pause / buffer) refresh past this cap.
+            grace_deadline = min(time.monotonic() + _HOLD_GRACE_S,
+                                 phase_start + per_phase_dwell)
             while (not stop_event.is_set()
                    and not ctx.phase_advance_event.is_set()):
                 if _seek_pending():

--- a/pluggable_protocol_tree/execution/signals.py
+++ b/pluggable_protocol_tree/execution/signals.py
@@ -56,3 +56,8 @@ class ExecutorSignals(HasTraits):
     # the phase's target time by this amount so "elapsed / target" stays
     # honest while the phase is held.
     phase_extended     = Event()            # payload: extra_s
+    # Dynamic duration loop (#477).
+    #: (cycle_pos 1-based, cycle_len, phase_dwell_s) — a unique phase is active.
+    dyn_phase_started  = Event()
+    #: cycle_len — the loop has entered its idle (electrodes-off) phase.
+    dyn_idle_entered   = Event()

--- a/pluggable_protocol_tree/models/protocol_status.py
+++ b/pluggable_protocol_tree/models/protocol_status.py
@@ -51,6 +51,9 @@ class ProtocolStatusModel(HasTraits):
     # --- run state ---
     running = Bool(False)
     paused = Bool(False)
+    # True while a dynamic duration-mode step is parked in its idle phase
+    # (the trailing dark-yellow cell). Drives the leaving-idle warning (#477).
+    dyn_idle = Bool(False)
 
     # --- clocks (plain helpers; default-constructed per model) ---
     protocol_clock = Instance(ScopeStopwatch, ())
@@ -76,7 +79,7 @@ class ProtocolStatusModel(HasTraits):
             repeats_completed=0, repeats_total=1,
             frame_index=0, frame_total=0, step_rep_index=0, step_rep_total=0,
             recent_step_name="-", next_step_name="-", rep_chain_label="",
-            phase_target_s=0.0, running=False, paused=False,
+            phase_target_s=0.0, running=False, paused=False, dyn_idle=False,
         )
 
     def on_protocol_start(self, now, step_total):
@@ -114,6 +117,19 @@ class ProtocolStatusModel(HasTraits):
         self.phase_clock.start(now)
         if self.paused:
             self.phase_clock.pause(now)
+
+    def on_dyn_phase(self, now, cycle_pos, cycle_len, phase_target_s):
+        """Dynamic duration loop: park the bar on unique phase ``cycle_pos``
+        (1-based) of a ``cycle_len``-phase loop. phase_total carries the extra
+        trailing idle cell so the bar renders cycle_len + 1 cells (#477)."""
+        self.dyn_idle = False
+        self.on_phase_start(now, cycle_pos, cycle_len + 1, phase_target_s)
+
+    def on_dyn_idle(self, now, cycle_len):
+        """Dynamic duration loop: park on the trailing idle cell (electrodes
+        off). The idle cell is the last of cycle_len + 1 cells (#477)."""
+        self.on_phase_start(now, cycle_len + 1, cycle_len + 1, 0.0)
+        self.dyn_idle = True
 
     def seek_step(self, now, step_index, step_total, step_path,
                   recent_name, next_name):

--- a/pluggable_protocol_tree/models/protocol_status.py
+++ b/pluggable_protocol_tree/models/protocol_status.py
@@ -54,6 +54,12 @@ class ProtocolStatusModel(HasTraits):
     # True while a dynamic duration-mode step is parked in its idle phase
     # (the trailing dark-yellow cell). Drives the leaving-idle warning (#477).
     dyn_idle = Bool(False)
+    # True while the current step is mid-dynamic-duration-loop (either an
+    # active dynamic phase or the idle cell). Lets the GUI seek/preview/paint
+    # paths tell they are operating on a dynamic step so they keep the live
+    # cycle_len+1 phase bar, preview the unit cycle (idle -> electrodes off),
+    # and gate the idle-tint correctly (#477).
+    dyn_loop_active = Bool(False)
 
     # --- clocks (plain helpers; default-constructed per model) ---
     protocol_clock = Instance(ScopeStopwatch, ())
@@ -80,6 +86,7 @@ class ProtocolStatusModel(HasTraits):
             frame_index=0, frame_total=0, step_rep_index=0, step_rep_total=0,
             recent_step_name="-", next_step_name="-", rep_chain_label="",
             phase_target_s=0.0, running=False, paused=False, dyn_idle=False,
+            dyn_loop_active=False,
         )
 
     def on_protocol_start(self, now, step_total):
@@ -104,6 +111,10 @@ class ProtocolStatusModel(HasTraits):
         self.phase_target_s = 0.0
         self.step_clock.start(now)
         self.phase_clock = ScopeStopwatch()      # fresh, unstarted
+        # Advancing to the next step clears any stale dynamic-loop state from
+        # the previous step (fixes BUG #2 — stale dyn_idle/dyn_loop_active).
+        self.dyn_idle = False
+        self.dyn_loop_active = False
         if self.paused:                          # started mid-pause: keep frozen
             self.step_clock.pause(now)
 
@@ -117,19 +128,27 @@ class ProtocolStatusModel(HasTraits):
         self.phase_clock.start(now)
         if self.paused:
             self.phase_clock.pause(now)
+        # A NORMAL phase clears the dynamic-loop flags; the dyn_* methods below
+        # call this first and re-set them afterward (#477).
+        self.dyn_idle = False
+        self.dyn_loop_active = False
 
     def on_dyn_phase(self, now, cycle_pos, cycle_len, phase_target_s):
         """Dynamic duration loop: park the bar on unique phase ``cycle_pos``
         (1-based) of a ``cycle_len``-phase loop. phase_total carries the extra
         trailing idle cell so the bar renders cycle_len + 1 cells (#477)."""
-        self.dyn_idle = False
         self.on_phase_start(now, cycle_pos, cycle_len + 1, phase_target_s)
+        # on_phase_start clears the flags; set the dynamic state afterward.
+        self.dyn_idle = False
+        self.dyn_loop_active = True
 
     def on_dyn_idle(self, now, cycle_len):
         """Dynamic duration loop: park on the trailing idle cell (electrodes
         off). The idle cell is the last of cycle_len + 1 cells (#477)."""
         self.on_phase_start(now, cycle_len + 1, cycle_len + 1, 0.0)
+        # on_phase_start clears the flags; set the dynamic/idle state afterward.
         self.dyn_idle = True
+        self.dyn_loop_active = True
 
     def seek_step(self, now, step_index, step_total, step_path,
                   recent_name, next_name):
@@ -151,6 +170,9 @@ class ProtocolStatusModel(HasTraits):
         self.step_clock.start(now)
         self.step_clock.stop(now)                # freeze elapsed at 0 while paused
         self.phase_clock = ScopeStopwatch()      # fresh, unstarted
+        # Navigating to a different step drops any stale dynamic-loop state.
+        self.dyn_idle = False
+        self.dyn_loop_active = False
 
     def seek_phase(self, now, phase_index, phase_total, phase_target_s):
         """Navigate to an arbitrary phase while paused: SET the counters and

--- a/pluggable_protocol_tree/services/phase_math.py
+++ b/pluggable_protocol_tree/services/phase_math.py
@@ -179,6 +179,43 @@ def duration_loop_parts(
     return ramp_up, unit_cycle, unit_cycle[0]
 
 
+def unit_cycle_len(static_electrodes, routes, *, trail_length=1,
+                   trail_overlay=0, soft_start=False) -> int:
+    """Number of phases in one unit loop (the unique, navigable phases)."""
+    _ramp, unit_cycle, _ret = duration_loop_parts(
+        static_electrodes, routes, trail_length=trail_length,
+        trail_overlay=trail_overlay, soft_start=soft_start)
+    return len(unit_cycle)
+
+
+def another_loop_fits(raw_elapsed: float, cycle_len: int,
+                      phase_dwell: float, budget: float) -> bool:
+    """True if a FULL fresh loop is guaranteed to finish within budget.
+
+    Worst case assumes every phase runs its full ``phase_dwell`` (the
+    volume-threshold timeout equals the duration-column value). Uses raw
+    wall-clock elapsed (pauses/holds already spent count against budget)."""
+    if cycle_len <= 0:
+        return False
+    return raw_elapsed + cycle_len * phase_dwell <= budget
+
+
+def loop_completion_fits(raw_elapsed: float, phase_in_cycle: int,
+                         cycle_len: int, phase_dwell: float,
+                         budget: float) -> bool:
+    """True if finishing the CURRENT loop from ``phase_in_cycle`` (0-based)
+    back to the start still fits the budget. Used for the mid-loop-expiry
+    check on resume after a seek."""
+    remaining = max(0, cycle_len - phase_in_cycle)
+    return raw_elapsed + remaining * phase_dwell <= budget
+
+
+def idle_cell_index(cycle_len: int) -> int:
+    """0-based index of the trailing idle cell on the phase bar
+    (the bar shows ``cycle_len`` unique phases + this idle cell)."""
+    return cycle_len
+
+
 def _ramp_up(phases: Iterator[Set[str]]) -> Iterator[Set[str]]:
     """Prepend ramp phases that grow from 1 electrode to the size of
     the first phase. K=1 first phase --> no-op. K=3 first phase {a,b,c}

--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesCategory, PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Bool, Dict, Directory, Enum, Float, Str
+from traits.api import Bool, Dict, Directory, Enum, Float, List, Str
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import Group, View, Item
 
@@ -94,6 +94,13 @@ class ProtocolPreferences(PreferencesHelper):
     # hidden_by_default flag; legacy col_name-keyed entries are read via
     # a fallback in the tree widget and rewritten on the next toggle.
     protocol_tree_column_visibility = Dict(Str, Bool)
+
+    # Programmatic preference (no Settings-dialog item): the visual left-to-
+    # right column order as a list of col_id, persisted when the user drags a
+    # header section. Keyed by the same stable col_id as visibility, so order
+    # survives display renames; col_ids absent from the saved list (columns
+    # added since) keep their natural position at the end on restore.
+    protocol_tree_column_order = List(Str)
 
     # {col_id: seconds} acknowledgement-wait time per wait-capable column
     # (issue #427), keyed by the stable col_id (base_id for compounds),

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -63,6 +63,8 @@ class ProtocolStatusController(HasTraits):
             ("step_repetition", self._on_step_repetition),
             ("phase_started", self._on_phase_started),
             ("phase_extended", self._on_phase_extended),
+            ("dyn_phase_started", self._on_dyn_phase_started),
+            ("dyn_idle_entered", self._on_dyn_idle_entered),
             ("protocol_paused", self._on_paused),
             ("protocol_resumed", self._on_resumed),
             ("protocol_repetition_finished", self._on_repetition_finished),
@@ -123,6 +125,13 @@ class ProtocolStatusController(HasTraits):
 
     def _on_phase_extended(self, event):
         self.model.on_phase_extended(event.new)
+
+    def _on_dyn_phase_started(self, event):
+        cycle_pos, cycle_len, phase_dwell = event.new
+        self.model.on_dyn_phase(self.clock(), cycle_pos, cycle_len, phase_dwell)
+
+    def _on_dyn_idle_entered(self, event):
+        self.model.on_dyn_idle(self.clock(), int(event.new))
 
     def _on_paused(self, event):
         self.model.pause(self.clock())

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -27,7 +27,9 @@ from pluggable_protocol_tree.consts import (
 )
 from pluggable_protocol_tree.models.display_state import ProtocolTreeDisplayMessage
 from pluggable_protocol_tree.models.protocol_status import ProtocolStatusModel
-from pluggable_protocol_tree.services.phase_math import iter_phases
+from pluggable_protocol_tree.services.phase_math import (
+    duration_loop_parts, iter_phases,
+)
 
 logger = get_logger(__name__)
 
@@ -242,17 +244,32 @@ class ProtocolStatusController(HasTraits):
         row = self._row_at(step_path)
         if row is None:
             return
-        phases = self._phases_for(row)
-        if not phases:
-            return
-        idx = max(0, min(int(phase_index), len(phases) - 1))
         try:
             mapping = self.manager.protocol_metadata.get(
                 ELECTRODE_TO_CHANNEL_KEY, {})
         except Exception:
             mapping = {}
-        electrodes = sorted(phases[idx])
-        channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        if self.model.dyn_loop_active:
+            # Dynamic duration step (#477): the unique navigable phases are the
+            # UNIT CYCLE and the trailing cell is the idle phase (electrodes
+            # off). Preview from the unit cycle, not the materialized phases.
+            _ramp, unit_cycle, _ret = duration_loop_parts(
+                static_electrodes=list(getattr(row, "electrodes", []) or []),
+                routes=list(getattr(row, "routes", []) or []),
+                trail_length=int(getattr(row, "trail_length", 1)),
+                trail_overlay=int(getattr(row, "trail_overlay", 0)),
+                soft_start=bool(getattr(row, "soft_start", False)))
+            idle_idx = len(unit_cycle)
+            electrodes = ([] if int(phase_index) >= idle_idx
+                          else sorted(unit_cycle[int(phase_index)]))
+            channels = sorted(mapping[e] for e in electrodes if e in mapping)
+        else:
+            phases = self._phases_for(row)
+            if not phases:
+                return
+            idx = max(0, min(int(phase_index), len(phases) - 1))
+            electrodes = sorted(phases[idx])
+            channels = sorted(mapping[e] for e in electrodes if e in mapping)
         # Navigation happens while paused (mid-run), so the viewer must stay
         # editable only in Advanced Mode — same rule the run-time and
         # selection-driven publishes use (#434). Without this, stepping to the
@@ -291,6 +308,10 @@ class ProtocolStatusController(HasTraits):
         step_idx = self._step_index_of(step_path)
         step_total = self._count_steps()
         phase_total = self._phase_total_for(row)
+        if self.model.dyn_loop_active:
+            # Mid-dynamic-loop: keep the live cycle_len+1 phase bar rather than
+            # flipping to the materialized duration count (#477).
+            phase_total = self.model.phase_total
         phase0 = max(0, min(int(phase_index), phase_total - 1))
         logger.debug(
             f"seek_to: step {step_idx}/{step_total} @ {tuple(step_path)} "

--- a/pluggable_protocol_tree/tests/test_column_order_persistence.py
+++ b/pluggable_protocol_tree/tests/test_column_order_persistence.py
@@ -1,0 +1,102 @@
+"""Tests for persisting protocol-tree column ORDER across restarts.
+
+Order lives in ProtocolPreferences.protocol_tree_column_order as a list of
+col_id in visual (left-to-right) order. Mirrors the visibility persistence:
+the preference round-trips across helper instances sharing one preferences
+node, and the ProtocolTreeWidget restores the order on construction and
+persists it whenever the user drags a header section (sectionMoved). Order is
+keyed by the stable col_id, independent of visibility, and tolerant of columns
+added/removed between sessions.
+"""
+
+import pytest
+
+from apptools.preferences.api import Preferences
+
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.trail_length_column import (
+    make_trail_length_column,
+)
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.services.preferences import ProtocolPreferences
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+@pytest.fixture
+def prefs_node():
+    """Isolated in-memory preferences node (no on-disk state shared
+    between tests)."""
+    return Preferences()
+
+
+@pytest.fixture
+def prefs(prefs_node):
+    return ProtocolPreferences(preferences=prefs_node)
+
+
+def _logical_of(manager, col_id):
+    for i, col in enumerate(manager.columns):
+        if col.model.col_id == col_id:
+            return i
+    raise AssertionError(f"column {col_id!r} not found")
+
+
+# --- preference round-trip -------------------------------------------------
+
+def test_order_preference_defaults_to_empty_list(prefs):
+    assert prefs.protocol_tree_column_order == []
+
+
+def test_order_preference_round_trip_across_helper_instances(prefs, prefs_node):
+    prefs.protocol_tree_column_order = ["trail_length", "name"]
+    # A fresh helper against the same node sees the persisted order —
+    # i.e. the value survives "restart" (helper reconstruction).
+    reread = ProtocolPreferences(preferences=prefs_node)
+    assert reread.protocol_tree_column_order == ["trail_length", "name"]
+
+
+# --- widget wiring -------------------------------------------------------
+
+def test_widget_keeps_natural_order_when_nothing_saved(qapp, prefs):
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+    # Visual order matches logical order (no reordering applied).
+    assert header.visualIndex(_logical_of(manager, "name")) == 0
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 1
+
+
+def test_widget_restores_persisted_order(qapp, prefs):
+    # Reverse of the natural order: Trail first, Name second.
+    prefs.protocol_tree_column_order = ["trail_length", "name"]
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 0
+    assert header.visualIndex(_logical_of(manager, "name")) == 1
+
+
+def test_widget_appends_unsaved_columns_at_end(qapp, prefs):
+    # Only Trail saved; Name (added/unknown to the saved order) must keep a
+    # position — appended after the saved columns rather than dropped.
+    prefs.protocol_tree_column_order = ["trail_length"]
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 0
+    assert header.visualIndex(_logical_of(manager, "name")) == 1
+
+
+def test_dragging_section_persists_full_order(qapp, prefs):
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+
+    # Move the section at visual 0 (Name) to visual 1 — same as a header drag.
+    # sectionMoved is wired, so this auto-persists the new visual order.
+    widget.tree.header().moveSection(0, 1)
+
+    assert prefs.protocol_tree_column_order == ["trail_length", "name"]

--- a/pluggable_protocol_tree/tests/test_electrodes_routes_columns.py
+++ b/pluggable_protocol_tree/tests/test_electrodes_routes_columns.py
@@ -779,13 +779,17 @@ def test_dynamic_vt_loop_runs_more_cycles_than_precalc(qapp):
     assert ctx.scratch.get(mod.DURATION_CONSUMED_KEY) is True
 
 
-def test_dynamic_vt_loop_emits_running_index_with_zero_total(qapp):
-    """Each phase emits phase_started with a monotonically increasing index
-    and phase_total == 0 (unknown while looping)."""
+def test_dynamic_vt_loop_drives_model_via_dyn_phase_started(qapp):
+    """The dynamic VT duration loop drives the model through dyn_phase_started
+    (cycle position within ONE loop), NOT the generic phase_started -- whose
+    handler clears dyn_loop_active, which would make the timeline/seek fall back
+    to the materialized predicted phase count instead of the single loop (#477).
+    """
     from unittest.mock import MagicMock, patch
     import threading
     import pluggable_protocol_tree.builtins.routes_column as mod
     from pluggable_protocol_tree.builtins.routes_column import RoutesHandler
+    from pluggable_protocol_tree.execution.signals import ExecutorSignals
 
     handler = RoutesHandler()
     row = MagicMock()
@@ -822,6 +826,15 @@ def test_dynamic_vt_loop_emits_running_index_with_zero_total(qapp):
     ctx.phase_extension_total.return_value = 0.0
     ctx.wait_for = MagicMock()
 
+    # Real signals so we can observe what the loop actually emits (assignment
+    # to a Traits Event), rather than a mock that swallows the contract.
+    sigs = ExecutorSignals()
+    phase_started_calls = []
+    dyn_calls = []
+    sigs.observe(lambda e: phase_started_calls.append(e.new), "phase_started")
+    sigs.observe(lambda e: dyn_calls.append(e.new), "dyn_phase_started")
+    proto.signals = sigs
+
     clock = {"t": 0.0}
     with patch.object(mod, "_monotonic", lambda: clock["t"]), \
          patch.object(mod, "_cooperative_sleep",
@@ -829,11 +842,19 @@ def test_dynamic_vt_loop_emits_running_index_with_zero_total(qapp):
          patch.object(mod, "publish_message", lambda **kw: None):
         handler.on_step(row, ctx)
 
-    calls = proto.signals.phase_started.emit.call_args_list
-    indices = [c.args[0] for c in calls]
-    totals = [c.args[1] for c in calls]
-    assert indices == list(range(1, len(indices) + 1))   # 1,2,3,... no gaps
-    assert all(t == 0 for t in totals)                   # total unknown
+    # The generic phase_started must NOT fire from the dynamic loop: its handler
+    # clears dyn_loop_active, which the timeline/seek rely on to keep showing a
+    # single loop's unique phases rather than the materialized predicted count.
+    assert phase_started_calls == []
+    # The loop drives the model via dyn_phase_started instead: each payload is
+    # (cycle_pos 1-based, cycle_len, dwell) within ONE loop shape.
+    assert dyn_calls, "expected dyn_phase_started emissions"
+    cycle_lens = {payload[1] for payload in dyn_calls}
+    assert len(cycle_lens) == 1                           # one stable loop shape
+    (cycle_len,) = cycle_lens
+    positions = [payload[0] for payload in dyn_calls]
+    assert positions[0] == 1                              # each loop starts at 1
+    assert all(1 <= p <= cycle_len for p in positions)    # never the full total
 
 
 def test_dynamic_vt_loop_not_taken_when_no_volume_threshold(qapp):

--- a/pluggable_protocol_tree/tests/test_phase_math.py
+++ b/pluggable_protocol_tree/tests/test_phase_math.py
@@ -6,6 +6,7 @@ gets its own section. Sections grow as later tasks land more helpers.
 
 from pluggable_protocol_tree.services.phase_math import (
     _is_loop_route, _route_windows,
+    unit_cycle_len, another_loop_fits, loop_completion_fits, idle_cell_index,
 )
 
 
@@ -406,3 +407,38 @@ def test_duration_loop_parts_no_routes_static_only():
     assert cycle == [{"x"}]
     assert ret is None
     assert ramp == []
+
+
+# --- unit_cycle_len ---
+
+def test_unit_cycle_len_loop_route():
+    # one loop route a-b-c-d, trail_length 1 -> 4 windows in the unit cycle
+    n = unit_cycle_len([], [["a", "b", "c", "d"]], trail_length=1, trail_overlay=0)
+    assert n == 4
+
+
+def test_unit_cycle_len_static_only_is_one():
+    assert unit_cycle_len(["a", "b"], []) == 1
+
+
+# --- another_loop_fits ---
+
+def test_another_loop_fits_boundary():
+    # cycle_len 4 * dwell 2.0 = 8.0 worst loop; budget 20
+    assert another_loop_fits(raw_elapsed=12.0, cycle_len=4, phase_dwell=2.0, budget=20.0) is True   # 12+8=20 exact fit
+    assert another_loop_fits(raw_elapsed=12.001, cycle_len=4, phase_dwell=2.0, budget=20.0) is False
+    assert another_loop_fits(raw_elapsed=0.0, cycle_len=0, phase_dwell=2.0, budget=20.0) is False    # no phases -> never
+
+
+# --- loop_completion_fits ---
+
+def test_loop_completion_fits_from_mid_cycle():
+    # from phase k=1 of a 4-phase loop, 3 phases remain * 2.0 = 6.0
+    assert loop_completion_fits(raw_elapsed=14.0, phase_in_cycle=1, cycle_len=4, phase_dwell=2.0, budget=20.0) is True  # 14+6=20
+    assert loop_completion_fits(raw_elapsed=14.5, phase_in_cycle=1, cycle_len=4, phase_dwell=2.0, budget=20.0) is False
+
+
+# --- idle_cell_index ---
+
+def test_idle_cell_index_is_cycle_len():
+    assert idle_cell_index(4) == 4

--- a/pluggable_protocol_tree/tests/test_phase_math.py
+++ b/pluggable_protocol_tree/tests/test_phase_math.py
@@ -412,8 +412,9 @@ def test_duration_loop_parts_no_routes_static_only():
 # --- unit_cycle_len ---
 
 def test_unit_cycle_len_loop_route():
-    # one loop route a-b-c-d, trail_length 1 -> 4 windows in the unit cycle
-    n = unit_cycle_len([], [["a", "b", "c", "d"]], trail_length=1, trail_overlay=0)
+    # a genuine loop route (first == last) a-b-c-d-a exercises the loop branch
+    # of _route_windows: 4 unique nodes -> 4 windows in the unit cycle.
+    n = unit_cycle_len([], [["a", "b", "c", "d", "a"]], trail_length=1, trail_overlay=0)
     assert n == 4
 
 

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -171,6 +171,17 @@ def _row(path, name="S", **kw):
                            **kw)
 
 
+def test_dyn_phase_and_idle_signals_update_model():
+    ctrl, sigs, clock, rows = _make()
+    sigs.dyn_phase_started = (2, 4, 2.0)
+    assert ctrl.model.phase_index == 2
+    assert ctrl.model.phase_total == 5      # cycle_len + 1 trailing idle cell
+    assert ctrl.model.dyn_idle is False
+    sigs.dyn_idle_entered = 4
+    assert ctrl.model.dyn_idle is True
+    assert ctrl.model.phase_index == 5      # idle cell = cycle_len + 1
+
+
 def test_seek_to_calls_executor_and_updates_model():
     row = _row((0,), name="Wash", electrodes=[], routes=[], trail_length=1,
                trail_overlay=0, soft_start=False, soft_end=False,

--- a/pluggable_protocol_tree/tests/test_protocol_status_model.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_model.py
@@ -165,6 +165,7 @@ def test_on_dyn_phase_sets_unique_phase_plus_idle_total():
     assert m.phase_index == 2
     assert m.phase_total == 5          # 4 unique + 1 idle cell
     assert m.dyn_idle is False
+    assert m.dyn_loop_active is True   # (#477) flags the live dynamic loop
 
 
 def test_on_dyn_idle_parks_on_idle_cell():
@@ -173,6 +174,36 @@ def test_on_dyn_idle_parks_on_idle_cell():
     assert m.phase_index == 5          # idle cell is the last (1-based)
     assert m.phase_total == 5
     assert m.dyn_idle is True
+    assert m.dyn_loop_active is True   # idle cell is still mid-dynamic-loop
+
+
+def test_step_start_clears_stale_dyn_loop_state():
+    """Bug #477: advancing to the next step must drop the previous step's
+    dynamic-loop state, or a normal step inherits a stale idle cell."""
+    m = ProtocolStatusModel()
+    m.on_dyn_phase(now=0.0, cycle_pos=2, cycle_len=4, phase_target_s=2.0)
+    assert m.dyn_loop_active is True
+    m.on_step_start(1.0, 2, 3, (1,), "Step B", "Step C")
+    assert m.dyn_idle is False
+    assert m.dyn_loop_active is False
+
+
+def test_normal_phase_clears_dyn_loop_active():
+    m = ProtocolStatusModel()
+    m.on_dyn_phase(now=0.0, cycle_pos=2, cycle_len=4, phase_target_s=2.0)
+    assert m.dyn_loop_active is True
+    m.on_phase_start(now=1.0, phase_index=1, phase_total=2, phase_target_s=1.0)
+    assert m.dyn_loop_active is False
+    assert m.dyn_idle is False
+
+
+def test_seek_step_clears_dyn_loop_active():
+    m = ProtocolStatusModel()
+    m.on_dyn_idle(now=0.0, cycle_len=4)
+    assert m.dyn_loop_active is True
+    m.seek_step(1.0, 4, 5, (3,), "D", "E")
+    assert m.dyn_idle is False
+    assert m.dyn_loop_active is False
 
 
 def test_reset_clears_dyn_idle():
@@ -180,3 +211,4 @@ def test_reset_clears_dyn_idle():
     m.on_dyn_idle(now=0.0, cycle_len=4)
     m.reset()
     assert m.dyn_idle is False
+    assert m.dyn_loop_active is False

--- a/pluggable_protocol_tree/tests/test_protocol_status_model.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_model.py
@@ -157,3 +157,26 @@ def test_seek_then_step_report_does_not_drift_index():
     m.on_step_start(3.0, 6, 9, (5,), "s6", "s7")
     assert m.step_index == 6                         # advances normally
     assert m.step_index <= m.step_total             # never exceeds total
+
+
+def test_on_dyn_phase_sets_unique_phase_plus_idle_total():
+    m = ProtocolStatusModel()
+    m.on_dyn_phase(now=0.0, cycle_pos=2, cycle_len=4, phase_target_s=2.0)
+    assert m.phase_index == 2
+    assert m.phase_total == 5          # 4 unique + 1 idle cell
+    assert m.dyn_idle is False
+
+
+def test_on_dyn_idle_parks_on_idle_cell():
+    m = ProtocolStatusModel()
+    m.on_dyn_idle(now=0.0, cycle_len=4)
+    assert m.phase_index == 5          # idle cell is the last (1-based)
+    assert m.phase_total == 5
+    assert m.dyn_idle is True
+
+
+def test_reset_clears_dyn_idle():
+    m = ProtocolStatusModel()
+    m.on_dyn_idle(now=0.0, cycle_len=4)
+    m.reset()
+    assert m.dyn_idle is False

--- a/pluggable_protocol_tree/tests/test_routes_dynamic_loop.py
+++ b/pluggable_protocol_tree/tests/test_routes_dynamic_loop.py
@@ -1,0 +1,23 @@
+"""Pure-logic seams of the dynamic duration loop (#477).
+
+Only ``dyn_resume_start`` is unit-tested here; the threaded loop in
+``_run_dynamic_duration_loop`` is verified manually (it runs on a worker
+thread under volume-threshold).
+"""
+
+from pluggable_protocol_tree.builtins.routes_column import dyn_resume_start
+
+
+def test_dyn_resume_start_normal_phase():
+    assert dyn_resume_start(0, 4) == (0, False)
+    assert dyn_resume_start(2, 4) == (2, False)
+
+
+def test_dyn_resume_start_idle_cell():
+    # cursor index == cycle_len -> idle cell
+    assert dyn_resume_start(4, 4) == (0, True)
+
+
+def test_dyn_resume_start_clamps_out_of_range():
+    assert dyn_resume_start(9, 4) == (0, True)   # >= cycle_len clamps to idle
+    assert dyn_resume_start(-1, 4) == (0, False)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -366,6 +366,17 @@ class PluggableProtocolDockPane(TraitsDockPane):
         sc = self.status_controller
         if sc is None or self._current_row is None:
             return
+        idle_cell = sc.model.phase_total - 1
+        if sc.model.dyn_idle and target0 != idle_cell:
+            if confirm(
+                None,
+                "The protocol is paused in the idle phase.\n"
+                "Seeking to a non-idle phase will leave the idle phase.\n\n"
+                "Continue?",
+                title="Leave idle phase?",
+                cancel=False,
+            ) != YES:
+                return
         path = tuple(self._current_row.path)
         sc.seek_to(path, target0)
         sc.preview_phase(path, target0, self._current_run_preview_mode)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -464,6 +464,13 @@ class PluggableProtocolDockPane(TraitsDockPane):
         phase_total = view["phase_total"] if show_phase else 0
         tb.set_position(cur if cur is not None else -1, len(rows),
                         view["phase_index"], phase_total)
+        # Dynamic duration step (#477): the last phase cell is the idle phase.
+        # Paint it dark yellow so the user can see the parking cell at a glance.
+        if (running and model.phase_total > 1 and self._current_row is not None
+                and bool(getattr(self._current_row, "repeat_duration_controls", False))):
+            tb.set_idle_cell(model.phase_total - 1)
+        else:
+            tb.set_idle_cell(None)
         self._update_timeline_controls(current_row, view)
 
     def _update_timeline_controls(self, current_row, view):
@@ -569,6 +576,9 @@ class PluggableProtocolDockPane(TraitsDockPane):
         if m is None:
             self._pane.navigation_bar.set_phase_navigation_enabled(False, False)
             return
+        # The idle cell is the last phase: index phase_total (1-based) / 0-based
+        # index phase_total-1. next_enabled becomes False at idle (phase_index ==
+        # phase_total), so the user can land on it via next and leave via prev.
         prev_enabled = m.phase_index > 1
         next_enabled = 0 < m.phase_index < m.phase_total
         self._pane.navigation_bar.set_phase_navigation_enabled(prev_enabled, next_enabled)

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -477,8 +477,10 @@ class PluggableProtocolDockPane(TraitsDockPane):
                         view["phase_index"], phase_total)
         # Dynamic duration step (#477): the last phase cell is the idle phase.
         # Paint it dark yellow so the user can see the parking cell at a glance.
-        if (running and model.phase_total > 1 and self._current_row is not None
-                and bool(getattr(self._current_row, "repeat_duration_controls", False))):
+        # Gate on the live dyn_loop_active flag (not repeat_duration_controls) so
+        # a STATIC duration step — which has no real idle cell — isn't mislabeled.
+        if (running and model is not None and model.dyn_loop_active
+                and model.phase_total > 1 and self._current_row is not None):
             tb.set_idle_cell(model.phase_total - 1)
         else:
             tb.set_idle_cell(None)

--- a/pluggable_protocol_tree/views/timeline_bar.py
+++ b/pluggable_protocol_tree/views/timeline_bar.py
@@ -88,6 +88,7 @@ class TimelineBar(QWidget):
         self._phase_total = 0
         self._running = False
         self._cell_colors = []
+        self._idle_cell = None
 
         # Relative-drag state: a press anchors at the current playhead, and a
         # drag moves it by the number of cells the pointer travels -- so
@@ -145,6 +146,12 @@ class TimelineBar(QWidget):
     def set_running(self, running):
         self._running = bool(running)
         self.update()
+
+    def set_idle_cell(self, index):
+        """Index of the dark-yellow idle cell on the phase track, or None."""
+        if self._idle_cell != index:
+            self._idle_cell = index
+            self.update()
 
     # --- geometry / hit testing --------------------------------------
 
@@ -279,13 +286,16 @@ class TimelineBar(QWidget):
     def _colors(self):
         if is_dark_mode():
             return dict(track=GREY["dark"], tick=GREY["lighter"],
-                        head=SECONDARY_SHADE[300], running_head=SECONDARY_SHADE[100])
+                        head=SECONDARY_SHADE[300], running_head=SECONDARY_SHADE[100],
+                        idle="#9a7d0a")
         return dict(track=GREY["light"], tick=GREY["dark"],
-                    head=SECONDARY_SHADE[700], running_head=SECONDARY_SHADE[900])
+                    head=SECONDARY_SHADE[700], running_head=SECONDARY_SHADE[900],
+                    idle="#b8860b")
 
     # --- paint ------------------------------------------------------
 
-    def _paint_track(self, painter, rect, count, position, colors, cell_colors=None):
+    def _paint_track(self, painter, rect, count, position, colors,
+                     cell_colors=None, idle_cell=None):
         # Video-timeline look: a track bar divided into one cell per item by
         # thin separators, with the current item drawn as a filled, outlined
         # box (the "you are here" cell) rather than a single tick.
@@ -311,6 +321,16 @@ class TimelineBar(QWidget):
         for i in range(count + 1):
             x = int(SIDE_MARGIN + i * seg)
             painter.drawLine(x, rect.top(), x, rect.bottom())
+        # Idle cell tint (phase track only, dynamic duration steps): fill the
+        # last cell dark yellow before the playhead box so the box draws on top.
+        if idle_cell is not None and 0 <= idle_cell < count:
+            left = int(SIDE_MARGIN + idle_cell * seg)
+            right = int(SIDE_MARGIN + (idle_cell + 1) * seg)
+            idle_fill = QColor(colors["idle"])
+            idle_fill.setAlpha(120)
+            painter.fillRect(
+                QRect(left, rect.top(), max(1, right - left), rect.height()),
+                idle_fill)
         if 0 <= position < count:
             left = int(SIDE_MARGIN + position * seg)
             right = int(SIDE_MARGIN + (position + 1) * seg)
@@ -334,5 +354,6 @@ class TimelineBar(QWidget):
                           cell_colors=self._cell_colors)
         if self._phase_track_visible():
             self._paint_track(painter, self._phase_track_rect(),
-                              self._phase_total, self._phase_index, colors)
+                              self._phase_total, self._phase_index, colors,
+                              idle_cell=self._idle_cell)
         painter.end()

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -108,6 +108,14 @@ class ProtocolTreeWidget(QWidget):
         header.setContextMenuPolicy(Qt.CustomContextMenu)
         header.customContextMenuRequested.connect(self._on_header_context_menu)
 
+        # Let the user drag header sections to reorder columns, and persist
+        # that order (like visibility) so it survives a restart. Apply the
+        # saved order BEFORE connecting sectionMoved so the restore moves
+        # don't recursively re-persist.
+        header.setSectionsMovable(True)
+        self._apply_column_order()
+        header.sectionMoved.connect(self._persist_column_order)
+
         self.delegate = ProtocolItemDelegate(row_manager, parent=self.tree)
         self.tree.setItemDelegate(self.delegate)
 
@@ -282,6 +290,54 @@ class ProtocolTreeWidget(QWidget):
             self._preferences.protocol_tree_column_visibility = visibility
         except Exception as exc:
             logger.warning(f"Could not save column visibility preference: {exc}")
+
+    def _load_column_order(self) -> list:
+        """Return the persisted [col_id, ...] visual order ([] when nothing
+        was saved yet or the preference is unreadable)."""
+        try:
+            saved = self._preferences.protocol_tree_column_order
+            return [str(cid) for cid in (saved or [])]
+        except Exception as exc:
+            logger.warning(f"Could not read column order preference: {exc}")
+            return []
+
+    def _apply_column_order(self):
+        """Reorder the header's visual sections to the persisted col_id
+        sequence. Columns absent from the saved order (added since the last
+        save) keep their natural logical position at the end. No-op when
+        nothing is saved. Visibility is independent of order, so hidden
+        columns still occupy (and are moved within) the visual sequence."""
+        saved_order = self._load_column_order()
+        if not saved_order:
+            return
+        header = self.tree.header()
+        id_to_logical = {col.model.col_id: i
+                         for i, col in enumerate(self._manager.columns)}
+        target = [id_to_logical[cid] for cid in saved_order
+                  if cid in id_to_logical]
+        seen = set(target)
+        target += [i for i in range(len(self._manager.columns))
+                   if i not in seen]
+        blocked = header.blockSignals(True)
+        try:
+            for visual, logical in enumerate(target):
+                cur = header.visualIndex(logical)
+                if cur != visual:
+                    header.moveSection(cur, visual)
+        finally:
+            header.blockSignals(blocked)
+
+    def _persist_column_order(self, *args):
+        """Save the current visual column order as a [col_id, ...] list.
+        Connected to the header's ``sectionMoved`` signal (which passes the
+        moved section's indices — ignored; we re-read the whole order)."""
+        header = self.tree.header()
+        order = [self._manager.columns[header.logicalIndex(v)].model.col_id
+                 for v in range(header.count())]
+        try:
+            self._preferences.protocol_tree_column_order = order
+        except Exception as exc:
+            logger.warning(f"Could not save column order preference: {exc}")
 
     def _add_step_at(self, idx):
         parent_path = self._parent_path_for_anchor(idx)


### PR DESCRIPTION
Supersedes the phase-index resolution proposed in #477 with a simpler, guaranteed-loop model for **route-rep-by-time (duration-mode) steps**.

Spec: `docs/superpowers/specs/2026-06-22-477-guaranteed-loop-duration-mode-design.md`
Plan: `docs/superpowers/plans/2026-06-22-477-guaranteed-loop-duration-mode.md`

## What it does (dynamic duration loop, i.e. duration mode + volume threshold)
- **Guaranteed-loop gate:** at each loop boundary, start another loop only if a full worst-case loop fits the remaining rep time — `raw_elapsed + cycle_len*duration_s <= repeat_duration` (raw wall-clock; pauses/holds count). Otherwise → **idle** (electrodes off) until the rep time elapses, then advance. So a started loop always returns to its start position within budget.
- **Unique-phase navigation:** the phase bar shows the loop's `cycle_len` unique phases + one trailing **dark-yellow idle cell** (no time axis). While paused, the operator toggles to any unique phase and resumes; the dynamic loop re-enters there (closes the #477 seek-re-entry gap).
- **Mid-loop-expiry warning:** if a seek lands where finishing the loop would exceed the rep time, on resume a dialog offers *finish the loop then advance* (ignore budget) vs *stay paused*.
- **Leaving-idle warning:** navigating off the idle cell warns first (electrodes may be left mid-loop).
- **Worst-case hold cap:** a phase's automatic hold is capped at `duration_s`, so the gate's bound is a true upper bound. The operator "extend" override stays unbounded by design.

## Layers touched
`phase_math` (pure gate/idle helpers) → `protocol_status` model (`dyn_phase`/`dyn_idle`/`dyn_loop_active`) → executor signals + controller wiring → `routes_column._run_dynamic_duration_loop` (gate/idle/seek re-entry/expiry) → timeline bar (idle cell) + dock pane (idle gate, leaving-idle warning, dynamic-aware seek/preview).

## Quality
Built task-by-task with per-task spec+quality review and a whole-branch review. Pure logic is unit-tested (written; per project policy not run in CI here). The broad review caught and fixed a same-step-seek `start_k` bug and three cross-layer UI-state bugs (seek `phase_total` flip, stale `dyn_idle` on step advance, mislabeled static-step idle tint).

## Manual verification (highest-risk first — not yet runtime-tested)
1. **Dynamic step, pause + phase-bar seek:** the track stays `cycle_len+1` cells (no flip to a larger count); clicking the idle cell previews electrodes **off**.
2. **Dynamic step idles, then advances to a normal step:** pause + seek on that normal step → **no** spurious "leave idle" dialog.
3. **Static duration step (no volume threshold):** last cell is **not** tinted as idle.
4. Idle → seek away → resume → runs from k → returns to idle.
5. Mid-loop-expiry: pause late, seek to a late phase → dialog; *Yes* finishes+advances, *No* pauses.
6. Gate timing: 4-phase loop, dwell 2 s, budget 20 s → loops until <8 s remain, then electrodes-off idle to 20 s, then advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)