### PR TITLE
fix(device-viewer): channel labels on curved devices

### DIFF
--- a/device_viewer/tests/test_label_geometry.py
+++ b/device_viewer/tests/test_label_geometry.py
@@ -1,0 +1,59 @@
+"""Tests for label_geometry — the channel-label anchor/extent for a shape.
+
+Pure geometry (no QApplication needed): the pole-of-inaccessibility anchor
+must sit inside curved/concave electrodes where the bbox center falls
+outside, while plain rectangles keep the exact legacy anchor and font
+extent so standard devices render pixel-identically.
+"""
+import numpy as np
+from shapely.geometry import Point, Polygon
+
+from device_viewer.utils.dmf_utils_helpers import SVGProcessor, as_valid_polygon
+from device_viewer.views.electrode_view.electrode_view_helpers import label_geometry
+
+
+def test_rectangle_keeps_legacy_center_and_extent():
+    anchor_x, anchor_y, extent = label_geometry(
+        np.array([(0, 0), (10, 0), (10, 5), (0, 5)], dtype=float))
+    # bbox center and min side — the old _fit_text_in_path values verbatim,
+    # even though the pole of inaccessibility ties all along the center line
+    assert (anchor_x, anchor_y, extent) == (5.0, 2.5, 5.0)
+
+
+def test_l_shape_anchor_moves_inside():
+    l_shape = np.array([(0, 0), (10, 0), (10, 4), (4, 4), (4, 10), (0, 10)],
+                       dtype=float)
+    polygon = Polygon(l_shape)
+    assert not polygon.contains(Point(5, 5))     # bbox center is in the notch
+
+    anchor_x, anchor_y, extent = label_geometry(l_shape)
+    assert polygon.contains(Point(anchor_x, anchor_y))
+    # extent is the inscribed diameter around the anchor, so a square of
+    # that clearance fits fully inside the shape
+    assert 0 < extent <= 4 * 2
+
+
+# The real notched Inkscape electrode from test_dmf_path_parsing.
+NOTCHED_D = ("m 484.35753,1040.403 "
+             "a 2.427163,2.427163 0 0 0 1.86089,1.7124 "
+             "v 1.3988 h -1.72913 -1.95591 v -2.0944 h -1.51181 "
+             "v -3.4898 h 1.51181 v -1.9749 h 3.68504 v 1.3988 "
+             "a 2.427163,2.427163 0 0 0 0,4.7615")
+
+
+def test_curved_electrode_anchor_inside_with_room():
+    points = np.array(SVGProcessor._parse_path_string(NOTCHED_D))
+    repaired = as_valid_polygon(Polygon(points))
+    coords = np.array(repaired.exterior.coords)
+
+    anchor_x, anchor_y, extent = label_geometry(coords)
+    assert repaired.contains(Point(anchor_x, anchor_y))
+    assert extent == 2 * repaired.exterior.distance(Point(anchor_x, anchor_y))
+    assert extent > 0
+
+
+def test_degenerate_ring_falls_back_to_bbox():
+    collinear = np.array([(0, 0), (5, 0), (10, 0)], dtype=float)
+    anchor_x, anchor_y, extent = label_geometry(collinear)
+    assert (anchor_x, anchor_y) == (5.0, 0.0)    # bbox center
+    assert extent == 0.0                          # no room — degenerate

--- a/device_viewer/views/electrode_view/electrode_layer.py
+++ b/device_viewer/views/electrode_view/electrode_layer.py
@@ -58,6 +58,14 @@ class ElectrodeLayer():
     def add_electrodes_to_scene(self, parent_scene: 'QGraphicsScene'):
         for electrode_id, electrode_view in self.electrode_views.items():
             parent_scene.addItem(electrode_view)
