### PR TITLE
fix(device-viewer): repair self-intersecting electrode rings

### DIFF
--- a/device_viewer/tests/test_dmf_path_parsing.py
+++ b/device_viewer/tests/test_dmf_path_parsing.py
@@ -48,3 +48,50 @@ def test_bezier_segments_are_sampled():
     points = SVGProcessor._parse_path_string("M 0,0 C 0,10 10,10 10,0 Z")
     assert len(points) == 1 + CURVE_SEGMENT_SAMPLES + 1
     assert Polygon(points).area > 0
+
+# A notched electrode mixing arcs with h/v runs (real Inkscape output). Its
+# final arc lands on the FIRST arc's endpoint rather than the path start, so
+# the raw flattened ring self-intersects near the seam — SVG's fill rule
+# tolerates that; shapely needs the buffer(0) repair applied in
+# SvgUtil.get_electrode_polygons.
+NOTCHED_D = ("m 484.35753,1040.403 "
+             "a 2.427163,2.427163 0 0 0 1.86089,1.7124 "
+             "v 1.3988 h -1.72913 -1.95591 v -2.0944 h -1.51181 "
+             "v -3.4898 h 1.51181 v -1.9749 h 3.68504 v 1.3988 "
+             "a 2.427163,2.427163 0 0 0 0,4.7615")
+
+
+def test_mixed_arc_and_straight_path_flattens():
+    from svg.path import parse_path, Arc
+
+    points = SVGProcessor._parse_path_string(NOTCHED_D)
+    segments = list(parse_path(NOTCHED_D))
+    arcs = [s for s in segments if isinstance(s, Arc)]
+    straights = [s for s in segments if not isinstance(s, Arc)]
+    assert len(arcs) == 2 and len(straights) == 11
+    assert len(points) == len(straights) + len(arcs) * CURVE_SEGMENT_SAMPLES
+
+    # Straight endpoints are preserved verbatim among the vertices.
+    for segment in straights:
+        end = (segment.end.real, segment.end.imag)
+        assert any(np.allclose(p, end) for p in points)
+
+    # Every sampled arc vertex lies on its arc's own circle (svg.path
+    # exposes the analytic center/radius — no magic numbers needed).
+    for arc in arcs:
+        center = np.array([arc.center.real, arc.center.imag])
+        for i in range(1, CURVE_SEGMENT_SAMPLES + 1):
+            p = arc.point(i / CURVE_SEGMENT_SAMPLES)
+            radius = np.linalg.norm(np.array([p.real, p.imag]) - center)
+            assert radius == pytest.approx(arc.radius.real, rel=1e-6)
+
+
+def test_self_intersecting_ring_is_repaired_like_downstream():
+    points = SVGProcessor._parse_path_string(NOTCHED_D)
+    raw = Polygon(points)
+    assert not raw.is_valid            # overlapping arc traversals at the seam
+
+    repaired = raw.buffer(0)           # what get_electrode_polygons applies
+    assert repaired.geom_type == "Polygon"
+    assert repaired.is_valid
+    assert repaired.area == pytest.approx(26.17, rel=0.01)

--- a/device_viewer/tests/test_dmf_path_parsing.py
+++ b/device_viewer/tests/test_dmf_path_parsing.py
@@ -52,8 +52,8 @@ def test_bezier_segments_are_sampled():
 # A notched electrode mixing arcs with h/v runs (real Inkscape output). Its
 # final arc lands on the FIRST arc's endpoint rather than the path start, so
 # the raw flattened ring self-intersects near the seam — SVG's fill rule
