### PR TITLE
Persist protocol-tree column order across restarts

### DIFF
--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -12,7 +12,7 @@ from pathlib import Path
 # Enthought library imports.
 from envisage.ui.tasks.api import PreferencesCategory, PreferencesPane
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Bool, Dict, Directory, Enum, Float, Str
+from traits.api import Bool, Dict, Directory, Enum, Float, List, Str
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import Group, View, Item
 
@@ -94,6 +94,13 @@ class ProtocolPreferences(PreferencesHelper):
     # hidden_by_default flag; legacy col_name-keyed entries are read via
     # a fallback in the tree widget and rewritten on the next toggle.
     protocol_tree_column_visibility = Dict(Str, Bool)
+
+    # Programmatic preference (no Settings-dialog item): the visual left-to-
+    # right column order as a list of col_id, persisted when the user drags a
+    # header section. Keyed by the same stable col_id as visibility, so order
+    # survives display renames; col_ids absent from the saved list (columns
+    # added since) keep their natural position at the end on restore.
+    protocol_tree_column_order = List(Str)
 
     # {col_id: seconds} acknowledgement-wait time per wait-capable column
     # (issue #427), keyed by the stable col_id (base_id for compounds),

--- a/pluggable_protocol_tree/tests/test_column_order_persistence.py
+++ b/pluggable_protocol_tree/tests/test_column_order_persistence.py
@@ -1,0 +1,102 @@
+"""Tests for persisting protocol-tree column ORDER across restarts.
+
+Order lives in ProtocolPreferences.protocol_tree_column_order as a list of
+col_id in visual (left-to-right) order. Mirrors the visibility persistence:
+the preference round-trips across helper instances sharing one preferences
+node, and the ProtocolTreeWidget restores the order on construction and
+persists it whenever the user drags a header section (sectionMoved). Order is
+keyed by the stable col_id, independent of visibility, and tolerant of columns
+added/removed between sessions.
+"""
+
+import pytest
+
+from apptools.preferences.api import Preferences
+
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.trail_length_column import (
+    make_trail_length_column,
+)
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.services.preferences import ProtocolPreferences
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+@pytest.fixture
+def prefs_node():
+    """Isolated in-memory preferences node (no on-disk state shared
+    between tests)."""
+    return Preferences()
+
+
+@pytest.fixture
+def prefs(prefs_node):
+    return ProtocolPreferences(preferences=prefs_node)
+
+
+def _logical_of(manager, col_id):
+    for i, col in enumerate(manager.columns):
+        if col.model.col_id == col_id:
+            return i
+    raise AssertionError(f"column {col_id!r} not found")
+
+
+# --- preference round-trip -------------------------------------------------
+
+def test_order_preference_defaults_to_empty_list(prefs):
+    assert prefs.protocol_tree_column_order == []
+
+
+def test_order_preference_round_trip_across_helper_instances(prefs, prefs_node):
+    prefs.protocol_tree_column_order = ["trail_length", "name"]
+    # A fresh helper against the same node sees the persisted order —
+    # i.e. the value survives "restart" (helper reconstruction).
+    reread = ProtocolPreferences(preferences=prefs_node)
+    assert reread.protocol_tree_column_order == ["trail_length", "name"]
+
+
+# --- widget wiring -------------------------------------------------------
+
+def test_widget_keeps_natural_order_when_nothing_saved(qapp, prefs):
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+    # Visual order matches logical order (no reordering applied).
+    assert header.visualIndex(_logical_of(manager, "name")) == 0
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 1
+
+
+def test_widget_restores_persisted_order(qapp, prefs):
+    # Reverse of the natural order: Trail first, Name second.
+    prefs.protocol_tree_column_order = ["trail_length", "name"]
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 0
+    assert header.visualIndex(_logical_of(manager, "name")) == 1
+
+
+def test_widget_appends_unsaved_columns_at_end(qapp, prefs):
+    # Only Trail saved; Name (added/unknown to the saved order) must keep a
+    # position — appended after the saved columns rather than dropped.
+    prefs.protocol_tree_column_order = ["trail_length"]
+
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+    header = widget.tree.header()
+
+    assert header.visualIndex(_logical_of(manager, "trail_length")) == 0
+    assert header.visualIndex(_logical_of(manager, "name")) == 1
+
+
+def test_dragging_section_persists_full_order(qapp, prefs):
+    manager = RowManager(columns=[make_name_column(), make_trail_length_column()])
+    widget = ProtocolTreeWidget(manager, preferences=prefs)
+
+    # Move the section at visual 0 (Name) to visual 1 — same as a header drag.
+    # sectionMoved is wired, so this auto-persists the new visual order.
+    widget.tree.header().moveSection(0, 1)
+
+    assert prefs.protocol_tree_column_order == ["trail_length", "name"]

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -108,6 +108,14 @@ class ProtocolTreeWidget(QWidget):
         header.setContextMenuPolicy(Qt.CustomContextMenu)
         header.customContextMenuRequested.connect(self._on_header_context_menu)
 
