### PR TITLE
Status-bar icons via extension point (new microdrop_status_bar plugin)

### DIFF
--- a/device_viewer/plugin.py
+++ b/device_viewer/plugin.py
@@ -1,6 +1,7 @@
 # Standard library imports.
 from traits.api import List, Str
 from message_router.consts import ACTOR_TOPIC_ROUTES
+from microdrop_status_bar.consts import STATUS_BAR_ICONS
 
 # Enthought library imports.
 from envisage.api import Plugin, TASK_EXTENSIONS, PREFERENCES_PANES, PREFERENCES_CATEGORIES
@@ -36,6 +37,11 @@ class DeviceViewerPlugin(Plugin):
 
     preferences_panes = List(contributes_to=PREFERENCES_PANES)
     preferences_categories = List(contributes_to=PREFERENCES_CATEGORIES)
+
+    #: Status-bar widgets contributed at runtime: the device-viewer dock
+    #: pane extends this list (joystick + recording icons); the
+    #: microdrop_status_bar plugin places, spaces, and removes them.
+    status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
 
     ###########################################################################
     # Protected interface.

--- a/device_viewer/services/electrode_interaction_service.py
+++ b/device_viewer/services/electrode_interaction_service.py
@@ -25,6 +25,7 @@ from device_viewer.consts import (
     GAMEPAD_DEBOUNCE_REALTIME_S, GAMEPAD_AXIS_THRESHOLD,
 )
 from logger.logger_service import get_logger
+from microdrop_style.colors import GREY, SUCCESS_COLOR
 from device_viewer.models.main_model import DeviceViewMainModel
 from device_viewer.models.route import Route, RouteLayer
 from device_viewer.views.electrode_view.electrode_layer import ElectrodeLayer
@@ -80,6 +81,11 @@ class ElectrodeInteractionControllerService(HasTraits):
 
     #: Optional: status bar manager for HUD messages
     status_bar_manager = Instance(object, allow_none=True)
+
+    #: Optional: persistent joystick indicator (QLabel) on the app status
+    #: bar. Created and contributed by the device-viewer dock pane; this
+    #: service only recolors it and sets its tooltip.
+    gamepad_icon = Instance(object, allow_none=True)
 
     autoroute_paths = Dict({})
 
@@ -217,27 +223,33 @@ class ElectrodeInteractionControllerService(HasTraits):
             pass
 
     def _set_gamepad_indicator(self, text: str) -> None:
-        """Update the persistent gamepad indicator on the app status bar.
+        """Color/tooltip the persistent joystick icon on the app status bar.
 
-        Empty ``text`` hides the indicator. Unlike ``_set_hud`` (a transient,
-        rotating action message), this is a persistent connection state.
+        Empty ``text`` shows the disconnected state. Unlike ``_set_hud`` (a
+        transient, rotating action message), this is a persistent connection
+        state: connected = the same green as the other status-bar icons with
+        the controller name as tooltip; disconnected = a theme-independent
+        light gray that reads correctly on both status-bar backgrounds.
         """
-        mgr = getattr(self, "status_bar_manager", None)
-        if mgr is None:
+        icon = self.gamepad_icon
+        if icon is None:
             return
         try:
-            mgr.gamepad_status = text
-        except Exception:
-            pass
+            connected = bool(text)
+            color = SUCCESS_COLOR if connected else GREY["lighter"]
+            icon.setStyleSheet(f"color: {color};")
+            icon.setToolTip(text if connected else "Gamepad disconnected")
+        except RuntimeError as e:       # icon deleted with the window
+            logger.debug(f"gamepad indicator gone: {e}")
 
-    @observe("status_bar_manager")
-    def _on_status_bar_manager_set(self, event):
-        """Re-apply the gamepad indicator when the status bar manager arrives.
+    @observe("gamepad_icon")
+    def _on_gamepad_icon_set(self, event):
+        """Re-apply the connection state when the joystick icon arrives.
 
-        The manager is typically None when this service is constructed (the task
-        creates it in activated(), after dock-pane creation) and is pushed in
-        later. Without this, a controller acquired during startup would set the
-        indicator against a None manager and never show the icon.
+        The icon is None when this service is constructed (the dock pane
+        creates and contributes it once the status bar exists) and is pushed
+        in later. Without this, a controller acquired during startup would
+        color a None icon and never show as connected.
         """
         if event.new is None or not self._pygame_enabled or self._pygame_joystick is None:
             return

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -9,6 +9,11 @@ from electrode_controller.consts import electrode_state_change_publisher
 
 from microdrop_style.icon_styles import STATUSBAR_ICON_POINT_SIZE
 from microdrop_style.fonts.fontnames import ICON_FONT_FAMILY
