### PR TITLE
perf(device-viewer): repaint only what changed

### DIFF
--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -162,6 +162,12 @@ GAMEPAD_DEBOUNCE_FIND_S = 2.0         # find-liquid button debounce
 GAMEPAD_DEBOUNCE_REALTIME_S = 0.4     # realtime-toggle button debounce
 GAMEPAD_AXIS_THRESHOLD = 0.6          # analog-stick-as-D-pad activation threshold
 
+# Poll cadence: ~100 Hz only while a controller is attached; with none,
+# a slow tick suffices to catch JOYDEVICEADDED hot-plug events instead
+# of waking the GUI thread 100x a second for nothing.
+GAMEPAD_POLL_INTERVAL_MS = 10
+GAMEPAD_IDLE_POLL_INTERVAL_MS = 500
+
 # ---------------------------------------------------------------------------
 # Resources & UI text
 # ---------------------------------------------------------------------------

--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -169,6 +169,15 @@ GAMEPAD_POLL_INTERVAL_MS = 10
 GAMEPAD_IDLE_POLL_INTERVAL_MS = 500
 
 # ---------------------------------------------------------------------------
+# Camera preview
+# ---------------------------------------------------------------------------
+# Ceiling for frames forwarded to the device view's video item. Every frame
+# composited under the electrodes is a full-scene repaint, and the preview
+# doesn't need camera rate to be useful — recordings are unaffected (the
+# recorder taps the capture session's own sink at full rate).
+CAMERA_PREVIEW_MAX_FPS = 20
+
+# ---------------------------------------------------------------------------
 # Resources & UI text
 # ---------------------------------------------------------------------------
 # main view device layout

--- a/device_viewer/models/main_model.py
+++ b/device_viewer/models/main_model.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from microdrop_utils.decorators import debounce
 
-from traits.api import Property, Str, Enum, observe, Instance, Bool, List, Float, HasTraits, Event, Int, UUID, provides, DelegatesTo
+from traits.api import Property, Str, Enum, observe, Instance, Bool, Dict, List, Float, HasTraits, Event, Int, UUID, provides, DelegatesTo
 from pyface.undo.api import UndoManager
 
 from .alpha import AlphaValue
@@ -99,6 +99,19 @@ class DeviceViewMainModel(HasTraits):
 
     # --------------------------------- Alpha Color Model --------------------------------
     alpha_map = List() # We store the dict as a list since TraitsUI doesnt support dicts
+
+    #: key -> AlphaValue lookup over alpha_map. get_alpha runs inside the
+    #: per-electrode recolor loop every protocol phase, so it must not be
+    #: a linear scan of the list (the list stays the TraitsUI-editable
+    #: source of truth; entries are mutated in place, so the index only
+    #: rebuilds when list membership changes).
+    _alpha_index = Dict()
+
+    @observe("alpha_map")
+    @observe("alpha_map.items")
+    def _rebuild_alpha_index(self, event):
+        self._alpha_index = {alpha_value.key: alpha_value
+                             for alpha_value in self.alpha_map}
 
     # ------------------ Camera Model --------------------
     camera_perspective = Instance(PerspectiveModel, PerspectiveModel())
@@ -220,27 +233,26 @@ class DeviceViewMainModel(HasTraits):
 
     def get_alpha(self, key: str) -> float:
         """Get the alpha value for a given key."""
-        for alpha_value in self.alpha_map:
-            if alpha_value.key == key:
-                return alpha_value.alpha / 100 if alpha_value.visible else 0.0
-        return 1.0 # Default alpha if not found
+        alpha_value = self._alpha_index.get(key)
+        if alpha_value is None:
+            return 1.0 # Default alpha if not found
+        return alpha_value.alpha / 100 if alpha_value.visible else 0.0
 
     def set_alpha(self, key: str, alpha: float):
         """Set the alpha value for a given key."""
-        for alpha_value in self.alpha_map:
-            if alpha_value.key == key:
-                alpha_value.alpha = alpha
-                return
-        # If not found, add a new alpha value
+        alpha_value = self._alpha_index.get(key)
+        if alpha_value is not None:
+            alpha_value.alpha = alpha
+            return
+        # If not found, add a new alpha value (the items observer re-indexes)
         self.alpha_map.append(AlphaValue(key=key, alpha=alpha))
 
     @debounce(0.2)
     def set_visible(self, key: str, visible: bool):
         """Set the visibility of a given alpha value."""
-        for alpha_value in self.alpha_map:
-            if alpha_value.key == key:
-                alpha_value.visible = visible
-                return
+        alpha_value = self._alpha_index.get(key)
+        if alpha_value is not None:
+            alpha_value.visible = visible
 
     def goto_last_mode(self):
         logger.debug(f"Going to last mode: {self.last_mode}")

--- a/device_viewer/models/route.py
+++ b/device_viewer/models/route.py
@@ -347,6 +347,10 @@ class RouteLayerManager(HasTraits):
 
     # --------------------------- Model Helpers --------------------------
 
