### PR TITLE
feat(device-viewer): flatten curved SVG path segments

### DIFF
--- a/device_viewer/tests/test_dmf_path_parsing.py
+++ b/device_viewer/tests/test_dmf_path_parsing.py
@@ -1,0 +1,50 @@
+"""SVG path flattening in SVGProcessor._parse_path_string.
+
+Curved segments (arcs, Béziers) are sampled into polygon vertices so
+circular electrodes/markers (Inkscape encodes a circle as two Arc
+segments) yield real shapely geometry. Straight-command paths keep their
+exact endpoint-only behavior.
+"""
+import numpy as np
+import pytest
+from shapely.geometry import Polygon
+
+from device_viewer.utils.dmf_utils_helpers import (
+    CURVE_SEGMENT_SAMPLES, SVGProcessor,
+)
+
+# A real Inkscape circle path (r = 2.238187) that previously parsed to three
+# nearly-collinear points — a degenerate, zero-area polygon.
+CIRCLE_D = ("m 519.5488,1056.6446 "
+            "a 2.238187,2.238187 0 0 1 -4.38913,-0.6729 "
+            "2.238187,2.238187 0 1 1 4.38913,0.6729")
+CIRCLE_RADIUS = 2.238187
+
+
+def test_circle_path_flattens_to_polygon():
+    points = SVGProcessor._parse_path_string(CIRCLE_D)
+    # 1 move endpoint + 2 sampled arcs
+    assert len(points) == 1 + 2 * CURVE_SEGMENT_SAMPLES
+
+    polygon = Polygon(points)
+    expected_area = np.pi * CIRCLE_RADIUS ** 2
+    assert polygon.is_valid
+    assert polygon.area == pytest.approx(expected_area, rel=0.01)
+
+    # Every vertex sits on the circle (measure from the shapely centroid,
+    # which is unbiased by the arcs' unequal sampling density).
+    center = np.array(polygon.centroid.coords[0])
+    radii = np.linalg.norm(points - center, axis=1)
+    assert radii == pytest.approx(CIRCLE_RADIUS, rel=0.01)
+
+
+def test_straight_command_paths_keep_endpoint_behavior():
+    points = SVGProcessor._parse_path_string("M 0,0 H 10 V 5 H 0 Z")
+    assert len(points) == 5                     # M + H + V + H + Z endpoints
+    assert Polygon(points).area == 50.0
+
+
+def test_bezier_segments_are_sampled():
+    points = SVGProcessor._parse_path_string("M 0,0 C 0,10 10,10 10,0 Z")
+    assert len(points) == 1 + CURVE_SEGMENT_SAMPLES + 1
+    assert Polygon(points).area > 0

--- a/device_viewer/utils/dmf_utils_helpers.py
+++ b/device_viewer/utils/dmf_utils_helpers.py
@@ -9,13 +9,18 @@ from collections import defaultdict
 from typing import List, Dict, Set, Union
 from traits.api import HasTraits, Instance, Array
 
-from svg.path import parse_path
+from svg.path import parse_path, Arc, CubicBezier, QuadraticBezier
 
 from logger.logger_service import get_logger
 from microdrop_application.dialogs.pyface_wrapper import error
 from microdrop_utils.shapely_helpers import sort_polygon_indices_along_line, draw_polygons_and_line
 
 logger = get_logger(__name__, "DEBUG")
+
+#: Vertices sampled along each curved path segment (arcs, Béziers) when a
+#: path is flattened to a polygon; 24/segment keeps an Inkscape circle
+#: (two Arc segments) within ~0.2% radial error of the true curve.
+CURVE_SEGMENT_SAMPLES = 24
 
 DPI = 96
 INCH_TO_MM = 25.4
@@ -357,6 +362,13 @@ class SVGProcessor:
         Robustly parses an SVG path 'd' string into an array of vertex
         coordinates using the original SVG coordinate system.
 
+        Straight segments (Move/Line/Close) contribute their endpoint.
+        Curved segments (Arc, cubic/quadratic Bézier) are flattened by
+        sampling CURVE_SEGMENT_SAMPLES points along the curve, so shapes
+        like Inkscape circles (encoded as two Arc segments) become regular
+        polygons instead of degenerate endpoint pairs — downstream shapely
+        Polygons then get real areas/centroids/neighbours for them.
+
         Args:
             d_string: The string from the 'd' attribute of an SVG path.
 
@@ -366,10 +378,16 @@ class SVGProcessor:
         path = parse_path(d_string)
         points = []
         for segment in path:
-            # The endpoint attribute is a complex number (x + yj)
-            end_point = segment.end
-            # Extract real (x) and imag (y) parts directly without flipping
-            points.append((end_point.real, end_point.imag))
+            if isinstance(segment, (Arc, CubicBezier, QuadraticBezier)):
+                # t=0 is the previous segment's end (already appended);
+                # sample up to and including this segment's own end.
+                for i in range(1, CURVE_SEGMENT_SAMPLES + 1):
+                    point = segment.point(i / CURVE_SEGMENT_SAMPLES)
+                    points.append((point.real, point.imag))
+            else:
+                # The endpoint attribute is a complex number (x + yj)
+                end_point = segment.end
+                points.append((end_point.real, end_point.imag))
         return np.array(points)
 
     def _update_bounding_box(self, points_list: List[np.ndarray]):

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -159,7 +159,7 @@ All inter-plugin communication goes through a pub/sub message router — plugins
 
 ### SVG Device Handling
 
-Electrode layouts are defined in SVG files. Metadata is parsed from SVG path elements (`data-channels` attribute). Centers are computed from path vertices and neighbors from distance calculations. Only simple path commands (M, H, V, Z) are supported — no curves. See `device_viewer/utils/dmf_utils.py`.
+Electrode layouts are defined in SVG files. Metadata is parsed from SVG path elements (`data-channels` attribute). Centers are computed from path vertices and neighbors from distance calculations. Straight path commands (M, L, H, V, Z) contribute endpoints; curved segments (arcs, Béziers — e.g. Inkscape circles) are flattened into polygon vertices by sampling (CURVE_SEGMENT_SAMPLES per segment). See `device_viewer/utils/dmf_utils.py`.
 
 ## Coding Conventions
 


### PR DESCRIPTION
## Summary

`SVGProcessor._parse_path_string` only extracted segment **endpoints**, so an Inkscape circle (encoded as two `a` arc segments) parsed to three nearly-collinear points — a degenerate, zero-area polygon that breaks the shapely-based areas/centroids/neighbour detection downstream.

- Curved segments (`Arc`, `CubicBezier`, `QuadraticBezier`) are now flattened by sampling `CURVE_SEGMENT_SAMPLES` (24) points along `segment.point(t)` — the circle becomes a 49-vertex polygon with area within 0.3% of `πr²`, every vertex on the true curve.
- Straight commands (M, L, H, V, Z) keep exact endpoint-only behavior (regression-tested).
- Downstream needs no changes: `svg_to_electrodes`/bounding box/shapely `Polygon` handling are vertex-count agnostic; `extract_connections` uses only endpoints by design.
- Tests in `device_viewer/tests/test_dmf_path_parsing.py` use the real circle path string from the reporting session; docs updated (the 'no curves' limitation is gone).

## Test plan
- [ ] Load a device SVG containing circular paths — circles render as circles, get valid areas/centroids, and participate in neighbour detection
- [ ] Existing rectangular devices render identically (straight-command parsing unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)