+        # Let the user drag header sections to reorder columns, and persist
+        # that order (like visibility) so it survives a restart. Apply the
+        # saved order BEFORE connecting sectionMoved so the restore moves
+        # don't recursively re-persist.
+        header.setSectionsMovable(True)
+        self._apply_column_order()
+        header.sectionMoved.connect(self._persist_column_order)
+
         self.delegate = ProtocolItemDelegate(row_manager, parent=self.tree)
         self.tree.setItemDelegate(self.delegate)
 
@@ -282,6 +290,54 @@ class ProtocolTreeWidget(QWidget):
             self._preferences.protocol_tree_column_visibility = visibility
         except Exception as exc:
             logger.warning(f"Could not save column visibility preference: {exc}")
+
+    def _load_column_order(self) -> list:
+        """Return the persisted [col_id, ...] visual order ([] when nothing
+        was saved yet or the preference is unreadable)."""
+        try:
+            saved = self._preferences.protocol_tree_column_order
+            return [str(cid) for cid in (saved or [])]
+        except Exception as exc:
+            logger.warning(f"Could not read column order preference: {exc}")
+            return []
+
+    def _apply_column_order(self):
+        """Reorder the header's visual sections to the persisted col_id
+        sequence. Columns absent from the saved order (added since the last
+        save) keep their natural logical position at the end. No-op when
+        nothing is saved. Visibility is independent of order, so hidden
+        columns still occupy (and are moved within) the visual sequence."""
+        saved_order = self._load_column_order()
+        if not saved_order:
+            return
+        header = self.tree.header()
+        id_to_logical = {col.model.col_id: i
+                         for i, col in enumerate(self._manager.columns)}
+        target = [id_to_logical[cid] for cid in saved_order
+                  if cid in id_to_logical]
+        seen = set(target)
+        target += [i for i in range(len(self._manager.columns))
+                   if i not in seen]
+        blocked = header.blockSignals(True)
+        try:
+            for visual, logical in enumerate(target):
+                cur = header.visualIndex(logical)
+                if cur != visual:
+                    header.moveSection(cur, visual)
+        finally:
+            header.blockSignals(blocked)
+
+    def _persist_column_order(self, *args):
+        """Save the current visual column order as a [col_id, ...] list.
+        Connected to the header's ``sectionMoved`` signal (which passes the
+        moved section's indices — ignored; we re-read the whole order)."""
+        header = self.tree.header()
+        order = [self._manager.columns[header.logicalIndex(v)].model.col_id
+                 for v in range(header.count())]
+        try:
+            self._preferences.protocol_tree_column_order = order
+        except Exception as exc:
+            logger.warning(f"Could not save column order preference: {exc}")
 
     def _add_step_at(self, idx):
         parent_path = self._parent_path_for_anchor(idx)


### PR DESCRIPTION
## What

Adds persistence of the protocol tree's **column order** to preferences, alongside the existing column-visibility persistence.

## Why

Column visibility already survives an app restart (`protocol_tree_column_visibility`), but the column order did not — in fact the header sections were not even movable, so the user could not reorder columns at all. This makes the order draggable **and** persistent.

## How

- **`services/preferences.py`** — new `ProtocolPreferences.protocol_tree_column_order = List(Str)`: the visual left-to-right order as a list of stable `col_id` (same key scheme as visibility, so the order survives display renames like Routes→Electrodes).
- **`views/tree_widget.py`**
  - `header.setSectionsMovable(True)` so the user can drag header sections to reorder columns.
  - On construction, restore the saved order via `header.moveSection(...)`, keyed by `col_id`, **before** connecting `sectionMoved` so the restore moves don't recursively re-persist. Columns absent from the saved order (added since the last save) keep their natural position, appended at the end. Order is independent of visibility (hidden columns still occupy/move within the visual sequence).
  - Persist the full visual order on every `sectionMoved`.
- **`tests/test_column_order_persistence.py`** — mirrors `test_column_visibility_persistence.py`: preference round-trip across helper instances, restore on construction, append-unsaved-at-end, and persist-on-drag.

## Note

With movable sections, dragging a column to visual position 0 moves the tree's expand/indent decoration to that column (standard `QTreeView` behavior). Let me know if the Name column should instead be pinned as the first column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)