-# tolerates that; shapely needs the buffer(0) repair applied in
-# SvgUtil.get_electrode_polygons.
+# tolerates that; shapely needs the as_valid_polygon repair,
+# applied once at the source (svg_to_electrodes).
 NOTCHED_D = ("m 484.35753,1040.403 "
              "a 2.427163,2.427163 0 0 0 1.86089,1.7124 "
              "v 1.3988 h -1.72913 -1.95591 v -2.0944 h -1.51181 "
@@ -93,7 +93,7 @@ def test_self_intersecting_ring_is_repaired():
     raw = Polygon(points)
     assert not raw.is_valid            # overlapping arc traversals at the seam
 
-    repaired = as_valid_polygon(raw)   # what get_electrode_polygons applies
+    repaired = as_valid_polygon(raw)   # what svg_to_electrodes applies
     assert repaired.geom_type == "Polygon"
     assert repaired.is_valid
     assert repaired.area == pytest.approx(26.17, rel=0.01)

--- a/device_viewer/tests/test_dmf_path_parsing.py
+++ b/device_viewer/tests/test_dmf_path_parsing.py
@@ -86,12 +86,37 @@ def test_mixed_arc_and_straight_path_flattens():
             assert radius == pytest.approx(arc.radius.real, rel=1e-6)
 
 
-def test_self_intersecting_ring_is_repaired_like_downstream():
+def test_self_intersecting_ring_is_repaired():
+    from device_viewer.utils.dmf_utils_helpers import as_valid_polygon
+
     points = SVGProcessor._parse_path_string(NOTCHED_D)
     raw = Polygon(points)
     assert not raw.is_valid            # overlapping arc traversals at the seam
 
-    repaired = raw.buffer(0)           # what get_electrode_polygons applies
+    repaired = as_valid_polygon(raw)   # what get_electrode_polygons applies
     assert repaired.geom_type == "Polygon"
     assert repaired.is_valid
     assert repaired.area == pytest.approx(26.17, rel=0.01)
+
+
+def test_multi_lobe_repair_keeps_largest_lobe():
+    from device_viewer.utils.dmf_utils_helpers import as_valid_polygon
+
+    # A ring pinched at the origin: buffer(0) splits it into two lobes
+    # (areas 1 and 4); real device SVGs produce such shapes and the
+    # SvgUtil.polygons trait requires a single Polygon per electrode.
+    pinched = Polygon([(0, 0), (1, 0), (1, 1), (0, 1),
+                       (0, 0), (-2, 0), (-2, -2), (0, -2)])
+    assert pinched.buffer(0).geom_type == "MultiPolygon"
+
+    repaired = as_valid_polygon(pinched)
+    assert repaired.geom_type == "Polygon"
+    assert repaired.is_valid
+    assert repaired.area == 4.0        # dominant lobe wins
+
+
+def test_valid_polygon_passes_through_untouched():
+    from device_viewer.utils.dmf_utils_helpers import as_valid_polygon
+
+    square = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
+    assert as_valid_polygon(square) is square

--- a/device_viewer/utils/dmf_utils.py
+++ b/device_viewer/utils/dmf_utils.py
@@ -7,7 +7,7 @@ from shapely.geometry import Polygon, MultiPolygon
 from traits.api import HasTraits, Float, Dict, Str, Bool, File, observe, List, Instance, Tuple, Property, cached_property
 
 from device_viewer.utils.dmf_utils_helpers import PolygonNeighborFinder, create_adjacency_dict, ElectrodeData, \
-    SVGProcessor, AlgorithmError, as_valid_polygon
+    SVGProcessor, AlgorithmError
 
 from logger.logger_service import get_logger
 logger = get_logger(__name__, "DEBUG")
@@ -125,7 +125,10 @@ class SvgUtil(HasTraits):
         for k, v in list(self.electrodes.items()):
             try:
                 coords = v.path.reshape(-1, 2)
-                polygons[k] = as_valid_polygon(Polygon(coords))
+                # Rings are repaired once, at the source (svg_to_electrodes
+                # stores the as_valid_polygon exterior), so construction
+                # here is plain — no per-call validity rescan.
+                polygons[k] = Polygon(coords)
             except Exception as e:
                 logger.error(f"Failed to create polygon for '{k}': {e}")
                 errors_found.append(k)

--- a/device_viewer/utils/dmf_utils.py
+++ b/device_viewer/utils/dmf_utils.py
@@ -125,7 +125,14 @@ class SvgUtil(HasTraits):
         for k, v in list(self.electrodes.items()):
             try:
                 coords = v.path.reshape(-1, 2)
-                polygons[k] = Polygon(coords)
+                polygon = Polygon(coords)
+                if not polygon.is_valid:
+                    # Self-intersecting ring (e.g. an Inkscape path whose arc
+                    # traversals overlap at the seam): SVG's fill rule renders
+                    # these fine, but shapely ops (area/centroid/STRtree) need
+                    # a valid ring — buffer(0) rebuilds one.
+                    polygon = polygon.buffer(0)
+                polygons[k] = polygon
             except Exception as e:
                 logger.error(f"Failed to create polygon for '{k}': {e}")
                 errors_found.append(k)

--- a/device_viewer/utils/dmf_utils.py
+++ b/device_viewer/utils/dmf_utils.py
@@ -2,12 +2,12 @@
 import re
 import numpy as np
 import xml.etree.ElementTree as ET
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, MultiPolygon
 
 from traits.api import HasTraits, Float, Dict, Str, Bool, File, observe, List, Instance, Tuple, Property, cached_property
 
 from device_viewer.utils.dmf_utils_helpers import PolygonNeighborFinder, create_adjacency_dict, ElectrodeData, \
-    SVGProcessor, AlgorithmError
+    SVGProcessor, AlgorithmError, as_valid_polygon
 
 from logger.logger_service import get_logger
 logger = get_logger(__name__, "DEBUG")
@@ -125,14 +125,7 @@ class SvgUtil(HasTraits):
         for k, v in list(self.electrodes.items()):
             try:
                 coords = v.path.reshape(-1, 2)
-                polygon = Polygon(coords)
-                if not polygon.is_valid:
-                    # Self-intersecting ring (e.g. an Inkscape path whose arc
-                    # traversals overlap at the seam): SVG's fill rule renders
-                    # these fine, but shapely ops (area/centroid/STRtree) need
-                    # a valid ring — buffer(0) rebuilds one.
-                    polygon = polygon.buffer(0)
-                polygons[k] = polygon
+                polygons[k] = as_valid_polygon(Polygon(coords))
             except Exception as e:
                 logger.error(f"Failed to create polygon for '{k}': {e}")
                 errors_found.append(k)

--- a/device_viewer/utils/dmf_utils_helpers.py
+++ b/device_viewer/utils/dmf_utils_helpers.py
@@ -15,7 +15,7 @@ from logger.logger_service import get_logger
 from microdrop_application.dialogs.pyface_wrapper import error
 from microdrop_utils.shapely_helpers import sort_polygon_indices_along_line, draw_polygons_and_line
 
-logger = get_logger(__name__, "DEBUG")
+logger = get_logger(__name__)
 
 #: Vertices sampled along each curved path segment (arcs, Béziers) when a
 #: path is flattened to a polygon; 24/segment keeps an Inkscape circle
@@ -95,7 +95,7 @@ def as_valid_polygon(polygon: Polygon) -> Polygon:
         largest = max(repaired.geoms, key=lambda g: g.area)
         dropped = repaired.area - largest.area
         if dropped > 0:
-            logger.debug(
+            logger.info(
                 f"Self-intersection repair dropped {dropped:.4f} area units "
                 f"({dropped / repaired.area:.1%}) of sliver lobes")
         repaired = largest
@@ -453,6 +453,22 @@ class SVGProcessor:
             if d_string and element_id:
                 # Parse the path using the original coordinate system
                 path_points = self._parse_path_string(d_string)
+
+                # Repair self-intersecting rings AT THE SOURCE so the
+                # rendered electrode (ElectrodeView fills this path) and the
+                # geometry math (shapely polygons) agree on one shape. Left
+                # raw, Qt's default odd-even fill rule unfills the seam
+                # overlap — a visible notch the SVG's nonzero fill rule
+                # (Inkscape) never shows.
+                if len(path_points) >= 3:
+                    try:
+                        ring = Polygon(path_points)
+                        if not ring.is_valid:
+                            path_points = np.array(
+                                as_valid_polygon(ring).exterior.coords)
+                    except Exception as e:
+                        logger.warning(
+                            f"Could not validity-check path '{element_id}': {e}")
 
                 # Apply all transformations: translation and then scaling
                 transformed_path = self.unit_normalization_func(path_points + transform)

--- a/device_viewer/utils/dmf_utils_helpers.py
+++ b/device_viewer/utils/dmf_utils_helpers.py
@@ -79,6 +79,29 @@ _mm_converter_func_inverse = {
 }
 
 
+def as_valid_polygon(polygon: Polygon) -> Polygon:
+    """Return a valid single Polygon for ``polygon``.
+
+    Self-intersecting rings (Inkscape paths whose arc traversals overlap at
+    the seam) render fine under SVG's fill rule but break shapely ops.
+    ``buffer(0)`` rebuilds a valid geometry; when the crossing splits the
+    ring into several lobes (a MultiPolygon), the dominant lobe is the
+    electrode body — keep it and log the discarded sliver area.
+    """
+    if polygon.is_valid:
+        return polygon
+    repaired = polygon.buffer(0)
+    if repaired.geom_type == "MultiPolygon":
+        largest = max(repaired.geoms, key=lambda g: g.area)
+        dropped = repaired.area - largest.area
+        if dropped > 0:
+            logger.debug(
+                f"Self-intersection repair dropped {dropped:.4f} area units "
+                f"({dropped / repaired.area:.1%}) of sliver lobes")
+        repaired = largest
+    return repaired
+
+
 class AlgorithmError(Exception):
     """Raised when the algorithm fails to find a valid solution."""
     pass


### PR DESCRIPTION
Follow-ups to #501 (merged before these landed on the branch). Real Inkscape electrode paths can end on an earlier arc's endpoint instead of the path start, so the flattened ring self-intersects at the seam — SVG's nonzero fill rule renders that fine, but shapely rejects it and Qt's odd-even `QPainterPath` default *unfills* the overlap (the visible notch).

- `as_valid_polygon()`: `buffer(0)` repair; multi-lobe results (seen on a real device — the `SvgUtil.polygons` trait crashed on a MultiPolygon) reduce to the dominant lobe with the dropped sliver area logged.
- **Repair happens once, at the source**: `svg_to_electrodes` stores the repaired exterior, so ElectrodeView rendering and the areas/centroids/neighbour math share one shape — this is what removes the notch in the device viewer. `get_electrode_polygons` builds plain Polygons (later path mutations are affine and preserve validity), dropping a per-electrode `is_valid` rescan per rebuild.
- Tests: real notched-electrode d-string (straight endpoints verbatim, arc samples on the analytic circle), multi-lobe reduction, valid-passthrough identity.

Verified on `sdl_teardrop.svg`: 119/119 rings valid at source, polygons + neighbour detection intact, notch gone in the Qt render.

## Test plan
- [ ] Load sdl_teardrop — repaired electrodes render without the notch, match Inkscape
- [ ] Rectangular devices unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)