### PR TITLE
fix(protocol-tree): centralize route execution — protocol runs mirror device-viewer playback

### DIFF
--- a/device_viewer/services/route_execution_service.py
+++ b/device_viewer/services/route_execution_service.py
@@ -1,4 +1,4 @@
-from traits.api import observe, HasTraits, Instance, Any, Int, Bool, provides
+from traits.api import observe, HasTraits, Instance, Bool, Int, List, Set, provides
 
 from ..interfaces.i_main_model import IDeviceViewMainModel
 from ..interfaces.i_route_execution_service import IRouteExecutionService
@@ -16,14 +16,17 @@ logger = get_logger(__name__)
 class RouteExecutionService(HasTraits):
     model = Instance(IDeviceViewMainModel)
 
-    _execution_plan = Any()  # List of execution plan dicts
+    #: Execution plan dicts from the centralized PathExecutionService.
+    _execution_plan = List()
     _current_phase_index = Int(0)
 
-    _user_toggled_channels = Any()  # set: channels the user manually toggled during execution
-    _last_set_channels = Any()  # set: channels we programmatically set last phase (for diffing)
+    #: Channels the user manually toggled during execution.
+    _user_toggled_channels = Set()
+    #: Channels we programmatically set last phase (for diffing).
+    _last_set_channels = Set()
 
-    _phase_timer = Any()  # PausableTimer instance
-    _display_timer = Any()  # QTimer for updating status display
+    _phase_timer = Instance(PausableTimer)
+    _display_timer = Instance(QTimer)
     _navigated_while_paused = Bool(False)
 
     _total_reps = Int(1)

--- a/device_viewer/services/route_execution_service.py
+++ b/device_viewer/services/route_execution_service.py
@@ -4,7 +4,7 @@ from ..interfaces.i_main_model import IDeviceViewMainModel
 from ..interfaces.i_route_execution_service import IRouteExecutionService
 from electrode_controller.consts import electrode_state_change_publisher
 from ..consts import ROUTES_EXECUTING
-from .path_execution_service import PathExecutionService
+from microdrop_utils.route_execution import PathExecutionService
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from PySide6.QtCore import QTimer
 from microdrop_utils.pyside_helpers import PausableTimer
@@ -116,52 +116,20 @@ class RouteExecutionService(HasTraits):
         self.model.route_execution_service_paused = False
         publish_message(topic=ROUTES_EXECUTING, message=str(True))
 
-        # Compute phases-per-rep from the longest loop cycle across all paths
-        max_cycle_length = 0
-        max_effective_reps = 1
-        has_loops = False
-        for path in paths:
-            if PathExecutionService.is_loop_path(path):
-                has_loops = True
-                effective_reps = PathExecutionService.calculate_effective_repetitions_for_path(
-                    path,
-                    self.model.routes.repetitions,
-                    self.model.routes.duration,
-                    self.model.routes.repeat_duration,  # repeat_duration
-                    self.model.routes.trail_length,
-                    self.model.routes.trail_overlay,
-                )
-                cycle_phases = PathExecutionService.calculate_loop_cycle_phases(
-                    path, self.model.routes.trail_length, self.model.routes.trail_overlay
-                )
-                cycle_length = len(cycle_phases)
-                if cycle_length > max_cycle_length or (
-                    cycle_length == max_cycle_length and effective_reps > max_effective_reps
-                ):
-                    max_cycle_length = cycle_length
-                    max_effective_reps = effective_reps
-
-        if has_loops:
-            # One rep = one full cycle of the longest loop path
-            self._phases_per_rep = max(max_cycle_length, 1)
-            self._total_reps = max_effective_reps
-        elif linear_repeats:
-            # Open-only paths with linear_repeats on: longest path's single
-            # traversal = one rep; total reps = the raw Repetitions count.
-            max_open_cycle = 0
-            for path in paths:
-                cycle_phases = PathExecutionService.calculate_trail_phases_for_path(
-                    path, self.model.routes.trail_length, self.model.routes.trail_overlay,
-                    soft_start=self.model.routes.soft_start,
-                    soft_terminate=self.model.routes.soft_terminate,
-                )
-                max_open_cycle = max(max_open_cycle, len(cycle_phases))
-            self._phases_per_rep = max(max_open_cycle, 1)
-            self._total_reps = max(int(self.model.routes.repetitions), 1)
-        else:
-            # Open paths only, no linear repeats — entire plan is one rep
-            self._phases_per_rep = max(len(plan), 1)
-            self._total_reps = 1
+        # Phases-per-rep / total reps from the centralized logic (shared
+        # with the protocol tree so both report the same breakdown).
+        self._phases_per_rep, self._total_reps = (
+            PathExecutionService.calculate_phase_rep_breakdown(
+                paths, len(plan),
+                duration=self.model.routes.duration,
+                repetitions=self.model.routes.repetitions,
+                repeat_duration=self.model.routes.repeat_duration,
+                trail_length=self.model.routes.trail_length,
+                trail_overlay=self.model.routes.trail_overlay,
+                soft_start=self.model.routes.soft_start,
+                soft_terminate=self.model.routes.soft_terminate,
+                linear_repeats=linear_repeats,
+            ))
 
         # Initialize status display
         self._total_phases = len(plan)

--- a/microdrop_utils/route_execution.py
+++ b/microdrop_utils/route_execution.py
@@ -1,16 +1,20 @@
-"""Phase-by-phase route execution planning for the device viewer's interactive
-route preview/playback (the per-layer Run / Pause / Step controls driven by
-``RouteExecutionService``).
+"""Centralized phase-by-phase route-execution planning.
 