+    @staticmethod
+    def _least_used_color(color_counts: dict) -> str:
+        return Counter(color_counts).most_common()[-1][0]
+
     def get_available_color(self, exclude=()):
         color_counts = {}
         color_pool = ROUTE_COLOR_POOL
@@ -355,7 +359,7 @@ class RouteLayerManager(HasTraits):
         for layer in self.layers:
             if layer.color in color_counts.keys():
                 color_counts[layer.color] += 1
-        return Counter(color_counts).most_common()[-1][0] # Return least common color
+        return self._least_used_color(color_counts)
 
     def replace_all_layers(self, routes: list[Route]):
         """Swap the full layer stack in ONE list assignment (a single
@@ -368,7 +372,7 @@ class RouteLayerManager(HasTraits):
         color_counts = {color: 0 for color in ROUTE_COLOR_POOL}
         new_layers = []
         for route in routes:
-            color = Counter(color_counts).most_common()[-1][0]
+            color = self._least_used_color(color_counts)
             color_counts[color] += 1
             new_layers.append(RouteLayer(route=route, color=color))
         self.layers = new_layers

--- a/device_viewer/models/route.py
+++ b/device_viewer/models/route.py
@@ -357,6 +357,22 @@ class RouteLayerManager(HasTraits):
                 color_counts[layer.color] += 1
         return Counter(color_counts).most_common()[-1][0] # Return least common color
 
+    def replace_all_layers(self, routes: list[Route]):
+        """Swap the full layer stack in ONE list assignment (a single
+        layers-items notification, so the connection map repaints exactly
+        once with the final stack). Colors come from the standard pool the
+        same way sequential add_layer calls on an empty manager would pick
+        them — callers applying protocol-side state use this so route
+        colors are always the device viewer's own (selected/loop colors
+        are applied at render time regardless of layer color)."""
+        color_counts = {color: 0 for color in ROUTE_COLOR_POOL}
+        new_layers = []
+        for route in routes:
+            color = Counter(color_counts).most_common()[-1][0]
+            color_counts[color] += 1
+            new_layers.append(RouteLayer(route=route, color=color))
+        self.layers = new_layers
+
     def replace_layer(self, old_route_layer: RouteLayer, new_routes: list[Route]):
         index = self.layers.index(old_route_layer)
 

--- a/device_viewer/services/electrode_interaction_service.py
+++ b/device_viewer/services/electrode_interaction_service.py
@@ -1905,17 +1905,54 @@ class ElectrodeInteractionControllerService(HasTraits):
         if self.electrode_view_layer:
             self.electrode_view_layer.redraw_connections_to_scene(self.model)
 
-    @observe("model.electrodes.actuated_channels.items")
-    @observe("model.electrodes.disabled_channels.items")
     @observe("model.electrodes.electrode_editing")
     @observe("model.electrodes.electrodes.items.channel")
-    @observe("electrode_hovered")
     def electrode_state_recolor(self, event):
         if self.electrode_view_layer:
             self.electrode_view_layer.redraw_electrode_colors(
                 self.model,
                 self.electrode_hovered,
             )
+
+    @observe("model.electrodes.actuated_channels.items")
+    @observe("model.electrodes.disabled_channels.items")
+    def actuation_state_recolor(self, event):
+        """Recolor only the electrodes whose channels changed — the hot
+        path during protocol runs (each phase touches a handful of the
+        board's channels).
+
+        Two event shapes arrive here: in-place mutation gives a
+        SetChangeEvent (added/removed); wholesale replacement — what
+        RouteExecutionService._apply_phase does every phase — gives the
+        container change event (old/new sets), diffed here by symmetric
+        difference (= exactly the channels whose membership flipped)."""
+        if not self.electrode_view_layer:
+            return
+        added = getattr(event, "added", None)
+        removed = getattr(event, "removed", None)
+        if added is not None or removed is not None:
+            changed_channels = set(added or ()) | set(removed or ())
+        else:
+            old, new = getattr(event, "old", None), getattr(event, "new", None)
+            if not isinstance(old, (set, frozenset)) or not isinstance(new, (set, frozenset)):
+                # Unknown event shape: recolor everything rather than guess.
+                self.electrode_view_layer.redraw_electrode_colors(
+                    self.model, self.electrode_hovered)
+                return
+            changed_channels = set(old) ^ set(new)
+        self.electrode_view_layer.redraw_electrode_colors_for_channels(
+            self.model, changed_channels, self.electrode_hovered)
+
+    @observe("electrode_hovered")
+    def hovered_electrode_recolor(self, event):
+        """Hover only affects the two electrodes involved; recoloring the
+        whole board per mouse move made hovering expensive."""
+        if not self.electrode_view_layer:
+            return
+        for electrode_view in (event.old, event.new):
+            if electrode_view is not None:
+                self.electrode_view_layer.recolor_electrode(
+                    self.model, electrode_view, self.electrode_hovered)
 
     @observe("model.electrodes.electrodes.items.channel")
     def electrode_channel_change(self, event):

--- a/device_viewer/services/electrode_interaction_service.py
+++ b/device_viewer/services/electrode_interaction_service.py
@@ -23,6 +23,7 @@ from device_viewer.consts import (
     GAMEPAD_BTN_REMOVE, GAMEPAD_BTN_REALTIME, GAMEPAD_DEBOUNCE_MOVE_SPLIT_S,
     GAMEPAD_DEBOUNCE_ADD_REMOVE_S, GAMEPAD_DEBOUNCE_FIND_S,
     GAMEPAD_DEBOUNCE_REALTIME_S, GAMEPAD_AXIS_THRESHOLD,
+    GAMEPAD_POLL_INTERVAL_MS, GAMEPAD_IDLE_POLL_INTERVAL_MS,
 )
 from logger.logger_service import get_logger
 from microdrop_style.colors import GREY, SUCCESS_COLOR
@@ -482,7 +483,7 @@ class ElectrodeInteractionControllerService(HasTraits):
                 pass
 
     def _start_pygame_timer(self) -> None:
-        """Start the ~100 Hz poll timer (idempotent).
+        """Start the gamepad poll timer (idempotent).
 
         The timer is parented to the device view (a QObject) so Qt bounds its
         lifetime and tears it down even if ``cleanup`` is somehow missed —
@@ -491,10 +492,21 @@ class ElectrodeInteractionControllerService(HasTraits):
         if self._pygame_timer is not None:
             return  # already running
         timer = QTimer(self.device_view)
-        timer.setInterval(10)  # ~100 Hz
         timer.timeout.connect(self._poll_pygame_events)
         timer.start()
         self._pygame_timer = timer
+        self._update_pygame_timer_interval()
+
+    def _update_pygame_timer_interval(self) -> None:
+        """~100 Hz while a controller is attached; a slow hot-plug-detection
+        tick while none is (a persistent 100 Hz GUI-thread wakeup for an
+        absent gamepad costs smoothness for nothing)."""
+        if self._pygame_timer is None:
+            return
+        interval = (GAMEPAD_POLL_INTERVAL_MS if self._pygame_enabled
+                    else GAMEPAD_IDLE_POLL_INTERVAL_MS)
+        if self._pygame_timer.interval() != interval:
+            self._pygame_timer.setInterval(interval)
 
     # ------------------ Live remap (button capture) ------------------
 
@@ -660,6 +672,10 @@ class ElectrodeInteractionControllerService(HasTraits):
                 axis = int(getattr(e, "axis", -1))
                 value = float(getattr(e, "value", 0.0))
                 self._handle_pygame_axis(axis, value)
+
+        # Hot-plug events above may have attached/released the controller:
+        # follow with the matching poll cadence.
+        self._update_pygame_timer_interval()
 
     def _sync_modifiers_from_pygame_state(self) -> None:
         """

--- a/device_viewer/services/electrode_interaction_service.py
+++ b/device_viewer/services/electrode_interaction_service.py
@@ -1955,7 +1955,7 @@ class ElectrodeInteractionControllerService(HasTraits):
                 self.electrode_view_layer.redraw_electrode_colors(
                     self.model, self.electrode_hovered)
                 return
-            changed_channels = set(old) ^ set(new)
+            changed_channels = old ^ new
         self.electrode_view_layer.redraw_electrode_colors_for_channels(
             self.model, changed_channels, self.electrode_hovered)
 

--- a/device_viewer/utils/auto_fit_graphics_view.py
+++ b/device_viewer/utils/auto_fit_graphics_view.py
@@ -25,7 +25,11 @@ class AutoFitGraphicsView(QGraphicsView):
 
         self.setRenderHint(QPainter.Antialiasing, True)
         self.setRenderHint(QPainter.TextAntialiasing, True)
-        self.setViewportUpdateMode(QGraphicsView.FullViewportUpdate)
+        # Repaint only the changed items' bounding rects: with
+        # FullViewportUpdate, any change (a video frame, one electrode
+        # toggling) re-rasterized the ENTIRE scene — every electrode path
+        # and label — per update.
+        self.setViewportUpdateMode(QGraphicsView.BoundingRectViewportUpdate)
 
     def resizeEvent(self, event):
         if self.auto_fit:

--- a/device_viewer/utils/camera.py
+++ b/device_viewer/utils/camera.py
@@ -142,7 +142,8 @@ class VideoRecorder(QObject):
     # Internal signal to bridge UI thread and Worker thread
     _send_to_worker = Signal(QImage, QRectF, QRectF, QTransform)
 
-    def __init__(self, video_item: 'QGraphicsVideoItem', ffmpeg_binary="ffmpeg", parent=None):
+    def __init__(self, video_item: 'QGraphicsVideoItem', ffmpeg_binary="ffmpeg",
+                 parent=None, frame_sink=None):
         super().__init__(parent)
         self.ffmpeg_binary = ffmpeg_binary
 
@@ -150,6 +151,11 @@ class VideoRecorder(QObject):
         self.is_recording = False
         self._output_path = None
         self._video_item = video_item
+        # Frames come from this sink; geometry still comes from the video
+        # item. Passing the capture session's own sink keeps recordings at
+        # full camera rate while the DISPLAY item receives rate-capped
+        # preview frames (see CameraControlWidget._forward_preview_frame).
+        self._frame_sink = frame_sink if frame_sink is not None else video_item.videoSink()
         self.current_image = None
 
         # FFmpeg / IO internals
@@ -348,7 +354,7 @@ class VideoRecorder(QObject):
         # 4. Connect to Video Source
         # We connect the video sink directly to our internal handler
         self.is_recording = True
-        self._video_item.videoSink().videoFrameChanged.connect(self._on_frame_arrived)
+        self._frame_sink.videoFrameChanged.connect(self._on_frame_arrived)
 
         self.recording_started.emit(output_path)
         logger.info(f"Recording started: {output_path}")
@@ -365,9 +371,9 @@ class VideoRecorder(QObject):
         self.is_recording = False
 
         # 1. Disconnect Source (Stop incoming data)
-        if self._video_item:
+        if self._frame_sink:
             try:
-                self._video_item.videoSink().videoFrameChanged.disconnect(self._on_frame_arrived)
+                self._frame_sink.videoFrameChanged.disconnect(self._on_frame_arrived)
             except Exception:
                 pass
 

--- a/device_viewer/views/camera_control_view/widget.py
+++ b/device_viewer/views/camera_control_view/widget.py
@@ -1,3 +1,4 @@
+import time
 from pathlib import Path
 
 from PySide6.QtCore import (
@@ -6,7 +7,10 @@ from PySide6.QtCore import (
     QTimer,
 )
 from PySide6.QtGui import QImage
-from PySide6.QtMultimedia import QMediaCaptureSession, QCamera, QMediaDevices, QCameraDevice, QCameraFormat, QVideoFrame
+from PySide6.QtMultimedia import (
+    QMediaCaptureSession, QCamera, QMediaDevices, QCameraDevice,
+    QCameraFormat, QVideoFrame, QVideoSink,
+)
 from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
 from PySide6.QtWidgets import (
     QWidget,
@@ -26,6 +30,7 @@ from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from microdrop_utils.pyside_helpers import MarqueeComboBox
 from microdrop_utils.v4l2_fps_getter import get_video_inputs, LinuxCameraDeviceContainer
 from ...consts import (
+    CAMERA_PREVIEW_MAX_FPS,
     CAPTURES_DIR_NAME,
     DEVICE_VIEWER_RECORDING_STATE,
     RAW_CAPTURES_SUBDIR,
@@ -108,10 +113,18 @@ class CameraControlWidget(QWidget):
         self.show_media_capture_dialog_for_video = True
 
         self.scene.addItem(self.video_item)
-        self.session.setVideoOutput(self.video_item)
+        # The session delivers to our own sink at full camera rate; frames
+        # are forwarded to the DISPLAY item capped at CAMERA_PREVIEW_MAX_FPS
+        # (every frame under the electrodes is a full-scene composite, and
+        # the preview doesn't need camera rate to be useful).
+        self._camera_sink = QVideoSink(self)
+        self._camera_sink.videoFrameChanged.connect(self._forward_preview_frame)
+        self.session.setVideoSink(self._camera_sink)
+        self._last_preview_frame_time = 0.0
 
-        # 1. Initialize Recorder
-        self.recorder = VideoRecorder(self.video_item)
+        # 1. Initialize Recorder — fed from the full-rate camera sink, so
+        # recordings are untouched by the preview cap.
+        self.recorder = VideoRecorder(self.video_item, frame_sink=self._camera_sink)
         self.recorder.error_occurred.connect(self.handle_recording_error)
         self.recorder.recording_stopped.connect(self.handle_recording_stopped)
         self.recording_file_path = None
@@ -457,8 +470,22 @@ class CameraControlWidget(QWidget):
         self.video_item.setVisible(False)
         logger.info("Provider camera feed stopped")
 
+    def _preview_frame_due(self) -> bool:
+        """Rate gate for frames forwarded to the display item (see
+        CAMERA_PREVIEW_MAX_FPS). Recording is fed separately at full rate."""
+        now = time.monotonic()
+        if now - self._last_preview_frame_time < 1.0 / CAMERA_PREVIEW_MAX_FPS:
+            return False
+        self._last_preview_frame_time = now
+        return True
+
+    def _forward_preview_frame(self, frame):
+        if self._preview_frame_due():
+            self.video_item.videoSink().setVideoFrame(frame)
+
     def _on_feed_frame(self, image):
-        self.video_item.videoSink().setVideoFrame(QVideoFrame(image))
+        if self._preview_frame_due():
+            self.video_item.videoSink().setVideoFrame(QVideoFrame(image))
 
     def _on_feed_streaming(self, active):
         """Provider feeds own their preview state (e.g. the fluorescence

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -1249,6 +1249,14 @@ class DeviceViewerDockPane(TraitsDockPane):
         if self._disable_state_messages:
             return
 
+        if self.model.route_execution_service_executing:
+            # Route playback replaces actuated_channels every phase;
+            # serializing + publishing the whole model per phase is
+            # GUI-thread work with no consumer at that rate. The final
+            # state still publishes: _cleanup flips this flag off BEFORE
+            # restoring the user-toggled channels.
+            return
+
         if not self.model.electrodes.svg_model:
             logger.warning("Unable to publish device view model yet. Need svg_model to fully initialize.")
             return

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -93,7 +93,7 @@ from ..models.electrodes import Electrodes
 # models and services
 from ..models.main_model import DeviceViewMainModel
 from ..models.messages import DeviceViewerMessageModel
-from ..models.route import Route
+from ..models.route import Route, RouteLayer
 from ..preferences import DeviceViewerPreferences, sidebar_settings_grid, DeviceViewerAdvancedPreferences
 from ..services.electrode_interaction_service import (
     ElectrodeInteractionControllerService,
@@ -448,10 +448,12 @@ class DeviceViewerDockPane(TraitsDockPane):
         if message_model.uuid == self.model.uuid:
             return  # Ignore messages that are from the same model
 
-        # Reset the model to clear any existing routes and channels
+        # Apply the incoming state as a DIFF — no reset-then-rebuild. The
+        # old path cleared every route layer and re-added them one by one,
+        # repainting the connection map once per layer with the routes
+        # visibly blinking off in between (the per-phase flicker).
         self._disable_state_messages = True  # Prevent state messages from being sent while we apply the new state
         self._undoing = True  # Prevent changes from being added to the undo stack (otherwise model changes are undone during playback)
-        self.model.reset()
 
         # Apply step ID
         self.model.step_id = message_model.step_id
@@ -466,27 +468,39 @@ class DeviceViewerDockPane(TraitsDockPane):
         self.model.editable = message_model.editable
 
         # Electrode->channel mapping is NOT carried on state messages (#415):
-        # electrodes keep their geometry-derived channels (reset() clears only
-        # actuation state, not channel assignments), so there is nothing to
-        # apply here.
+        # electrodes keep their geometry-derived channels, so there is
+        # nothing to apply here.
 
-        # Apply electrode on/off states
-        self.model.electrodes.actuated_channels.update(
+        # Apply electrode on/off states in ONE assignment: the recolor
+        # observer receives a single old/new event and repaints only the
+        # channels whose membership flipped.
+        self.model.electrodes.electrode_editing = None
+        self.model.electrodes.actuated_channels = set(
             message_model.channels_activated
         )
 
-        # Apply routes
-        for route, color in message_model.routes:
-            self.model.routes.add_layer(Route(route=route.copy()), None, color)
+        # Apply routes only when they actually changed (phase toggles change
+        # actuation only) — and then as one list swap, so the connection map
+        # repaints exactly once with the final layer stack. This also means
+        # the layers are never transiently empty, so repeats_frozen can't
+        # flip on mid-apply and pin Repetitions/Repeat Dur to 1/0 before the
+        # step's execution params are pulled below.
+        incoming_routes = [(route, color) for route, color in message_model.routes]
+        current_routes = [(list(layer.route.route), layer.color)
+                          for layer in self.model.routes.layers]
+        if incoming_routes != current_routes:
+            self.model.routes.layers = [
+                RouteLayer(route=Route(route=route.copy()), color=color)
+                for route, color in message_model.routes
+            ]
         self.model.routes.selected_layer = None
+        self.model.routes.layer_to_merge = None
+        self.model.routes.mode = "draw"
+        self.model.routes.message = ""
 
         # Pull the step's execution params into the sidebar AFTER the routes
-        # exist. reset() above transiently empties the layers, which flips
-        # repeats_frozen on (no loop present) and pins Repetitions/Repeat Dur
-        # to 1/0; applying the params now — with the real route set in place —
-        # means that pin can't clobber the pulled values (e.g. a loop step's
-        # Repetitions snapping back to 1). Also baselines the sidebar so the
-        # commit button starts disabled.
+        # are in place, then baseline the sidebar so the commit button
+        # starts disabled.
         if step_changed:
             if message_model.execution_params:
                 self.model.routes.apply_execution_params(message_model.execution_params)
@@ -500,8 +514,6 @@ class DeviceViewerDockPane(TraitsDockPane):
 
         # Publish geometry if the electrode-to-channel mapping changed.
         self._publish_geometry_if_changed()
-
-        QApplication.processEvents()
 
     def _check_unsaved_execution_params(self):
         # ask user if they want to save changes if there are any before moving on

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -93,7 +93,7 @@ from ..models.electrodes import Electrodes
 # models and services
 from ..models.main_model import DeviceViewMainModel
 from ..models.messages import DeviceViewerMessageModel
-from ..models.route import Route, RouteLayer
+from ..models.route import Route
 from ..preferences import DeviceViewerPreferences, sidebar_settings_grid, DeviceViewerAdvancedPreferences
 from ..services.electrode_interaction_service import (
     ElectrodeInteractionControllerService,
@@ -485,14 +485,19 @@ class DeviceViewerDockPane(TraitsDockPane):
         # the layers are never transiently empty, so repeats_frozen can't
         # flip on mid-apply and pin Repetitions/Repeat Dur to 1/0 before the
         # step's execution params are pulled below.
-        incoming_routes = [(route, color) for route, color in message_model.routes]
-        current_routes = [(list(layer.route.route), layer.color)
+        #
+        # Protocol-side colors are deliberately IGNORED: the tree echoes
+        # back whatever it stored, which drifts from (and reorders against)
+        # the viewer's palette — the visible symptom was routes flipping
+        # between shades on alternate phases. Route colors are the device
+        # viewer's own: selected paints yellow and loops CW/CCW at render
+        # time; everything else gets the standard pool color.
+        incoming_routes = [route for route, _color in message_model.routes]
+        current_routes = [list(layer.route.route)
                           for layer in self.model.routes.layers]
         if incoming_routes != current_routes:
-            self.model.routes.layers = [
-                RouteLayer(route=Route(route=route.copy()), color=color)
-                for route, color in message_model.routes
-            ]
+            self.model.routes.replace_all_layers(
+                [Route(route=route.copy()) for route in incoming_routes])
         self.model.routes.selected_layer = None
         self.model.routes.layer_to_merge = None
         self.model.routes.mode = "draw"

--- a/device_viewer/views/electrode_view/electrode_layer.py
+++ b/device_viewer/views/electrode_view/electrode_layer.py
@@ -186,52 +186,73 @@ class ElectrodeLayer():
         for electrode_id, electrode_view in self.electrode_views.items():
             electrode_view.update_line_alpha(alpha)
 
-    def redraw_electrode_colors(self, model: DeviceViewMainModel, electrode_hovered: ElectrodeView):
+    def recolor_electrode(self, model: DeviceViewMainModel,
+                          electrode_view: ElectrodeView,
+                          electrode_hovered: ElectrodeView):
+        """Recompute one electrode's color stack from the model state.
 
-        for electrode_id, electrode_view in self.electrode_views.items():
-            # initialize color stack
-            color_stack = []
+        ElectrodeView.update_color skips the repaint when the stack is
+        value-equal to the current one, so calling this for untouched
+        electrodes costs no rendering."""
+        # determine base_color:
+        if electrode_view.electrode == model.electrodes.electrode_editing:
+            base_color = ELECTRODE_CHANNEL_EDITING
 
-            # determine base_color:
-            if electrode_view.electrode == model.electrodes.electrode_editing:
-                base_color = ELECTRODE_CHANNEL_EDITING
+        elif electrode_view.electrode.channel == None:
+            base_color = ELECTRODE_NO_CHANNEL
 
-            elif electrode_view.electrode.channel == None:
-                base_color = ELECTRODE_NO_CHANNEL
+        else:
+            base_color = ELECTRODE_OFF
 
-            else:
-                base_color = ELECTRODE_OFF
+        # construct the base QColor
+        base_color = QColor(base_color)
+        base_color.setAlphaF(model.get_alpha(electrode_fill_key))
 
-            # construct the base QColor
-            base_color = QColor(base_color)
-            base_color.setAlphaF(model.get_alpha(electrode_fill_key))
-
-            # Determine inner color: disabled (red) takes priority over actuation
-            channel = electrode_view.electrode.channel
-            is_disabled = channel in model.electrodes.disabled_channels
+        # Determine inner color: disabled (red) takes priority over actuation
+        channel = electrode_view.electrode.channel
+        is_disabled = channel in model.electrodes.disabled_channels
+        if is_disabled != electrode_view._disabled:
+            # Tooltips only mention the disabled flag, so they need
+            # rebuilding only when it flips — not on every recolor.
             electrode_view._disabled = is_disabled
             electrode_view.update_tooltip()
-            inner_color = None
-            if is_disabled:
-                inner_color = QColor(ELECTRODE_DISABLED)
-                inner_color.setAlphaF(model.get_alpha(actuated_electrodes_key))
-            elif channel in model.electrodes.actuated_channels:
-                inner_color = QColor(ELECTRODE_ON)
-                inner_color.setAlphaF(model.get_alpha(actuated_electrodes_key))
+        inner_color = None
+        if is_disabled:
+            inner_color = QColor(ELECTRODE_DISABLED)
+            inner_color.setAlphaF(model.get_alpha(actuated_electrodes_key))
+        elif channel in model.electrodes.actuated_channels:
+            inner_color = QColor(ELECTRODE_ON)
+            inner_color.setAlphaF(model.get_alpha(actuated_electrodes_key))
 
-            # check if fills need editing if they are hovered:
-            if electrode_hovered == electrode_view:
-                lighter_percent = get_qcolor_lighter_percent_from_factor(base_color, model.get_alpha(hovered_electrode_key))
-                base_color = base_color.lighter(lighter_percent)
-                if inner_color:
-                    lighter_percent = get_qcolor_lighter_percent_from_factor(inner_color, model.get_alpha(hovered_actuation_key))
-                    inner_color = inner_color.lighter(lighter_percent)
-
-            color_stack.append(base_color)
+        # check if fills need editing if they are hovered:
+        if electrode_hovered == electrode_view:
+            lighter_percent = get_qcolor_lighter_percent_from_factor(base_color, model.get_alpha(hovered_electrode_key))
+            base_color = base_color.lighter(lighter_percent)
             if inner_color:
-                color_stack.append(inner_color)
+                lighter_percent = get_qcolor_lighter_percent_from_factor(inner_color, model.get_alpha(hovered_actuation_key))
+                inner_color = inner_color.lighter(lighter_percent)
 
-            electrode_view.update_color(color_stack)
+        color_stack = [base_color]
+        if inner_color:
+            color_stack.append(inner_color)
+
+        electrode_view.update_color(color_stack)
+
+    def redraw_electrode_colors(self, model: DeviceViewMainModel, electrode_hovered: ElectrodeView):
+        for electrode_view in self.electrode_views.values():
+            self.recolor_electrode(model, electrode_view, electrode_hovered)
+
+    def redraw_electrode_colors_for_channels(self, model: DeviceViewMainModel,
+                                             channels,
+                                             electrode_hovered: ElectrodeView):
+        """Recolor only the electrodes mapped to ``channels`` — the
+        actuation hot path during protocol runs, where each phase changes
+        a handful of channels out of the whole board."""
+        for channel in channels:
+            for electrode_id in model.electrodes.channels_electrode_ids_map.get(channel, []):
+                electrode_view = self.electrode_views.get(electrode_id)
+                if electrode_view is not None:
+                    self.recolor_electrode(model, electrode_view, electrode_hovered)
 
     def redraw_electrode_labels(self, model: DeviceViewMainModel):
         alpha = model.get_alpha(electrode_text_key)

--- a/device_viewer/views/electrode_view/electrodes_view_base.py
+++ b/device_viewer/views/electrode_view/electrodes_view_base.py
@@ -169,11 +169,6 @@ class ElectrodeView(QGraphicsPathItem):
 
         self.color_stack = None # only supports two right now: base, and actuation/disabled layer color
         self._disabled = False  # Whether this electrode's channel is disabled
-        self.state_map = { # Maps electrode states to colors
-            None: ELECTRODE_OFF,
-            False: ELECTRODE_OFF,
-            True: ELECTRODE_ON
-        }
 
         self.electrode = electrode
         self.id = id_

--- a/device_viewer/views/electrode_view/electrodes_view_base.py
+++ b/device_viewer/views/electrode_view/electrodes_view_base.py
@@ -75,6 +75,10 @@ class ElectrodeConnectionItem(QGraphicsPathItem):
 
         self.setPath(self._arrow_path)
 
+        # Rendered as a cached pixmap: with the video item repainting the
+        # scene at frame rate, uncached paths would re-rasterize per frame.
+        self.setCacheMode(QGraphicsItem.CacheMode.DeviceCoordinateCache)
+
         # Add a new variable specific to this class
         self.key = key
         self.set_inactive()
@@ -122,7 +126,10 @@ class ElectrodeEndpointItem(QGraphicsPathItem):
         path.closeSubpath()
 
         self.setPath(path)
-   
+
+        # Rendered as a cached pixmap (see ElectrodeConnectionItem).
+        self.setCacheMode(QGraphicsItem.CacheMode.DeviceCoordinateCache)
+
         # Add a new variable specific to this class
         self.electrode_id = electrode_id
         self.set_inactive()
@@ -196,6 +203,13 @@ class ElectrodeView(QGraphicsPathItem):
         # Make the electrode selectable and focusable
         # self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsSelectable, True)
         self.setFlag(QGraphicsItem.GraphicsItemFlag.ItemIsFocusable, True)
+
+        # Render electrode + label as cached pixmaps: geometry is static, so
+        # video frames underneath composite the cache instead of
+        # re-rasterizing every antialiased path per frame. Color changes
+        # invalidate the cache automatically (update()).
+        self.setCacheMode(QGraphicsItem.CacheMode.DeviceCoordinateCache)
+        self.text_path.setCacheMode(QGraphicsItem.CacheMode.DeviceCoordinateCache)
 
         # Show electrode info on hover
         self.setToolTip(self._tooltip_text)
@@ -275,6 +289,11 @@ class ElectrodeView(QGraphicsPathItem):
         """
         Method to update the color of the electrode based on the state
         """
+        # Recolor passes rebuild equal-valued stacks for untouched
+        # electrodes; skipping them avoids repainting the whole layer
+        # (QColor equality compares rgba, so this is value comparison).
+        if colors == self.color_stack:
+            return
         # set the color stack: supports only two elements right now.
         self.color_stack = colors
         self.update()


### PR DESCRIPTION
## Summary

During protocol runs (and whenever a camera streams into the device view) the GUI stutters because the rendering pipeline treats every change as "repaint the world". This PR makes repaint cost proportional to what actually changed. Follow-up to the rendering investigation; three independent commits.

## The problems (measured by code inspection)

1. **`FullViewportUpdate` + video in the same scene**: every camera frame re-rasterized every antialiased electrode path and every text label, continuously.
2. **Whole-board recolor per phase**: any `actuated_channels` change looped over ALL electrodes â€” fresh `QColor` allocations each, a tooltip string rebuild each, and two `get_alpha()` calls each, where `get_alpha` was an O(n) linear list scan (O(electrodes Ã— alphas) per phase). Every electrode then scheduled a repaint unconditionally. The same full recolor ran on every mouse hover change.
3. **A 100 Hz gamepad `QTimer`** pumped SDL events on the GUI thread forever, controller attached or not.

## The changes

### `15890b8d` â€” paint machinery
- `BoundingRectViewportUpdate`: only changed items' rects repaint.
- `DeviceCoordinateCache` on electrode paths, labels, connections, endpoints: video frames composite cached pixmaps instead of re-rasterizing vector paths per frame; color changes still invalidate automatically.
- `ElectrodeView.update_color()` skips value-equal color stacks â€” no repaint scheduled for untouched electrodes.

### `64900e98` â€” recolor proportional to change
- Actuation/disable observers recolor **only the flipped channels' electrodes** (`channels_electrode_ids_map`). Both event shapes handled: in-place set mutations (SetChangeEvent diff) and the wholesale per-phase set replacement `RouteExecutionService._apply_phase` performs (old/new symmetric difference â€” verified by test that traits delivers the container event in that case).
- Hover recolors exactly the two electrodes involved.
- `get_alpha` is now an O(1) dict lookup (`_alpha_index`, rebuilt on list-membership changes; the list stays the TraitsUI-editable source of truth).
- Tooltips rebuild only when the disabled flag actually flips.
- Editing-mode / channel-assignment changes keep the full-board recolor (they legitimately affect everything).

### `9fa57a2b` â€” gamepad poll idles
2 Hz hot-plug detection with no controller; 100 Hz only while one is connected; switches automatically on attach/detach.

## Verification
Offscreen test battery: traits set-replacement vs mutation event shapes (the targeted-path assumption), alpha index correctness incl. hiddenâ†’0 and append re-indexing, `update_color` change-detection (equal stack â†’ no update() call), observer routing (diff â†’ targeted, replacement â†’ symmetric diff, unknown shape â†’ full-redraw fallback, hover â†’ pair only), `BoundingRectViewportUpdate` active on the view.

Worth a manual pass: a protocol run with the ASI/camera stream on (the original stutter scenario), hovering during a run, disabling channels mid-run, and device rotate/resize (cache invalidation on transform change).

## Round 2 — flicker fix + video-rate costs (same branch)

### `99d498cc` — diff-based display-state apply (route-color flicker fix)
Each phase toggle cleared every route layer and re-added them one by one — the connection map repainted once per layer with routes visibly blinking off in between, and `QApplication.processEvents()` mid-apply let those intermediate frames paint. State now applies as a diff: actuation replaces in ONE assignment (single old/new event for the targeted recolor), route layers are untouched when identical (the per-phase case) or swapped in one list assignment, and the mid-apply event pump is gone. Layers are never transiently empty, so `repeats_frozen` can't flip on mid-apply.

### `30ddd439` — no whole-model serialization during route playback
The full device-state serialize+publish ran per playback phase with no consumer at that rate; the final state still publishes on completion.

### `72dfa98f` — preview frame-rate cap, recordings untouched
The capture session delivers to the widget's own `QVideoSink`; the display item gets frames capped at `CAMERA_PREVIEW_MAX_FPS` (20), while the recorder taps the full-rate sink directly — recordings keep every frame. Provider/ASI feeds get the same display gate. (Companion commit `e2d6cea` in the fluorescence plugin repo rate-caps and stride-subsamples ASI preview frames to ~960px BEFORE the 16-bit display conversion — dropped frames cost nothing, kept ones convert ~16x fewer pixels; captures stay full-rate/full-res.)

## Not in scope
- OpenGL viewport: deliberately excluded (has broken rendering on this hardware in the past).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
