### PR TITLE
ci: commitizen versioning + conventional-commit PR check

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,6 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+version_provider = "scm"
+tag_format = "v$version"
+bump_message = "chore: release v$new_version"
+update_changelog_on_bump = true

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,24 @@
+name: Conventional commits
+
+# Every PR commit must follow Conventional Commits (feat/fix/refactor/...),
+# so releases can be derived from history: `cz bump` (see .cz.toml) computes
+# the version bump and CHANGELOG.md from these messages. cz check's default
+# allowed prefixes (Merge, Revert, fixup!, squash!) are permitted.
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # cz check walks the PR's commit range
+
+      - name: Install commitizen
+        run: pipx install "commitizen>=4,<5"
+
+      - name: Check PR commit messages
+        run: cz check --rev-range "origin/${{ github.base_ref }}..HEAD"

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -65,8 +65,13 @@ with proxy.transaction_lock:
 
 ## Git & PR Workflow
 - Commit early, commit frequently — make multiple small, incremental commits for each iterative change (e.g., add constant, then add listener, then add dialog, then wire it up). Each commit should have a clear, descriptive message.
+- Commit messages MUST follow Conventional Commits (a CI check enforces this on PRs): `type(scope): subject` with types `feat` / `fix` / `refactor` / `perf` / `docs` / `ci` / `chore` / `test`; append `!` or a `BREAKING CHANGE:` footer for breaking changes. These messages drive versioning and CHANGELOG.md generation (commitizen).
 - Always create a new branch for resolving issues (never commit directly to main/master)
 - Always submit a PR for reviewing changes after pushing the branch
+
+## Releases & changelogs
+- **This repo (the app)**: version = git tags (`.cz.toml`, `version_provider = "scm"`). Cut a release from an up-to-date `main`: `pixi exec --spec "commitizen>=4,<5" -- cz bump` (derives the bump from conventional commits since the last `v*` tag, updates CHANGELOG.md, tags `vX.Y.Z`), then `git push origin main --follow-tags` (requires branch-protection bypass, i.e. an admin).
+- **heater/magnet plugin repos**: releases are fully automatic — every push to `main` with release-worthy conventional commits bumps, updates CHANGELOG.md, publishes the conda package to `prefix.dev/microdrop-plugins`, and tags. Non-release commits (docs/ci/chore/non-conventional) skip publishing.
 
 ## Presentation (`microdrop-architecture.html`)
 - Self-contained HTML presentation about MicroDrop architecture and DropBot hardware communication


### PR DESCRIPTION
## Summary

Third leg of the commitizen rollout (heater + magnet plugin repos already done):

- `.cz.toml`: version derives from git tags (`version_provider = "scm"` — this repo has no package metadata to stamp), `tag_format v$version`, changelog maintained on bump. Baseline tag `v1.0.0` pushed on current main.
- **Conventional-commits PR check**: `cz check` over each PR's commit range — commit messages now drive versioning and CHANGELOG.md, so they're enforced (Merge/Revert/fixup! prefixes allowed).
- `CLAUDE.md`: documents the commit convention and both release flows (this repo: manual `cz bump` + push by an admin, since main is PR-protected; plugin repos: fully automatic on push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)