+        # Promote labels to top-level items above every electrode: as
+        # children they are painted over by later-added sibling electrodes
+        # wherever a label overhangs its own shape. ElectrodeViews sit at
+        # the origin, so the labels' coordinates are already scene coords.
+        for electrode_view in self.electrode_views.values():
+            electrode_view.text_path.setParentItem(None)
+            electrode_view.text_path.setZValue(1)
+            parent_scene.addItem(electrode_view.text_path)
 
     def add_connections_to_scene(self, parent_scene: 'QGraphicsScene'):
         """
@@ -73,6 +81,7 @@ class ElectrodeLayer():
     ######################## remove electrodes/connections from scene ###################################
     def remove_electrodes_to_scene(self, parent_scene: 'QGraphicsScene'):
         for electrode_id, electrode_view in self.electrode_views.items():
+            parent_scene.removeItem(electrode_view.text_path)
             parent_scene.removeItem(electrode_view)
 
     def remove_connections_to_scene(self, parent_scene: 'QGraphicsScene'):

--- a/device_viewer/views/electrode_view/electrode_view_helpers.py
+++ b/device_viewer/views/electrode_view/electrode_view_helpers.py
@@ -1,12 +1,14 @@
 import numpy as np
 from PySide6.QtWidgets import QGraphicsScene
-from .electrodes_view_base import ElectrodeConnectionItem
 from device_viewer.models.route import Route
-from shapely.geometry import LinearRing
+from shapely.geometry import LinearRing, Point, Polygon
+from shapely.ops import polylabel
 
 
 def find_path_item(scene: QGraphicsScene, connected_electrodes_keys):
     """Find a QGraphicsPathItem with the exact path sequence"""
+    # Local import: electrodes_view_base imports label_geometry from here.
+    from .electrodes_view_base import ElectrodeConnectionItem
     for item in scene.items():
         if isinstance(item, ElectrodeConnectionItem):
             if item.key[0] in connected_electrodes_keys and item.key[1] in connected_electrodes_keys:
@@ -25,3 +27,40 @@ def loop_is_ccw(route: Route, electrode_centers: dict[object, tuple[float]]):
 
 def get_mean_path(item):
     return np.mean(item.electrode.path, axis=0)
+
+
+def label_geometry(path_data: np.ndarray) -> tuple[float, float, float]:
+    """Anchor point and available room for an electrode's channel label.
+
+    Returns ``(anchor_x, anchor_y, extent)`` where the anchor is the polygon's
+    pole of inaccessibility (the interior point farthest from any edge) and
+    extent is the inscribed-circle diameter around it. The bounding-box center
+    is wrong for curved/concave electrodes — it can fall outside the shape
+    entirely, dropping the label onto a neighbour — and bbox extents oversize
+    the font for shapes much thinner than their box. For rectangles this
+    reduces exactly to the old behaviour (bbox center, min side).
+
+    Falls back to the bounding box for degenerate rings.
+    """
+    xs, ys = path_data[:, 0], path_data[:, 1]
+    left, right, top, bottom = np.min(xs), np.max(xs), np.min(ys), np.max(ys)
+    bbox_fallback = ((left + right) / 2, (top + bottom) / 2,
+                     min(right - left, bottom - top))
+    try:
+        polygon = Polygon(path_data)
+        if not polygon.is_valid or polygon.is_empty:
+            return bbox_fallback
+        anchor = polylabel(polygon, tolerance=0.01 * max(right - left, bottom - top))
+        clearance = polygon.exterior.distance(anchor)
+        # The pole is non-unique on elongated shapes (any point along a
+        # rectangle's center line ties) and polylabel picks an arbitrary
+        # winner — keep the classic centered look whenever the bbox center
+        # has essentially the same clearance.
+        bbox_center = Point(bbox_fallback[0], bbox_fallback[1])
+        if polygon.contains(bbox_center):
+            bbox_clearance = polygon.exterior.distance(bbox_center)
+            if bbox_clearance >= 0.95 * clearance:
+                return bbox_fallback[0], bbox_fallback[1], 2 * bbox_clearance
+        return anchor.x, anchor.y, 2 * clearance
+    except Exception:
+        return bbox_fallback

--- a/device_viewer/views/electrode_view/electrodes_view_base.py
+++ b/device_viewer/views/electrode_view/electrodes_view_base.py
@@ -258,6 +258,11 @@ class ElectrodeView(QGraphicsPathItem):
         text_size = self.text_path.document().size()
         self.text_path.setPos(self.label_anchor_x - text_size.width() / 2,
                               self.label_anchor_y - text_size.height() / 2)
+        # Any rotation (device-view counter-rotation) must pivot about the
+        # NEW text's center: after an edit changes the label's size, the
+        # origin set at load would be stale and swing the label off its
+        # anchor — load-time and refresh placement must match.
+        self.text_path.setTransformOriginPoint(self.text_path.boundingRect().center())
 
     def rotate_electrode_text(self, angle=0):
         self.text_path.setTransformOriginPoint(self.text_path.boundingRect().center())

--- a/device_viewer/views/electrode_view/electrodes_view_base.py
+++ b/device_viewer/views/electrode_view/electrodes_view_base.py
@@ -19,6 +19,7 @@ from microdrop_utils.decorators import debounce
 from ...default_settings import ELECTRODE_OFF, ELECTRODE_ON, ELECTRODE_NO_CHANNEL, ELECTRODE_LINE, ELECTRODE_TEXT_COLOR, \
     CONNECTION_LINE_ON_DEFAULT, default_alphas, electrode_text_key, electrode_outline_key
 from device_viewer.models.electrodes import Electrode
+from device_viewer.views.electrode_view.electrode_view_helpers import label_geometry
 
 logger = get_logger(__name__, level='INFO')
 
@@ -187,8 +188,9 @@ class ElectrodeView(QGraphicsPathItem):
         self.text_path = QGraphicsTextItem(parent=self)
         self.text_color = QColor(ELECTRODE_TEXT_COLOR)
         self.text_path.setDefaultTextColor(self.text_color)
-        self.path_extremes = [np.min(path_data[:, 0]), np.max(path_data[:, 0]),
-                              np.min(path_data[:, 1]), np.max(path_data[:, 1])]
+        # Pole of inaccessibility + inscribed diameter: keeps the label
+        # inside curved/concave shapes where the bbox center falls outside.
+        self.label_anchor_x, self.label_anchor_y, self.label_extent =             label_geometry(path_data)
         self._fit_text_in_path(alpha=default_alphas.get(electrode_text_key, 1.0)) # Called again by electrode_layer set the proper alphas using the model
 
         # Make the electrode selectable and focusable
@@ -230,20 +232,17 @@ class ElectrodeView(QGraphicsPathItem):
         """
 
         text = str(self.electrode.channel)