+from microdrop_style.icons.icons import ICON_JOYSTICK
+from microdrop_status_bar.consts import (
+    ICON_PRIORITY_LEFT,
+    ICON_PRIORITY_LEFTMOST,
+)
 
 from microdrop_application.dialogs.pyface_wrapper import (
     NO,
@@ -25,6 +30,7 @@ from pyface.qt.QtWidgets import (
     QApplication,
     QFrame,
     QHBoxLayout,
+    QLabel,
     QMenu,
     QPushButton,
     QScrollArea,
@@ -1353,38 +1359,47 @@ class DeviceViewerDockPane(TraitsDockPane):
         # media-capture notifications can use it directly.
         self.camera_control_widget.status_bar_manager = event.new
 
-        # Same for the gamepad interaction service: it was constructed before
-        # the manager existed, so push it now. The service re-applies its
-        # connection indicator (and HUD) once the manager is set.
-        svc = self._gamepad_interaction_service()
-        if svc is not None:
-            svc.status_bar_manager = event.new
+        _font = QFont(ICON_FONT_FAMILY)
+        _font.setPointSize(STATUSBAR_ICON_POINT_SIZE)
 
-        # --- Initialize widgets ---
+        # Recording indicator: hidden until the camera's record toggle fires.
         self.recording_icon = PulsingLabel(
             icon_str="album",
             stylesheet="color: red;",
             tooltip="Recording in progress...",
         )
-
-        # Apply font settings
-        _font = QFont(ICON_FONT_FAMILY)
-        _font.setPointSize(STATUSBAR_ICON_POINT_SIZE)
         self.recording_icon.setFont(_font)
-
-        # --- Add to Status Bar ---
-        self.task.window.status_bar_manager.status_bar.insertPermanentWidget(1, self.recording_icon)
-
-        # Hide recording icon initially so it waits for a trigger
         self.recording_icon.hide()
+        self.recording_icon.status_bar_icon_priority = ICON_PRIORITY_LEFT
+        self.camera_control_widget.record_toggle_button.toggled.connect(
+            self.recording_icon.set_enabled
+        )
 
-        self.camera_control_widget.record_toggle_button.toggled.connect(self.recording_icon.set_enabled)
+        # Joystick indicator: always visible, outermost-left of all status
+        # icons via priority. Created in the disconnected state; the gamepad
+        # interaction service recolors it on controller connect/disconnect.
+        self.gamepad_icon = QLabel(ICON_JOYSTICK)
+        self.gamepad_icon.setFont(_font)
+        self.gamepad_icon.setStyleSheet(f"color: {GREY['lighter']};")
+        self.gamepad_icon.setToolTip("Gamepad disconnected")
+        self.gamepad_icon.status_bar_icon_priority = ICON_PRIORITY_LEFTMOST
 
-        # Place the joystick icon as the outermost-LEFT status-bar icon.
-        # Deferred via singleShot(0) so it runs after every other plugin's
-        # synchronous status-bar setup (realtime icon, ladder, etc.) has added
-        # its icons; attach_gamepad_indicator then inserts the joystick at the
-        # first permanent slot, to the left of them all, with uniform spacing.
-        _mgr = event.new
-        if _mgr is not None and hasattr(_mgr, "attach_gamepad_indicator"):
-            QTimer.singleShot(0, _mgr.attach_gamepad_indicator)
+        # Hand the gamepad service its HUD sink (the manager) and its
+        # indicator icon; both were unavailable when it was constructed.
+        # Setting gamepad_icon re-applies the current connection state.
+        svc = self._gamepad_interaction_service()
+        if svc is not None:
+            svc.status_bar_manager = event.new
+            svc.gamepad_icon = self.gamepad_icon
+
+        # Contribute both icons; the microdrop_status_bar plugin owns their
+        # placement, spacing, and removal.
+        plugin = self.task.window.application.get_plugin(PKG)
+        if plugin is None:
+            logger.warning(
+                f"{PKG}: plugin not found; status-bar icons not shown"
+            )
+            return
+        plugin.status_bar_icons.extend(
+            [self.gamepad_icon, self.recording_icon]
+        )

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -68,7 +68,6 @@ from microdrop_utils.i_dramatiq_controller_base import IDramatiqControllerBase
 from microdrop_utils.pyface_helpers import app_statusbar_message_from_dock_pane
 from microdrop_utils.pyside_helpers import (
     CollapsibleVStackBox,
-    horizontal_spacer_widget,
     PulsingLabel, ClickableToggleIcon,
 )
 from microdrop_utils.trait_change_commands import SetChangeCommand
@@ -1355,6 +1354,9 @@ class DeviceViewerDockPane(TraitsDockPane):
 
     @observe("task:window:status_bar_manager")
     def _setup_app_statusbar(self, event):
+        if getattr(self, "gamepad_icon", None) is not None:
+            return                      # already built; a re-fired manager
+                                        # assignment must not duplicate icons
         # Push the manager to the camera widget now that it exists, so
         # media-capture notifications can use it directly.
         self.camera_control_widget.status_bar_manager = event.new

--- a/docs/ENVISAGE_TRAITS_GUIDE.md
+++ b/docs/ENVISAGE_TRAITS_GUIDE.md
@@ -168,8 +168,8 @@ decision constants (conventions skill).
 
 **Pyface widgets extended with traits** — `microdrop_utils/pyface_helpers.py`:
 `StatusBarManager` subclasses pyface's status-bar manager and adds
-`center_message = Str()` / `gamepad_status = Str()` with `@observe` handlers driving
-Qt labels. `microdrop_utils/dramatiq_traits_helpers.py` subclasses
+`center_message = Str()` with an `@observe` handler driving the centered
+Qt label. `microdrop_utils/dramatiq_traits_helpers.py` subclasses
 `pyface.tasks.action.TaskWindowAction`.
 
 **Preferences** — `microdrop_application/preferences.py` and

--- a/docs/superpowers/plans/2026-07-03-status-bar-extension-point.md
+++ b/docs/superpowers/plans/2026-07-03-status-bar-extension-point.md
@@ -1,0 +1,486 @@
+# Status-Bar Extension Point Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Status-bar icons become Envisage extension-point contributions managed by one new `microdrop_status_bar` plugin — no dock pane ever touches the `QStatusBar` directly, spacing is uniform by construction, and hot load/unload cleans the bar automatically.
+
+**Architecture:** A new `StatusBarPlugin` declares a `status_bar_icons` extension point and observes contribution deltas exactly the way `MessageRouterPlugin` observes `actor_topic_routing` (`connect_extension_point_traits()` + `@on_trait_change("<name>_items")`). It creates the window's `StatusBarManager` (moved out of `MicrodropTask.activated()`) and appends a single icon-container widget whose `QHBoxLayout` spacing gives every icon the same gap. `BaseStatusDockPane` contributes its widgets by extending its own plugin's `status_bar_icons = List(contributes_to=...)` trait (declared once on `BaseStatusPlugin`) and withdraws them in teardown.
+
+**Tech Stack:** Envisage (Plugin, ExtensionPoint), Traits (`observe`, `on_trait_change`), Pyface/PySide6 (`QStatusBar`, `QWidget`, `QHBoxLayout`).
+
+**Spec:** `docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md`
+
+## Global Constraints
+
+- f-strings everywhere, including log messages — never `%s` / `.format()`.
+- Logging via `from logger.logger_service import get_logger; logger = get_logger(__name__)`.
+- No cross-plugin references — plugins communicate via extension points / app globals only.
+- Testing is **manual** (project preference — do NOT run pytest or launch the app yourself); each task ends at "code compiles + committed", and Task 6 is the human verification checklist.
+- Qt imports come from `pyface.qt.QtGui` (project convention in `template_status_and_controls/base_dock_pane.py`).
+- Work happens in the `microdrop-py/src` git repo (the submodule), branch `status_bar_contribution_extention_point`. Note: `microdrop_application/task.py` has a small pre-existing uncommitted user edit (inlining `_add_status_bar_to_window`) — Task 4 replaces that whole block anyway; do not revert unrelated working-tree changes.
+- Commit messages end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: `microdrop_status_bar` plugin package
+
+**Files:**
+- Create: `microdrop_status_bar/__init__.py`
+- Create: `microdrop_status_bar/consts.py`
+- Create: `microdrop_status_bar/plugin.py`
+
+**Interfaces:**
+- Consumes: `microdrop_utils.pyface_helpers.StatusBarManager` (existing).
+- Produces: extension-point id constant `microdrop_status_bar.consts.STATUS_BAR_ICONS = "status_bar_icons"` (Task 2 imports it); `microdrop_status_bar.plugin.StatusBarPlugin` (Task 5 registers it). Contributed items are QWidget instances; once contributed, this plugin owns their placement AND their deletion (`deleteLater()` on removal).
+
+- [ ] **Step 1: Create the package**
+
+`microdrop_status_bar/__init__.py` — empty file.
+
+`microdrop_status_bar/consts.py`:
+
+```python
+# This module's package.
+PKG = '.'.join(__name__.split('.')[:-1])
+PKG_name = PKG.title().replace("_", " ")
+
+#: Extension-point id: QWidget instances to show in the app status bar.
+STATUS_BAR_ICONS = "status_bar_icons"
+
+#: Uniform gap (px) between adjacent contributed status-bar icons.
+ICON_SPACING = 10
+
+#: Status-bar message shown from startup until something replaces it.
+DEFAULT_STATUS_MESSAGE = "Free Mode"
+
+#: Contents margins (left, top, right, bottom) of the status bar.
+STATUS_BAR_CONTENTS_MARGINS = (30, 0, 30, 0)
+```
+
+- [ ] **Step 2: Write the plugin**
+
+`microdrop_status_bar/plugin.py`:
+
+```python
+"""
+StatusBarPlugin — the one home for the application status bar.
+
+Creates the window's StatusBarManager and owns the ``status_bar_icons``
+extension point: other plugins contribute QWidget instances (typically at
+runtime, from their dock panes) and this plugin places them in a single
+icon container whose QHBoxLayout gives every icon the same gap. Removing
+a widget from the extension point removes it from the bar and deletes it.
+
+Dynamic contribution handling mirrors MessageRouterPlugin: apply the
+current extensions once the container exists, then react to
+``<name>_items`` delta events for runtime (hot load/unload) changes.
+"""
+from envisage.api import ExtensionPoint, Plugin
+from pyface.qt.QtGui import QHBoxLayout, QWidget
+from traits.api import Any, List, observe, on_trait_change
+
+from logger.logger_service import get_logger
+from microdrop_utils.pyface_helpers import StatusBarManager
+
+from .consts import (
+    DEFAULT_STATUS_MESSAGE,
+    ICON_SPACING,
+    PKG,
+    PKG_name,
+    STATUS_BAR_CONTENTS_MARGINS,
+    STATUS_BAR_ICONS,
+)
+
+logger = get_logger(__name__)
+
+
+class StatusBarPlugin(Plugin):
+    """Creates the app status bar and manages contributed status icons."""
+
+    id = PKG + ".plugin"
+    name = f"{PKG_name} Plugin"
+
+    status_bar_icons = ExtensionPoint(
+        List(),
+        id=STATUS_BAR_ICONS,
+        desc="QWidget instances to show in the app status bar; this plugin "
+             "owns their placement, spacing, and removal",
+    )
+
+    #: Single container appended to the status bar; its HBox layout gives
+    #: every contributed icon the same gap.
+    _icon_container = Any(None)
+
+    def start(self):
+        # Wire the registry's extension-point listeners to this plugin's
+        # traits so the handlers below fire when contributions change at
+        # runtime. Opt-in (envisage never calls it for you), and only
+        # possible once the plugin is attached to the application.
+        self.connect_extension_point_traits()
+
+    @observe("application:active_window")
+    def _setup_status_bar(self, event):
+        """Build the status bar on the first window; later re-fires no-op."""
+        window = event.new
+        if window is None or self._icon_container is not None:
+            return
+        if window.status_bar_manager is None:
+            window.status_bar_manager = StatusBarManager(
+                messages=[DEFAULT_STATUS_MESSAGE], size_grip=True
+            )
+        status_bar = window.status_bar_manager.status_bar
+        status_bar.setContentsMargins(*STATUS_BAR_CONTENTS_MARGINS)
+
+        container = QWidget()
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(ICON_SPACING)
+        # Appended, i.e. rightmost — so the joystick indicator's deferred
+        # insert at the first permanent slot stays LEFT of every
+        # contributed icon (see StatusBarManager.attach_gamepad_indicator).
+        status_bar.addPermanentWidget(container)
+        self._icon_container = container
+
+        # Contributions made before the window existed already sit in the
+        # extension point — apply them now; the _items handler below keeps
+        # the bar in sync from here on.
+        self._apply_icon_changes(added=self.status_bar_icons, removed=[])
+
+    # ------------------------------------------------------------------ #
+    # Extension-point sync                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _apply_icon_changes(self, added, removed):
+        """Apply contribution deltas to the icon container."""
+        if self._icon_container is None:
+            return  # no window yet; current extensions applied at setup
+        layout = self._icon_container.layout()
+        for widget in removed:
+            try:
+                layout.removeWidget(widget)
+                widget.deleteLater()
+            except RuntimeError as e:
+                logger.debug(f"status-bar icon already deleted: {e}")
+        for widget in added:
+            layout.addWidget(widget)
+        logger.info(
+            f"status bar icons changed: +{len(added)} -{len(removed)}; "
+            f"{layout.count()} in the bar"
+        )
+
+    @on_trait_change("status_bar_icons_items")
+    def _on_status_bar_icons_items_changed(self, event):
+        """A contribution changed while the app is running.
+
+        Plugin-driven changes (a contributing plugin mutating its
+        contribution trait, plugins added/removed from the manager) always
+        carry an index, which ExtensionPoint.connect surfaces as this
+        synthetic "<name>_items" property event. No real
+        ``status_bar_icons_items`` trait exists, so the string-matched
+        on_trait_change must bind it — observe() rejects unknown names.
+        """
+        self._apply_icon_changes(event.added, event.removed)
+
+    @observe("status_bar_icons")
+    def _on_status_bar_icons_replaced(self, event):
+        """Index-less wholesale replacement of the extension point
+        (registry.set_extensions) — never fired for plugin contribution
+        changes; covered for completeness."""
+        self._apply_icon_changes(added=event.new, removed=event.old)
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `python -c "import ast; ast.parse(open('microdrop_status_bar/plugin.py').read()); ast.parse(open('microdrop_status_bar/consts.py').read())"` from `microdrop-py/src`.
+Expected: no output (exit 0).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add microdrop_status_bar
+git commit -m "feat: microdrop_status_bar plugin with status_bar_icons extension point"
+```
+
+---
+
+### Task 2: Contribution trait on `BaseStatusPlugin`
+
+**Files:**
+- Modify: `template_status_and_controls/base_plugin.py`
+
+**Interfaces:**
+- Consumes: `microdrop_status_bar.consts.STATUS_BAR_ICONS` (Task 1).
+- Produces: `BaseStatusPlugin.status_bar_icons` (a `List(contributes_to=STATUS_BAR_ICONS)`, empty by default) — Task 3's pane code extends/removes items on this trait. All five device plugins (dropbot, opendrop, mock, heater, magnet) inherit it; no per-device edits.
+
+- [ ] **Step 1: Add the import and trait**
+
+In `template_status_and_controls/base_plugin.py`, after the existing import
+`from message_router.consts import ACTOR_TOPIC_ROUTES` add:
+
+```python
+from microdrop_status_bar.consts import STATUS_BAR_ICONS
+```
+
+In the class body, right after `actor_topic_routing = List(contributes_to=ACTOR_TOPIC_ROUTES)` (line 71) add:
+
+```python
+    #: Status-bar widgets contributed at runtime: BaseStatusDockPane
+    #: extends this list when it populates the bar; the
+    #: microdrop_status_bar plugin places, spaces, and removes them.
+    status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
+```
+
+Also extend the module docstring's boilerplate list (lines 5-6) with a third bullet:
+
+```
+  - status_bar_icons             (runtime status-bar icon contributions)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add template_status_and_controls/base_plugin.py
+git commit -m "feat: BaseStatusPlugin contributes to status_bar_icons extension point"
+```
+
+---
+
+### Task 3: `BaseStatusDockPane` contributes instead of inserting
+
+**Files:**
+- Modify: `template_status_and_controls/base_dock_pane.py`
+
+**Interfaces:**
+- Consumes: `BaseStatusPlugin.status_bar_icons` (Task 2), resolved via `self.task.window.application.get_plugin(self.status_bar_plugin_id)`.
+- Produces: unchanged factory hooks (`_create_status_bar_icon`, `_create_status_bar_widgets`, `_build_status_bar_tooltip`) — `RealtimeModeIconMixin` and the heater/magnet overrides keep working untouched. New overridable trait `status_bar_plugin_id` (default: pane id `"<pkg>.dock_pane"` → `"<pkg>.plugin"`).
+
+- [ ] **Step 1: Delete the placement constants and spacer import**
+
+Remove from `base_dock_pane.py`:
+- the line `from microdrop_utils.pyside_helpers import horizontal_spacer_widget`
+- the module constants block:
+
+```python
+#: Position in the status bar at which every pane widget is inserted.
+STATUS_BAR_INSERT_INDEX = 2
+
+#: Width (px) of the spacer inserted alongside each status-bar widget.
+STATUS_BAR_SPACER_WIDTH = 10
+```
+
+Change the traits import to include `Str`:
+
+```python
+from traits.api import Any, Instance, List, Str, observe
+```
+
+- [ ] **Step 2: Replace the tracking trait with contribution traits**
+
+Replace (lines 121-124):
+
+```python
+    #: Every widget this pane inserted into the status bar (icons AND their
+    #: spacers), tracked so destroy() can remove exactly what was added —
+    #: required for runtime hot unload of the pane.
+    _status_bar_inserted_widgets = List()
+```
+
+with:
+
+```python
+    #: Id of the Envisage plugin whose ``status_bar_icons`` contribution
+    #: list this pane extends; "<pkg>.dock_pane" → "<pkg>.plugin" by
+    #: convention (override for panes that don't follow it).
+    status_bar_plugin_id = Str()
+
+    #: The contribution plugin resolved at populate time, cached so
+    #: teardown can withdraw contributions without touching the window.
+    _contribution_plugin = Any(None)
+
+    #: Widgets this pane contributed to the status bar, tracked so
+    #: teardown withdraws exactly what was added — required for runtime
+    #: hot unload of the pane.
+    _contributed_status_bar_widgets = List()
+
+    def _status_bar_plugin_id_default(self):
+        return self.id.rsplit(".", 1)[0] + ".plugin"
+```
+
+- [ ] **Step 3: Rewrite `_populate_status_bar`**
+
+Replace the whole method (keeping the decorator):
+
+```python
+    @observe("task:window:status_bar_manager")
+    def _populate_status_bar(self, event):
+        """Build the pane's status-bar widgets and contribute them to the
+        status-bar extension point — the microdrop_status_bar plugin owns
+        placement, spacing, and removal.
+
+        Subclass overrides MUST re-apply the @observe decorator above —
+        an undecorated override silently drops the observer registration."""
+        if self._contributed_status_bar_widgets:
+            return                      # already populated (observer + hot-mount)
+        plugin = self.task.window.application.get_plugin(
+            self.status_bar_plugin_id
+        )
+        if plugin is None:
+            logger.warning(
+                f"{self.id}: no plugin {self.status_bar_plugin_id!r} to carry "
+                f"status-bar contributions; status-bar icons not shown"
+            )
+            return
+        self.status_bar_icon = self._create_status_bar_icon()
+        self._refresh_status_bar_tooltip()
+        QApplication.styleHints().colorSchemeChanged.connect(
+            self._refresh_status_bar_tooltip
+        )
+        widgets = self._create_status_bar_widgets()
+        self._contribution_plugin = plugin
+        self._contributed_status_bar_widgets = list(widgets)
+        plugin.status_bar_icons.extend(widgets)
+```
+
+- [ ] **Step 4: Rewrite `_teardown_status_bar`**
+
+Replace the whole method:
+
+```python
+    def _teardown_status_bar(self):
+        """Withdraw this pane's status-bar contributions and signal hookups.
+
+        Removing the widgets from the plugin's contribution list fires the
+        extension-point event that makes the status-bar plugin take them
+        out of the bar and delete them. Idempotent: widgets already gone
+        from the list (e.g. the plugin was hot-unloaded first) are skipped.
+        """
+        if self._contributed_status_bar_widgets:
+            try:
+                QApplication.styleHints().colorSchemeChanged.disconnect(
+                    self._refresh_status_bar_tooltip
+                )
+            except (RuntimeError, TypeError):
+                pass                    # never connected / already gone
+            contributed = self._contribution_plugin.status_bar_icons
+            for widget in self._contributed_status_bar_widgets:
+                if widget in contributed:
+                    contributed.remove(widget)
+            self._contributed_status_bar_widgets = []
+            self._contribution_plugin = None
+        self.status_bar_icon = None
+```
+
+- [ ] **Step 5: Syntax check**
+
+Run: `python -c "import ast; ast.parse(open('template_status_and_controls/base_dock_pane.py').read())"`
+Expected: no output (exit 0). Also grep to confirm nothing else references the deleted names:
+`grep -rn "STATUS_BAR_INSERT_INDEX\|STATUS_BAR_SPACER_WIDTH\|_status_bar_inserted_widgets" --include="*.py" .`
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add template_status_and_controls/base_dock_pane.py
+git commit -m "refactor: BaseStatusDockPane contributes status-bar icons via extension point"
+```
+
+---
+
+### Task 4: Remove status-bar creation from `MicrodropTask` + stale-comment touch-up
+
+**Files:**
+- Modify: `microdrop_application/task.py`
+- Modify: `microdrop_utils/pyface_helpers.py` (comments only)
+
+**Interfaces:**
+- Consumes: nothing new. StatusBarPlugin (Task 1) now creates the `StatusBarManager`; `device_viewer` and the panes react to the same `task:window:status_bar_manager` / `application:active_window` events regardless of who set the trait.
+
+- [ ] **Step 1: Shrink `activated()`**
+
+In `microdrop_application/task.py` replace the `activated` method with:
+
+```python
+    def activated(self):
+        """Called when the task is activated."""
+        logger.info("Microdrop task activated")
+```
+
+(The status-bar creation moved to the `microdrop_status_bar` plugin.) Delete the now-unused import:
+
+```python
+from microdrop_utils.pyface_helpers import StatusBarManager
+```
+
+Verify `StatusBarManager` has no other use in the file: `grep -n "StatusBarManager" microdrop_application/task.py` → no matches.
+
+- [ ] **Step 2: Fix the stale cross-reference comments in `pyface_helpers.py`**
+
+Replace the `STATUSBAR_FIRST_PERMANENT_INDEX` comment (lines 27-30):
+
+```python
+#: First permanent-widget slot. Indices 0/1 are the non-permanent persistent and
+#: center labels, so permanent icons start at 2. Inserting here lands LEFT of
+#: the microdrop_status_bar icon container, which is appended at the right end.
+STATUSBAR_FIRST_PERMANENT_INDEX = 2
+```
+
+In `attach_gamepad_indicator`'s docstring, replace the sentence
+"Mirrors the icon+spacer pattern used by template_status_and_controls so spacing stays uniform: insert the icon, then a leading spacer, both at the first permanent index — giving [spacer][joystick][…other icons, each with their own leading spacer]."
+with:
+"Insert the icon, then a leading spacer, both at the first permanent index — giving [spacer][joystick][microdrop_status_bar icon container]." (code unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add microdrop_application/task.py microdrop_utils/pyface_helpers.py
+git commit -m "refactor: move status-bar creation out of MicrodropTask into microdrop_status_bar"
+```
+
+---
+
+### Task 5: Register `StatusBarPlugin`
+
+**Files:**
+- Modify: `examples/plugin_consts.py`
+
+**Interfaces:**
+- Consumes: `microdrop_status_bar.plugin.StatusBarPlugin` (Task 1).
+
+- [ ] **Step 1: Import and list it**
+
+In `examples/plugin_consts.py` add with the other plugin imports:
+
+```python
+from microdrop_status_bar.plugin import StatusBarPlugin
+```
+
+In `FRONTEND_PLUGINS`, insert directly after `TasksPlugin`:
+
+```python
+FRONTEND_PLUGINS = [
+    MicrodropPlugin,
+    TasksPlugin,
+    StatusBarPlugin,
+    ...
+```
+
+(Frontend-only: the backend application has no windows. Load order carries no service-priority concern here — the plugin offers no services — but early placement means the extension point exists before any contributor starts.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/plugin_consts.py
+git commit -m "feat: register StatusBarPlugin in frontend plugin list"
+```
+
+---
+
+### Task 6: Manual verification (human)
+
+No automated runs — hand this checklist to the user:
+
+- [ ] Launch the app (`python examples/run_device_viewer_pluggable.py` with Redis up) — the DropBot status icon and realtime toggle appear right of the joystick icon, evenly spaced; "Free Mode" shows on the left.
+- [ ] Hover the icons — tooltips render; switch OS theme — tooltip colors follow.
+- [ ] Tools → Peripherals: enable the magnet group — its icon appears with the same spacing; disable — it disappears, remaining icons close ranks.
+- [ ] Start/stop camera recording — the recording icon still pulses in its usual spot (device_viewer path untouched).
+- [ ] Quit — no status-bar teardown errors in the log.

--- a/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
+++ b/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
@@ -61,11 +61,13 @@ microdrop_status_bar/
   ```
 
 - **Creates the status bar.** `start()` calls
-  `connect_extension_point_traits()` and observes the application's
-  `window_created` event. When the window appears it sets
-  `window.status_bar_manager = StatusBarManager(messages=DEFAULT_MESSAGES,
-  size_grip=True)`, applies the `setContentsMargins(30, 0, 30, 0)`
-  margins, and inserts **one container widget** (`QWidget` +
+  `connect_extension_point_traits()`; a null-guarded, idempotent
+  `@observe("application:active_window")` (the canonical lifecycle hook
+  per `docs/PLUGIN_DEVELOPMENT.md` §6) sets
+  `window.status_bar_manager = StatusBarManager(
+  messages=[DEFAULT_STATUS_MESSAGE], size_grip=True)`, applies the
+  `setContentsMargins(30, 0, 30, 0)` margins, and appends **one
+  container widget** (`QWidget` +
   `QHBoxLayout` with `spacing=ICON_SPACING`, zero contents margins) as a
   permanent widget. This wholly replaces the status-bar block in
   `MicrodropTask.activated()`, which is deleted.
@@ -90,13 +92,15 @@ widgets exist anywhere.
 
 ### 2. Contributing plugins
 
-Each device plugin declares an initially-empty runtime contribution:
+All five contributors subclass
+`template_status_and_controls.base_plugin.BaseStatusPlugin`, so the
+initially-empty runtime contribution is declared **once** there:
 
 ```python
 status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
 ```
 
-(All five current contributors get this one-liner in their `plugin.py`.)
+No per-device `plugin.py` changes are needed.
 
 ### 3. `base_dock_pane.py` — panes build widgets, never place them
 
@@ -154,7 +158,15 @@ status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
   guards removal with the same `RuntimeError`/broad-`Exception` guards
   the pane teardown uses today.
 - **Single window:** the app is single-window; the manager binds to the
-  first `window_created` event.
+  first non-None `active_window` and ignores later re-fires.
+- **Other status-bar citizens are untouched:** `device_viewer`'s
+  recording icon (direct `insertPermanentWidget(1, ...)`) and the
+  `StatusBarManager`'s own joystick indicator
+  (`attach_gamepad_indicator`, inserted at the first permanent slot
+  after all other icons so it is the outermost-LEFT icon) keep their
+  existing direct-insertion paths. The icon container is *appended*
+  (rightmost), so the joystick stays left of all pane icons. Migrating
+  those two into the extension point is deliberately out of scope.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
+++ b/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
@@ -168,14 +168,45 @@ No per-device `plugin.py` changes are needed.
   ran in `task.activated()` — that timing was load-bearing.
   `application_initialized` fires via `set_trait_later` after
   `_create_windows()` returns, safely past both hazards.
-- **Other status-bar citizens are untouched:** `device_viewer`'s
-  recording icon (direct `insertPermanentWidget(1, ...)`) and the
-  `StatusBarManager`'s own joystick indicator
-  (`attach_gamepad_indicator`, inserted at the first permanent slot
-  after all other icons so it is the outermost-LEFT icon) keep their
-  existing direct-insertion paths. The icon container is *appended*
-  (rightmost), so the joystick stays left of all pane icons. Migrating
-  those two into the extension point is deliberately out of scope.
+- ~~Other status-bar citizens are untouched~~ — superseded by Phase 2
+  (below): the joystick and recording icons are migrated too.
+
+## Phase 2 (same branch): icon priorities + last two direct inserts
+
+User-approved follow-up 2026-07-03: every icon flows through the
+extension point; no `insertPermanentWidget` outside `microdrop_status_bar`.
+
+- **Priority:** contributions stay bare QWidgets. An optional plain
+  attribute `status_bar_icon_priority` (int, default 0) orders the
+  container: sorted by `(priority, arrival order)`, lower = further
+  left; positives land right of defaults. `consts.py` adds
+  `ICON_PRIORITY_DEFAULT = 0`, `ICON_PRIORITY_LEFT = -1`,
+  `ICON_PRIORITY_LEFTMOST = -2`. `_apply_icon_changes` inserts at the
+  index of the first existing widget with a strictly greater priority.
+- **Joystick → device_viewer** (owner of the gamepad service): the
+  dock pane creates the QLabel (same glyph/font/colors), tags it
+  `ICON_PRIORITY_LEFTMOST`, hands it to the gamepad service
+  (`svc.gamepad_icon`), and contributes it via a new
+  `DeviceViewerPlugin.status_bar_icons` trait. The service colors the
+  icon directly (green/controller-name vs grey/"Gamepad disconnected",
+  logic moved from `StatusBarManager._apply_gamepad_label_state`); its
+  re-apply observer watches `gamepad_icon`. The deferred
+  `QTimer.singleShot(0, attach_gamepad_indicator)` ordering hack is
+  deleted — priority replaces timing.
+- **Recording icon → contribution**, tagged `ICON_PRIORITY_LEFT`
+  (right of joystick, left of device icons), still hidden until the
+  record toggle fires; the `insertPermanentWidget(1, ...)` call is
+  deleted.
+- **StatusBarManager slims down:** `gamepad_label`, `gamepad_status`,
+  `_gamepad_attached`, `attach_gamepad_indicator`,
+  `_gamepad_status_updated`, `_apply_gamepad_label_state`,
+  `STATUSBAR_ICON_SPACING`, `STATUSBAR_FIRST_PERMANENT_INDEX`, and the
+  joystick-related imports are deleted; the manager handles messages,
+  the center label, and theming only. HUD messages keep using the
+  manager unchanged.
+- **Visible change (accepted):** joystick/recording gaps become the
+  container's uniform `ICON_SPACING` instead of the old style-default
+  gaps.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
+++ b/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
@@ -1,0 +1,167 @@
+# Status-Bar Extension Point (`microdrop_status_bar`) — Design
+
+**Date:** 2026-07-03
+**Scope:** new `microdrop_status_bar` plugin;
+`template_status_and_controls/base_dock_pane.py`;
+`microdrop_application/task.py`; the five contributing device plugins
+(`dropbot_status_and_controls`, `opendrop_status_and_controls`,
+`mock_dropbot_status`, heater `heater_controls_ui`, magnet
+`peripherals_ui`); frontend plugin registration (`plugin_consts.py` /
+run scripts).
+**Goal:** status-bar icons become Envisage extension-point contributions
+managed by one central plugin — no pane ever touches the `QStatusBar`
+directly, spacing is uniform by construction, and hot load/unload cleans
+the bar automatically. Zero visible behavior change beyond spacing
+consistency.
+
+## Problems
+
+1. **Every pane hand-places its own widgets.** `_populate_status_bar`
+   computes an insert index (`STATUS_BAR_INSERT_INDEX = 2`), manufactures
+   a spacer per widget (`STATUS_BAR_SPACER_WIDTH`), and pokes
+   `task.window.status_bar_manager.status_bar` directly.
+2. **Every pane hand-tracks teardown.** `_status_bar_inserted_widgets`
+   exists only so `destroy()` can remove exactly what was added — per-pane
+   bookkeeping for what is really a central concern.
+3. **Spacing is emergent, not guaranteed.** Each pane inserts its own
+   spacers; nothing ensures one uniform gap between adjacent icons.
+4. **Status-bar code is scattered.** The bar itself is created in
+   `MicrodropTask.activated()`; icon placement lives in the pane template;
+   no single point of change.
+
+The codebase already has the exact mechanism for this:
+`MessageRouterPlugin` declares an `ExtensionPoint`, calls
+`connect_extension_point_traits()` in `start()`, applies current
+contributions, then observes `<name>_items` deltas for runtime changes.
+This design replicates that shape for status-bar icons.
+
+## Design
+
+### 1. New plugin: `microdrop_status_bar`
+
+```
+microdrop_status_bar/
+├── __init__.py
+├── consts.py    # PKG, PKG_name, STATUS_BAR_ICONS extension-point id,
+│                # ICON_SPACING (10), DEFAULT_MESSAGES (["Free Mode"])
+└── plugin.py    # StatusBarPlugin
+```
+
+`StatusBarPlugin(Plugin)`:
+
+- **Extension point** (mirrors `MessageRouterPlugin.actor_topic_routing`):
+
+  ```python
+  status_bar_icons = ExtensionPoint(
+      List(),  # QWidget instances, contributed at runtime
+      id=STATUS_BAR_ICONS,
+      desc="Widgets to show in the app status bar; the manager owns "
+           "placement, spacing, and removal",
+  )
+  ```
+
+- **Creates the status bar.** `start()` calls
+  `connect_extension_point_traits()` and observes the application's
+  `window_created` event. When the window appears it sets
+  `window.status_bar_manager = StatusBarManager(messages=DEFAULT_MESSAGES,
+  size_grip=True)`, applies the `setContentsMargins(30, 0, 30, 0)`
+  margins, and inserts **one container widget** (`QWidget` +
+  `QHBoxLayout` with `spacing=ICON_SPACING`, zero contents margins) as a
+  permanent widget. This wholly replaces the status-bar block in
+  `MicrodropTask.activated()`, which is deleted.
+- **Applies current + observes deltas.** After building the container it
+  adds every widget already in `self.status_bar_icons` (contributions can
+  arrive before the window exists), then reacts to changes:
+  - `@on_trait_change("status_bar_icons_items")` — plugin-driven
+    contribution changes (a contributing plugin mutating its trait,
+    plugins added/removed from the manager). Added widgets →
+    `layout.addWidget`; removed widgets → `layout.removeWidget` +
+    `deleteLater()`.
+  - `@observe("status_bar_icons")` — index-less wholesale replacement,
+    covered for completeness exactly as in the router.
+- **Ownership rule:** once contributed, the manager owns a widget's
+  status-bar lifecycle — removal from the extension point means removal
+  from the bar and `deleteLater()`. Contributors keep behavior wiring
+  (signals, observers, tooltips) but never delete contributed widgets
+  themselves.
+
+Equal spacing is a property of the single `QHBoxLayout` — no spacer
+widgets exist anywhere.
+
+### 2. Contributing plugins
+
+Each device plugin declares an initially-empty runtime contribution:
+
+```python
+status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
+```
+
+(All five current contributors get this one-liner in their `plugin.py`.)
+
+### 3. `base_dock_pane.py` — panes build widgets, never place them
+
+- `_populate_status_bar` keeps its trigger points (the
+  `@observe("task:window:status_bar_manager")` decorator and the
+  `on_live_mounted()` hot-mount path) and its idempotence guard, but its
+  body becomes: build `self.status_bar_icon`, apply tooltip, wire
+  `colorSchemeChanged` → `_refresh_status_bar_tooltip`, then
+
+  ```python
+  self._contribution_plugin.status_bar_icons.extend(
+      self._create_status_bar_widgets())
+  ```
+
+  Mutating the plugin's list fires the extension-point `_items` event →
+  the manager inserts the widgets.
+- **Plugin lookup:** `_contribution_plugin` resolves via
+  `self.task.window.application.get_plugin(plugin_id)`. Default
+  `plugin_id` is derived from the pane id — `"<pkg>.dock_pane"` →
+  `"<pkg>.plugin"` — overridable via a class-level trait for panes that
+  don't follow the convention (all current panes do).
+- `_teardown_status_bar` removes the pane's contributed widgets from the
+  plugin's `status_bar_icons` list (the manager pulls them from the bar
+  and deletes them), disconnects `colorSchemeChanged`, and drops
+  references. Removal is idempotent: widgets already gone from the list
+  (e.g. the plugin was hot-unloaded first) are skipped.
+- **Deleted:** `STATUS_BAR_INSERT_INDEX`, `STATUS_BAR_SPACER_WIDTH`, the
+  `horizontal_spacer_widget` import, the `_status_bar_inserted_widgets`
+  trait, and all direct `status_bar` access.
+- **Unchanged:** widget factories (`_create_status_bar_icon`,
+  `_create_status_bar_widgets`), tooltip builders, model→color observers.
+  `RealtimeModeIconMixin` and the heater's overrides work as-is — they
+  only override factories.
+
+### 4. Hot load/unload
+
+- Pane teardown removes its widgets from its plugin's contribution list →
+  manager removes them from the bar.
+- Independently, removing a plugin from the plugin manager makes Envisage
+  fire removed-contribution events for everything that plugin contributed
+  — the manager cleans the bar even if a pane's teardown never ran. Both
+  paths are safe to run in either order (list removal is idempotent;
+  the manager ignores widgets it no longer holds).
+
+### 5. Wiring & edge cases
+
+- `StatusBarPlugin` is added to the frontend plugin list in
+  `plugin_consts.py` (and any run script that assembles plugins
+  explicitly). It has no ordering dependency: contributions before the
+  window exists are applied when the container is built.
+- **Icon order** = contribution arrival order (deterministic from pane
+  creation order). The current insert-at-index-2 behavior wasn't
+  meaningfully ordered either; no one depends on a specific order.
+- **App shutdown:** the container dies with the window; the manager
+  guards removal with the same `RuntimeError`/broad-`Exception` guards
+  the pane teardown uses today.
+- **Single window:** the app is single-window; the manager binds to the
+  first `window_created` event.
+
+## Testing
+
+Manual (per project preference — no automated test runs):
+
+1. Launch the app — the dropbot status icon + realtime toggle appear with
+   even spacing; tooltips and theme switching work.
+2. Toggle the magnet group via Tools → Peripherals — its icon appears on
+   load and disappears on unload, spacing stays uniform.
+3. Quit the app — no teardown errors in the log.

--- a/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
+++ b/docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md
@@ -62,8 +62,7 @@ microdrop_status_bar/
 
 - **Creates the status bar.** `start()` calls
   `connect_extension_point_traits()`; a null-guarded, idempotent
-  `@observe("application:active_window")` (the canonical lifecycle hook
-  per `docs/PLUGIN_DEVELOPMENT.md` §6) sets
+  `@observe("application:application_initialized")` sets
   `window.status_bar_manager = StatusBarManager(
   messages=[DEFAULT_STATUS_MESSAGE], size_grip=True)`, applies the
   `setContentsMargins(30, 0, 30, 0)` margins, and appends **one
@@ -157,8 +156,18 @@ No per-device `plugin.py` changes are needed.
 - **App shutdown:** the container dies with the window; the manager
   guards removal with the same `RuntimeError`/broad-`Exception` guards
   the pane teardown uses today.
-- **Single window:** the app is single-window; the manager binds to the
-  first non-None `active_window` and ignores later re-fires.
+- **Single window:** the app is single-window; the manager binds once at
+  `application_initialized` and ignores later re-fires.
+- **Why `application_initialized`, not `active_window`:** `active_window`
+  fires on the first Qt focus-activation, mid `window.open()` — before
+  dock-pane contents exist (their `task:window:status_bar_manager`
+  observers would run against half-built panes), and before pyface's
+  task-activation sweep (`TaskWindow._update_traits_given_new_active_state`)
+  overwrites `window.status_bar_manager` with `task.status_bar` (None),
+  discarding an early-installed manager. This is also why the legacy code
+  ran in `task.activated()` — that timing was load-bearing.
+  `application_initialized` fires via `set_trait_later` after
+  `_create_windows()` returns, safely past both hazards.
 - **Other status-bar citizens are untouched:** `device_viewer`'s
   recording icon (direct `insertPermanentWidget(1, ...)`) and the
   `StatusBarManager`'s own joystick indicator

--- a/examples/plugin_consts.py
+++ b/examples/plugin_consts.py
@@ -7,6 +7,7 @@ from manual_controls.plugin import ManualControlsPlugin
 from microdrop_application.application import MicrodropApplication
 from microdrop_application.backend_application import MicrodropBackendApplication
 from microdrop_application.plugin import MicrodropPlugin
+from microdrop_status_bar.plugin import StatusBarPlugin
 from dropbot_tools_menu.plugin import DropbotToolsMenuPlugin
 from opendrop_status_and_controls.plugin import OpendropStatusAndControlsPlugin
 from pluggable_protocol_tree.plugin import PluggableProtocolTreePlugin
@@ -60,6 +61,7 @@ from user_help_plugin.plugin import UserHelpPlugin
 FRONTEND_PLUGINS = [
     MicrodropPlugin,
     TasksPlugin,
+    StatusBarPlugin,
     LoggerUIPlugin,
     PluginManagementPlugin,
     DeviceViewerPlugin,

--- a/message_router/plugin.py
+++ b/message_router/plugin.py
@@ -59,7 +59,7 @@ class MessageRouterPlugin(Plugin):
                 for topic in topics_list:
                     try:
                         data.remove_subscriber_from_topic(topic, actor_name)
-                        logger.info(f"router unsubscribed {actor_name} from {topic}")
+                        logger.debug(f"router unsubscribed {actor_name} from {topic}")
                     except (KeyError, ValueError):
                         # Two contributions can declare the same (actor,
                         # topic) pair; the flat map holds it once, so the
@@ -72,7 +72,7 @@ class MessageRouterPlugin(Plugin):
                 for topic in topics_list:
                     data.add_subscriber_to_topic(topic, actor_name)
 
-                logger.info(f"router subscribed {actor_name} to {topics_list}")
+                logger.debug(f"router subscribed {actor_name} to {topics_list}")
 
     @on_trait_change("actor_topic_routing_items")
     def _on_actor_topic_routing_items_changed(self, event):

--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -15,7 +15,6 @@ from electrode_controller.consts import electrode_disable_request_publisher, dis
 from .consts import PKG
 from dropbot_controller.models.self_tests import TestEvent
 
-from microdrop_utils.pyface_helpers import StatusBarManager
 from microdrop_utils.dramatiq_controller_base import (generate_class_method_dramatiq_listener_actor,
                                                       basic_listener_actor_routine)
 from microdrop_application.views.microdrop_pane import MicrodropCentralCanvas
@@ -102,15 +101,6 @@ class MicrodropTask(Task):
     def activated(self):
         """Called when the task is activated."""
         logger.info("Microdrop task activated")
-        if self.window.status_bar_manager is None:
-            logger.info("Microdrop task: No status bar manager created: Adding now...")
-            self._add_status_bar_to_window()
-
-    def _add_status_bar_to_window(self):
-        logger.info(f"Adding status bar to Microdrop Task window.")
-        self.window.status_bar_manager = StatusBarManager(messages=["Free Mode"], size_grip=True)
-
-        self.window.status_bar_manager.status_bar.setContentsMargins(30, 0, 30, 0)
 
     ###########################################################################
     # Protected interface.

--- a/microdrop_status_bar/consts.py
+++ b/microdrop_status_bar/consts.py
@@ -1,0 +1,15 @@
+# This module's package.
+PKG = '.'.join(__name__.split('.')[:-1])
+PKG_name = PKG.title().replace("_", " ")
+
+#: Extension-point id: QWidget instances to show in the app status bar.
+STATUS_BAR_ICONS = "status_bar_icons"
+
+#: Uniform gap (px) between adjacent contributed status-bar icons.
+ICON_SPACING = 10
+
+#: Status-bar message shown from startup until something replaces it.
+DEFAULT_STATUS_MESSAGE = "Free Mode"
+
+#: Contents margins (left, top, right, bottom) of the status bar.
+STATUS_BAR_CONTENTS_MARGINS = (30, 0, 30, 0)

--- a/microdrop_status_bar/consts.py
+++ b/microdrop_status_bar/consts.py
@@ -13,3 +13,10 @@ DEFAULT_STATUS_MESSAGE = "Free Mode"
 
 #: Contents margins (left, top, right, bottom) of the status bar.
 STATUS_BAR_CONTENTS_MARGINS = (30, 0, 30, 0)
+
+#: Contributors may set ``widget.status_bar_icon_priority`` (plain int
+#: attribute) on a contributed widget to order it in the bar: lower =
+#: further left, ties keep arrival order. Unset means ICON_PRIORITY_DEFAULT.
+ICON_PRIORITY_DEFAULT = 0
+ICON_PRIORITY_LEFT = -1
+ICON_PRIORITY_LEFTMOST = -2

--- a/microdrop_status_bar/plugin.py
+++ b/microdrop_status_bar/plugin.py
@@ -90,7 +90,12 @@ class StatusBarPlugin(Plugin):
         """Apply contribution deltas to the icon container."""
         if self._icon_container is None:
             return  # no window yet; current extensions applied at setup
-        layout = self._icon_container.layout()
+        try:
+            layout = self._icon_container.layout()
+        except RuntimeError as e:   # container died with the window (app exit)
+            logger.debug(f"status-bar icon container gone: {e}")
+            self._icon_container = None
+            return
         for widget in removed:
             try:
                 layout.removeWidget(widget)

--- a/microdrop_status_bar/plugin.py
+++ b/microdrop_status_bar/plugin.py
@@ -1,0 +1,125 @@
+"""
+StatusBarPlugin — the one home for the application status bar.
+
+Creates the window's StatusBarManager and owns the ``status_bar_icons``
+extension point: other plugins contribute QWidget instances (typically at
+runtime, from their dock panes) and this plugin places them in a single
+icon container whose QHBoxLayout gives every icon the same gap. Removing
+a widget from the extension point removes it from the bar and deletes it.
+
+Dynamic contribution handling mirrors MessageRouterPlugin: apply the
+current extensions once the container exists, then react to
+``<name>_items`` delta events for runtime (hot load/unload) changes.
+"""
+from envisage.api import ExtensionPoint, Plugin
+from pyface.qt.QtGui import QHBoxLayout, QWidget
+from traits.api import Any, List, observe, on_trait_change
+
+from logger.logger_service import get_logger
+from microdrop_utils.pyface_helpers import StatusBarManager
+
+from .consts import (
+    DEFAULT_STATUS_MESSAGE,
+    ICON_SPACING,
+    PKG,
+    PKG_name,
+    STATUS_BAR_CONTENTS_MARGINS,
+    STATUS_BAR_ICONS,
+)
+
+logger = get_logger(__name__)
+
+
+class StatusBarPlugin(Plugin):
+    """Creates the app status bar and manages contributed status icons."""
+
+    id = PKG + ".plugin"
+    name = f"{PKG_name} Plugin"
+
+    status_bar_icons = ExtensionPoint(
+        List(),
+        id=STATUS_BAR_ICONS,
+        desc="QWidget instances to show in the app status bar; this plugin "
+             "owns their placement, spacing, and removal",
+    )
+
+    #: Single container appended to the status bar; its HBox layout gives
+    #: every contributed icon the same gap.
+    _icon_container = Any(None)
+
+    def start(self):
+        # Wire the registry's extension-point listeners to this plugin's
+        # traits so the handlers below fire when contributions change at
+        # runtime. Opt-in (envisage never calls it for you), and only
+        # possible once the plugin is attached to the application.
+        self.connect_extension_point_traits()
+
+    @observe("application:active_window")
+    def _setup_status_bar(self, event):
+        """Build the status bar on the first window; later re-fires no-op."""
+        window = event.new
+        if window is None or self._icon_container is not None:
+            return
+        if window.status_bar_manager is None:
+            window.status_bar_manager = StatusBarManager(
+                messages=[DEFAULT_STATUS_MESSAGE], size_grip=True
+            )
+        status_bar = window.status_bar_manager.status_bar
+        status_bar.setContentsMargins(*STATUS_BAR_CONTENTS_MARGINS)
+
+        container = QWidget()
+        layout = QHBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(ICON_SPACING)
+        # Appended, i.e. rightmost — so the joystick indicator's deferred
+        # insert at the first permanent slot stays LEFT of every
+        # contributed icon (see StatusBarManager.attach_gamepad_indicator).
+        status_bar.addPermanentWidget(container)
+        self._icon_container = container
+
+        # Contributions made before the window existed already sit in the
+        # extension point — apply them now; the _items handler below keeps
+        # the bar in sync from here on.
+        self._apply_icon_changes(added=self.status_bar_icons, removed=[])
+
+    # ------------------------------------------------------------------ #
+    # Extension-point sync                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _apply_icon_changes(self, added, removed):
+        """Apply contribution deltas to the icon container."""
+        if self._icon_container is None:
+            return  # no window yet; current extensions applied at setup
+        layout = self._icon_container.layout()
+        for widget in removed:
+            try:
+                layout.removeWidget(widget)
+                widget.deleteLater()
+            except RuntimeError as e:
+                logger.debug(f"status-bar icon already deleted: {e}")
+        for widget in added:
+            layout.addWidget(widget)
+        logger.info(
+            f"status bar icons changed: +{len(added)} -{len(removed)}; "
+            f"{layout.count()} in the bar"
+        )
+
+    @on_trait_change("status_bar_icons_items")
+    def _on_status_bar_icons_items_changed(self, event):
+        """A contribution changed while the app is running.
+
+        Plugin-driven changes (a contributing plugin mutating its
+        contribution trait, plugins added/removed from the manager) always
+        carry an index, which ExtensionPoint.connect surfaces as this
+        synthetic "<name>_items" property event. No real
+        ``status_bar_icons_items`` trait exists, so the string-matched
+        on_trait_change must bind it — observe() rejects unknown names.
+        """
+        self._apply_icon_changes(event.added, event.removed)
+
+    @observe("status_bar_icons")
+    def _on_status_bar_icons_replaced(self, event):
+        """Index-less wholesale replacement of the extension point
+        (registry.set_extensions) — never fired for plugin contribution
+        changes; covered for completeness."""
+        self._apply_icon_changes(added=event.new, removed=event.old)

--- a/microdrop_status_bar/plugin.py
+++ b/microdrop_status_bar/plugin.py
@@ -54,10 +54,24 @@ class StatusBarPlugin(Plugin):
         # possible once the plugin is attached to the application.
         self.connect_extension_point_traits()
 
-    @observe("application:active_window")
+    @observe("application:application_initialized")
     def _setup_status_bar(self, event):
-        """Build the status bar on the first window; later re-fires no-op."""
-        window = event.new
+        """Build the status bar once windows and their pane contents exist.
+
+        Deliberately NOT ``application:active_window``: that fires on the
+        first Qt focus-activation, mid ``window.open()`` — before dock-pane
+        contents are created (their status-bar observers would run against
+        half-built panes), and before the task-activation sweep (pyface
+        ``TaskWindow._update_traits_given_new_active_state``) overwrites
+        ``window.status_bar_manager`` with ``task.status_bar`` (None),
+        discarding anything installed earlier. ``application_initialized``
+        is set via ``set_trait_later`` after ``_create_windows()`` returns,
+        so both hazards are past.
+        """
+        windows = self.application.windows
+        window = self.application.active_window or (
+            windows[0] if windows else None
+        )
         if window is None or self._icon_container is not None:
             return
         if window.status_bar_manager is None:

--- a/microdrop_status_bar/plugin.py
+++ b/microdrop_status_bar/plugin.py
@@ -20,6 +20,7 @@ from microdrop_utils.pyface_helpers import StatusBarManager
 
 from .consts import (
     DEFAULT_STATUS_MESSAGE,
+    ICON_PRIORITY_DEFAULT,
     ICON_SPACING,
     PKG,
     PKG_name,
@@ -85,9 +86,8 @@ class StatusBarPlugin(Plugin):
         layout = QHBoxLayout(container)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(ICON_SPACING)
-        # Appended, i.e. rightmost — so the joystick indicator's deferred
-        # insert at the first permanent slot stays LEFT of every
-        # contributed icon (see StatusBarManager.attach_gamepad_indicator).
+        # One container, appended once; icons order INSIDE it by their
+        # ``status_bar_icon_priority`` attribute (see consts).
         status_bar.addPermanentWidget(container)
         self._icon_container = container
 
@@ -117,11 +117,28 @@ class StatusBarPlugin(Plugin):
             except RuntimeError as e:
                 logger.debug(f"status-bar icon already deleted: {e}")
         for widget in added:
-            layout.addWidget(widget)
+            layout.insertWidget(self._insert_index(layout, widget), widget)
         logger.info(
             f"status bar icons changed: +{len(added)} -{len(removed)}; "
             f"{layout.count()} in the bar"
         )
+
+    @staticmethod
+    def _insert_index(layout, widget):
+        """Slot for ``widget`` in the priority-ordered container: before the
+        first icon with a strictly greater ``status_bar_icon_priority``, so
+        equal priorities keep arrival order (lower priority = further left).
+        """
+        priority = getattr(
+            widget, "status_bar_icon_priority", ICON_PRIORITY_DEFAULT
+        )
+        for i in range(layout.count()):
+            other = layout.itemAt(i).widget()
+            if priority < getattr(
+                other, "status_bar_icon_priority", ICON_PRIORITY_DEFAULT
+            ):
+                return i
+        return layout.count()
 
     @on_trait_change("status_bar_icons_items")
     def _on_status_bar_icons_items_changed(self, event):

--- a/microdrop_utils/pyface_helpers.py
+++ b/microdrop_utils/pyface_helpers.py
@@ -1,33 +1,12 @@
 from pyface.action.api import StatusBarManager as _StatusBarManager
 from pyface.qt.QtWidgets import QApplication, QStatusBar, QLabel
-from pyface.qt.QtGui import QFont
 from pyface.qt.QtCore import Qt, QTimer
 from pyface.tasks.dock_pane import DockPane
-from traits.api import Bool, Str, observe
+from traits.api import Str, observe
 
 from microdrop_style.helpers import QT_THEME_NAMES, is_dark_mode
 from microdrop_style.label_style import get_label_style
 from microdrop_style.status_bar_style import get_status_bar_stylesheet
-from microdrop_style.fonts.fontnames import ICON_FONT_FAMILY
-from microdrop_style.icon_styles import STATUSBAR_ICON_POINT_SIZE
-from microdrop_style.icons.icons import ICON_JOYSTICK
-from microdrop_style.colors import SUCCESS_COLOR, GREY
-from microdrop_utils.pyside_helpers import horizontal_spacer_widget
-
-#: Fixed width of the spacer widget inserted before the joystick icon. NOTE:
-#: this is only a minor contributor to the visible gap — QStatusBar lays its
-#: permanent widgets out in its own QHBoxLayout, which applies the dominant
-#: (style-default, ~6px-per-side) inter-item spacing around every widget,
-#: including this spacer. So tuning this value barely moves the gap; it exists
-#: only to mirror the icon+spacer pattern other plugins use so the joystick is
-#: spaced consistently with them. Equal spacing across icons comes from every
-#: icon using an identical leading spacer, not from this exact number.
-STATUSBAR_ICON_SPACING = 2
-
-#: First permanent-widget slot. Indices 0/1 are the non-permanent persistent and
-#: center labels, so permanent icons start at 2. Inserting here lands LEFT of
-#: the microdrop_status_bar icon container, which is appended at the right end.
-STATUSBAR_FIRST_PERMANENT_INDEX = 2
 
 from logger.logger_service import get_logger
 logger = get_logger(__name__)
@@ -75,15 +54,6 @@ class StatusBarManager(_StatusBarManager):
     # for an auto-clearing timed message; setting this directly is persistent.
     center_message = Str()
 
-    # Persistent right-side gamepad indicator. Holds the connected controller's
-    # name (shown as a tooltip) or "" when disconnected. The joystick icon is
-    # always visible: green while this is non-empty, grayed out otherwise.
-    # Driven by the gamepad service on controller connect/disconnect.
-    gamepad_status = Str()
-
-    # Guards attach_gamepad_indicator against double-adding the widget.
-    _gamepad_attached = Bool(False)
-
     # ------------------------------------------------------------------------
     # 'StatusBarManager' interface.
     # ------------------------------------------------------------------------
@@ -109,22 +79,6 @@ class StatusBarManager(_StatusBarManager):
             self.center_label.setOpenExternalLinks(True)
             self.center_label.setAlignment(Qt.AlignCenter)
             self.status_bar.addWidget(self.center_label, 1)
-
-            # Gamepad connection indicator: the Material "joystick" icon,
-            # rendered in the icon font. Always visible — the same green as the
-            # other status bar icons while a controller is connected, grayed out
-            # when none is. The controller name (or "Gamepad disconnected") is
-            # exposed as the tooltip. Color/tooltip are driven by
-            # ``gamepad_status`` (see _gamepad_status_updated).
-            #
-            # Created here but NOT added to the bar yet — the owner calls
-            # attach_gamepad_indicator() after every other plugin has added its
-            # icons, so the joystick can be inserted as the outermost-LEFT icon.
-            self.gamepad_label = QLabel(ICON_JOYSTICK)
-            _gp_font = QFont(ICON_FONT_FAMILY)
-            _gp_font.setPointSize(STATUSBAR_ICON_POINT_SIZE)
-            self.gamepad_label.setFont(_gp_font)
-            self._apply_gamepad_label_state()
 
         # initial values
         if len(self.messages) > 1:
@@ -156,54 +110,10 @@ class StatusBarManager(_StatusBarManager):
 
         self.messages = [msg for msg in self.messages if msg != message]
 
-    def attach_gamepad_indicator(self):
-        """Place the joystick as the outermost-LEFT status-bar icon.
-
-        Call this *after* every other plugin has added its status-bar icons
-        (defer it), so inserting at the first permanent slot pushes the joystick
-        to the left of them all. Insert the icon, then a leading spacer, both at
-        the first permanent index — giving [spacer][joystick][microdrop_status_bar
-        icon container].
-        Idempotent.
-        """
-        if self.status_bar is None or getattr(self, "gamepad_label", None) is None:
-            return
-        if self._gamepad_attached:
-            return
-        self._gamepad_attached = True
-        self.status_bar.insertPermanentWidget(STATUSBAR_FIRST_PERMANENT_INDEX, self.gamepad_label)
-        self.status_bar.insertPermanentWidget(
-            STATUSBAR_FIRST_PERMANENT_INDEX, horizontal_spacer_widget(STATUSBAR_ICON_SPACING)
-        )
-
     @observe("center_message")
     def _center_message_updated(self, event):
         if getattr(self, "center_label", None) is not None:
             self.center_label.setText(self.center_message)
-
-    @observe("gamepad_status")
-    def _gamepad_status_updated(self, event):
-        self._apply_gamepad_label_state()
-
-    def _apply_gamepad_label_state(self):
-        """Color/tooltip the always-visible joystick icon from ``gamepad_status``.
-
-        Connected (non-empty status): green, tooltip = controller name.
-        Disconnected (empty status): grayed out, tooltip = "Gamepad disconnected".
-
-        Mirrors the realtime/ladder icons' active/inactive scheme exactly
-        (SUCCESS_COLOR when active, GREY["lighter"] when not) — that light gray
-        is theme-independent and reads correctly on both status-bar backgrounds,
-        so the joystick matches its neighbours in either theme.
-        """
-        label = getattr(self, "gamepad_label", None)
-        if label is None:
-            return
-        name = self.gamepad_status or ""
-        connected = bool(name)
-        color = SUCCESS_COLOR if connected else GREY["lighter"]
-        label.setStyleSheet(f"color: {color};")
-        label.setToolTip(name if connected else "Gamepad disconnected")
 
     def show_center_message(self, html: str, timeout: int = 5000):
         """Show ``html`` in the centered status bar label and auto-clear after ``timeout`` ms.

--- a/microdrop_utils/pyface_helpers.py
+++ b/microdrop_utils/pyface_helpers.py
@@ -25,8 +25,8 @@ from microdrop_utils.pyside_helpers import horizontal_spacer_widget
 STATUSBAR_ICON_SPACING = 2
 
 #: First permanent-widget slot. Indices 0/1 are the non-permanent persistent and
-#: center labels, so permanent icons start at 2 (same convention as
-#: template_status_and_controls.base_dock_pane).
+#: center labels, so permanent icons start at 2. Inserting here lands LEFT of
+#: the microdrop_status_bar icon container, which is appended at the right end.
 STATUSBAR_FIRST_PERMANENT_INDEX = 2
 
 from logger.logger_service import get_logger
@@ -161,10 +161,9 @@ class StatusBarManager(_StatusBarManager):
 
         Call this *after* every other plugin has added its status-bar icons
         (defer it), so inserting at the first permanent slot pushes the joystick
-        to the left of them all. Mirrors the icon+spacer pattern used by
-        template_status_and_controls so spacing stays uniform: insert the icon,
-        then a leading spacer, both at the first permanent index — giving
-        [spacer][joystick][…other icons, each with their own leading spacer].
+        to the left of them all. Insert the icon, then a leading spacer, both at
+        the first permanent index — giving [spacer][joystick][microdrop_status_bar
+        icon container].
         Idempotent.
         """
         if self.status_bar is None or getattr(self, "gamepad_label", None) is None:

--- a/microdrop_utils/tasks_runtime_helpers.py
+++ b/microdrop_utils/tasks_runtime_helpers.py
@@ -138,4 +138,4 @@ def rebuild_menu_bar_live(window, task, application):
             logger.exception(
                 "rebuild_menu_bar_live: failed to destroy old menu bar manager"
             )
-    logger.info("rebuild_menu_bar_live: menu bar rebuilt")
+    logger.debug("rebuild_menu_bar_live: menu bar rebuilt")

--- a/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
+++ b/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
@@ -1,6 +1,6 @@
 import json
 
-from traits.api import provides, HasTraits, Bool, Instance, Str, List, observe
+from traits.api import provides, HasTraits, Bool, Instance, Str, List, observe, Event
 from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_SCHEDULER_SHUTDOWN
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -38,7 +38,7 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
 
     _default_hwids = List(Str)
     _error_shown = Bool(False)  # Track if we've shown the error for current disconnection
-    _searching = Bool(False)    # Is the monitor thread actively scanning right now?
+    _searching = Event(desc="Is the monitor thread actively scanning right now?")
 
     @observe("_searching")
     def _searching_changed(self, event):

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -360,7 +360,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
         # grid entries and push any persisted ack waits into them.
         self.preferences.seed_ack_times_from_columns(self.columns)
         self._sync_handler_ack_times()
-        logger.info(
+        logger.debug(
             f"protocol columns rebuilt: +{sorted(added)} -{sorted(removed)}"
         )
 

--- a/template_status_and_controls/base_dock_pane.py
+++ b/template_status_and_controls/base_dock_pane.py
@@ -24,10 +24,9 @@ from microdrop_style.fonts.fontnames import ICON_FONT_FAMILY
 from microdrop_style.colors import WHITE, GREY
 from microdrop_style.helpers import is_dark_mode
 from microdrop_style.icon_styles import STATUSBAR_ICON_POINT_SIZE
-from microdrop_utils.pyside_helpers import horizontal_spacer_widget
 from pyface.tasks.api import TraitsDockPane
 from pyface.qt.QtGui import QApplication, QLabel, QFont
-from traits.api import Any, Instance, List, observe
+from traits.api import Any, Instance, List, Str, observe
 from traitsui.api import Handler
 
 from logger.logger_service import get_logger
@@ -35,12 +34,6 @@ from logger.logger_service import get_logger
 from .interfaces import IMessageHandler
 
 logger = get_logger(__name__)
-
-#: Position in the status bar at which every pane widget is inserted.
-STATUS_BAR_INSERT_INDEX = 2
-
-#: Width (px) of the spacer inserted alongside each status-bar widget.
-STATUS_BAR_SPACER_WIDTH = 10
 
 
 def status_bar_icon_font() -> QFont:
@@ -118,10 +111,22 @@ class BaseStatusDockPane(TraitsDockPane):
     #: Status-bar icon widget (built once the window's status bar appears).
     status_bar_icon = Any(None)
 
-    #: Every widget this pane inserted into the status bar (icons AND their
-    #: spacers), tracked so destroy() can remove exactly what was added —
-    #: required for runtime hot unload of the pane.
-    _status_bar_inserted_widgets = List()
+    #: Id of the Envisage plugin whose ``status_bar_icons`` contribution
+    #: list this pane extends; "<pkg>.dock_pane" → "<pkg>.plugin" by
+    #: convention (override for panes that don't follow it).
+    status_bar_plugin_id = Str()
+
+    #: The contribution plugin resolved at populate time, cached so
+    #: teardown can withdraw contributions without touching the window.
+    _contribution_plugin = Any(None)
+
+    #: Widgets this pane contributed to the status bar, tracked so
+    #: teardown withdraws exactly what was added — required for runtime
+    #: hot unload of the pane.
+    _contributed_status_bar_widgets = List()
+
+    def _status_bar_plugin_id_default(self):
+        return self.id.rsplit(".", 1)[0] + ".plugin"
 
     # ------------------------------------------------------------------ #
     # Lifecycle                                                             #
@@ -166,24 +171,26 @@ class BaseStatusDockPane(TraitsDockPane):
         super().destroy()
 
     def _teardown_status_bar(self):
-        """Remove this pane's status-bar widgets and signal hookups."""
-        if self._status_bar_inserted_widgets:
+        """Withdraw this pane's status-bar contributions and signal hookups.
+
+        Removing the widgets from the plugin's contribution list fires the
+        extension-point event that makes the status-bar plugin take them
+        out of the bar and delete them. Idempotent: widgets already gone
+        from the list (e.g. the plugin was hot-unloaded first) are skipped.
+        """
+        if self._contributed_status_bar_widgets:
             try:
                 QApplication.styleHints().colorSchemeChanged.disconnect(
                     self._refresh_status_bar_tooltip
                 )
             except (RuntimeError, TypeError):
                 pass                    # never connected / already gone
-            try:
-                status_bar = self.task.window.status_bar_manager.status_bar
-            except Exception as e:      # window already torn down (app exit)
-                logger.debug(f"Status bar gone before pane teardown: {e}")
-                status_bar = None
-            for widget in self._status_bar_inserted_widgets:
-                if status_bar is not None:
-                    status_bar.removeWidget(widget)
-                widget.deleteLater()
-            self._status_bar_inserted_widgets = []
+            contributed = self._contribution_plugin.status_bar_icons
+            for widget in self._contributed_status_bar_widgets:
+                if widget in contributed:
+                    contributed.remove(widget)
+            self._contributed_status_bar_widgets = []
+            self._contribution_plugin = None
         self.status_bar_icon = None
 
     # ------------------------------------------------------------------ #
@@ -246,24 +253,32 @@ class BaseStatusDockPane(TraitsDockPane):
 
     @observe("task:window:status_bar_manager")
     def _populate_status_bar(self, event):
-        """Build the status-bar widgets and insert each (plus a spacer).
+        """Build the pane's status-bar widgets and contribute them to the
+        status-bar extension point — the microdrop_status_bar plugin owns
+        placement, spacing, and removal.
 
         Subclass overrides MUST re-apply the @observe decorator above —
         an undecorated override silently drops the observer registration."""
-        if self._status_bar_inserted_widgets:
+        if self._contributed_status_bar_widgets:
             return                      # already populated (observer + hot-mount)
+        plugin = self.task.window.application.get_plugin(
+            self.status_bar_plugin_id
+        )
+        if plugin is None:
+            logger.warning(
+                f"{self.id}: no plugin {self.status_bar_plugin_id!r} to carry "
+                f"status-bar contributions; status-bar icons not shown"
+            )
+            return
         self.status_bar_icon = self._create_status_bar_icon()
         self._refresh_status_bar_tooltip()
         QApplication.styleHints().colorSchemeChanged.connect(
             self._refresh_status_bar_tooltip
         )
-        status_bar = self.task.window.status_bar_manager.status_bar
-        for widget in self._create_status_bar_widgets():
-            spacer = horizontal_spacer_widget(STATUS_BAR_SPACER_WIDTH)
-            status_bar.insertPermanentWidget(STATUS_BAR_INSERT_INDEX, widget)
-            status_bar.insertPermanentWidget(STATUS_BAR_INSERT_INDEX, spacer)
-            # Track both so destroy() removes exactly what this pane added.
-            self._status_bar_inserted_widgets.extend([widget, spacer])
+        widgets = self._create_status_bar_widgets()
+        self._contribution_plugin = plugin
+        self._contributed_status_bar_widgets = list(widgets)
+        plugin.status_bar_icons.extend(widgets)
 
     def _create_status_bar_icon(self):
         """

--- a/template_status_and_controls/base_plugin.py
+++ b/template_status_and_controls/base_plugin.py
@@ -4,6 +4,7 @@ BaseStatusPlugin — Envisage plugin wiring for device status-and-controls panel
 Every device panel plugin needs the same Envisage boilerplate:
   - contributed_task_extensions  (dock pane + optional menu items)
   - actor_topic_routing          (Dramatiq topic subscriptions)
+  - status_bar_icons             (runtime status-bar icon contributions)
 
 Subclasses provide the device-specific pieces through factory methods,
 keeping the Envisage machinery out of each device module.
@@ -22,6 +23,7 @@ from envisage.ui.tasks.api import TaskExtension
 
 from microdrop_application.consts import PKG as microdrop_application_PKG
 from message_router.consts import ACTOR_TOPIC_ROUTES
+from microdrop_status_bar.consts import STATUS_BAR_ICONS
 
 from logger.logger_service import get_logger
 
@@ -69,6 +71,10 @@ class BaseStatusPlugin(Plugin):
 
     contributed_task_extensions = List(contributes_to=TASK_EXTENSIONS)
     actor_topic_routing = List(contributes_to=ACTOR_TOPIC_ROUTES)
+    #: Status-bar widgets contributed at runtime: BaseStatusDockPane
+    #: extends this list when it populates the bar; the
+    #: microdrop_status_bar plugin places, spaces, and removes them.
+    status_bar_icons = List(contributes_to=STATUS_BAR_ICONS)
 
     # ------------------------------------------------------------------ #
     # Trait defaults                                                        #


### PR DESCRIPTION
## Summary

All status-bar icons are now Envisage extension-point contributions managed by one central plugin — zero `insertPermanentWidget` calls outside `microdrop_status_bar`.

- **New `microdrop_status_bar` plugin**: declares the `status_bar_icons` extension point, creates the window's `StatusBarManager` (moved out of `MicrodropTask.activated()`; built at `application_initialized` — see below), and places contributed widgets in a single container whose `QHBoxLayout` gives every icon the same gap, no spacer widgets anywhere. Dynamic contribution handling mirrors `MessageRouterPlugin` (`connect_extension_point_traits()` + `_items` delta events).
- **Priority ordering**: contributors may set `widget.status_bar_icon_priority` (int, default 0); the container stays sorted by `(priority, arrival)` — lower = further left (`ICON_PRIORITY_DEFAULT/LEFT/LEFTMOST`).
- **`BaseStatusPlugin`** declares `status_bar_icons = List(contributes_to=...)` once — all five device plugins (dropbot, opendrop, mock, heater, magnet) inherit it with zero per-device changes.
- **`BaseStatusDockPane`** builds its widgets as before but contributes them by extending its plugin's list (plugin id derived from pane id); teardown withdraws them. Deleted: `STATUS_BAR_INSERT_INDEX`, `STATUS_BAR_SPACER_WIDTH`, per-pane spacer manufacture and `_status_bar_inserted_widgets` bookkeeping.
- **Joystick + recording icons migrated too**: `device_viewer` creates and contributes both (joystick `LEFTMOST`, recording `LEFT`); the gamepad service colors its own icon via `svc.gamepad_icon`. `StatusBarManager` loses all gamepad code (-91 lines) and the `attach_gamepad_indicator` deferred-`singleShot` ordering hack.
- **Hot load/unload**: pane teardown and plugin-removal events are overlapping, idempotent cleanup paths — the bar stays correct in either order.

**Lifecycle note**: the status bar is built at `application:application_initialized`, NOT `active_window` — `active_window` fires mid `window.open()` before pane contents exist, and pyface's task-activation sweep then overwrites `window.status_bar_manager` with `task.status_bar` (None). The legacy `task.activated()` placement was load-bearing; this is now documented in the spec and plugin docstring.

Spec: `docs/superpowers/specs/2026-07-03-status-bar-extension-point-design.md`
Plan: `docs/superpowers/plans/2026-07-03-status-bar-extension-point.md`

## Test plan (manual)

- [ ] Launch app — order left→right: joystick → device icon(s) → realtime toggle, uniform spacing, "Free Mode" left
- [ ] Tooltips render; theme switch follows
- [ ] Gamepad connect/disconnect recolors joystick (controller name tooltip)
- [ ] Camera recording — icon pulses between joystick and device icons, hides on stop
- [ ] Tools → Peripherals: enable/disable magnet group — icon appears/disappears, spacing stays uniform
- [ ] Quit — no teardown errors in log

🤖 Generated with [Claude Code](https://claude.com/claude-code)