-Lifted from the legacy ``protocol_grid.services.path_execution_service`` during
-PPT-9 (#371): the device viewer's route playback is a live feature that must
-outlive the deleted ``protocol_grid`` plugin. Only the parameter-based planning
-helpers ``RouteExecutionService`` actually uses are kept here; the legacy
-``ProtocolStep`` / ``DeviceState`` couplings are replaced by tiny local stand-ins
-so this module carries no ``protocol_grid`` dependency. Protocol-RUN route
-execution in the new system is handled separately by ``pluggable_protocol_tree``
-(``RoutesHandler`` / ``phase_math``); this module only drives the device
-viewer's standalone preview.
+THE single source of route-execution geometry: which electrodes are active
+at each timed phase of a step, and how phases break down into repetitions.
+Two consumers drive their playback from it so routes behave identically in
+both places:
+
+* the device viewer's interactive route preview/playback
+  (``device_viewer.services.route_execution_service``), and
+* protocol-run route execution in ``pluggable_protocol_tree``
+  (``RoutesHandler`` via ``services.phase_math``, a thin adapter).
+
+Originally lifted from the legacy ``protocol_grid.services.
+path_execution_service`` during PPT-9 (#371) and centralized here from
+``device_viewer.services``; the legacy ``ProtocolStep`` / ``DeviceState``
+couplings are replaced by tiny local stand-ins so this module has no
+plugin dependencies.
 """
 
 import copy
@@ -555,6 +559,67 @@ class PathExecutionService:
             soft_start=soft_start, soft_terminate=soft_terminate,
             linear_repeats=linear_repeats,
         )
+
+    @staticmethod
+    def calculate_phase_rep_breakdown(
+        paths: List[List[str]],
+        plan_length: int,
+        *,
+        duration: float,
+        repetitions: int,
+        repeat_duration: float,
+        trail_length: int,
+        trail_overlay: int,
+        soft_start: bool = False,
+        soft_terminate: bool = False,
+        linear_repeats: bool = False,
+    ) -> tuple:
+        """(phases_per_rep, total_reps) for an execution plan's status
+        display.
+
+        One repetition is one full cycle of the LONGEST loop path (ties
+        broken by the higher effective-rep count). With open paths only and
+        ``linear_repeats`` on, one rep is the longest path's single
+        traversal and total reps is the raw ``repetitions`` count.
+        Otherwise the whole plan (``plan_length`` phases) is one rep.
+        """
+        max_cycle_length = 0
+        max_effective_reps = 1
+        has_loops = False
+        for path in paths:
+            if not PathExecutionService.is_loop_path(path):
+                continue
+            has_loops = True
+            effective_reps = PathExecutionService.calculate_effective_repetitions_for_path(
+                path, repetitions, duration, repeat_duration,
+                trail_length, trail_overlay,
+            )
+            cycle_length = len(PathExecutionService.calculate_loop_cycle_phases(
+                path, trail_length, trail_overlay))
+            if cycle_length > max_cycle_length or (
+                cycle_length == max_cycle_length
+                and effective_reps > max_effective_reps
+            ):
+                max_cycle_length = cycle_length
+                max_effective_reps = effective_reps
+
+        if has_loops:
+            # One rep = one full cycle of the longest loop path
+            return max(max_cycle_length, 1), max_effective_reps
+        if linear_repeats:
+            # Open-only paths with linear_repeats on: longest path's single
+            # traversal = one rep; total reps = the raw Repetitions count.
+            max_open_cycle = 0
+            for path in paths:
+                max_open_cycle = max(max_open_cycle, len(
+                    PathExecutionService.calculate_trail_phases_for_path(
+                        path, trail_length, trail_overlay,
+                        soft_start=soft_start,
+                        soft_terminate=soft_terminate,
+                    )))
+            return max(max_open_cycle, 1), max(int(repetitions), 1)
+        # Open paths only, no linear repeats — entire plan is one rep
+        return max(plan_length, 1), 1
 
     @staticmethod
     def get_active_channels_from_map(id_to_channel: Dict[str, int], active_electrodes: List[str]) -> set:

--- a/microdrop_utils/route_execution.py
+++ b/microdrop_utils/route_execution.py
@@ -12,46 +12,18 @@ both places:
 
 Originally lifted from the legacy ``protocol_grid.services.
 path_execution_service`` during PPT-9 (#371) and centralized here from
-``device_viewer.services``; the legacy ``ProtocolStep`` / ``DeviceState``
-couplings are replaced by tiny local stand-ins so this module has no
-plugin dependencies.
+``device_viewer.services``, dropping the legacy ``ProtocolStep`` /
+``DeviceState`` couplings so this module has no plugin dependencies.
+
+``PathExecutionService`` is a stateless calculator (static methods only),
+so it deliberately stays a plain class rather than HasTraits.
 """
 
-import copy
 from typing import Any, Dict, List, Optional
 
 from logger.logger_service import get_logger
 
 logger = get_logger(__name__)
-
-
-def _read_linear_repeats_from_step(step) -> bool:
-    """Read the per-step ``Lin Reps`` cell value (parsed bool). Falls back to
-    False if the field is missing (the params-based entry point never sets it)."""
-    raw = step.parameters.get("Lin Reps", "0")
-    try:
-        return bool(int(raw))
-    except (TypeError, ValueError):
-        return str(raw).strip().lower() in ("1", "true", "yes", "on")
-
-
-class _Step:
-    """Minimal stand-in for the legacy ``ProtocolStep`` — just a parameters dict."""
-
-    def __init__(self, parameters: Dict[str, str]):
-        self.parameters = parameters
-
-
-class _DeviceState:
-    """Minimal stand-in for the legacy ``DeviceState`` — activated electrodes
-    plus the list of routes (paths)."""
-
-    def __init__(self, activated_electrodes=None, paths=None):
-        self.activated_electrodes = list(activated_electrodes or [])
-        self.paths = list(paths or [])
-
-    def has_paths(self) -> bool:
-        return len(self.paths) > 0
 
 
 class PathExecutionService:
@@ -238,7 +210,7 @@ class PathExecutionService:
     def calculate_loop_cycle_phases(path: List[str], trail_length: int, trail_overlay: int) -> List[List[int]]:
         if not PathExecutionService.is_loop_path(path):
             result = PathExecutionService.calculate_trail_phases_for_path(path, trail_length, trail_overlay)
-            logger.info(f"Open path phases: {result}")
+            logger.debug(f"Open path phases: {result}")
             return result
 
         # for loops, make it a path without duplicating last electrode
@@ -250,7 +222,7 @@ class PathExecutionService:
         if step_size <= 0:
             # all positions, no smooth transition needed
             phases = [[i] for i in range(effective_length)]
-            logger.info(f"Step size <= 0, generated phases: {phases}")
+            logger.debug(f"Step size <= 0, generated phases: {phases}")
             return phases
 
         phases = []
@@ -268,45 +240,56 @@ class PathExecutionService:
 
             # check if the loop is completed
             if position >= effective_length:
-                logger.info(f"Loop completed at position {position}")
+                logger.debug(f"Loop completed at position {position}")
                 break
 
-        logger.info(f"Final loop cycle phases: {phases}")
+        logger.debug(f"Final loop cycle phases: {phases}")
         return phases
 
     @staticmethod
-    def calculate_step_execution_plan(step: "_Step", device_state: "_DeviceState",
-                                      soft_start: bool = False, soft_terminate: bool = False,
-                                      linear_repeats: Optional[bool] = None) -> List[Dict[str, Any]]:
+    def calculate_execution_plan_from_params(
+        duration: float,
+        repetitions: int,
+        repeat_duration: float,
+        trail_length: int,
+        trail_overlay: int,
+        paths: List[List[str]],
+        activated_electrodes: List[str] = None,
+        step_uid: str = "",
+        step_id: str = "",
+        step_description: str = "Step",
+        repeat_duration_mode: bool = True,
+        soft_start: bool = False,
+        soft_terminate: bool = False,
+        linear_repeats: Optional[bool] = None,
+    ) -> List[Dict[str, Any]]:
         """Build the full phase-by-phase execution plan for a step.
 
         Each entry describes one timed phase with its activated electrodes.
-        Respects "Repeat Duration Mode" to decide whether loop repetitions are
-        time-capped (with idle padding) or count-based. Soft start/terminate add
-        ramp phases on top. When ``linear_repeats`` is True, linear (non-loop)
-        paths are replayed ``Repetitions`` times.
+        When ``repeat_duration_mode`` is True (default), ``repeat_duration``
+        caps how many loops fit in the allotted time and idle phases pad any
+        remaining balance; when False, each loop runs exactly
+        ``repetitions`` times. ``soft_start`` / ``soft_terminate`` add ramp
+        phases on top. When ``linear_repeats`` is True, linear (non-loop)
+        paths are replayed ``repetitions`` times.
         """
-        duration = float(step.parameters.get("Duration", "1.0"))
-        repetitions = int(step.parameters.get("Repetitions", "1"))
-        repeat_duration_mode = step.parameters.get("Repeat Duration Mode", "0") == "1"
-        repeat_duration = int(float(step.parameters.get("Repeat Duration", "1"))) if repeat_duration_mode else 0
-        trail_length = int(step.parameters.get("Trail Length", "1"))
-        trail_overlay = int(step.parameters.get("Trail Overlay", "0"))
-
-        if linear_repeats is None:
-            linear_repeats = _read_linear_repeats_from_step(step)
-
-        step_uid = step.parameters.get("UID", "")
-        step_id = step.parameters.get("ID", "")
-        step_description = step.parameters.get("Description", "Step")
+        duration = float(duration)
+        repetitions = int(repetitions)
+        repeat_duration = (int(float(repeat_duration))
+                           if repeat_duration_mode else 0)
+        trail_length = int(trail_length)
+        trail_overlay = int(trail_overlay)
+        linear_repeats = bool(linear_repeats)
+        activated_electrodes = list(activated_electrodes or [])
+        paths = list(paths or [])
 
         execution_plan = []
 
-        if not device_state.has_paths():
+        if not paths:
             execution_plan.append({
                 "time": 0.0,
                 "duration": duration,
-                "activated_electrodes": copy.deepcopy(device_state.activated_electrodes),
+                "activated_electrodes": list(activated_electrodes),
                 "step_uid": step_uid,
                 "step_id": step_id,
                 "step_description": step_description
@@ -318,7 +301,7 @@ class PathExecutionService:
         path_info = []
         max_open_path_length = 0
 
-        for i, path in enumerate(device_state.paths):
+        for i, path in enumerate(paths):
             is_loop = PathExecutionService.is_loop_path(path)
 
             if is_loop:
@@ -395,7 +378,7 @@ class PathExecutionService:
 
         for phase_idx in range(total_phases):
             # individually activated electrodes always active
-            phase_electrodes = set(copy.deepcopy(device_state.activated_electrodes))
+            phase_electrodes = set(activated_electrodes)
 
             for path_idx, path_data in enumerate(path_info):
                 path = path_data["path"]
@@ -513,52 +496,6 @@ class PathExecutionService:
             })
 
         return execution_plan
-
-    @staticmethod
-    def calculate_execution_plan_from_params(
-        duration: float,
-        repetitions: int,
-        repeat_duration: float,
-        trail_length: int,
-        trail_overlay: int,
-        paths: List[List[str]],
-        activated_electrodes: List[str] = None,
-        step_uid: str = "",
-        step_id: str = "",
-        step_description: str = "Step",
-        repeat_duration_mode: bool = True,
-        soft_start: bool = False,
-        soft_terminate: bool = False,
-        linear_repeats: Optional[bool] = None,
-    ) -> List[Dict[str, Any]]:
-        """Calculate an execution plan from raw parameters (no ProtocolStep /
-        DeviceState needed).
-
-        When ``repeat_duration_mode`` is True (default), ``repeat_duration`` caps
-        how many loops fit in the allotted time and idle phases pad any remaining
-        balance. When False, each loop runs exactly ``repetitions`` times.
-        ``soft_start`` / ``soft_terminate`` prepend/append ramp phases.
-        """
-        step = _Step(parameters={
-            "Duration": str(duration),
-            "Repetitions": str(repetitions),
-            "Repeat Duration": str(repeat_duration),
-            "Repeat Duration Mode": "1" if repeat_duration_mode else "0",
-            "Trail Length": str(trail_length),
-            "Trail Overlay": str(trail_overlay),
-            "UID": step_uid,
-            "ID": step_id,
-            "Description": step_description,
-        })
-        device_state = _DeviceState(
-            activated_electrodes=list(activated_electrodes or []),
-            paths=paths,
-        )
-        return PathExecutionService.calculate_step_execution_plan(
-            step, device_state,
-            soft_start=soft_start, soft_terminate=soft_terminate,
-            linear_repeats=linear_repeats,
-        )
 
     @staticmethod
     def calculate_phase_rep_breakdown(

--- a/pluggable_protocol_tree/services/phase_math.py
+++ b/pluggable_protocol_tree/services/phase_math.py
@@ -1,257 +1,92 @@
-"""Pure-function phase-generation helpers for the RoutesHandler.
+"""Phase-generation helpers for the RoutesHandler, delegating ALL phase
+geometry to the centralized ``PathExecutionService``
+(``microdrop_utils.route_execution``) so protocol-run route execution
+exactly mirrors the device viewer's route playback — same trail windows,
+same loop cycles and return phase, same soft ramps, same idle padding and
+repetition math.
 
-A "phase" is one snapshot in time of which electrodes are actuated.
-Each step of a protocol expands to a sequence of phases, each yielded
-by iter_phases() and consumed (publish + wait_for ack) by the
-RoutesHandler.
+A "phase" is one snapshot in time of which electrodes are actuated. Each
+step of a protocol expands to a sequence of phases, each yielded by
+iter_phases() and consumed (publish + wait_for ack) by the RoutesHandler.
 
-Composed of small one-job helpers so each can be tested in isolation:
-
-  _is_loop_route       — first == last, len >= 2
-  _route_windows       — sliding windows over one route (open or loop)
-  _route_with_repeats  — wrap windows in linear-repeats / loop-cycles /
-                         repeat_duration_s budget logic   (Task 3)
-  _zip_with_static     — at each tick, union static + each route's
-                         current window                          (Task 4)
-  _ramp_up / _ramp_down — soft-start / soft-end ramp transformers  (Task 5)
-  iter_phases          — public composition                        (Task 5)
+Only the dynamic duration-mode loop helpers stay local (budget gates and
+unit cycles for volume-threshold steps — a runtime mode the device viewer
+doesn't have); their phase windows also come from the central geometry.
 
 No Traits, no Qt, no broker — testable as plain Python.
 """
 
 from typing import Iterator, List, Optional, Set, Tuple
 
-
-def _is_loop_route(route: List[str]) -> bool:
-    """A loop route is one where first == last (and there are at least
-    two electrodes — a single-element route can't be a loop)."""
-    return len(route) >= 2 and route[0] == route[-1]
+from microdrop_utils.route_execution import PathExecutionService
 
 
-def _route_windows(route: List[str], trail_length: int,
-                   trail_overlay: int) -> Iterator[Set[str]]:
-    """Sliding-window iterator over a single route.
-
-    Open route: yields ceil((len - trail_length) / step + 1) windows,
-    each a set of trail_length consecutive electrodes (or fewer at the
-    tail). Trail_length > len(route) --> one window of the whole route.
-
-    Loop route (first == last): drops the duplicated last electrode,
-    yields one full cycle of windows that wrap around the effective
-    path. Subsequent cycles, if any, are the caller's job
-    (_route_with_repeats handles loop reps).
-
-    step_size = max(1, trail_length - trail_overlay) — clamped to 1
-    so progress is guaranteed even with overlay >= length.
-    """
-    if not route:
-        return
-    if _is_loop_route(route):
-        effective = route[:-1]
-        n = len(effective)
-        step = max(1, trail_length - trail_overlay)
-        size = min(trail_length, n)
-        pos = 0
-        emitted = 0
-        while emitted == 0 or pos % n != 0:
-            yield {effective[(pos + i) % n] for i in range(size)}
-            pos += step
-            emitted += 1
-            # Safety: never loop forever.
-            if emitted > n:
-                return
-    else:
-        n = len(route)
-        if trail_length >= n:
-            yield set(route)
-            return
-        step = max(1, trail_length - trail_overlay)
-        pos = 0
-        while pos < n:
-            window = {route[pos + i] for i in range(trail_length)
-                      if pos + i < n}
-            yield window
-            if pos + trail_length >= n:
-                return
-            pos += step
-
-
-def _route_with_repeats(
-    route: List[str],
-    trail_length: int,
-    trail_overlay: int,
-    *,
-    linear_repeats: bool = False,
-    n_repeats: int = 1,
-    repeat_duration_s: float = 0.0,
-    step_duration_s: float = 1.0,
-) -> Iterator[Set[str]]:
-    """Wraps _route_windows with repeat-count + duration-budget logic.
-
-    Open route + linear_repeats=False --> one pass of _route_windows.
-    Open route + linear_repeats=True  --> n_repeats passes (the row's
-                                        `route_repetitions` column).
-    Loop route --> ``cycles`` full cycles plus one return-to-start phase at
-                 the very end (mirrors the legacy device-viewer route
-                 executor: N cycles of a C-phase loop yields N*C + 1
-                 phases, the final one being the window at position 0 so a
-                 loop that starts at electrode X also ends at X). The
-                 return phase is emitted in BOTH modes; only ``cycles``
-                 differs: count mode uses ``max(1, n_repeats)``; duration
-                 mode uses ``max(1, floor(repeat_duration_s /
-                 (cycle_phases * step_duration_s)))``. The minimum of 1
-                 guarantees at least one cycle even on tiny budgets.
-
-    Empty route yields nothing.
-    """
-    if not route:
-        return
-    cycle = list(_route_windows(route, trail_length, trail_overlay))
-    if not cycle:
-        return
-
-    is_loop = _is_loop_route(route)
-    if is_loop:
-        # Count vs duration mode differ ONLY in how many full cycles run;
-        # both close the loop with a final return-to-start phase so a loop
-        # that begins at electrode X also ends at X. Timing stays exact in
-        # duration mode because the RoutesHandler's hold-pad is computed
-        # from the actual emitted phase count (len(phases) * per_phase_dwell),
-        # which already includes this return phase.
-        if repeat_duration_s > 0 and step_duration_s > 0:
-            cycle_phases = len(cycle)
-            cycles = max(1, int(repeat_duration_s
-                                / (cycle_phases * step_duration_s)))
-        else:
-            cycles = max(1, int(n_repeats))
-        for _ in range(cycles):
-            yield from cycle
-        yield cycle[0]   # return-to-start so the loop visibly closes
-    else:
-        passes = max(1, int(n_repeats)) if linear_repeats else 1
-        for _ in range(passes):
-            yield from cycle
-
-
-def duration_loop_parts(
+def iter_phases(
     static_electrodes: List[str],
     routes: List[List[str]],
     *,
     trail_length: int = 1,
     trail_overlay: int = 0,
     soft_start: bool = False,
-) -> Tuple[List[Set[str]], List[Set[str]], Optional[Set[str]]]:
-    """Decompose a step into the pieces the RoutesHandler needs to drive a
-    *dynamic* duration-mode loop under volume threshold:
+    soft_end: bool = False,
+    repeat_duration_s: float = 0.0,
+    linear_repeats: bool = False,
+    n_repeats: int = 1,
+    step_duration_s: float = 1.0,
+) -> Iterator[Set[str]]:
+    """Yield each phase as the set of electrode IDs to actuate.
 
-        (ramp_up_phases, unit_cycle, return_phase)
+    Each yield is one snapshot in time: static electrodes always included;
+    per-route trail windows unioned in. The caller (a RoutesHandler)
+    publishes the set, waits for the device's apply confirmation, then
+    asks for the next phase.
 
-    ``unit_cycle`` is ONE pass of the zipped route windows + static set
-    (the repeatable unit). ``ramp_up_phases`` is the soft-start ramp toward
-    ``unit_cycle[0]`` (empty when soft_start is False or the first phase has
-    <= 1 electrode). ``return_phase`` is ``unit_cycle[0]`` (to close the loop
-    back to its origin) or None when there are no routes.
-
-    There is deliberately NO soft-end ramp: volume threshold reaching its
-    target guarantees the droplet's position, so the gentle-release ramp is
-    dropped. See the design spec.
-
-    Open (non-loop) routes are handled by the same machinery — one forward
-    pass becomes the unit_cycle and return_phase is its first window; the
-    helper is designed for loop routes, and an open-route caller is
-    responsible for that semantic.
+    The sequence is exactly the centralized execution plan's — including
+    loop cycles capped by ``repeat_duration_s`` with idle hold-at-start
+    padding (when > 0), the closing return-to-start phase for loops, and
+    soft start/end ramps.
     """
-    static = set(static_electrodes or [])
-    if not routes:
-        # Static-only step: the single static set is the repeatable unit;
-        # nothing to "return to", so no closing phase.
-        return [], [set(static)], None
-    per_route = [_route_windows(r, trail_length, trail_overlay)
-                 for r in routes]
-    unit_cycle = list(_zip_with_static(per_route, static))
-    if not unit_cycle:
-        return [], [set(static)], None
-    ramp_up: List[Set[str]] = []
-    first = unit_cycle[0]
-    if soft_start and len(first) > 1:
-        ordered = sorted(first)
-        ramp_up = [set(ordered[:size]) for size in range(1, len(first))]
-    return ramp_up, unit_cycle, unit_cycle[0]
+    plan = PathExecutionService.calculate_execution_plan_from_params(
+        duration=float(step_duration_s),
+        repetitions=int(n_repeats),
+        repeat_duration=float(repeat_duration_s),
+        trail_length=int(trail_length),
+        trail_overlay=int(trail_overlay),
+        paths=[list(route) for route in (routes or [])],
+        activated_electrodes=list(static_electrodes or []),
+        repeat_duration_mode=repeat_duration_s > 0,
+        soft_start=soft_start,
+        soft_terminate=soft_end,
+        linear_repeats=linear_repeats,
+    )
+    for plan_item in plan:
+        yield set(plan_item["activated_electrodes"])
 
 
-def unit_cycle_len(static_electrodes, routes, *, trail_length=1,
-                   trail_overlay=0, soft_start=False) -> int:
-    """Number of phases in one unit loop (the unique, navigable phases)."""
-    _ramp, unit_cycle, _ret = duration_loop_parts(
-        static_electrodes, routes, trail_length=trail_length,
-        trail_overlay=trail_overlay, soft_start=soft_start)
-    return len(unit_cycle)
+def effective_repetitions_for_duration(
+    *,
+    routes: List[List[str]],
+    trail_length: int = 1,
+    trail_overlay: int = 0,
+    step_duration_s: float = 1.0,
+    repeat_duration_s: float = 0.0,
+) -> int:
+    """How many full loop cycles fit inside ``repeat_duration_s`` — the
+    centralized breakdown's rep count (one rep = one cycle of the longest
+    loop route, like the device viewer's status display).
 
-
-def another_loop_fits(raw_elapsed: float, cycle_len: int,
-                      phase_dwell: float, budget: float) -> bool:
-    """True if a FULL fresh loop is guaranteed to finish within budget.
-
-    Worst case assumes every phase runs its full ``phase_dwell`` (the
-    volume-threshold timeout equals the duration-column value). Uses raw
-    wall-clock elapsed (pauses/holds already spent count against budget)."""
-    if cycle_len <= 0:
-        return False
-    return raw_elapsed + cycle_len * phase_dwell <= budget
-
-
-def loop_completion_fits(raw_elapsed: float, phase_in_cycle: int,
-                         cycle_len: int, phase_dwell: float,
-                         budget: float) -> bool:
-    """True if finishing the CURRENT loop from ``phase_in_cycle`` (0-based)
-    back to the start still fits the budget. Used for the mid-loop-expiry
-    check on resume after a seek."""
-    remaining = max(0, cycle_len - phase_in_cycle)
-    return raw_elapsed + remaining * phase_dwell <= budget
-
-
-def idle_cell_index(cycle_len: int) -> int:
-    """0-based index of the trailing idle cell on the phase bar
-    (the bar shows ``cycle_len`` unique phases + this idle cell)."""
-    return cycle_len
-
-
-def _ramp_up(phases: Iterator[Set[str]]) -> Iterator[Set[str]]:
-    """Prepend ramp phases that grow from 1 electrode to the size of
-    the first phase. K=1 first phase --> no-op. K=3 first phase {a,b,c}
-    --> yields {a}, {a,b} BEFORE the original {a,b,c}.
-
-    Element ordering within a set is non-deterministic; the ramp picks
-    elements in `sorted()` order so the choice is at least stable
-    across runs."""
-    try:
-        first = next(phases)
-    except StopIteration:
-        return
-    if len(first) > 1:
-        ordered = sorted(first)
-        for size in range(1, len(first)):
-            yield set(ordered[:size])
-    yield first
-    yield from phases
-
-
-def _ramp_down(phases: Iterator[Set[str]]) -> Iterator[Set[str]]:
-    """Append ramp phases that shrink from the last phase's size down
-    to 1. Mirror of _ramp_up — same sorted-element ordering for
-    stability."""
-    last = None
-    for p in phases:
-        if last is not None:
-            yield last
-        last = p
-    if last is None:
-        return
-    yield last
-    if len(last) > 1:
-        ordered = sorted(last)
-        for size in range(len(last) - 1, 0, -1):
-            yield set(ordered[-size:])
+    Returns 1 if no loop routes or the budget is too small for one cycle.
+    """
+    _phases_per_rep, total_reps = (
+        PathExecutionService.calculate_phase_rep_breakdown(
+            routes or [], 1,
+            duration=step_duration_s,
+            repetitions=1,
+            repeat_duration=repeat_duration_s,
+            trail_length=trail_length,
+            trail_overlay=trail_overlay,
+        ))
+    return total_reps
 
 
 def estimate_repeat_duration_s(
@@ -291,114 +126,113 @@ def estimate_repeat_duration_s(
     return len(phases) * float(step_duration_s)
 
 
-def effective_repetitions_for_duration(
-    *,
-    routes: List[List[str]],
-    trail_length: int = 1,
-    trail_overlay: int = 0,
-    step_duration_s: float = 1.0,
-    repeat_duration_s: float = 0.0,
-) -> int:
-    """How many full loop cycles fit inside ``repeat_duration_s``,
-    given each cycle takes ``cycle_phases * step_duration_s`` seconds.
-    Mirrors the legacy
-    PathExecutionService.calculate_effective_repetitions_for_path
-    formula: N <= (repeat_duration / step_duration - 1) / cycle_length.
+# --------------------------------------------------------------------- #
+# Dynamic duration-mode loop helpers (volume-threshold steps)             #
+# --------------------------------------------------------------------- #
 
-    Returns 1 if no loop routes or budget is too small for one cycle.
-    """
-    loop_lengths = []
-    for r in routes or []:
-        if not _is_loop_route(r):
-            continue
-        cycle = list(_route_windows(r, trail_length, trail_overlay))
-        if cycle:
-            loop_lengths.append(len(cycle))
-    if not loop_lengths or step_duration_s <= 0 or repeat_duration_s <= 0:
-        return 1
-    cycle_length = max(loop_lengths)
-    n = int(((repeat_duration_s / step_duration_s) - 1) / cycle_length)
-    return max(1, n)
-
-
-def iter_phases(
+def duration_loop_parts(
     static_electrodes: List[str],
     routes: List[List[str]],
     *,
     trail_length: int = 1,
     trail_overlay: int = 0,
     soft_start: bool = False,
-    soft_end: bool = False,
-    repeat_duration_s: float = 0.0,
-    linear_repeats: bool = False,
-    n_repeats: int = 1,
-    step_duration_s: float = 1.0,
-) -> Iterator[Set[str]]:
-    """Yield each phase as the set of electrode IDs to actuate.
+) -> Tuple[List[Set[str]], List[Set[str]], Optional[Set[str]]]:
+    """Decompose a step into the pieces the RoutesHandler needs to drive a
+    *dynamic* duration-mode loop under volume threshold:
 
-    Each yield is one snapshot in time: static electrodes always
-    included; per-route trail windows unioned in. The caller (a
-    RoutesHandler) publishes the set, waits for the device's apply
-    confirmation, then asks for the next phase.
+        (ramp_up_phases, unit_cycle, return_phase)
 
-    Composes the small helpers in this module — see the module
-    docstring for the full pipeline.
+    ``unit_cycle`` is ONE pass of the centralized plan's phases (the
+    repeatable unit — a single-rep plan minus the closing return phase for
+    loop routes, since the dynamic loop closes cycles itself).
+    ``ramp_up_phases`` are the centralized plan's own soft-start phases
+    (device-viewer semantics: route electrodes grow in PATH order from the
+    route start; static electrodes are always fully on and never ramp).
+    Empty when soft_start is False or the first trail window has <= 1
+    electrode. ``return_phase`` is ``unit_cycle[0]`` (to close the loop
+    back to its origin) or None when there are no routes.
+
+    There is deliberately NO soft-end ramp: volume threshold reaching its
+    target guarantees the droplet's position, so the gentle-release ramp is
+    dropped. See the design spec.
     """
     static = set(static_electrodes or [])
     if not routes:
-        # No paths to traverse; the static set is the only phase.
-        yield static
-        return
-    per_route = [_route_with_repeats(r, trail_length, trail_overlay,
-                                     linear_repeats=linear_repeats,
-                                     n_repeats=n_repeats,
-                                     repeat_duration_s=repeat_duration_s,
-                                     step_duration_s=step_duration_s)
-                 for r in routes]
-    base = _zip_with_static(per_route, static)
+        # Static-only step: the single static set is the repeatable unit;
+        # nothing to "return to", so no closing phase.
+        return [], [set(static)], None
+
+    def build_plan(with_soft_start):
+        return PathExecutionService.calculate_execution_plan_from_params(
+            duration=1.0,
+            repetitions=1,
+            repeat_duration=0.0,
+            trail_length=int(trail_length),
+            trail_overlay=int(trail_overlay),
+            paths=[list(route) for route in routes],
+            activated_electrodes=list(static),
+            repeat_duration_mode=False,
+            soft_start=with_soft_start,
+            soft_terminate=False,
+            linear_repeats=False,
+        )
+
+    plan = build_plan(False)
+    unit_cycle = [set(plan_item["activated_electrodes"])
+                  for plan_item in plan]
+    # A single-rep plan for loop routes ends with the return-to-start
+    # phase; the dynamic loop closes cycles itself (the next loop's phase
+    # 0 IS the return), so drop it from the repeatable unit.
+    if (len(unit_cycle) > 1
+            and any(PathExecutionService.is_loop_path(list(route))
+                    for route in routes)):
+        unit_cycle = unit_cycle[:-1]
+    if not unit_cycle:
+        return [], [set(static)], None
+    ramp_up: List[Set[str]] = []
     if soft_start:
-        base = _ramp_up(base)
-    if soft_end:
-        base = _ramp_down(base)
-    yield from base
+        # The soft plan prepends the ramp phases before the same cycle, so
+        # the length difference IS the ramp — taken from the plan itself
+        # to match the device viewer's ramp exactly.
+        soft_plan = build_plan(True)
+        ramp_up = [set(plan_item["activated_electrodes"])
+                   for plan_item in soft_plan[:len(soft_plan) - len(plan)]]
+    return ramp_up, unit_cycle, unit_cycle[0]
 
 
-def _zip_with_static(per_route_iters: list,
-                     static: Set[str]) -> Iterator[Set[str]]:
-    """At each tick, union the static set with each route's current
-    window. Routes that exhaust early hold at their last yielded
-    window; the iteration stops only when ALL routes are exhausted.
+def unit_cycle_len(static_electrodes, routes, *, trail_length=1,
+                   trail_overlay=0, soft_start=False) -> int:
+    """Number of phases in one unit loop (the unique, navigable phases)."""
+    _ramp, unit_cycle, _ret = duration_loop_parts(
+        static_electrodes, routes, trail_length=trail_length,
+        trail_overlay=trail_overlay, soft_start=soft_start)
+    return len(unit_cycle)
 
-    No routes at all --> yield the static set exactly once (the step
-    still gets one phase). No static + no routes --> yield one empty
-    phase (preserves the 'every step has at least one phase'
-    invariant the executor relies on).
-    """
-    if not per_route_iters:
-        yield set(static)
-        return
 
-    # Drive each iterator forward by one step; remember the last value
-    # so an exhausted route can keep contributing.
-    last_windows: list = [None] * len(per_route_iters)
+def another_loop_fits(raw_elapsed: float, cycle_len: int,
+                      phase_dwell: float, budget: float) -> bool:
+    """True if a FULL fresh loop is guaranteed to finish within budget.
 
-    while True:
-        any_advanced = False
-        for i, it in enumerate(per_route_iters):
-            try:
-                last_windows[i] = next(it)
-                any_advanced = True
-            except StopIteration:
-                pass   # keep last_windows[i] as the held value
-        # If on the very first tick none of the iterators yielded, fall
-        # back to one phase of just the static set.
-        if not any_advanced and all(w is None for w in last_windows):
-            yield set(static)
-            return
-        if not any_advanced:
-            return
-        merged = set(static)
-        for w in last_windows:
-            if w is not None:
-                merged |= w
-        yield merged
+    Worst case assumes every phase runs its full ``phase_dwell`` (the
+    volume-threshold timeout equals the duration-column value). Uses raw
+    wall-clock elapsed (pauses/holds already spent count against budget)."""
+    if cycle_len <= 0:
+        return False
+    return raw_elapsed + cycle_len * phase_dwell <= budget
+
+
+def loop_completion_fits(raw_elapsed: float, phase_in_cycle: int,
+                         cycle_len: int, phase_dwell: float,
+                         budget: float) -> bool:
+    """True if finishing the CURRENT loop from ``phase_in_cycle`` (0-based)
+    back to the start still fits the budget. Used for the mid-loop-expiry
+    check on resume after a seek."""
+    remaining = max(0, cycle_len - phase_in_cycle)
+    return raw_elapsed + remaining * phase_dwell <= budget
+
+
+def idle_cell_index(cycle_len: int) -> int:
+    """0-based index of the trailing idle cell on the phase bar
+    (the bar shows ``cycle_len`` unique phases + this idle cell)."""
+    return cycle_len

--- a/pluggable_protocol_tree/tests/test_phase_math.py
+++ b/pluggable_protocol_tree/tests/test_phase_math.py
@@ -1,256 +1,40 @@
 """Tests for services.phase_math.
 
-Pure-function unit tests — no Traits, no Qt, no broker. Each helper
-gets its own section. Sections grow as later tasks land more helpers.
+Pure-function unit tests — no Traits, no Qt, no broker. phase_math is a
+thin adapter over the centralized ``PathExecutionService``
+(``microdrop_utils.route_execution``), so these tests pin the DELEGATION
+contract (protocol-run phases exactly mirror the device viewer's
+execution plan) plus the tree-local dynamic-loop helpers.
 """
 
+from microdrop_utils.route_execution import PathExecutionService
+
 from pluggable_protocol_tree.services.phase_math import (
-    _is_loop_route, _route_windows,
-    unit_cycle_len, another_loop_fits, loop_completion_fits, idle_cell_index,
+    another_loop_fits, duration_loop_parts, effective_repetitions_for_duration,
+    estimate_repeat_duration_s, idle_cell_index, iter_phases,
+    loop_completion_fits, unit_cycle_len,
 )
 
 
-# --- _is_loop_route ---
-
-def test_is_loop_route_first_equals_last():
-    assert _is_loop_route(["a", "b", "c", "a"]) is True
-
-
-def test_is_loop_route_open_path():
-    assert _is_loop_route(["a", "b", "c"]) is False
-
-
-def test_is_loop_route_single_element_not_a_loop():
-    assert _is_loop_route(["a"]) is False
-
-
-def test_is_loop_route_empty_not_a_loop():
-    assert _is_loop_route([]) is False
-
-
-# --- _route_windows ---
-
-def test_windows_open_route_trail_length_1_no_overlap():
-    """trail_length=1, trail_overlay=0: window = single electrode at
-    each position, advancing by 1 each step (step = max(1, 1-0))."""
-    out = list(_route_windows(["a", "b", "c"], trail_length=1, trail_overlay=0))
-    assert out == [{"a"}, {"b"}, {"c"}]
-
-
-def test_windows_open_route_trail_length_2_overlap_1():
-    """trail_length=2, trail_overlay=1: step = 1, window slides by 1."""
-    out = list(_route_windows(["a", "b", "c", "d"], trail_length=2, trail_overlay=1))
-    assert out == [{"a", "b"}, {"b", "c"}, {"c", "d"}]
-
-
-def test_windows_trail_length_exceeds_route():
-    """trail_length larger than route: one window of the whole route."""
-    out = list(_route_windows(["a", "b"], trail_length=5, trail_overlay=0))
-    assert out == [{"a", "b"}]
-
-
-def test_windows_overlap_ge_length_clamps_step_to_1():
-    """trail_overlay >= trail_length: step clamped to 1 (always advance)."""
-    out = list(_route_windows(["a", "b", "c"], trail_length=2, trail_overlay=10))
-    assert out == [{"a", "b"}, {"b", "c"}]
-
-
-def test_windows_loop_route_one_cycle():
-    """Loop route: drop the duplicated last electrode, walk one cycle
-    of windows that wrap around."""
-    out = list(_route_windows(["a", "b", "c", "a"], trail_length=1, trail_overlay=0))
-    assert out == [{"a"}, {"b"}, {"c"}]
-
-
-def test_windows_loop_route_trail_2_wraps():
-    """Loop route with trail_length=2 wraps the window across the cycle."""
-    out = list(_route_windows(["a", "b", "c", "a"], trail_length=2, trail_overlay=1))
-    # Effective path is ['a', 'b', 'c'], step=1, windows wrap mod 3:
-    # pos 0: {a, b}; pos 1: {b, c}; pos 2: {c, a}
-    assert out == [{"a", "b"}, {"b", "c"}, {"c", "a"}]
-
-
-def test_windows_empty_route_yields_nothing():
-    out = list(_route_windows([], trail_length=1, trail_overlay=0))
-    assert out == []
-
-
-# --- _route_with_repeats ---
-
-from pluggable_protocol_tree.services.phase_math import (
-    _route_with_repeats,
-)
-
-
-def test_repeats_open_route_no_linear_repeats_one_pass():
-    """Open route, linear_repeats=False: same as one _route_windows pass."""
-    out = list(_route_with_repeats(
-        ["a", "b", "c"], trail_length=1, trail_overlay=0,
-        linear_repeats=False, repeat_duration_s=0.0, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"c"}]
-
-
-def test_repeats_open_route_linear_repeats_replays_n_times():
-    """Open route, linear_repeats=True: replay the windows N=2 times."""
-    out = list(_route_with_repeats(
-        ["a", "b"], trail_length=1, trail_overlay=0,
-        linear_repeats=True, n_repeats=2,
-        repeat_duration_s=0.0, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"a"}, {"b"}]
-
-
-def test_repeats_loop_route_default_one_cycle():
-    """One cycle of a 3-electrode loop yields 4 phases — the three
-    cycle windows plus a return-to-start phase (matches the legacy
-    device-viewer route executor)."""
-    out = list(_route_with_repeats(
-        ["a", "b", "c", "a"], trail_length=1, trail_overlay=0,
-        linear_repeats=False, repeat_duration_s=0.0, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"c"}, {"a"}]
-
-
-def test_repeats_loop_route_n_repeats():
-    """Loop route + n_repeats=2 --> 2 full cycles + 1 return phase."""
-    out = list(_route_with_repeats(
-        ["a", "b", "c", "a"], trail_length=1, trail_overlay=0,
-        linear_repeats=False, n_repeats=2,
-        repeat_duration_s=0.0, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"c"}, {"a"}, {"b"}, {"c"}, {"a"}]
-
-
-def test_repeats_loop_with_repeat_duration_caps_cycles():
-    """Loop route, repeat_duration_s=2.5, step_duration_s=1.0,
-    cycle_phases=3 --> 2.5/3 = 0.83, floor --> 0 cycles. But minimum is 1
-    cycle. Duration mode still closes the loop with a return-to-start
-    phase (the RoutesHandler's len(phases)-based hold-pad keeps timing
-    exact)."""
-    out = list(_route_with_repeats(
-        ["a", "b", "c", "a"], trail_length=1, trail_overlay=0,
-        linear_repeats=False, n_repeats=999,   # would otherwise loop 999×
-        repeat_duration_s=2.5, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"c"}, {"a"}]   # 1 cycle + return-to-start
-
-
-def test_repeats_loop_with_repeat_duration_fits_two_cycles():
-    """Loop route, repeat_duration_s=6.5, step_duration_s=1.0,
-    cycle_phases=3 --> 6.5/3 = 2.17, floor --> 2 cycles. Duration mode closes
-    the loop with a return-to-start phase, same as count mode."""
-    out = list(_route_with_repeats(
-        ["a", "b", "c", "a"], trail_length=1, trail_overlay=0,
-        linear_repeats=False, n_repeats=999,
-        repeat_duration_s=6.5, step_duration_s=1.0,
-    ))
-    assert out == [{"a"}, {"b"}, {"c"}, {"a"}, {"b"}, {"c"}, {"a"}]   # 2 cycles + return
-
-
-def test_repeats_empty_route_yields_nothing():
-    out = list(_route_with_repeats(
-        [], trail_length=1, trail_overlay=0,
-        linear_repeats=False, repeat_duration_s=0.0, step_duration_s=1.0,
-    ))
-    assert out == []
-
-
-# --- _zip_with_static ---
-
-from pluggable_protocol_tree.services.phase_math import _zip_with_static
-
-
-def test_zip_no_routes_yields_static_once_then_stops():
-    out = list(_zip_with_static([], static={"x", "y"}))
-    assert out == [{"x", "y"}]
-
-
-def test_zip_no_routes_no_static_yields_one_empty_phase():
-    """Edge case: still emit one (empty) phase to keep the executor
-    semantics that 'every step has at least one phase'."""
-    out = list(_zip_with_static([], static=set()))
-    assert out == [set()]
-
-
-def test_zip_one_route_unions_static_each_phase():
-    route_iter = iter([{"a"}, {"b"}, {"c"}])
-    out = list(_zip_with_static([route_iter], static={"x"}))
-    assert out == [{"a", "x"}, {"b", "x"}, {"c", "x"}]
-
-
-def test_zip_two_routes_same_length_union_each_phase():
-    r1 = iter([{"a"}, {"b"}])
-    r2 = iter([{"p"}, {"q"}])
-    out = list(_zip_with_static([r1, r2], static=set()))
-    assert out == [{"a", "p"}, {"b", "q"}]
-
-
-def test_zip_routes_of_different_length_shorter_holds_at_last():
-    """The shorter route holds at its last window once exhausted, so
-    the longer route's remaining windows still get emitted."""
-    r1 = iter([{"a"}, {"b"}, {"c"}])
-    r2 = iter([{"p"}])
-    out = list(_zip_with_static([r1, r2], static=set()))
-    assert out == [{"a", "p"}, {"b", "p"}, {"c", "p"}]
-
-
-def test_zip_stops_when_all_routes_exhausted():
-    """An empty-from-the-start route iterator contributes nothing; the
-    other route's iterator drives the output."""
-    r1 = iter([{"a"}, {"b"}])
-    r2 = iter([])
-    out = list(_zip_with_static([r1, r2], static={"x"}))
-    assert out == [{"a", "x"}, {"b", "x"}]
-
-
-# --- _ramp_up / _ramp_down ---
-
-from pluggable_protocol_tree.services.phase_math import (
-    _ramp_up, _ramp_down,
-)
-
-
-def test_ramp_up_single_electrode_first_phase_is_noop():
-    """First phase has 1 electrode --> nothing to ramp."""
-    out = list(_ramp_up(iter([{"a"}, {"b"}])))
-    assert out == [{"a"}, {"b"}]
-
-
-def test_ramp_up_three_electrode_first_phase_prepends_two():
-    """First phase {a,b,c} --> prepend {a}, {a,b} so the trail grows."""
-    out = list(_ramp_up(iter([{"a", "b", "c"}, {"d", "e", "f"}])))
-    assert len(out) == 4
-    assert len(out[0]) == 1 and out[0].issubset({"a", "b", "c"})
-    assert len(out[1]) == 2 and out[1].issubset({"a", "b", "c"})
-    assert out[2] == {"a", "b", "c"}
-    assert out[3] == {"d", "e", "f"}
-
-
-def test_ramp_up_empty_input_yields_empty():
-    out = list(_ramp_up(iter([])))
-    assert out == []
-
-
-def test_ramp_down_single_electrode_last_phase_is_noop():
-    out = list(_ramp_down(iter([{"a"}, {"b"}])))
-    assert out == [{"a"}, {"b"}]
-
-
-def test_ramp_down_three_electrode_last_phase_appends_two():
-    """Last phase {x,y,z} --> append two ramp-down phases shrinking by 1."""
-    out = list(_ramp_down(iter([{"a"}, {"x", "y", "z"}])))
-    assert len(out) == 4
-    assert out[0] == {"a"}
-    assert out[1] == {"x", "y", "z"}
-    assert len(out[2]) == 2 and out[2].issubset({"x", "y", "z"})
-    assert len(out[3]) == 1 and out[3].issubset({"x", "y", "z"})
-
-
-# --- iter_phases (public composition) ---
-
-from pluggable_protocol_tree.services.phase_math import iter_phases
-
+# --- iter_phases mirrors the centralized execution plan -------------------
+
+def test_iter_phases_equals_central_execution_plan():
+    """The delegation contract: phase sets are exactly the centralized
+    plan's activated-electrode sets, in order."""
+    kwargs = dict(trail_length=2, trail_overlay=1, soft_start=True,
+                  soft_end=True, repeat_duration_s=0.0, linear_repeats=True,
+                  n_repeats=2, step_duration_s=0.5)
+    phases = list(iter_phases(["s"], [["a", "b", "c", "d"]], **kwargs))
+    plan = PathExecutionService.calculate_execution_plan_from_params(
+        duration=0.5, repetitions=2, repeat_duration=0.0,
+        trail_length=2, trail_overlay=1, paths=[["a", "b", "c", "d"]],
+        activated_electrodes=["s"], repeat_duration_mode=False,
+        soft_start=True, soft_terminate=True, linear_repeats=True)
+    assert phases == [set(item["activated_electrodes"]) for item in plan]
+    assert phases   # non-empty
+
+
+# --- iter_phases behavior ---
 
 def test_iter_phases_no_routes_static_only():
     out = list(iter_phases(static_electrodes=["a", "b"], routes=[]))
@@ -281,8 +65,8 @@ def test_iter_phases_one_loop_route():
 
 def test_iter_phases_four_electrode_loop_yields_five_phases():
     """Loop with 4 unique electrodes, trail=1, one square at a time:
-    A-->B-->C-->D-->A. Five phases total (4 forward + 1 return). Mirrors the
-    legacy device-viewer loop execution that the user expects."""
+    A-->B-->C-->D-->A. Five phases total (4 forward + 1 return), same as
+    the device viewer's route playback."""
     out = list(iter_phases(
         static_electrodes=[], routes=[["a", "b", "c", "d", "a"]],
         trail_length=1, trail_overlay=0,
@@ -323,10 +107,11 @@ def test_iter_phases_soft_end_appends_ramp():
     assert len(out[4]) == 1
 
 
-def test_iter_phases_repeat_duration_caps_loop_cycles():
-    """Loop with cycle=3, step_duration=1, budget=6.5 --> 2 cycles, then a
-    return-to-start phase so the loop closes (timing stays exact via the
-    RoutesHandler's len(phases)-based hold-pad)."""
+def test_iter_phases_repeat_duration_caps_loop_cycles_with_idle():
+    """Loop with cycle=3, step_duration=1, budget=6.5. Like the device
+    viewer: effective reps = floor((6.5/1 - 1) / 3) = 1 cycle + return,
+    then idle phases (hold at the loop start) pad the remaining budget:
+    int(6.5 - 4) = 2 idle phases."""
     out = list(iter_phases(
         static_electrodes=[],
         routes=[["a", "b", "c", "a"]],
@@ -334,7 +119,7 @@ def test_iter_phases_repeat_duration_caps_loop_cycles():
         repeat_duration_s=6.5, step_duration_s=1.0,
         n_repeats=999,
     ))
-    assert out == [{"a"}, {"b"}, {"c"}, {"a"}, {"b"}, {"c"}, {"a"}]   # 2 cycles + return
+    assert out == [{"a"}, {"b"}, {"c"}, {"a"}, {"a"}, {"a"}]
 
 
 def test_iter_phases_linear_repeats_replays_open_route():
@@ -352,27 +137,55 @@ def test_iter_phases_linear_repeats_replays_open_route():
 
 def test_loop_closes_with_return_phase_in_both_modes():
     """A loop that starts at electrode 'a' must also end at 'a' in both
-    count and duration mode. 4-window cycle; both modes append the
-    return-to-start phase. Only the cycle count differs."""
-    route = ["a", "b", "c", "d", "a"]   # loop, effective len 4, trail 1 => 4 windows
-    count_mode = list(_route_with_repeats(
-        route, trail_length=1, trail_overlay=0,
+    count and duration mode. 4-window cycle: count mode runs the asked
+    reps + return; duration mode caps reps by budget and idles at the
+    start for the balance — either way the last phase is back at 'a'."""
+    route = ["a", "b", "c", "d", "a"]   # loop, effective len 4, trail 1
+    count_mode = list(iter_phases(
+        [], [route], trail_length=1, trail_overlay=0,
         n_repeats=2, repeat_duration_s=0.0, step_duration_s=1.0))
-    dur_mode = list(_route_with_repeats(
-        route, trail_length=1, trail_overlay=0,
+    dur_mode = list(iter_phases(
+        [], [route], trail_length=1, trail_overlay=0,
         n_repeats=2, repeat_duration_s=8.0, step_duration_s=1.0))
-    # Both: cycles * 4 windows + 1 return-to-start (= the first window).
+    # Count: 2 cycles * 4 windows + 1 return-to-start.
     assert len(count_mode) == 2 * 4 + 1
-    assert len(dur_mode) == 2 * 4 + 1
+    # Duration: floor((8-1)/4) = 1 cycle + return = 5 active, + 3 idle.
+    assert len(dur_mode) == 8
     # The loop closes: last phase == first phase (back at the start, 'a').
     assert count_mode[-1] == count_mode[0] == {"a"}
     assert dur_mode[-1] == dur_mode[0] == {"a"}
 
 
+# --- effective_repetitions_for_duration / estimate_repeat_duration_s ---
+
+def test_effective_repetitions_matches_central_formula():
+    # cycle 3, dwell 1, budget 10 --> floor((10-1)/3) = 3 reps.
+    reps = effective_repetitions_for_duration(
+        routes=[["a", "b", "c", "a"]], trail_length=1, trail_overlay=0,
+        step_duration_s=1.0, repeat_duration_s=10.0)
+    assert reps == 3
+
+
+def test_effective_repetitions_no_loops_or_budget_is_one():
+    assert effective_repetitions_for_duration(
+        routes=[["a", "b"]], repeat_duration_s=10.0) == 1
+    assert effective_repetitions_for_duration(
+        routes=[["a", "b", "a"]], repeat_duration_s=0.0) == 1
+
+
+def test_estimate_repeat_duration_counts_phases():
+    # Loop cycle 3 + return = 4 phases * 0.5 s.
+    est = estimate_repeat_duration_s(
+        routes=[["a", "b", "c", "a"]], trail_length=1, trail_overlay=0,
+        n_repeats=1, step_duration_s=0.5)
+    assert est == 4 * 0.5
+
+
+def test_estimate_repeat_duration_no_routes_is_zero():
+    assert estimate_repeat_duration_s(routes=[]) == 0.0
+
+
 # --- duration_loop_parts ---
-
-from pluggable_protocol_tree.services.phase_math import duration_loop_parts
-
 
 def test_duration_loop_parts_loop_route_basic():
     """One loop route, trail 1: unit cycle is the two windows; the return
@@ -385,17 +198,28 @@ def test_duration_loop_parts_loop_route_basic():
     assert ramp == []
 
 
-def test_duration_loop_parts_soft_start_ramps_first_unit_phase():
-    """soft_start grows 1->N toward the first unit phase (sorted order),
-    just like _ramp_up, but as an explicit list."""
+def test_duration_loop_parts_soft_start_statics_never_ramp():
+    """Device-viewer soft-start semantics: static electrodes are always
+    fully on (they never ramp), and a 1-electrode trail window needs no
+    ramp at all."""
     ramp, cycle, ret = duration_loop_parts(
         static_electrodes=["s1", "s2"], routes=[["a", "b", "a"]],
         trail_length=1, trail_overlay=0, soft_start=True)
-    first = cycle[0]
-    assert first == {"s1", "s2", "a"}            # static unioned into window
-    ordered = sorted(first)
-    assert ramp == [set(ordered[:1]), set(ordered[:2])]
-    assert ret == first
+    assert cycle[0] == {"s1", "s2", "a"}         # static unioned into window
+    assert ramp == []                            # nothing to ramp
+    assert ret == cycle[0]
+
+
+def test_duration_loop_parts_soft_start_ramps_in_path_order():
+    """Device-viewer soft-start semantics: the ramp grows the first trail
+    window in PATH order from the route start (with statics fully on),
+    not in sorted-ID order."""
+    ramp, cycle, _ret = duration_loop_parts(
+        static_electrodes=["s"], routes=[["b", "a", "c", "b"]],
+        trail_length=2, trail_overlay=1, soft_start=True)
+    assert cycle[0] == {"s", "b", "a"}           # first window: b, a
+    # Ramp starts from the ROUTE's first electrode ('b'), not sorted 'a'.
+    assert ramp == [{"s", "b"}]
 
 
 def test_duration_loop_parts_no_routes_static_only():
@@ -412,8 +236,8 @@ def test_duration_loop_parts_no_routes_static_only():
 # --- unit_cycle_len ---
 
 def test_unit_cycle_len_loop_route():
-    # a genuine loop route (first == last) a-b-c-d-a exercises the loop branch
-    # of _route_windows: 4 unique nodes -> 4 windows in the unit cycle.
+    # a genuine loop route (first == last) a-b-c-d-a: 4 unique nodes ->
+    # 4 windows in the unit cycle (the return phase is not part of it).
     n = unit_cycle_len([], [["a", "b", "c", "d", "a"]], trail_length=1, trail_overlay=0)
     assert n == 4
 


### PR DESCRIPTION
## Summary

Protocol-run route execution and the device viewer's interactive route playback previously used two independent phase-generation engines (`pluggable_protocol_tree/services/phase_math.py` vs `device_viewer/services/path_execution_service.py`) that had drifted apart — routes behaved differently in a protocol run than in the viewer's preview, and the protocol side's soft start/end was wrong. This PR centralizes the logic with the device viewer's implementation as canonical.

## Changes

### Centralized engine (`microdrop_utils/route_execution.py`)
- `PathExecutionService` moved (git rename, history preserved) from `device_viewer/services/path_execution_service.py` to `microdrop_utils/route_execution.py` so both plugins import it without cross-plugin coupling.
- New `calculate_phase_rep_breakdown()`: the phases-per-rep / total-reps math extracted verbatim from `RouteExecutionService`'s inline block, so the Phase/Rep status breakdown is shared logic too.
- `RouteExecutionService` (device viewer) is behaviorally unchanged — its inline rep math is now one call to the central method (verified equivalent across loop/open/mixed/linear-repeat scenarios).

### Protocol tree mirrors the device viewer (`services/phase_math.py`)
`phase_math` becomes a thin adapter over the central engine. Its public contract is untouched (`iter_phases`, `duration_loop_parts`, `unit_cycle_len`, `estimate_repeat_duration_s`, `effective_repetitions_for_duration`, budget gates) so the routes column, repeat-duration column, status controller and dock pane need no changes — but internally every phase now comes from the centralized execution plan. The tree's private window/zip/ramp reimplementation (~350 lines) is deleted.

**Intentional behavior changes** — protocol runs now match device-viewer playback where they previously diverged:
1. **Open-path tail windows** re-anchor flush to the last electrode at full trail width instead of truncating to a partial window.
2. **Loop cycle lengths** use the device viewer's cycle termination (window counts now match for trail/overlay combos that don't divide the loop evenly).
3. **Repeat-duration mode** caps loop cycles by the device-viewer formula and pads the remaining budget with idle hold-at-start phases, instead of squeezing in extra cycles — a step's wall clock now matches its budget the same way playback does.
4. **Rep counts** (`effective_repetitions_for_duration`) use the device viewer's longest-loop selection rule.
5. **Soft start / soft end** follow the device viewer's (correct) semantics: route electrodes ramp in **path order** from the route start and statics stay fully on throughout — previously the tree ramped the merged set in sorted-ID order, which could start a ramp mid-trail and flicker static electrodes. The volume-threshold dynamic loop takes its ramp phases from the central plan itself, so it can't drift again.

### Tests
`test_phase_math.py` rewritten to pin the new contract: a direct iter_phases-equals-central-plan delegation test, the new repeat-duration/idle and path-order-ramp semantics, and the unchanged budget-gate math. (25 tests, all passing.)

## Verification
- Old inline device-viewer rep math run side-by-side against the extracted `calculate_phase_rep_breakdown` over four scenario families — identical results.
- All 25 phase_math contract tests pass.
- Worth a hardware pass: a protocol step with a repeat-duration loop (timing semantics changed per #3) and a volume-threshold step with soft start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)