-        path_extremes = self.path_extremes
 
         self.text_path.setPlainText(text if text != "None" else "")
 
-        # Determine the font size based on the path size
-        left, right, top, bottom = path_extremes
-        range_x = right - left
-        range_y = bottom - top
+        # Size the font by the room actually available around the anchor
+        # (inscribed-circle diameter — equals the bbox min side for rectangles)
         if len(text) == 1:
-            font_size = min(range_x, range_y) / 1.2
+            font_size = self.label_extent / 1.2
         elif len(text) == 2:
-            font_size = min(range_x, range_y) / 2
+            font_size = self.label_extent / 2
         else:
-            font_size = min(range_x, range_y) / 3
+            font_size = self.label_extent / 3
             if font_size < default_font_size:
                 font_size = default_font_size
 
@@ -255,12 +254,10 @@ class ElectrodeView(QGraphicsPathItem):
         new_color.setAlphaF(alpha)
         self.text_path.setDefaultTextColor(new_color)
 
-        # Adjust the font size to fit the text in the path
+        # center the text on the label anchor
         text_size = self.text_path.document().size()
-        # center the text to the path
-        posx = left + (right - left - text_size.width()) / 2
-        posy = top + (bottom - top - text_size.height()) / 2
-        self.text_path.setPos(posx, posy)
+        self.text_path.setPos(self.label_anchor_x - text_size.width() / 2,
+                              self.label_anchor_y - text_size.height() / 2)
 
     def rotate_electrode_text(self, angle=0):
         self.text_path.setTransformOriginPoint(self.text_path.boundingRect().center())


### PR DESCRIPTION
Two label defects visible on curved devices (follow-on to #503):

1. **Placement** — labels were anchored on the bounding-box center, which falls outside curved/concave electrodes (L-shapes, notched arcs), dropping the label onto a neighbouring shape; bbox extents also oversize the font for shapes thinner than their box. New `label_geometry` helper anchors on the **pole of inaccessibility** and sizes by the **inscribed-circle diameter**. Rectangles keep the exact legacy center and font size (the pole ties along a rectangle's center line, so the bbox center is preferred whenever its clearance matches) — standard devices render pixel-identically.
2. **Stacking** — labels are children of their ElectrodeView, and Qt paints later-added sibling electrodes over earlier ones *including their children*, so an overhanging label gets covered by the next shape. `ElectrodeLayer` now promotes each label to a top-level z=1 scene item (label coordinates are already scene coordinates since ElectrodeViews sit at the origin) and removes them with their electrodes.

Also breaks a helper↔base import cycle (`ElectrodeConnectionItem` import made local to `find_path_item`).

Verified on `sdl_teardrop.svg`: 119/119 anchors inside their shape (79 shift measurably vs bbox center), all labels top-level at z=1, offscreen render clean. Hardware-free tests cover rectangle identity, L-shape containment, the real notched-arc electrode, and degenerate fallback.

## Test plan
- [x] Curved device: every channel id sits inside its electrode, none covered by neighbours
- [x] Rectangular device: labels unchanged
- [x] Channel-edit mode: labels update in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)