### PR TITLE
feat(device-viewer): native recording, Recording Viewer + recording preferences

### DIFF
--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from device_viewer.models.media import RecordingStatePublisher, RecordingStateModel
+from device_viewer.models.media import (
+    MediaCaptureEventModel, RecordingStatePublisher, RecordingStateModel,
+)
 from dropbot_controller.consts import (
     CHIP_INSERTED,
     CAPACITANCE_UPDATED,
@@ -114,6 +116,11 @@ DEVICE_VIEWER_RECORDING_ACTIVE_KEY = "device_viewer.recording_active" # live vid
 # Mirrors the live recording state to app_globals (see DEVICE_VIEWER_RECORDING_ACTIVE_KEY).
 recording_state_model = RecordingStateModel(globals_key=DEVICE_VIEWER_RECORDING_ACTIVE_KEY)
 
+# Fires with the saved file's path when a capture finishes writing — the
+# event-driven alternative to polling the captures folder (e.g. the
+# fluorescence image viewer refreshes on it).
+media_capture_event_model = MediaCaptureEventModel()
+
 APP_GLOBALS_KEYS = [CHANNEL_AREAS_KEY, FILLER_CAPACITANCE_KEY,
                     LIQUID_CAPACITANCE_KEY, DEVICE_SVG_PATH_KEY]
 
@@ -167,6 +174,11 @@ GAMEPAD_AXIS_THRESHOLD = 0.6          # analog-stick-as-D-pad activation thresho
 # of waking the GUI thread 100x a second for nothing.
 GAMEPAD_POLL_INTERVAL_MS = 10
 GAMEPAD_IDLE_POLL_INTERVAL_MS = 500
+
+# Sidecar written next to every recording by NativeVideoRecorder: the video
+# item's alignment geometry, letting viewers reproduce the device-aligned
+# (perspective-warped) view of the raw camera file on demand.
+RECORDING_TRANSFORM_SIDECAR_SUFFIX = ".transform.json"
 
 # ---------------------------------------------------------------------------
 # Camera preview

--- a/device_viewer/consts.py
+++ b/device_viewer/consts.py
@@ -181,6 +181,50 @@ GAMEPAD_IDLE_POLL_INTERVAL_MS = 500
 RECORDING_TRANSFORM_SIDECAR_SUFFIX = ".transform.json"
 
 # ---------------------------------------------------------------------------
+# Video recording preferences (camera preferences node). The recorder is
+# rebuilt from these at every recording start, so changes apply live.
+# ---------------------------------------------------------------------------
+RECORDER_BACKEND_QT = "Qt MediaRecorder (hardware)"
+RECORDER_BACKEND_FFMPEG = "FFmpeg process"
+
+# Qt recorder container choices (drive both the QMediaFormat and the
+# recording file extension).
+QT_RECORDER_FORMAT_MP4 = "MP4"
+QT_RECORDER_FORMAT_MKV = "MKV"
+
+# FFmpeg-process recorder encoding choices. fps, resolution and pixel
+# format are always taken from the camera, never from preferences.
+FFMPEG_CONTAINERS = ("mkv", "mp4")
+FFMPEG_VIDEO_CODECS = ("libx264", "libx265")
+FFMPEG_PRESETS = ("ultrafast", "superfast", "veryfast", "faster", "fast",
+                  "medium", "slow", "slower", "veryslow")
+FFMPEG_DEFAULT_CRF = 17
+
+#: Qt/MKV recording quality tiers, easiest first: Auto is the recommended
+#: rate for the class (same as Medium — the sweet spot of the commonly
+#: recommended H.264 delivery bitrates), Low..Ultra span that range.
+RECORDING_BITRATE_TIERS = ("Auto", "Low", "Medium", "High", "Ultra")
+
+#: Resolution class label -> (CameraPreferences trait, {tier: Mbps}).
+RECORDING_BITRATE_CLASSES = {
+    "1080p @ 30 fps": ("qt_bitrate_1080p30_tier",
+                       {"Auto": 4.5, "Low": 3, "Medium": 4.5,
+                        "High": 6, "Ultra": 8}),
+    "1080p @ 60 fps": ("qt_bitrate_1080p60_tier",
+                       {"Auto": 6, "Low": 4.5, "Medium": 6,
+                        "High": 7.5, "Ultra": 9}),
+    "4K @ 24/30 fps": ("qt_bitrate_4k30_tier",
+                       {"Auto": 20, "Low": 15, "Medium": 20,
+                        "High": 25, "Ultra": 30}),
+    "4K @ 60 fps": ("qt_bitrate_4k60_tier",
+                    {"Auto": 45, "Low": 35, "Medium": 45,
+                     "High": 55, "Ultra": 70}),
+}
+# Class-matching thresholds for the ACTUAL camera format at record time.
+RECORDING_4K_MIN_HEIGHT = 1600   # frames at least this tall use the 4K classes
+RECORDING_60FPS_MIN_FPS = 45     # at least this fps uses the 60 fps classes
+
+# ---------------------------------------------------------------------------
 # Camera preview
 # ---------------------------------------------------------------------------
 # Ceiling for frames forwarded to the device view's video item. Every frame

--- a/device_viewer/models/media.py
+++ b/device_viewer/models/media.py
@@ -2,7 +2,7 @@ import json
 
 from pydantic import BaseModel, FilePath, StrictBool
 from enum import Enum
-from traits.api import HasTraits, Bool, observe, Str
+from traits.api import HasTraits, Bool, Event, observe, Str
 
 from microdrop_utils.dramatiq_pub_sub_helpers import ValidatedTopicPublisher
 
@@ -45,6 +45,18 @@ class RecordingStatePublisher(ValidatedTopicPublisher):
         (Validated as StrictBool by RecordingActiveState on publish.)
         """
         super().publish({"state": state})
+
+
+class MediaCaptureEventModel(HasTraits):
+    """In-process notification that a capture file finished writing.
+
+    Lives as a singleton in device_viewer.consts (like
+    recording_state_model) so any frontend plugin can observe it instead
+    of polling the captures folder; the event's payload is the saved
+    file's path. Fired AFTER the file is on disk.
+    """
+
+    captured = Event(Str)
 
 
 class RecordingStateModel(HasTraits):

--- a/device_viewer/plugin.py
+++ b/device_viewer/plugin.py
@@ -68,12 +68,13 @@ class DeviceViewerPlugin(Plugin):
 
     def _contributed_task_extensions_default(self):
         from .views.device_view_dock_pane import DeviceViewerDockPane
+        from .views.video_viewer.dock_pane import VideoViewerDockPane
         from .menus import tools_menu_factory
 
-        return [ 
+        return [
             TaskExtension(
                 task_id=self.task_id_to_contribute_view,
-                dock_pane_factories=[DeviceViewerDockPane],
+                dock_pane_factories=[DeviceViewerDockPane, VideoViewerDockPane],
                 actions=[
                     SchemaAddition(
                         factory=tools_menu_factory,

--- a/device_viewer/plugin.py
+++ b/device_viewer/plugin.py
@@ -64,7 +64,8 @@ class DeviceViewerPlugin(Plugin):
 
     def _preferences_categories_default(self):
         from .preferences import device_viewer_tab
-        return [device_viewer_tab]
+        from .views.camera_control_view.preferences import video_settings_tab
+        return [device_viewer_tab, video_settings_tab]
 
     def _contributed_task_extensions_default(self):
         from .views.device_view_dock_pane import DeviceViewerDockPane

--- a/device_viewer/preferences.py
+++ b/device_viewer/preferences.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from apptools.preferences.api import PreferencesHelper
 from envisage.ui.tasks.api import PreferencesCategory, PreferencesPane
 from microdrop_application.preferences_dialog import advanced_mode_tab
-from traits.api import Button, Dict, Directory, File, Instance, Property, Range, Bool, Str, observe
+from traits.api import Button, Dict, Directory, File, Float, Instance, Property, Range, Bool, Str, observe
 from traits.etsconfig.api import ETSConfig
 from traitsui.api import FileEditor, Group, HGroup, Item, View
 from pyface.qt.QtCore import QTimer
@@ -70,6 +70,14 @@ class DeviceViewerPreferences(PreferencesHelper):
 
     default_visibility = Dict(default_visibility)
     default_alphas = Dict(default_alphas)
+
+    ### Recording viewer (video_viewer pane) prefs ###
+    # Persisted zoom/pan of the playback canvas — the alignment transform
+    # can push the frame outside the pane's bounds, so the user's chosen
+    # framing must survive reloads. zoom 0.0 = unset (fit to view).
+    video_viewer_zoom = Float(0.0)
+    video_viewer_center_x = Float(0.0)
+    video_viewer_center_y = Float(0.0)
 
     ### main view prefs ###
     AUTO_FIT_MARGIN_SCALE = Range(

--- a/device_viewer/utils/camera.py
+++ b/device_viewer/utils/camera.py
@@ -2,14 +2,16 @@ import json
 import shutil
 import subprocess
 import threading
+from pathlib import Path
 from typing import List, Tuple
 import queue
 
-from PySide6.QtCore import QPointF, QRectF, Signal, QObject, QRunnable, Slot, QThread
+from PySide6.QtCore import QPointF, QRectF, QSize, QUrl, Signal, QObject, QRunnable, Slot, QThread
 from PySide6.QtGui import QImage, QTransform, Qt, QPainter
-from PySide6.QtMultimedia import QVideoFrame
+from PySide6.QtMultimedia import QMediaFormat, QMediaRecorder, QVideoFrame
 from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
 
+from device_viewer.consts import RECORDING_TRANSFORM_SIDECAR_SUFFIX
 from device_viewer.models.media import MediaType
 from device_viewer.views.camera_control_view.utils import _cache_media_capture
 from logger.logger_service import get_logger
@@ -128,6 +130,112 @@ class VideoProcessWorker(QObject):
     def stop(self):
         self._is_running = False
         logger.debug(f"Video image processing worker thread Stopped.")
+
+
+class NativeVideoRecorder(QObject):
+    """Records the RAW camera stream through Qt's own QMediaRecorder —
+    the platform's hardware-accelerated encoding pipeline (Media
+    Foundation on Windows). Per-frame cost to the application: zero — no
+    frames pass through Python at all, so the GUI stays smooth while
+    recording at any resolution.
+
+    The device-alignment perspective warp is NOT baked into the file
+    (baking it is what forced every frame through the GUI thread — see
+    VideoRecorder below). Instead the video item's alignment geometry is
+    written to a ``<video>.transform.json`` sidecar next to the
+    recording, so the aligned view can be reproduced offline on demand
+    (same parameters ``get_transformed_frame`` consumes per frame).
+
+    Drop-in for VideoRecorder's public surface: start/stop, is_recording,
+    current_image (always None — screenshots fall back to the live sink),
+    and the recording_started/recording_stopped/error_occurred signals.
+    """
+
+    recording_started = Signal(str)  # Emits path when started
+    recording_stopped = Signal(str)  # Emits output path
+    error_occurred = Signal(str)
+
+    def __init__(self, session, video_item: 'QGraphicsVideoItem', parent=None):
+        super().__init__(parent)
+        self._video_item = video_item
+        self.current_image = None  # VideoRecorder parity (see class docstring)
+        self._was_recording = False
+
+        self._recorder = QMediaRecorder(self)
+        session.setRecorder(self._recorder)
+        # Matroska/H.264, matching the legacy ffmpeg-pipe recordings'
+        # .mkv container (Qt's FFmpeg multimedia backend muxes it).
+        media_format = QMediaFormat(QMediaFormat.FileFormat.Matroska)
+        media_format.setVideoCodec(QMediaFormat.VideoCodec.H264)
+        self._recorder.setMediaFormat(media_format)
+        self._recorder.setQuality(QMediaRecorder.Quality.HighQuality)
+        self._recorder.errorOccurred.connect(self._on_recorder_error)
+        self._recorder.recorderStateChanged.connect(self._on_recorder_state_changed)
+
+    @property
+    def is_recording(self) -> bool:
+        return (self._recorder.recorderState()
+                == QMediaRecorder.RecorderState.RecordingState)
+
+    def start(self, output_path, resolution, fps):
+        """Start recording the RAW camera stream. ``resolution`` is the
+        selected camera format's size — pinned on the recorder so the
+        output is guaranteed full resolution (e.g. a 1920x1080 format
+        records a 1920x1080 file); the backend already records the active
+        format by default, this makes it explicit. ``fps`` is left to the
+        camera's real delivery rate."""
+        if self.is_recording:
+            return
+        if resolution:
+            self._recorder.setVideoResolution(QSize(*[int(side)
+                                                      for side in resolution]))
+        self._recorder.setOutputLocation(QUrl.fromLocalFile(str(output_path)))
+        self._recorder.record()
+        logger.info(f"Native recording requested: {output_path} "
+                    f"at {resolution}")
+
+    def stop(self):
+        """Stop recording; recording_stopped fires on the state change."""
+        if self.is_recording:
+            logger.info("Stopping native recording...")
+            self._recorder.stop()
+
+    def _on_recorder_state_changed(self, state):
+        if state == QMediaRecorder.RecorderState.RecordingState:
+            self._was_recording = True
+            self.recording_started.emit(
+                self._recorder.actualLocation().toLocalFile())
+        elif (state == QMediaRecorder.RecorderState.StoppedState
+                and self._was_recording):
+            self._was_recording = False
+            path = self._recorder.actualLocation().toLocalFile()
+            self._write_transform_sidecar(path)
+            _cache_media_capture.send(MediaType.VIDEO, path)
+            self.recording_stopped.emit(path)
+            logger.info(f"Native recording stopped: {path}")
+
+    def _on_recorder_error(self, _error, error_string):
+        logger.error(f"Native recorder error: {error_string}")
+        self.error_occurred.emit(error_string)
+
+    def _write_transform_sidecar(self, video_path):
+        """Persist the alignment geometry needed to reproduce the
+        device-aligned (warped) view offline — the same parameters the
+        legacy pipeline fed to get_transformed_frame for every frame."""
+        sidecar = {
+            "transform": json.loads(
+                qtransform_serialize(self._video_item.transform())),
+            "scene_bounding_rect": list(
+                self._video_item.sceneBoundingRect().getRect()),
+            "bounding_rect": list(self._video_item.boundingRect().getRect()),
+        }
+        sidecar_path = Path(video_path).with_suffix(
+            RECORDING_TRANSFORM_SIDECAR_SUFFIX)
+        try:
+            sidecar_path.write_text(json.dumps(sidecar, indent=2))
+            logger.info(f"Wrote recording transform sidecar: {sidecar_path}")
+        except Exception as e:
+            logger.warning(f"Could not write transform sidecar: {e}")
 
 
 class VideoRecorder(QObject):

--- a/device_viewer/utils/camera.py
+++ b/device_viewer/utils/camera.py
@@ -168,7 +168,15 @@ class NativeVideoRecorder(QObject):
         media_format = QMediaFormat(QMediaFormat.FileFormat.Matroska)
         media_format.setVideoCodec(QMediaFormat.VideoCodec.H264)
         self._recorder.setMediaFormat(media_format)
-        self._recorder.setQuality(QMediaRecorder.Quality.HighQuality)
+        # Highest-fidelity settings the API offers: quality-driven encoding
+        # (the quality level is IGNORED in the bitrate-driven modes) at the
+        # top quality tier — the FFmpeg backend maps this to a low-CRF,
+        # visually near-lossless encode. The remaining ceiling is the
+        # pipeline's 4:2:0 chroma subsampling; full-fidelity data lives in
+        # the 16-bit raw still captures.
+        self._recorder.setEncodingMode(
+            QMediaRecorder.EncodingMode.ConstantQualityEncoding)
+        self._recorder.setQuality(QMediaRecorder.Quality.VeryHighQuality)
         self._recorder.errorOccurred.connect(self._on_recorder_error)
         self._recorder.recorderStateChanged.connect(self._on_recorder_state_changed)
 

--- a/device_viewer/utils/camera.py
+++ b/device_viewer/utils/camera.py
@@ -1,21 +1,34 @@
 import json
+import shlex
 import shutil
 import subprocess
+import tempfile
 import threading
 from pathlib import Path
 from typing import List, Tuple
 import queue
 
-from PySide6.QtCore import QPointF, QRectF, QSize, QUrl, Signal, QObject, QRunnable, Slot, QThread
+import numpy as np
+from PySide6.QtCore import QPointF, QRectF, QSize, QUrl, Signal, QObject, QRunnable, Slot
 from PySide6.QtGui import QImage, QTransform, Qt, QPainter
-from PySide6.QtMultimedia import QMediaFormat, QMediaRecorder, QVideoFrame
+from PySide6.QtMultimedia import (QMediaFormat, QMediaRecorder, QVideoFrame,
+                                  QVideoFrameFormat)
 from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
 
-from device_viewer.consts import RECORDING_TRANSFORM_SIDECAR_SUFFIX
+from device_viewer.consts import (FFMPEG_DEFAULT_CRF, FFMPEG_PRESETS,
+                                  FFMPEG_VIDEO_CODECS,
+                                  QT_RECORDER_FORMAT_MKV,
+                                  QT_RECORDER_FORMAT_MP4,
+                                  RECORDING_TRANSFORM_SIDECAR_SUFFIX)
 from device_viewer.models.media import MediaType
 from device_viewer.views.camera_control_view.utils import _cache_media_capture
-from logger.logger_service import get_logger
+from logger.logger_service import get_logger, debug_throttled
 logger = get_logger(__name__)
+
+#: Bound on frames buffered between the GUI thread and the raw recorder's
+#: ffmpeg encoder (~2 s at 30 fps); when the encoder falls behind, new
+#: frames are dropped so the GUI thread never stalls.
+RAW_RECORDER_QUEUE_MAX_FRAMES = 60
 
 def qtransform_serialize(transform: QTransform) -> str:
     return json.dumps([transform.m11(), transform.m12(), transform.m13(),
@@ -93,46 +106,80 @@ class ImageSaver(QRunnable):
             logger.error(f"Failed to save image: {e}")
 
 
-class VideoProcessWorker(QObject):
+class VideoRecorderBase(QObject):
+    """Common surface of the interchangeable video recorders
+    (NativeVideoRecorder, RawFFMPEGVideoRecorder), so call sites can swap
+    implementations without touching anything but construction:
+
+    - ``start(output_path, resolution, fps)`` / ``stop()``
+    - ``is_recording`` property
+    - ``current_image`` (always None — screenshots fall back to the live
+      sink)
+    - ``recording_started`` / ``recording_stopped`` / ``error_occurred``
+      signals
+
+    Subclasses call ``_finalize_recording`` when a recording lands on disk;
+    it performs the shared stop-side bookkeeping (alignment-transform
+    sidecar, capture cache, ``recording_stopped``).
     """
-    Internal Worker: Runs on a background QThread.
-    Handles heavy image transformations and pushing to the thread-safe queue.
-    """
-    def __init__(self, write_queue, target_resolution):
-        super().__init__()
-        self._write_queue = write_queue
-        self._resolution = target_resolution
-        self._is_running = True
 
-    @Slot(QImage, QRectF, QRectF, QTransform)
-    def process_frame(self, src_image, src_rect, target_rect, transform):
-        if not self._is_running:
-            return
+    recording_started = Signal(str)  # Emits path when started
+    recording_stopped = Signal(str)  # Emits output path
+    error_occurred = Signal(str)
 
-        try:
-            # 1. Perform the heavy affine transformations (Cropping/Zooming)
-            result_image = get_transformed_frame(
-                src_image, src_rect, target_rect, transform, self._resolution
-            )
+    def __init__(self, video_item: 'QGraphicsVideoItem', parent=None):
+        super().__init__(parent)
+        self._video_item = video_item
+        self.current_image = None  # screenshots fall back to the live sink
 
-            logger.debug(f"Processed frame: {result_image}")
+    @property
+    def is_recording(self) -> bool:
+        raise NotImplementedError
 
-            # 2. Push to the thread-safe queue for the FFmpeg writer
-            if not result_image.isNull():
-                logger.debug(f"Pushing frame to ffmpeg queue")
-                self._write_queue.put(result_image)
-            else:
-                logger.warning(f"Got null image. Skipping frame")
-
-        except Exception as e:
-            logger.error(f"Video image processing worker Error: {e}")
+    def start(self, output_path, resolution, fps):
+        """Start recording to ``output_path``. ``resolution`` is the
+        selected camera format's size; ``fps`` its nominal frame rate."""
+        raise NotImplementedError
 
     def stop(self):
-        self._is_running = False
-        logger.debug(f"Video image processing worker thread Stopped.")
+        """Stop recording; ``recording_stopped`` fires once the file is
+        finalized."""
+        raise NotImplementedError
+
+    def _finalize_recording(self, output_path):
+        """Shared stop-side bookkeeping: persist the alignment geometry
+        sidecar, cache the capture, announce the recording."""
+        write_transform_sidecar(self._video_item, output_path)
+        _cache_media_capture.send(MediaType.VIDEO, output_path)
+        self.recording_stopped.emit(output_path)
 
 
-class NativeVideoRecorder(QObject):
+#: Preference token -> QMediaFormat container (see NativeVideoRecorder).
+QT_MEDIA_FILE_FORMATS = {
+    QT_RECORDER_FORMAT_MP4: QMediaFormat.FileFormat.MPEG4,
+    QT_RECORDER_FORMAT_MKV: QMediaFormat.FileFormat.Matroska,
+}
+
+
+def supported_qt_video_codec_names(file_format_token) -> List[str]:
+    """Names of the video codecs the platform backend can ENCODE into the
+    given container (QT_RECORDER_FORMAT_* token). Must run with the
+    application up — the backend reports a reduced set headless."""
+    media_format = QMediaFormat(QT_MEDIA_FILE_FORMATS[file_format_token])
+    return [QMediaFormat.videoCodecName(codec)
+            for codec in media_format.supportedVideoCodecs(
+                QMediaFormat.ConversionMode.Encode)]
+
+
+def qt_video_codec_from_name(name: str):
+    """QMediaFormat.VideoCodec whose display name matches, else None."""
+    for codec in QMediaFormat.VideoCodec:
+        if QMediaFormat.videoCodecName(codec) == name:
+            return codec
+    return None
+
+
+class NativeVideoRecorder(VideoRecorderBase):
     """Records the RAW camera stream through Qt's own QMediaRecorder —
     the platform's hardware-accelerated encoding pipeline (Media
     Foundation on Windows). Per-frame cost to the application: zero — no
@@ -140,43 +187,56 @@ class NativeVideoRecorder(QObject):
     recording at any resolution.
 
     The device-alignment perspective warp is NOT baked into the file
-    (baking it is what forced every frame through the GUI thread — see
-    VideoRecorder below). Instead the video item's alignment geometry is
-    written to a ``<video>.transform.json`` sidecar next to the
-    recording, so the aligned view can be reproduced offline on demand
-    (same parameters ``get_transformed_frame`` consumes per frame).
+    (baking it would force every frame through the GUI thread). Instead
+    the video item's alignment geometry is written to a
+    ``<video>.transform.json`` sidecar next to the recording, so the
+    aligned view can be reproduced offline on demand (same parameters
+    ``get_transformed_frame`` consumes per frame).
 
-    Drop-in for VideoRecorder's public surface: start/stop, is_recording,
-    current_image (always None — screenshots fall back to the live sink),
-    and the recording_started/recording_stopped/error_occurred signals.
+    Public surface: see VideoRecorderBase.
     """
 
-    recording_started = Signal(str)  # Emits path when started
-    recording_stopped = Signal(str)  # Emits output path
-    error_occurred = Signal(str)
-
-    def __init__(self, session, video_item: 'QGraphicsVideoItem', parent=None):
-        super().__init__(parent)
-        self._video_item = video_item
-        self.current_image = None  # VideoRecorder parity (see class docstring)
+    def __init__(self, session, video_item: 'QGraphicsVideoItem',
+                 file_format=None, video_codec=None, video_bitrate=None,
+                 parent=None):
+        """``file_format`` is a QT_RECORDER_FORMAT_* token (None lets the
+        backend infer the container from the output file's extension).
+        ``video_codec`` is a QMediaFormat codec display name (see
+        supported_qt_video_codec_names); unknown/None falls back to H.264.
+        ``video_bitrate`` is bits/s; None records in constant-quality mode
+        instead (the encoder picks the rate)."""
+        super().__init__(video_item, parent)
         self._was_recording = False
 
         self._recorder = QMediaRecorder(self)
+
         session.setRecorder(self._recorder)
-        # Matroska/H.264, matching the legacy ffmpeg-pipe recordings'
-        # .mkv container (Qt's FFmpeg multimedia backend muxes it).
-        media_format = QMediaFormat(QMediaFormat.FileFormat.Matroska)
-        media_format.setVideoCodec(QMediaFormat.VideoCodec.H264)
-        self._recorder.setMediaFormat(media_format)
-        # Highest-fidelity settings the API offers: quality-driven encoding
-        # (the quality level is IGNORED in the bitrate-driven modes) at the
-        # top quality tier — the FFmpeg backend maps this to a low-CRF,
-        # visually near-lossless encode. The remaining ceiling is the
-        # pipeline's 4:2:0 chroma subsampling; full-fidelity data lives in
-        # the 16-bit raw still captures.
-        self._recorder.setEncodingMode(
-            QMediaRecorder.EncodingMode.ConstantQualityEncoding)
-        self._recorder.setQuality(QMediaRecorder.Quality.VeryHighQuality)
+        if file_format is not None:
+            media_format = QMediaFormat(QT_MEDIA_FILE_FORMATS[file_format])
+            codec = (qt_video_codec_from_name(video_codec)
+                     if video_codec else None)
+            if codec is None:
+                codec = QMediaFormat.VideoCodec.H264
+                if video_codec:
+                    logger.warning(f"Unknown video codec {video_codec!r}; "
+                                   f"falling back to H.264")
+            media_format.setVideoCodec(codec)
+            self._recorder.setMediaFormat(media_format)
+        if video_bitrate:
+            # setVideoBitRate is IGNORED in the default constant-quality
+            # encoding mode — the bitrate only applies in a bitrate mode.
+            self._recorder.setEncodingMode(
+                QMediaRecorder.EncodingMode.AverageBitRateEncoding)
+            self._recorder.setVideoBitRate(video_bitrate)
+        else:
+            # Pin quality-driven encoding explicitly (the quality level is
+            # IGNORED in the bitrate-driven modes) at the top tier — the
+            # FFmpeg backend maps this to a low-CRF, visually near-lossless
+            # encode — so a backend default change can't silently demote
+            # recordings.
+            self._recorder.setEncodingMode(
+                QMediaRecorder.EncodingMode.ConstantQualityEncoding)
+            self._recorder.setQuality(QMediaRecorder.Quality.VeryHighQuality)
         self._recorder.errorOccurred.connect(self._on_recorder_error)
         self._recorder.recorderStateChanged.connect(self._on_recorder_state_changed)
 
@@ -198,9 +258,19 @@ class NativeVideoRecorder(QObject):
             self._recorder.setVideoResolution(QSize(*[int(side)
                                                       for side in resolution]))
         self._recorder.setOutputLocation(QUrl.fromLocalFile(str(output_path)))
+        self._recorder.setVideoFrameRate(fps)
         self._recorder.record()
-        logger.info(f"Native recording requested: {output_path} "
-                    f"at {resolution}")
+        # Read the settings back FROM the recorder — this is the
+        # confirmation that the preference-driven configuration stuck.
+        applied_format = self._recorder.mediaFormat()
+        logger.info(
+            f"Native recording requested: {output_path} at {resolution}; "
+            f"applied settings: "
+            f"container={applied_format.fileFormat().name}, "
+            f"codec={QMediaFormat.videoCodecName(applied_format.videoCodec())}, "
+            f"encoding mode={self._recorder.encodingMode().name}, "
+            f"video bitrate={self._recorder.videoBitRate():,} bps, "
+            f"quality={self._recorder.quality().name}")
 
     def stop(self):
         """Stop recording; recording_stopped fires on the state change."""
@@ -217,296 +287,314 @@ class NativeVideoRecorder(QObject):
                 and self._was_recording):
             self._was_recording = False
             path = self._recorder.actualLocation().toLocalFile()
-            self._write_transform_sidecar(path)
-            _cache_media_capture.send(MediaType.VIDEO, path)
-            self.recording_stopped.emit(path)
+            self._finalize_recording(path)
             logger.info(f"Native recording stopped: {path}")
 
     def _on_recorder_error(self, _error, error_string):
         logger.error(f"Native recorder error: {error_string}")
         self.error_occurred.emit(error_string)
 
-    def _write_transform_sidecar(self, video_path):
-        """Persist the alignment geometry needed to reproduce the
-        device-aligned (warped) view offline — the same parameters the
-        legacy pipeline fed to get_transformed_frame for every frame."""
-        sidecar = {
-            "transform": json.loads(
-                qtransform_serialize(self._video_item.transform())),
-            "scene_bounding_rect": list(
-                self._video_item.sceneBoundingRect().getRect()),
-            "bounding_rect": list(self._video_item.boundingRect().getRect()),
-        }
-        sidecar_path = Path(video_path).with_suffix(
-            RECORDING_TRANSFORM_SIDECAR_SUFFIX)
-        try:
-            sidecar_path.write_text(json.dumps(sidecar, indent=2))
-            logger.info(f"Wrote recording transform sidecar: {sidecar_path}")
-        except Exception as e:
-            logger.warning(f"Could not write transform sidecar: {e}")
+
+def write_transform_sidecar(video_item, video_path):
+    """Persist the alignment geometry needed to reproduce the
+    device-aligned (warped) view offline — the same parameters the
+    legacy pipeline fed to get_transformed_frame for every frame."""
+    sidecar = {
+        "transform": json.loads(
+            qtransform_serialize(video_item.transform())),
+        "scene_bounding_rect": list(
+            video_item.sceneBoundingRect().getRect()),
+        "bounding_rect": list(video_item.boundingRect().getRect()),
+    }
+    sidecar_path = Path(video_path).with_suffix(
+        RECORDING_TRANSFORM_SIDECAR_SUFFIX)
+    try:
+        sidecar_path.write_text(json.dumps(sidecar, indent=2))
+        logger.info(f"Wrote recording transform sidecar: {sidecar_path}")
+    except Exception as e:
+        logger.warning(f"Could not write transform sidecar: {e}")
 
 
-class VideoRecorder(QObject):
+#: QVideoFrameFormat.PixelFormat -> ffmpeg rawvideo pix_fmt for the camera
+#: formats the raw recorder can pipe WITHOUT a color conversion (a plain
+#: plane memcpy). ffmpeg converts to the encoder's format internally (in C).
+QT_TO_FFMPEG_PIXEL_FORMATS = {
+    QVideoFrameFormat.PixelFormat.Format_NV12: "nv12",
+    QVideoFrameFormat.PixelFormat.Format_NV21: "nv21",
+    QVideoFrameFormat.PixelFormat.Format_YUV420P: "yuv420p",
+    QVideoFrameFormat.PixelFormat.Format_YUV422P: "yuv422p",
+    QVideoFrameFormat.PixelFormat.Format_YUYV: "yuyv422",
+    QVideoFrameFormat.PixelFormat.Format_UYVY: "uyvy422",
+    QVideoFrameFormat.PixelFormat.Format_RGBA8888: "rgba",
+    QVideoFrameFormat.PixelFormat.Format_RGBX8888: "rgba",
+    QVideoFrameFormat.PixelFormat.Format_BGRA8888: "bgra",
+    QVideoFrameFormat.PixelFormat.Format_BGRX8888: "bgra",
+    QVideoFrameFormat.PixelFormat.Format_ARGB8888: "argb",
+    QVideoFrameFormat.PixelFormat.Format_XRGB8888: "argb",
+    QVideoFrameFormat.PixelFormat.Format_ABGR8888: "abgr",
+    QVideoFrameFormat.PixelFormat.Format_XBGR8888: "abgr",
+}
+
+
+def _plane_layout(pix_fmt, width, height):
+    """[(tight_row_bytes, rows)] per plane for an ffmpeg rawvideo stream —
+    used to strip Qt's per-row stride padding while copying."""
+    if pix_fmt in ("rgba", "bgra", "argb", "abgr"):
+        return [(width * 4, height)]
+    if pix_fmt in ("yuyv422", "uyvy422"):
+        return [(width * 2, height)]
+    if pix_fmt in ("nv12", "nv21"):
+        return [(width, height), (width, height // 2)]
+    if pix_fmt == "yuv420p":
+        return [(width, height),
+                (width // 2, height // 2), (width // 2, height // 2)]
+    if pix_fmt == "yuv422p":
+        return [(width, height), (width // 2, height), (width // 2, height)]
+    raise ValueError(f"Unhandled pixel format {pix_fmt}")
+
+
+class RawFFMPEGVideoRecorder(VideoRecorderBase):
+    """Records the RAW camera frames to H.264 via an ffmpeg subprocess,
+    with NO device-alignment perspective warp AND without a per-frame color
+    conversion.
+
+    Each frame is mapped and its NATIVE pixel planes are copied ONCE into a
+    payload buffer that goes straight to ffmpeg (a memcpy — no conversion),
+    in the camera's own pixel format; ffmpeg converts to the encoder's
+    format internally (in C). The file is the untransformed camera image at
+    its native resolution, and the GUI-thread cost per frame is just that
+    single plane copy — no ``frame.toImage()`` (which would force a full
+    RGBA color conversion). The alignment geometry is written to a
+    ``<video>.transform.json`` sidecar so the aligned view can be
+    reproduced offline.
+
+    Frames are handed to a background IO thread that writes to ffmpeg's
+    stdin; the queue drops frames when the encoder falls behind so the GUI
+    thread never stalls. ffmpeg's stderr goes to a temp file (never a pipe
+    nobody drains — a full pipe would block the encoder). The ffmpeg
+    pipeline starts lazily on the first frame, because the pixel format and
+    size aren't known until then.
+
+    Public surface: see VideoRecorderBase.
     """
-    Main Public API.
-    Manages FFmpeg process, IO Thread, and Processing QThread.
-    """
-    recording_started = Signal(str) # Emits path when started
-    recording_stopped = Signal(str) # Emits output path
-    error_occurred = Signal(str)
-
-    # Internal signal to bridge UI thread and Worker thread
-    _send_to_worker = Signal(QImage, QRectF, QRectF, QTransform)
 
     def __init__(self, video_item: 'QGraphicsVideoItem', ffmpeg_binary="ffmpeg",
-                 parent=None, frame_sink=None):
-        super().__init__(parent)
+                 parent=None, frame_sink=None,
+                 video_codec=FFMPEG_VIDEO_CODECS[0],
+                 preset=FFMPEG_PRESETS[0],
+                 crf=FFMPEG_DEFAULT_CRF,
+                 extra_output_args=""):
+        super().__init__(video_item, parent)
         self.ffmpeg_binary = ffmpeg_binary
+        self.video_codec = video_codec
+        self.preset = preset
+        self.crf = crf
+        # Advanced escape hatch: extra ffmpeg output options, shell-style
+        # (split with shlex and appended before the output path).
+        self.extra_output_args = extra_output_args
 
-        # State
-        self.is_recording = False
+        self._recording_active = False
         self._output_path = None
-        self._video_item = video_item
         # Frames come from this sink; geometry still comes from the video
         # item. Passing the capture session's own sink keeps recordings at
         # full camera rate while the DISPLAY item receives rate-capped
         # preview frames (see CameraControlWidget._forward_preview_frame).
-        self._frame_sink = frame_sink if frame_sink is not None else video_item.videoSink()
-        self.current_image = None
+        self._frame_sink = (frame_sink if frame_sink is not None
+                            else video_item.videoSink())
 
-        # FFmpeg / IO internals
         self._process = None
+        self._stderr_file = None
         self._io_thread = None
-        self._queue = queue.Queue(maxsize=60)
+        self._queue = queue.Queue(maxsize=RAW_RECORDER_QUEUE_MAX_FRAMES)
+        self._layout = None
+        self._frame_payload_bytes = 0
+        self._fps = 30.0
 
-        # QThread Worker internals
-        self._worker_thread = None
-        self._worker = None
-
-    ######################################################################################################
-    # Protected Helper methods
-    ######################################################################################################
-
-    def _start_worker_thread(self, resolution):
-        """Sets up the QThread for image transformation."""
-
-        logger.debug("Starting video recorder worker thread...")
-
-        self._worker_thread = QThread()
-        self._worker = VideoProcessWorker(self._queue, resolution)
-        self._worker.moveToThread(self._worker_thread)
-
-        # Connect internal signal to worker slot
-        self._send_to_worker.connect(self._worker.process_frame)
-
-        # Cleanup hooks
-        self._worker_thread.finished.connect(self._worker.deleteLater)
-        self._worker_thread.start()
-
-        logger.debug("Done starting video image processing worker thread.")
-
-    @Slot(QVideoFrame)
-    def _on_frame_arrived(self, frame):
-        """
-        Captured on UI Thread.
-        Extracts geometry and image, then emits to Worker Thread immediately.
-        """
-        if not self.is_recording:
-            return
-
-        logger.debug(f"Frame arrived: {frame}")
-
-        # Convert to QImage in UI thread (fast enough usually, and safe)
-        # We do this here because QVideoFrame ownership can be tricky across threads
-        image = frame.toImage()
-
-        # Capture geometry state NOW (UI thread), as it might change while worker processes
-        self._send_to_worker.emit(
-            image,
-            self._video_item.sceneBoundingRect(),
-            self._video_item.boundingRect(),
-            self._video_item.transform()
-        )
-
-    ## ------------------- FFMPEG Process Management -------------------------------------------
-
-    def _start_ffmpeg(self, path, resolution, fps):
-        """Launches the FFmpeg subprocess and the Python IO writer thread."""
-        w, h = resolution
-        command = [
-            self.ffmpeg_binary,
-            "-y",
-            "-hide_banner",
-            "-loglevel",
-            "error",
-            "-f",
-            "rawvideo",
-            "-vcodec",
-            "rawvideo",
-            "-s",
-            f"{w}x{h}",
-            "-pix_fmt",
-            "rgba",
-            "-r",
-            str(fps),
-            "-i",
-            "-",
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-preset",
-            "ultrafast",
-            "-crf",
-            "17",
-            path,
-        ]
-
-        try:
-            self._process = subprocess.Popen(
-                command,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.PIPE,
-            )
-
-            logger.debug(f"Done starting FFmpeg subprocess: {command}")
-
-            # Start the IO thread (Python thread, not QThread, for blocking file I/O)
-            self._io_thread = threading.Thread(target=self._io_writer, daemon=True)
-            self._io_thread.start()
-
-            logger.debug(f"Done starting FFmpeg queue pushing thread.")
-
-            return True
-
-        except Exception as e:
-            logger.error(f"Failed to start FFmpeg: {e}")
-            self.error_occurred.emit(str(e))
-            return False
+    @property
+    def is_recording(self) -> bool:
+        return self._recording_active
 
     def _stop_ffmpeg(self):
-        """Cleanly closes FFmpeg."""
-        logger.debug("Attempting to stop FFmpeg process...")
-        # Wait for IO thread to empty the queue
+        """Cleanly close ffmpeg: drain the IO thread, EOF stdin, wait."""
         if self._io_thread:
             self._io_thread.join()
-
-        # Close stdin to signal EOF to FFmpeg
+            self._io_thread = None
         if self._process:
             if self._process.stdin:
-                self._process.stdin.close()
-
+                try:
+                    self._process.stdin.close()
+                except OSError as e:
+                    logger.debug(f"Raw recorder stdin close: {e}")
             self._process.wait()
-
-            if self._process.returncode != 0:
-                _, err = self._process.communicate()
-                logger.error(
-                    f"FFmpeg Error: {err.decode('utf-8', errors='ignore')}"
-                )
-
-        # Reset
+            if self._process.returncode != 0 and self._stderr_file:
+                self._stderr_file.seek(0)
+                logger.error(f"FFmpeg Error: "
+                             f"{self._stderr_file.read().decode('utf-8', errors='ignore')}")
+        if self._stderr_file:
+            self._stderr_file.close()
+            self._stderr_file = None
         self._process = None
-        self._queue = queue.Queue(maxsize=60)
-
-        logger.debug(f"FFmpeg process stopped")
-
-    def _io_writer(self):
-        """Thread that strictly writes bytes to FFmpeg stdin."""
-        while self._process and self._process.poll() is None:
-            try:
-                # Timeout allows us to check loop condition periodically
-                img = self._queue.get(timeout=0.1)
-
-                self._process.stdin.write(img.constBits())
-                self.current_image = img
-
-                logger.debug(f"Writing image: {self.current_image}")
-
-            except queue.Empty:
-
-                if not self.is_recording and self._queue.empty():
-                    logger.debug("Fffmpeg Queue Empty and not recording anymore.")
-                    break
-
-                logger.debug("Fffmpeg Queue Empty")
-
-            except (BrokenPipeError, ValueError):
-                logger.info("FFmpeg broken pipe error")
-                break
-
-    ############################################################################################
-    # Public Main Start and Stop routines
-    ############################################################################################
+        self._queue = queue.Queue(maxsize=RAW_RECORDER_QUEUE_MAX_FRAMES)
 
     def start(self, output_path, resolution, fps):
-        """
-        Starts the recording pipeline.
-        :param video_item: The QGraphicsVideoItem to record from.
-        """
         if self.is_recording:
             return None
-
-        # 1. Validation
         if not shutil.which(self.ffmpeg_binary):
             self.error_occurred.emit("FFmpeg binary not found.")
             return None
 
         self._output_path = output_path
+        self._fps = float(fps) if fps else 30.0
+        # Deferred until the first frame reveals the pixel format/size.
+        self._process = None
+        self._layout = None
+        self._queue = queue.Queue(maxsize=RAW_RECORDER_QUEUE_MAX_FRAMES)
 
-        # Handle odd resolutions (FFmpeg libx264 requirement)
-        w, h = int(resolution[0]), int(resolution[1])
-        w -= 1 if w % 2 != 0 else 0
-        h -= 1 if h % 2 != 0 else 0
-        final_res = (w, h)
-
-        # 2. Start FFmpeg Process
-        if not self._start_ffmpeg(output_path, final_res, fps):
-            return None
-
-        # 3. Start Background Processing Thread (QThread)
-        self._start_worker_thread(final_res)
-
-        # 4. Connect to Video Source
-        # We connect the video sink directly to our internal handler
-        self.is_recording = True
+        self._recording_active = True
         self._frame_sink.videoFrameChanged.connect(self._on_frame_arrived)
 
         self.recording_started.emit(output_path)
-        logger.info(f"Recording started: {output_path}")
-
+        logger.info(f"Raw recording started: {output_path}")
         return True
 
+    @Slot(QVideoFrame)
+    def _on_frame_arrived(self, frame):
+        """GUI thread: memcpy the native pixel planes, queue for ffmpeg."""
+        if not self.is_recording or not frame.isValid():
+            return
+
+        if self._process is None and not self._start_native_ffmpeg(frame):
+            return
+
+        if self._queue.full():
+            debug_throttled(logger, "raw_recorder_queue_full",
+                            "Raw recorder encoder behind; dropping frame")
+            return
+
+        if not frame.map(QVideoFrame.MapMode.ReadOnly):
+            return
+        try:
+            # ONE copy per plane: each plane lands directly in its final
+            # position in the payload (no intermediate chunks, no join).
+            payload = bytearray(self._frame_payload_bytes)
+            payload_np = np.frombuffer(payload, np.uint8)
+            offset = 0
+            for plane, (row_bytes, rows) in enumerate(self._layout):
+                plane_bytes = row_bytes * rows
+                bytes_per_line = frame.bytesPerLine(plane)
+                plane_data = np.frombuffer(frame.bits(plane), np.uint8)
+                if bytes_per_line == row_bytes:
+                    payload_np[offset:offset + plane_bytes] = \
+                        plane_data[:plane_bytes]
+                else:
+                    # Strip the per-row stride padding while copying.
+                    payload_np[offset:offset + plane_bytes].reshape(
+                        rows, row_bytes)[:] = (
+                        plane_data[:bytes_per_line * rows]
+                        .reshape(rows, bytes_per_line)[:, :row_bytes])
+                offset += plane_bytes
+        finally:
+            frame.unmap()
+
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            debug_throttled(logger, "raw_recorder_queue_full",
+                            "Raw recorder encoder behind; dropping frame")
+
+    def _disconnect_frame_sink(self):
+        try:
+            self._frame_sink.videoFrameChanged.disconnect(
+                self._on_frame_arrived)
+        except Exception as e:
+            logger.debug(f"Raw recorder frame sink already disconnected: {e}")
+
+    def _start_native_ffmpeg(self, frame) -> bool:
+        pixel_format = frame.surfaceFormat().pixelFormat()
+        pix_fmt = QT_TO_FFMPEG_PIXEL_FORMATS.get(pixel_format)
+        if pix_fmt is None:
+            self._recording_active = False
+            self._disconnect_frame_sink()
+            self.error_occurred.emit(
+                f"Raw recording does not support the camera's "
+                f"{pixel_format.name} pixel format")
+            return False
+
+        width, height = frame.width(), frame.height()
+        self._layout = _plane_layout(pix_fmt, width, height)
+        self._frame_payload_bytes = sum(
+            row_bytes * rows for row_bytes, rows in self._layout)
+        command = [
+            self.ffmpeg_binary, "-y", "-hide_banner", "-loglevel", "error",
+            "-f", "rawvideo", "-pix_fmt", pix_fmt,
+            "-s", f"{width}x{height}", "-r", f"{self._fps}", "-i", "-",
+            "-c:v", self.video_codec, "-pix_fmt", "yuv420p",
+            "-preset", self.preset, "-crf", str(self.crf),
+            *shlex.split(self.extra_output_args),
+            self._output_path,
+        ]
+        # stderr goes to a temp file, NOT a pipe: nothing drains a pipe
+        # while recording, and a full pipe would block the encoder.
+        self._stderr_file = tempfile.TemporaryFile()
+        try:
+            self._process = subprocess.Popen(
+                command, stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL, stderr=self._stderr_file)
+        except Exception as e:
+            self._recording_active = False
+            self._stderr_file.close()
+            self._stderr_file = None
+            self.error_occurred.emit(f"Failed to start ffmpeg: {e}")
+            return False
+        self._io_thread = threading.Thread(target=self._io_writer,
+                                           daemon=True,
+                                           name="raw-recorder-io")
+        self._io_thread.start()
+        logger.info(f"Raw pipeline: {width}x{height} {pix_fmt} "
+                    f"@ {self._fps} fps -> {self.video_codec} "
+                    f"(preset {self.preset}, crf {self.crf}"
+                    + (f", extra args {self.extra_output_args!r}"
+                       if self.extra_output_args else "") + ")")
+        return True
+
+    def _io_writer(self):
+        """Write raw plane bytes straight to ffmpeg stdin. A None payload
+        is the stop sentinel: everything queued before it gets written."""
+        while self._process and self._process.poll() is None:
+            try:
+                payload = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                if not self.is_recording and self._queue.empty():
+                    break
+                continue
+            if payload is None:
+                break
+            try:
+                self._process.stdin.write(payload)
+            except (BrokenPipeError, ValueError, OSError):
+                logger.info("Raw recorder ffmpeg pipe closed")
+                break
+
     def stop(self):
-        """Stops recording, joins threads, cleans up."""
         if not self.is_recording:
             return
 
-        logger.debug("Attempting to stop recording...")
+        self._recording_active = False
 
-        self.is_recording = False
-
-        # 1. Disconnect Source (Stop incoming data)
         if self._frame_sink:
+            self._disconnect_frame_sink()
+
+        path = self._output_path
+        if self._process is not None:
             try:
-                self._frame_sink.videoFrameChanged.disconnect(self._on_frame_arrived)
-            except Exception:
-                pass
+                self._queue.put_nowait(None)  # stop sentinel
+            except queue.Full:
+                pass  # _io_writer falls back to the is_recording check
+            self._stop_ffmpeg()
+            self._finalize_recording(path)
+        else:
+            logger.warning("Raw recording stopped with no frames")
+            self.recording_stopped.emit("")
 
-        # 2. Stop Worker Thread (Image Processing)
-        if self._worker:
-            self._worker.stop()
-        if self._worker_thread:
-            self._worker_thread.quit()
-            self._worker_thread.wait()
-
-        # 3. Stop IO Thread & FFmpeg (Write remaining queue)
-        self._stop_ffmpeg()
-
-        ## Save path to cache
-        _cache_media_capture.send(MediaType.VIDEO, self._output_path)
-
-        # update UI for any dialogs.
-        self.recording_stopped.emit(self._output_path)
-        logger.info(f"Recording stopped: {self._output_path}")
+        logger.info(f"Raw recording stopped: {path}")
         self._output_path = None

--- a/device_viewer/views/camera_control_view/preferences.py
+++ b/device_viewer/views/camera_control_view/preferences.py
@@ -1,6 +1,6 @@
 import platform
 
-from envisage.ui.tasks.api import PreferencesPane
+from envisage.ui.tasks.api import PreferencesPane, PreferencesCategory
 from traitsui.api import View, Item, Group, EnumEditor
 from apptools.preferences.api import PreferencesHelper
 from traits.api import Str, Bool, Enum, List, Range, observe
@@ -24,7 +24,6 @@ from device_viewer.consts import (
     RECORDING_BITRATE_CLASSES,
     RECORDING_BITRATE_TIERS,
 )
-from device_viewer.preferences import device_viewer_tab
 from microdrop_style.text_styles import preferences_group_style_sheet
 from microdrop_utils.preferences_UI_helpers import create_item_label_group
 
@@ -291,6 +290,11 @@ qt_recorder_settings_group = Group(
 )
 
 
+video_settings_tab = PreferencesCategory(
+    id="microdrop.video_settings.preferences",
+    name="Video Settings",
+)
+
 class CameraPreferencesPane(PreferencesPane):
     """Device Viewer preferences pane based on enthought envisage's The preferences pane for the Attractors application."""
 
@@ -299,7 +303,7 @@ class CameraPreferencesPane(PreferencesPane):
     # The factory to use for creating the preferences model object.
     model_factory = CameraPreferences
 
-    category = device_viewer_tab.id
+    category = video_settings_tab.id
 
     ########################################################################################
     video_format_item = create_item_label_group(

--- a/device_viewer/views/camera_control_view/preferences.py
+++ b/device_viewer/views/camera_control_view/preferences.py
@@ -1,10 +1,29 @@
 import platform
 
 from envisage.ui.tasks.api import PreferencesPane
-from traitsui.api import View, Item, Group
+from traitsui.api import View, Item, Group, EnumEditor
 from apptools.preferences.api import PreferencesHelper
-from traits.api import Str, Bool, Enum
+from traits.api import Str, Bool, Enum, List, Range, observe
 
+from device_viewer.utils.camera import supported_qt_video_codec_names
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+from device_viewer.consts import (
+    FFMPEG_CONTAINERS,
+    FFMPEG_DEFAULT_CRF,
+    FFMPEG_PRESETS,
+    FFMPEG_VIDEO_CODECS,
+    QT_RECORDER_FORMAT_MKV,
+    QT_RECORDER_FORMAT_MP4,
+    RECORDER_BACKEND_FFMPEG,
+    RECORDER_BACKEND_QT,
+    RECORDING_4K_MIN_HEIGHT,
+    RECORDING_60FPS_MIN_FPS,
+    RECORDING_BITRATE_CLASSES,
+    RECORDING_BITRATE_TIERS,
+)
 from device_viewer.preferences import device_viewer_tab
 from microdrop_style.text_styles import preferences_group_style_sheet
 from microdrop_utils.preferences_UI_helpers import create_item_label_group
@@ -28,6 +47,14 @@ else:
     default_video_format = "JPEG"
 
 
+def _bitrate_tier_label(tier: str, mbps: float) -> str:
+    """Dropdown entry text: the tier with its bitrate and one-minute file
+    size, so the size estimate is always in sight and can never go stale."""
+    megabytes_per_minute = mbps * 60 / 8
+    return (f"{tier} — {mbps:g} Mbps "
+            f"(≈ {megabytes_per_minute:,.0f} MB per minute)")
+
+
 class CameraPreferences(PreferencesHelper):
     """The preferences helper, inspired by envisage one for the Attractors application.
     The underlying preference object is the global default since we do not pass a
@@ -44,11 +71,224 @@ class CameraPreferences(PreferencesHelper):
     strict_video_format = Bool
     resolution = Str
 
+    #### Recording preferences ################################################
+    recorder_backend = Enum(RECORDER_BACKEND_QT, RECORDER_BACKEND_FFMPEG)
+
+    # FFmpeg-process recorder. fps, resolution and pixel format always come
+    # from the camera itself, so only encoding choices are exposed.
+    ffmpeg_container = Enum(*FFMPEG_CONTAINERS)
+    ffmpeg_video_codec = Enum(*FFMPEG_VIDEO_CODECS)
+    ffmpeg_preset = Enum(*FFMPEG_PRESETS)
+    ffmpeg_crf = Range(low=0, high=51, value=FFMPEG_DEFAULT_CRF)
+    ffmpeg_extra_output_args = Str
+
+    # Qt native recorder.
+    qt_video_format = Enum(QT_RECORDER_FORMAT_MP4, QT_RECORDER_FORMAT_MKV)
+
+    # Codec name persisted as a plain Str (never validated against the
+    # dynamic list, so a stored choice survives backend differences); the
+    # dropdown constrains picks to qt_supported_video_codecs_.
+    qt_video_codec = Str
+    # Codecs the platform backend can encode into the selected container,
+    # queried live (the backend reports a reduced set headless). Trailing
+    # underscore keeps the list OUT of the preferences node.
+    qt_supported_video_codecs_ = List(Str)
+
+    # Per-resolution-class MKV quality tiers (Auto = recommended rate).
+    # The class dropdown picks which tier dropdown is shown; at record time
+    # the class is matched from the ACTUAL camera resolution/fps (see
+    # recording_bitrate_bps).
+    qt_bitrate_resolution_class = Enum(*RECORDING_BITRATE_CLASSES)
+    qt_bitrate_1080p30_tier = Enum(*RECORDING_BITRATE_TIERS)
+    qt_bitrate_1080p60_tier = Enum(*RECORDING_BITRATE_TIERS)
+    qt_bitrate_4k30_tier = Enum(*RECORDING_BITRATE_TIERS)
+    qt_bitrate_4k60_tier = Enum(*RECORDING_BITRATE_TIERS)
+
+    def _qt_video_codec_default(self):
+        if self.qt_video_format == QT_RECORDER_FORMAT_MP4:
+            return "H264"
+        else:
+            return "MPEG1"
+
+    def traits_init(self):
+        self._refresh_qt_supported_video_codecs()
+
+    @observe("qt_video_format")
+    def _refresh_qt_supported_video_codecs(self, event=None):
+        codec_names = supported_qt_video_codec_names(self.qt_video_format)
+        self.qt_supported_video_codecs_ = codec_names
+        logger.info(f"Video codecs supported for {self.qt_video_format}: "
+                    f"{codec_names}")
+        if codec_names and self.qt_video_codec not in codec_names:
+            if "H264" in codec_names:
+                fallback = "H264"
+            elif "MPEG4" in codec_names:
+                fallback = "MPEG4"
+            else:
+                fallback = codec_names[0]
+
+            logger.info(f"Video codec {self.qt_video_codec!r} not supported "
+                        f"for {self.qt_video_format}; resetting to "
+                        f"{fallback!r}")
+            self.qt_video_codec = fallback
+
     def _preferred_video_format_default(self):
         return default_video_format
 
     def _strict_video_format_default(self):
         return strict_video_format
+
+    #### Recording helpers ####################################################
+
+    def recording_file_extension(self) -> str:
+        """Extension of the next recording file — drives the container for
+        both backends (ffmpeg muxes by extension; Qt gets the matching
+        QMediaFormat as well)."""
+        if self.recorder_backend == RECORDER_BACKEND_FFMPEG:
+            return f".{self.ffmpeg_container}"
+        return (".mkv" if self.qt_video_format == QT_RECORDER_FORMAT_MKV
+                else ".mp4")
+
+    def recording_bitrate_class(self, height: int, fps: float) -> str:
+        """Nearest configured resolution class for an actual camera format."""
+        if height >= RECORDING_4K_MIN_HEIGHT:
+            return ("4K @ 60 fps" if fps >= RECORDING_60FPS_MIN_FPS
+                    else "4K @ 24/30 fps")
+        return ("1080p @ 60 fps" if fps >= RECORDING_60FPS_MIN_FPS
+                else "1080p @ 30 fps")
+
+    def recording_bitrate_bps(self, resolution, fps) -> int | None:
+        """Configured bitrate (bits/s) for the Qt recorder, or None when the
+        Qt encoder should pick (MP4 format, or format/rate unknown)."""
+        if (self.qt_video_format != QT_RECORDER_FORMAT_MKV
+                or not resolution or not fps):
+            return None
+        class_label = self.recording_bitrate_class(resolution[1], fps)
+        tier_trait, tier_mbps = RECORDING_BITRATE_CLASSES[class_label]
+        return int(tier_mbps[getattr(self, tier_trait)] * 1_000_000)
+
+
+#### Recording preference view pieces #########################################
+
+recorder_backend_item = create_item_label_group(
+    "recorder_backend",
+    label_text="Recording Engine",
+    item_tooltip=(
+        "Qt MediaRecorder: the platform's hardware-accelerated encoding "
+        "pipeline — zero per-frame Python work, lowest CPU use.\n\n"
+        "FFmpeg process: raw camera frames piped to an external ffmpeg — "
+        "full control over the encoder at higher CPU cost."
+    ),
+)
+
+ffmpeg_settings_group = Group(
+    create_item_label_group(
+        "ffmpeg_container",
+        label_text="Container",
+        item_tooltip=(
+            "mkv: stays recoverable if the app crashes mid-recording.\n"
+            "mp4: most widely supported, but corrupts if not closed cleanly."
+        ),
+    ),
+    create_item_label_group(
+        "ffmpeg_video_codec",
+        label_text="Video Codec",
+        item_tooltip=(
+            "libx264 (H.264): fastest, plays everywhere.\n"
+            "libx265 (H.265): ~half the file size, higher CPU, "
+            "less player support."
+        ),
+    ),
+    create_item_label_group(
+        "ffmpeg_preset",
+        label_text="Preset",
+        item_tooltip=(
+            "Encoder speed/compression trade-off: faster presets use less "
+            "CPU but produce larger files for the same quality."
+        ),
+    ),
+    create_item_label_group(
+        "ffmpeg_crf",
+        label_text="Quality (CRF)",
+        item_tooltip=(
+            "Constant Rate Factor: 0 = lossless, 51 = worst. "
+            "~17 is visually lossless; lower values mean larger files."
+        ),
+    ),
+    create_item_label_group(
+        "ffmpeg_extra_output_args",
+        label_text="Extra Output Args",
+        item_tooltip=(
+            "Advanced: extra ffmpeg output options appended to the command, "
+            'e.g. "-tune zerolatency". fps, resolution and pixel format are '
+            "set automatically from the camera."
+        ),
+    ),
+    label="FFmpeg Recording",
+    show_labels=False,
+    show_border=True,
+    visible_when=f'recorder_backend == "{RECORDER_BACKEND_FFMPEG}"',
+)
+
+# One quality-tier dropdown per resolution class (each tier labeled with
+# its bitrate and per-minute file size); only the class-dropdown-selected
+# one is shown.
+bitrate_tier_items = [
+    Item(
+        tier_trait,
+        show_label=False,
+        editor=EnumEditor(values={tier: _bitrate_tier_label(tier, mbps)
+                                  for tier, mbps in tier_mbps.items()}),
+        visible_when=f'qt_bitrate_resolution_class == "{class_label}"',
+    )
+    for class_label, (tier_trait, tier_mbps) in
+    RECORDING_BITRATE_CLASSES.items()
+]
+
+qt_recorder_settings_group = Group(
+    create_item_label_group(
+        "qt_video_format",
+        label_text="Video Format",
+        item_tooltip=(
+            "MP4: plays everywhere (browsers, editors, OS previews), but "
+            "the index is written when recording stops — a crash "
+            "mid-recording can leave the file unreadable.\n\n"
+            "MKV: written progressively, so the recording stays recoverable "
+            "if the app crashes; less universally supported by players and "
+            "editors."
+        ),
+    ),
+    create_item_label_group(
+        "qt_video_codec",
+        label_text="Video Codec",
+        item_editor=EnumEditor(name="qt_supported_video_codecs_"),
+        item_tooltip=(
+            "Video codecs this machine's backend can encode into the "
+            "selected format, queried live from Qt. H.264 is the most "
+            "widely playable."
+        ),
+    ),
+    Group(
+        create_item_label_group(
+            "qt_bitrate_resolution_class",
+            label_text="Resolution",
+            item_tooltip=(
+                "Which resolution class's quality tier to edit below. When "
+                "a recording starts, the class matching the actual camera "
+                "resolution and frame rate is applied."
+            ),
+        ),
+        *bitrate_tier_items,
+        label="MKV Quality",
+        show_labels=False,
+        show_border=True,
+        visible_when=f'qt_video_format == "{QT_RECORDER_FORMAT_MKV}"',
+    ),
+    label="Qt Recording",
+    show_labels=False,
+    show_border=True,
+    visible_when=f'recorder_backend == "{RECORDER_BACKEND_QT}"',
+)
 
 
 class CameraPreferencesPane(PreferencesPane):
@@ -74,6 +314,16 @@ class CameraPreferencesPane(PreferencesPane):
         Group(
             [video_format_item, strict_video_format_item],
             label="Video Format",
+            show_labels=False,
+            show_border=True,
+            style_sheet=preferences_group_style_sheet,
+        ),
+        Item("_"),  # Separator
+        Group(
+            recorder_backend_item,
+            ffmpeg_settings_group,
+            qt_recorder_settings_group,
+            label="Video Recording",
             show_labels=False,
             show_border=True,
             style_sheet=preferences_group_style_sheet,

--- a/device_viewer/views/camera_control_view/widget.py
+++ b/device_viewer/views/camera_control_view/widget.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import QImage
 from PySide6.QtMultimedia import (
-    QMediaCaptureSession, QCamera, QMediaDevices, QCameraDevice,
+    QMediaCaptureSession, QCamera, QCameraDevice,
     QCameraFormat, QVideoFrame, QVideoSink,
 )
 from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
@@ -26,14 +26,13 @@ from apptools.preferences.api import Preferences
 
 from microdrop_application.dialogs.pyface_wrapper import error, warning, YES, OK, disclaimer
 from microdrop_application.helpers import get_current_experiment_directory
-from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from microdrop_utils.pyside_helpers import MarqueeComboBox
 from microdrop_utils.v4l2_fps_getter import get_video_inputs, LinuxCameraDeviceContainer
 from ...consts import (
     CAMERA_PREVIEW_MAX_FPS,
     CAPTURES_DIR_NAME,
-    DEVICE_VIEWER_RECORDING_STATE,
     RAW_CAPTURES_SUBDIR,
+    RECORDER_BACKEND_FFMPEG,
     RECORDINGS_DIR_NAME,
     device_viewer_recording_state_publisher,
     media_capture_event_model,
@@ -50,7 +49,7 @@ from ...default_settings import video_key
 from ...utils.camera import (
     NativeVideoRecorder,
     get_transformed_frame,
-    ImageSaver,
+    ImageSaver, RawFFMPEGVideoRecorder
 )
 from ...models.media import MediaType
 
@@ -123,13 +122,11 @@ class CameraControlWidget(QWidget):
         self.session.setVideoSink(self._camera_sink)
         self._last_preview_frame_time = 0.0
 
-        # 1. Initialize Recorder — Qt's native QMediaRecorder on the capture
-        # session: hardware-encoded raw camera stream, zero per-frame Python
-        # work, alignment geometry saved to a sidecar (see
-        # NativeVideoRecorder). Untouched by the preview frame cap.
-        self.recorder = NativeVideoRecorder(self.session, self.video_item)
-        self.recorder.error_occurred.connect(self.handle_recording_error)
-        self.recorder.recording_stopped.connect(self.handle_recording_stopped)
+        # 1. Initialize Recorder. The backend (Qt MediaRecorder vs FFmpeg
+        # process) and its encoding settings come from the camera
+        # preferences; the recorder is rebuilt from them at every recording
+        # start (see _build_recorder), so preference changes apply live.
+        self.recorder = self._build_recorder()
         self.recording_file_path = None
         self._camera_state_pre_recording = None
 
@@ -144,6 +141,53 @@ class CameraControlWidget(QWidget):
         # Check initial camera state
         self.initialize_camera_list()
         self.check_initial_camera_state()
+
+    def _build_recorder(self, resolution=None, fps=None):
+        """Recorder configured from the camera preferences. Both recorders
+        share VideoRecorderBase, so the rest of the widget is agnostic.
+        ``resolution``/``fps`` (known at recording start) select which
+        per-resolution-class bitrate preference applies to the Qt/MKV
+        recorder; at construction time they are unknown and the bitrate
+        stays encoder-chosen."""
+        if self.preferences.recorder_backend == RECORDER_BACKEND_FFMPEG:
+            # Raw camera planes piped to an ffmpeg subprocess at full
+            # camera rate (untouched by the preview frame cap thanks to
+            # frame_sink=self._camera_sink).
+            logger.info(
+                f"Recorder from preferences: FFmpeg process — "
+                f"container={self.preferences.ffmpeg_container}, "
+                f"codec={self.preferences.ffmpeg_video_codec}, "
+                f"preset={self.preferences.ffmpeg_preset}, "
+                f"crf={self.preferences.ffmpeg_crf}, "
+                f"extra args={self.preferences.ffmpeg_extra_output_args!r}")
+            recorder = RawFFMPEGVideoRecorder(
+                self.video_item,
+                frame_sink=self._camera_sink,
+                video_codec=self.preferences.ffmpeg_video_codec,
+                preset=self.preferences.ffmpeg_preset,
+                crf=self.preferences.ffmpeg_crf,
+                extra_output_args=self.preferences.ffmpeg_extra_output_args,
+            )
+        else:
+            # Qt's own QMediaRecorder: hardware-encoded, zero per-frame
+            # Python work.
+            video_bitrate = self.preferences.recording_bitrate_bps(
+                resolution, fps)
+            logger.info(
+                f"Recorder from preferences: Qt MediaRecorder — "
+                f"format={self.preferences.qt_video_format}, "
+                f"codec={self.preferences.qt_video_codec}, "
+                f"bitrate={f'{video_bitrate:,} bps' if video_bitrate else 'encoder default'}")
+            recorder = NativeVideoRecorder(
+                session=self.session,
+                video_item=self.video_item,
+                file_format=self.preferences.qt_video_format,
+                video_codec=self.preferences.qt_video_codec,
+                video_bitrate=video_bitrate,
+            )
+        recorder.error_occurred.connect(self.handle_recording_error)
+        recorder.recording_stopped.connect(self.handle_recording_stopped)
+        return recorder
 
     def _init_ui(self):
         # Camera Combo Box
@@ -843,7 +887,9 @@ class CameraControlWidget(QWidget):
         return self._generate_media_filename(step_description, step_id, ".png")
 
     def _generate_recording_filename(self, step_description=None, step_id=None):
-        return self._generate_media_filename(step_description, step_id, ".mkv")
+        return self._generate_media_filename(
+            step_description, step_id,
+            self.preferences.recording_file_extension())
 
     def on_recording_active(self, recording_data):
         if isinstance(recording_data, dict):
@@ -919,6 +965,10 @@ class CameraControlWidget(QWidget):
     ):
         logger.info("Starting video recorder...")
 
+        # A rebuild while recording would orphan the active recorder.
+        if self.recorder.is_recording:
+            return
+
         # Provider feeds (ASI) bypass the QtMultimedia session the recorder
         # taps: recording is unsupported for them. The button is disabled
         # while a provider source is selected, so this guard covers the
@@ -966,6 +1016,10 @@ class CameraControlWidget(QWidget):
             _current_fmt.resolution().height(),
         )
 
+        # Rebuild from current preferences so backend/container/bitrate
+        # changes apply without a restart, with the bitrate class matched
+        # to the actual camera resolution and frame rate.
+        self.recorder = self._build_recorder(_resolution, fps)
         self.recorder.start(
             _recording_file_path, _resolution, fps
         )

--- a/device_viewer/views/camera_control_view/widget.py
+++ b/device_viewer/views/camera_control_view/widget.py
@@ -36,6 +36,7 @@ from ...consts import (
     RAW_CAPTURES_SUBDIR,
     RECORDINGS_DIR_NAME,
     device_viewer_recording_state_publisher,
+    media_capture_event_model,
     recording_state_model,
 )
 
@@ -47,7 +48,7 @@ from ..electrode_view.electrode_scene import ElectrodeScene
 from ...default_settings import video_key
 
 from ...utils.camera import (
-    VideoRecorder,
+    NativeVideoRecorder,
     get_transformed_frame,
     ImageSaver,
 )
@@ -122,9 +123,11 @@ class CameraControlWidget(QWidget):
         self.session.setVideoSink(self._camera_sink)
         self._last_preview_frame_time = 0.0
 
-        # 1. Initialize Recorder — fed from the full-rate camera sink, so
-        # recordings are untouched by the preview cap.
-        self.recorder = VideoRecorder(self.video_item, frame_sink=self._camera_sink)
+        # 1. Initialize Recorder — Qt's native QMediaRecorder on the capture
+        # session: hardware-encoded raw camera stream, zero per-frame Python
+        # work, alignment geometry saved to a sidecar (see
+        # NativeVideoRecorder). Untouched by the preview frame cap.
+        self.recorder = NativeVideoRecorder(self.session, self.video_item)
         self.recorder.error_occurred.connect(self.handle_recording_error)
         self.recorder.recording_stopped.connect(self.handle_recording_stopped)
         self.recording_file_path = None
@@ -776,6 +779,7 @@ class CameraControlWidget(QWidget):
             raw_path.parent.mkdir(parents=True, exist_ok=True)
             if raw_image.save(str(raw_path)):
                 _cache_media_capture(MediaType.IMAGE, str(raw_path))
+                media_capture_event_model.captured = str(raw_path)
                 logger.info(f"Raw sensor frame saved: {raw_path}")
                 if show_dialog:
                     _show_media_capture_dialog(
@@ -795,6 +799,7 @@ class CameraControlWidget(QWidget):
 
         def _post_image_capture():
             _cache_media_capture(MediaType.IMAGE, str(save_path))
+            media_capture_event_model.captured = str(save_path)
             if show_dialog:
                 _show_media_capture_dialog(MediaType.IMAGE, str(save_path), self.status_bar_manager)
 

--- a/device_viewer/views/device_view_dock_pane.py
+++ b/device_viewer/views/device_view_dock_pane.py
@@ -1238,7 +1238,13 @@ class DeviceViewerDockPane(TraitsDockPane):
     def model_change_handler_with_timeout(self, event=None):
         if not self._undoing:
             self.add_traits_event_to_undo_stack(event)
-            if not self.model.editable:
+            # The not-editable revert protects STEP state (electrodes,
+            # routes, camera alignment) while a protocol runs. Alphas are
+            # global display preferences, not step state — they stay
+            # adjustable mid-run (like the visibility toggles, which this
+            # handler never observed).
+            if not self.model.editable and not isinstance(event.object,
+                                                          AlphaValue):
                 self.undo()  # Revert changes if not editable
                 return
 

--- a/device_viewer/views/video_viewer/dock_pane.py
+++ b/device_viewer/views/video_viewer/dock_pane.py
@@ -1,0 +1,291 @@
+"""Dock pane for viewing recorded videos.
+
+Plays the raw recordings the native recorder writes, with a
+Device-Aligned toggle that reconstructs the perspective-warped view from
+the recording's ``.transform.json`` sidecar — the same alignment the live
+device view showed while recording. Regions of interest can be keyframed
+over playback time (Edit Region mode) and the aligned + cropped
+rendition exported to a file next to the recording.
+"""
+import json
+from pathlib import Path
+
+from pyface.gui import GUI
+from pyface.tasks.api import TraitsDockPane
+from pyface.api import DirectoryDialog, OK
+from traits.api import Any, Bool, Instance, Button, observe
+from traitsui.api import (
+    CustomEditor, EnumEditor, HGroup, Item, Readonly, UItem, VGroup, View,
+)
+
+
+from microdrop_application.helpers import get_current_experiment_directory
+from microdrop_style.icons.icons import (
+    ICON_CROP, ICON_DELETE, ICON_FIT_SCREEN, ICON_FOLDER_OPEN, ICON_HOME,
+    ICON_PAUSE, ICON_PLAY, ICON_REFRESH, ICON_SAVE, ICON_TRANSFORM,
+)
+from microdrop_utils.traitsui_qt_helpers import (
+    IconButtonEditor, IconToggleEditor,
+)
+
+from ...consts import (
+    PKG, RECORDINGS_DIR_NAME, RECORDING_TRANSFORM_SIDECAR_SUFFIX,
+    recording_state_model,
+)
+from .model import VideoViewerModel
+from .video_canvas import video_canvas_factory
+from .video_export import AlignedVideoExporter
+
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+#: Recording containers the viewer lists (native recorder writes .mkv,
+#: like the legacy ffmpeg-pipe recorder; .mp4 covers stray files).
+RECORDING_GLOBS = ("*.mp4", "*.mkv")
+
+#: Region-of-interest keyframes saved next to each recording, so a crop
+#: setup survives reloads and exports stay reproducible.
+ROI_SIDECAR_SUFFIX = ".roi.json"
+
+
+class VideoViewerDockPane(TraitsDockPane):
+    """Viewer for recorded videos (raw or device-aligned playback)."""
+
+    id = PKG + ".video_viewer.dock_pane"
+    name = "Recording Viewer"
+
+    model = Instance(VideoViewerModel)
+    # Compact icon toolbar (words live in the tooltips), mirroring the
+    # fluorescence image viewer's button row.
+    view = View(
+    VGroup(
+        HGroup(
+            UItem("pane.directory_button", editor=IconButtonEditor(
+                glyph=ICON_FOLDER_OPEN,
+                tooltip="Choose the recordings folder (defaults to the "
+                        "current experiment's recordings)")),
+            UItem("pane.home_button", editor=IconButtonEditor(
+                glyph=ICON_HOME,
+                tooltip="Back to the current experiment's recordings "
+                        "(newest recording)")),
+            UItem("pane.refresh_button", editor=IconButtonEditor(
+                glyph=ICON_REFRESH,
+                tooltip="Re-scan the current folder for new recordings")),
+            UItem("pane.fit_button", editor=IconButtonEditor(
+                glyph=ICON_FIT_SCREEN,
+                tooltip="Fit the video to the pane (clears the saved "
+                        "zoom/pan)")),
+            UItem("aligned", editor=IconToggleEditor(
+                on_glyph=ICON_TRANSFORM, off_glyph=ICON_TRANSFORM,
+                tooltip="Show the device-aligned (perspective-warped) "
+                        "view from the recording's transform sidecar"),
+                enabled_when="has_transform"),
+            UItem("roi_edit_mode", editor=IconToggleEditor(
+                on_glyph=ICON_CROP, off_glyph=ICON_CROP,
+                tooltip="Edit the region of interest: drag on the video "
+                        "to set the region at the current time"),
+                enabled_when="aligned"),
+            UItem("pane.clear_roi_button", editor=IconButtonEditor(
+                glyph=ICON_DELETE,
+                tooltip="Clear all region-of-interest keyframes"),
+                enabled_when="roi_keyframes"),
+            UItem("pane.export_button", editor=IconButtonEditor(
+                glyph=ICON_SAVE,
+                tooltip="Save the device-aligned (and region-cropped) "
+                        "video next to the recording"),
+                enabled_when="has_transform and current_path "
+                             "and not exporting"),
+            Readonly("export_status", show_label=False),
+        ),
+        Item("selected_video", label="Recording",
+             editor=EnumEditor(name="object.video_names")),
+        UItem("current_path", editor=CustomEditor(video_canvas_factory)),
+        HGroup(
+            UItem("playing", editor=IconToggleEditor(
+                on_glyph=ICON_PAUSE, off_glyph=ICON_PLAY,
+                tooltip="Play / pause"),
+                enabled_when="current_path"),
+            UItem("position_ms", enabled_when="current_path"),
+            Readonly("time_text", show_label=False),
+        ),
+    ),
+    resizable=True,
+)
+
+    # Toolbar buttons (view elements, so they live on the PANE and the
+    # View references them via the "pane." prefix).
+    directory_button = Button()
+    #: Back to the current experiment's recordings folder.
+    home_button = Button()
+    #: Re-scan the browsed folder for new recordings.
+    refresh_button = Button()
+    #: Refit the canvas to the frame (clears the persisted zoom/pan).
+    fit_button = Button()
+    clear_roi_button = Button()
+    #: Export the device-aligned (+ ROI-cropped) rendition.
+    export_button = Button()
+
+    def traits_init(self):
+        self.model = VideoViewerModel()
+        # Auto-refresh when a recording finishes: the camera widget flips
+        # this shared state AFTER the recorder's stopped signal, so the
+        # file and its transform sidecar are already on disk.
+        recording_state_model.observe(self._on_recording_state_changed,
+                                      "recording")
+
+    def destroy(self):
+        recording_state_model.observe(self._on_recording_state_changed,
+                                      "recording", remove=True)
+        super().destroy()
+
+    def _on_recording_state_changed(self, event):
+        if event.old and not event.new:
+            # Recording just finished — recordings land in the current
+            # experiment's folder: point there and pick up the new file
+            # (discovery auto-selects the newest recording).
+            self._go_home()
+
+    @observe("model")
+    def _model_updated(self, event):
+        self._go_home()
+
+    # ------------------------------------------------------------------ #
+    # Discovery                                                            #
+    # ------------------------------------------------------------------ #
+    @observe("model:directory")
+    def _refresh_recordings(self, event=None):
+        directory = Path(self.model.directory) if self.model.directory else None
+        recordings = []
+        if directory is not None and directory.is_dir():
+            for pattern in RECORDING_GLOBS:
+                recordings.extend(directory.glob(pattern))
+            recordings.sort(key=lambda path: path.stat().st_mtime)
+        self.model.recordings = recordings
+        if recordings:
+            # Newest recording is usually the one of interest.
+            self.model.selected_video = recordings[-1].name
+        else:
+            self.model.selected_video = ""
+            self.model.current_path = ""
+
+    @observe("model:selected_video")
+    def _load_selected(self, event):
+        for path in self.model.recordings:
+            if path.name == self.model.selected_video:
+                self.model.current_path = str(path)
+                self._load_roi_sidecar(path)
+                return
+
+    # ------------------------------------------------------------------ #
+    # Region-of-interest persistence (per recording)                       #
+    # ------------------------------------------------------------------ #
+    #: Guards the ROI sidecar sync against echoing its own load.
+    _loading_roi = Bool(False)
+
+    def _load_roi_sidecar(self, video_path):
+        roi_path = Path(video_path).with_suffix(ROI_SIDECAR_SUFFIX)
+        keyframes = []
+        if roi_path.is_file():
+            try:
+                keyframes = [(int(ms), tuple(region))
+                             for ms, region in json.loads(roi_path.read_text())]
+            except Exception as e:
+                logger.warning(f"Unreadable ROI sidecar {roi_path}: {e}")
+        self._loading_roi = True
+        try:
+            self.model.roi_keyframes = keyframes
+        finally:
+            self._loading_roi = False
+
+    @observe("model:roi_keyframes")
+    def _persist_roi_sidecar(self, event):
+        if self._loading_roi or not self.model.current_path:
+            return
+        roi_path = Path(self.model.current_path).with_suffix(ROI_SIDECAR_SUFFIX)
+        try:
+            if self.model.roi_keyframes:
+                roi_path.write_text(json.dumps(
+                    [[ms, list(region)]
+                     for ms, region in self.model.roi_keyframes]))
+            elif roi_path.is_file():
+                roi_path.unlink()
+        except Exception as e:
+            logger.warning(f"Could not persist ROI sidecar {roi_path}: {e}")
+
+    @observe("clear_roi_button")
+    def _clear_roi(self, event):
+        self.model.roi_keyframes = []
+
+    @observe("fit_button")
+    def _request_fit(self, event):
+        self.model.fit_request = True
+
+    # ------------------------------------------------------------------ #
+    # Aligned export                                                       #
+    # ------------------------------------------------------------------ #
+    #: The running exporter (kept referenced for its lifetime).
+    _exporter = Any()
+
+    @observe("export_button")
+    def _export_aligned_video(self, event):
+        model = self.model
+        if model.exporting or not model.current_path:
+            return
+        sidecar_path = Path(model.current_path).with_suffix(
+            RECORDING_TRANSFORM_SIDECAR_SUFFIX)
+        try:
+            sidecar = json.loads(sidecar_path.read_text())
+        except Exception as e:
+            model.export_status = f"No usable transform sidecar: {e}"
+            return
+        model.exporting = True
+        model.export_status = "Exporting…"
+        self._exporter = AlignedVideoExporter(
+            model.current_path, sidecar, list(model.roi_keyframes))
+        # Exporter signals fire on its worker thread; marshal every trait
+        # write back onto the GUI thread.
+        self._exporter.progress.connect(
+            lambda text: GUI.invoke_later(
+                setattr, model, "export_status", text))
+        self._exporter.finished.connect(
+            lambda path: GUI.invoke_later(
+                model.trait_set, exporting=False,
+                export_status=f"Saved {Path(path).name}"))
+        self._exporter.failed.connect(
+            lambda message: GUI.invoke_later(
+                model.trait_set, exporting=False,
+                export_status=f"Export failed: {message}"))
+        self._exporter.start()
+
+    # ------------------------------------------------------------------ #
+    # Toolbar buttons                                                      #
+    # ------------------------------------------------------------------ #
+    @observe("directory_button")
+    def _pick_directory(self, event):
+        dialog = DirectoryDialog(default_path=self.model.directory or "")
+        if dialog.open() == OK:
+            self.model.directory = dialog.path
+
+    @observe("home_button")
+    def _on_home(self, event):
+        self._go_home()
+
+    @observe("refresh_button")
+    def _on_refresh(self, event):
+        self._refresh_recordings()
+
+    def _go_home(self):
+        """Point at the current experiment's recordings folder."""
+        try:
+            experiment_directory = get_current_experiment_directory()
+        except Exception as e:
+            logger.debug(f"No current experiment directory: {e}")
+            return
+        if experiment_directory:
+            recordings_directory = Path(experiment_directory) / RECORDINGS_DIR_NAME
+            if str(recordings_directory) == self.model.directory:
+                self._refresh_recordings()   # same folder: re-scan for new files
+            else:
+                self.model.directory = str(recordings_directory)
+

--- a/device_viewer/views/video_viewer/dock_pane.py
+++ b/device_viewer/views/video_viewer/dock_pane.py
@@ -4,8 +4,9 @@ Plays the raw recordings the native recorder writes, with a
 Device-Aligned toggle that reconstructs the perspective-warped view from
 the recording's ``.transform.json`` sidecar — the same alignment the live
 device view showed while recording. Regions of interest can be keyframed
-over playback time (Edit Region mode) and the aligned + cropped
-rendition exported to a file next to the recording.
+over playback time (Edit Region mode) in EITHER view — raw or aligned,
+sidecar or not — and the matching rendition (aligned and/or cropped)
+exported to a file next to the recording.
 """
 import json
 from pathlib import Path
@@ -84,18 +85,19 @@ class VideoViewerDockPane(TraitsDockPane):
             UItem("roi_edit_mode", editor=IconToggleEditor(
                 on_glyph=ICON_CROP, off_glyph=ICON_CROP,
                 tooltip="Edit the region of interest: drag on the video "
-                        "to set the region at the current time"),
-                enabled_when="aligned"),
+                        "to set the region at the current time (works in "
+                        "the raw and the device-aligned view)"),
+                enabled_when="current_path"),
             UItem("pane.clear_roi_button", editor=IconButtonEditor(
                 glyph=ICON_DELETE,
                 tooltip="Clear all region-of-interest keyframes"),
                 enabled_when="roi_keyframes"),
             UItem("pane.export_button", editor=IconButtonEditor(
                 glyph=ICON_SAVE,
-                tooltip="Save the device-aligned (and region-cropped) "
-                        "video next to the recording"),
-                enabled_when="has_transform and current_path "
-                             "and not exporting"),
+                tooltip="Save the current rendition (device-aligned "
+                        "and/or region-cropped) next to the recording"),
+                enabled_when="current_path and not exporting "
+                             "and (aligned or roi_keyframes)"),
             Readonly("export_status", show_label=False),
         ),
         Item("selected_video", label="Recording",
@@ -185,15 +187,24 @@ class VideoViewerDockPane(TraitsDockPane):
 
     def _load_roi_sidecar(self, video_path):
         roi_path = Path(video_path).with_suffix(ROI_SIDECAR_SUFFIX)
-        keyframes = []
+        keyframes, roi_aligned = [], True
         if roi_path.is_file():
             try:
+                data = json.loads(roi_path.read_text())
+                if isinstance(data, dict):
+                    roi_aligned = bool(data.get("aligned", True))
+                    raw_keyframes = data.get("keyframes", [])
+                else:
+                    # Legacy bare-list sidecar: regions were always drawn
+                    # in the aligned view back then.
+                    raw_keyframes = data
                 keyframes = [(int(ms), tuple(region))
-                             for ms, region in json.loads(roi_path.read_text())]
+                             for ms, region in raw_keyframes]
             except Exception as e:
                 logger.warning(f"Unreadable ROI sidecar {roi_path}: {e}")
         self._loading_roi = True
         try:
+            self.model.roi_aligned = roi_aligned
             self.model.roi_keyframes = keyframes
         finally:
             self._loading_roi = False
@@ -205,9 +216,11 @@ class VideoViewerDockPane(TraitsDockPane):
         roi_path = Path(self.model.current_path).with_suffix(ROI_SIDECAR_SUFFIX)
         try:
             if self.model.roi_keyframes:
-                roi_path.write_text(json.dumps(
-                    [[ms, list(region)]
-                     for ms, region in self.model.roi_keyframes]))
+                roi_path.write_text(json.dumps({
+                    "aligned": self.model.roi_aligned,
+                    "keyframes": [[ms, list(region)]
+                                  for ms, region in self.model.roi_keyframes],
+                }))
             elif roi_path.is_file():
                 roi_path.unlink()
         except Exception as e:
@@ -232,17 +245,25 @@ class VideoViewerDockPane(TraitsDockPane):
         model = self.model
         if model.exporting or not model.current_path:
             return
-        sidecar_path = Path(model.current_path).with_suffix(
-            RECORDING_TRANSFORM_SIDECAR_SUFFIX)
-        try:
-            sidecar = json.loads(sidecar_path.read_text())
-        except Exception as e:
-            model.export_status = f"No usable transform sidecar: {e}"
-            return
+        # The regions' space decides the rendition (they only make sense in
+        # the view they were drawn in); with no regions, export whatever
+        # view is displayed.
+        export_aligned = (model.roi_aligned if model.roi_keyframes
+                          else model.aligned)
+        sidecar = None
+        if export_aligned:
+            sidecar_path = Path(model.current_path).with_suffix(
+                RECORDING_TRANSFORM_SIDECAR_SUFFIX)
+            try:
+                sidecar = json.loads(sidecar_path.read_text())
+            except Exception as e:
+                model.export_status = f"No usable transform sidecar: {e}"
+                return
         model.exporting = True
         model.export_status = "Exporting…"
         self._exporter = AlignedVideoExporter(
-            model.current_path, sidecar, list(model.roi_keyframes))
+            model.current_path, sidecar, list(model.roi_keyframes),
+            aligned=export_aligned)
         # Exporter signals fire on its worker thread; marshal every trait
         # write back onto the GUI thread.
         self._exporter.progress.connect(

--- a/device_viewer/views/video_viewer/model.py
+++ b/device_viewer/views/video_viewer/model.py
@@ -1,0 +1,110 @@
+"""Qt-free HasTraits model for the recordings viewer pane: the browsed
+folder, its discovered recordings, playback state, and the raw-vs-aligned
+display toggle. Mutated only on the GUI thread (buttons, the canvas's
+player callbacks), so no Qt bridging is needed.
+"""
+from traits.api import (
+    Bool, Directory, Event, HasTraits, Int, List, Property, Range, Str,
+)
+
+
+class VideoViewerModel(HasTraits):
+    """State for the recorded-video viewer."""
+
+    #: Folder being browsed. '' follows the current experiment's
+    #: recordings folder; the folder button points it elsewhere.
+    directory = Directory()
+
+    #: Discovered recordings in the browsed folder (Path objects),
+    #: oldest first.
+    recordings = List()
+
+    #: Path of the loaded recording ('' before the first load). Setting it
+    #: is the ONE way a video gets shown — the canvas loads it.
+    current_path = Str()
+
+    #: Basename choices for the recording dropdown (mirrors ``recordings``).
+    video_names = Property(List(Str), observe="recordings.items")
+
+    #: Basename of the loaded recording — the dropdown selection.
+    selected_video = Str()
+
+    #: True when the loaded recording has an alignment sidecar
+    #: (see consts.RECORDING_TRANSFORM_SIDECAR_SUFFIX).
+    has_transform = Bool(False)
+
+    #: Show the device-aligned (perspective-warped) view instead of the
+    #: raw camera frames. Only meaningful when has_transform.
+    aligned = Bool(False)
+
+    #: Playback state (the play/pause toggle; the canvas drives the player
+    #: and reflects the player's real state back here).
+    playing = Bool(False)
+
+    #: Playback position/duration in milliseconds. position_ms doubles as
+    #: the seek slider (its upper bound rides the loaded duration).
+    duration_ms = Int(0)
+    position_ms = Range(0, "duration_ms", 0, mode="slider")
+
+    #: "m:ss / m:ss" readout next to the seek slider.
+    time_text = Property(Str, observe="position_ms, duration_ms")
+
+    # ------------------------------------------------------------------ #
+    # Region of interest (dynamic: keyframed over playback time)           #
+    # ------------------------------------------------------------------ #
+    #: (position_ms, (x, y, w, h)) keyframes in the ALIGNED view's scene
+    #: coordinates, sorted by time. Each keyframe's region holds until the
+    #: next one, so drawing regions at different times makes the export's
+    #: crop follow the action frame to frame. Empty = no crop.
+    roi_keyframes = List()
+
+    #: Rubber-band ROI drawing mode (the Edit Region toggle): while on,
+    #: dragging on the canvas defines the region at the CURRENT position.
+    roi_edit_mode = Bool(False)
+
+    #: The keyframe region active at the current playback position (what
+    #: the canvas outlines), or None.
+    active_roi = Property(observe="roi_keyframes.items, position_ms")
+
+    #: One-shot request to refit the canvas to the frame (also clears the
+    #: persisted zoom/pan). Fired by the pane's Fit View button.
+    fit_request = Event()
+
+    # Export of the device-aligned (+ ROI-cropped) rendition.
+    exporting = Bool(False)
+    export_status = Str("")
+
+    def _get_video_names(self):
+        return [path.name for path in self.recordings]
+
+    def _get_time_text(self):
+        def clock(milliseconds):
+            seconds = int(milliseconds // 1000)
+            return f"{seconds // 60:d}:{seconds % 60:02d}"
+        return f"{clock(self.position_ms)} / {clock(self.duration_ms)}"
+
+    def _get_active_roi(self):
+        return self.roi_at(self.position_ms)
+
+    def roi_at(self, position_ms):
+        """The region holding at ``position_ms`` (stepwise: the latest
+        keyframe at or before it). Times BEFORE the first keyframe use the
+        first keyframe's region — a single region drawn mid-video means
+        "crop the whole video here", not "crop from this moment on"."""
+        if not self.roi_keyframes:
+            return None
+        active = self.roi_keyframes[0][1]
+        for keyframe_ms, region in self.roi_keyframes:
+            if keyframe_ms > position_ms:
+                break
+            active = region
+        return active
+
+    def set_roi_keyframe(self, position_ms, region):
+        """Add (or replace) the region keyframe at ``position_ms``.
+        ``region`` is an (x, y, w, h) tuple in aligned-scene coordinates."""
+        keyframes = [(ms, rect) for ms, rect in self.roi_keyframes
+                     if ms != position_ms]
+        keyframes.append((int(position_ms), tuple(region)))
+        keyframes.sort(key=lambda keyframe: keyframe[0])
+        self.roi_keyframes = keyframes

--- a/device_viewer/views/video_viewer/model.py
+++ b/device_viewer/views/video_viewer/model.py
@@ -52,11 +52,18 @@ class VideoViewerModel(HasTraits):
     # ------------------------------------------------------------------ #
     # Region of interest (dynamic: keyframed over playback time)           #
     # ------------------------------------------------------------------ #
-    #: (position_ms, (x, y, w, h)) keyframes in the ALIGNED view's scene
-    #: coordinates, sorted by time. Each keyframe's region holds until the
-    #: next one, so drawing regions at different times makes the export's
-    #: crop follow the action frame to frame. Empty = no crop.
+    #: (position_ms, (x, y, w, h)) keyframes in the scene coordinates of
+    #: the view they were drawn in (see roi_aligned), sorted by time. Each
+    #: keyframe's region holds until the next one, so drawing regions at
+    #: different times makes the export's crop follow the action frame to
+    #: frame. Empty = no crop.
     roi_keyframes = List()
+
+    #: Which view's coordinates the keyframes live in: the device-aligned
+    #: scene (True) or the raw frame (False). Regions live in ONE space at
+    #: a time — drawing in the other view clears them (the two coordinate
+    #: systems don't mix).
+    roi_aligned = Bool(True)
 
     #: Rubber-band ROI drawing mode (the Edit Region toggle): while on,
     #: dragging on the canvas defines the region at the CURRENT position.
@@ -100,11 +107,17 @@ class VideoViewerModel(HasTraits):
             active = region
         return active
 
-    def set_roi_keyframe(self, position_ms, region):
+    def set_roi_keyframe(self, position_ms, region, aligned):
         """Add (or replace) the region keyframe at ``position_ms``.
-        ``region`` is an (x, y, w, h) tuple in aligned-scene coordinates."""
-        keyframes = [(ms, rect) for ms, rect in self.roi_keyframes
-                     if ms != position_ms]
+        ``region`` is an (x, y, w, h) tuple in the scene coordinates of the
+        view it was drawn in (``aligned``). Drawing in the other view than
+        the existing keyframes clears them — the spaces don't mix."""
+        if aligned != self.roi_aligned:
+            keyframes = []
+        else:
+            keyframes = [(ms, rect) for ms, rect in self.roi_keyframes
+                         if ms != position_ms]
+        self.roi_aligned = aligned
         keyframes.append((int(position_ms), tuple(region)))
         keyframes.sort(key=lambda keyframe: keyframe[0])
         self.roi_keyframes = keyframes

--- a/device_viewer/views/video_viewer/video_canvas.py
+++ b/device_viewer/views/video_viewer/video_canvas.py
@@ -1,0 +1,305 @@
+"""Playback canvas for the recordings viewer: a QGraphicsView hosting a
+QMediaPlayer-fed video item, switchable between the raw camera view and
+the device-aligned (perspective-warped) view reconstructed from the
+recording's ``.transform.json`` sidecar (written by NativeVideoRecorder).
+
+The canvas is zoomable (wheel, anchored under the cursor) and pannable
+(drag); the framing persists to preferences because the alignment
+transform can push the frame outside the pane's bounds. It also renders
+and edits the model's region-of-interest keyframes (the Edit Region
+mode): dragging in edit mode sets the region at the current playback
+position.
+"""
+import json
+from pathlib import Path
+
+from PySide6.QtCore import QPointF, QRectF, QSizeF, Qt, QTimer, QUrl
+from PySide6.QtGui import QColor, QPainter, QPen, QTransform
+from PySide6.QtMultimedia import QMediaPlayer
+from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
+from PySide6.QtWidgets import QGraphicsRectItem, QGraphicsScene, QGraphicsView
+
+from logger.logger_service import get_logger
+
+from ...consts import RECORDING_TRANSFORM_SIDECAR_SUFFIX
+from ...preferences import DeviceViewerPreferences
+from ...utils.camera import qtransform_deserialize
+
+logger = get_logger(__name__)
+
+#: Ignore seek-slider echoes closer than this to the player's position
+#: (the player's own positionChanged updates the slider ~25x a second).
+SEEK_ECHO_TOLERANCE_MS = 300
+
+#: Wheel zoom step per notch, and the debounce before the current
+#: zoom/pan framing is written to preferences.
+ZOOM_STEP_FACTOR = 1.2
+VIEW_STATE_SAVE_DEBOUNCE_MS = 500
+
+#: Regions smaller than this (scene units) are treated as stray clicks.
+MIN_ROI_SIZE = 4.0
+
+
+class VideoPlaybackCanvas(QGraphicsView):
+    """Renders the model's current recording; follows its playback,
+    aligned-view, framing and ROI traits and reflects the player's real
+    state back."""
+
+    def __init__(self, model, parent=None):
+        super().__init__(parent)
+        self._model = model
+        self._sidecar = None
+        self._syncing_position = False
+        self._restoring_view = False
+        self._roi_drag_origin = None
+        self._preferences = DeviceViewerPreferences()
+
+        self.setScene(QGraphicsScene(self))
+        self.setRenderHint(QPainter.SmoothPixmapTransform, True)
+        self.setBackgroundBrush(Qt.black)
+        self.setTransformationAnchor(QGraphicsView.ViewportAnchor.AnchorUnderMouse)
+        self.setDragMode(QGraphicsView.DragMode.ScrollHandDrag)
+        self._video_item = QGraphicsVideoItem()
+        self.scene().addItem(self._video_item)
+
+        roi_pen = QPen(QColor("#FFD60A"), 0)
+        roi_pen.setStyle(Qt.PenStyle.DashLine)
+        self._roi_item = QGraphicsRectItem()
+        self._roi_item.setPen(roi_pen)
+        self._roi_item.setZValue(10)
+        self._roi_item.setVisible(False)
+        self.scene().addItem(self._roi_item)
+
+        self._player = QMediaPlayer(self)
+        self._player.setVideoOutput(self._video_item)
+        self._player.durationChanged.connect(self._on_duration_changed)
+        self._player.positionChanged.connect(self._on_position_changed)
+        self._player.playbackStateChanged.connect(self._on_playback_state)
+        self._video_item.nativeSizeChanged.connect(self._on_native_size)
+
+        # Debounced persistence of the zoom/pan framing.
+        self._view_state_timer = QTimer(self)
+        self._view_state_timer.setSingleShot(True)
+        self._view_state_timer.setInterval(VIEW_STATE_SAVE_DEBOUNCE_MS)
+        self._view_state_timer.timeout.connect(self._save_view_state)
+        self.horizontalScrollBar().valueChanged.connect(self._on_view_panned)
+        self.verticalScrollBar().valueChanged.connect(self._on_view_panned)
+
+        model.observe(self._on_current_path_changed, "current_path")
+        model.observe(self._on_aligned_changed, "aligned")
+        model.observe(self._on_playing_changed, "playing")
+        model.observe(self._on_seek_requested, "position_ms")
+        model.observe(self._on_active_roi_changed, "active_roi")
+        model.observe(self._on_roi_edit_mode_changed, "roi_edit_mode")
+        model.observe(self._on_fit_requested, "fit_request")
+
+    # ------------------------------------------------------------------ #
+    # Model -> player                                                      #
+    # ------------------------------------------------------------------ #
+    def _on_current_path_changed(self, event):
+        path = event.new
+        self._player.stop()
+        self._sidecar = self._read_sidecar(path) if path else None
+        self._model.has_transform = self._sidecar is not None
+        if not self._model.has_transform:
+            self._model.aligned = False
+        if path:
+            self._player.setSource(QUrl.fromLocalFile(path))
+            # Show the first frame immediately (source alone stays blank).
+            self._player.play()
+            self._player.pause()
+        self._apply_view()
+
+    def _on_aligned_changed(self, event):
+        self._apply_view()
+
+    def _on_playing_changed(self, event):
+        if event.new:
+            self._player.play()
+        else:
+            self._player.pause()
+
+    def _on_seek_requested(self, event):
+        if self._syncing_position:
+            return
+        if abs(event.new - self._player.position()) > SEEK_ECHO_TOLERANCE_MS:
+            self._player.setPosition(int(event.new))
+
+    # ------------------------------------------------------------------ #
+    # Player -> model                                                      #
+    # ------------------------------------------------------------------ #
+    def _on_duration_changed(self, duration):
+        self._model.duration_ms = int(duration)
+
+    def _on_position_changed(self, position):
+        self._syncing_position = True
+        try:
+            self._model.position_ms = min(int(position),
+                                          self._model.duration_ms)
+        finally:
+            self._syncing_position = False
+
+    def _on_playback_state(self, state):
+        self._model.playing = (state == QMediaPlayer.PlaybackState.PlayingState)
+
+    def _on_native_size(self, size):
+        if not self._model.aligned and not size.isEmpty():
+            self._video_item.setSize(size)
+            self._apply_view()
+
+    # ------------------------------------------------------------------ #
+    # Raw vs device-aligned rendering                                      #
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _read_sidecar(video_path):
+        sidecar_path = Path(video_path).with_suffix(
+            RECORDING_TRANSFORM_SIDECAR_SUFFIX)
+        if not sidecar_path.is_file():
+            return None
+        try:
+            return json.loads(sidecar_path.read_text())
+        except Exception as e:
+            logger.warning(f"Unreadable transform sidecar {sidecar_path}: {e}")
+            return None
+
+    def _apply_view(self):
+        """Aligned: reproduce the live scene's geometry — the item sized to
+        its recorded bounding rect with the alignment transform applied,
+        framed on the recorded scene rect. Raw: identity at native size.
+        Framing comes from the persisted zoom/pan when set, else a fit."""
+        if self._model.aligned and self._sidecar is not None:
+            transform = qtransform_deserialize(
+                json.dumps(self._sidecar["transform"]))
+            bounding = self._sidecar["bounding_rect"]
+            scene_bounding = self._sidecar["scene_bounding_rect"]
+            # Reproduce the live item's content rect EXACTLY: the recorded
+            # bounding_rect is the video content's rect INSIDE the item —
+            # including a non-zero origin (the letterbox offset), which the
+            # alignment transform was calibrated against. Content at (0,0)
+            # lands the warp over a thousand scene units off. Fill the rect
+            # like the live pipeline's drawImage did (no re-letterboxing).
+            self._video_item.setAspectRatioMode(
+                Qt.AspectRatioMode.IgnoreAspectRatio)
+            self._video_item.setOffset(QPointF(bounding[0], bounding[1]))
+            self._video_item.setSize(QSizeF(bounding[2], bounding[3]))
+            self._video_item.setTransform(transform)
+            frame_rect = QRectF(*scene_bounding)
+        else:
+            self._video_item.setAspectRatioMode(
+                Qt.AspectRatioMode.KeepAspectRatio)
+            self._video_item.setOffset(QPointF(0, 0))
+            self._video_item.setTransform(QTransform())
+            native = self._video_item.nativeSize()
+            if not native.isEmpty():
+                self._video_item.setSize(native)
+            frame_rect = self._video_item.sceneBoundingRect()
+        if frame_rect.isEmpty():
+            return
+        # Margin so an out-of-bounds warp can still be panned into view.
+        margin = max(frame_rect.width(), frame_rect.height())
+        self.scene().setSceneRect(
+            frame_rect.adjusted(-margin, -margin, margin, margin))
+        self._restore_view_state(frame_rect)
+
+    # ------------------------------------------------------------------ #
+    # Zoom / pan, persisted to preferences                                 #
+    # ------------------------------------------------------------------ #
+    def _restore_view_state(self, frame_rect):
+        self._restoring_view = True
+        try:
+            zoom = self._preferences.video_viewer_zoom
+            if zoom > 0:
+                self.setTransform(QTransform.fromScale(zoom, zoom))
+                self.centerOn(self._preferences.video_viewer_center_x,
+                              self._preferences.video_viewer_center_y)
+            else:
+                self.fitInView(frame_rect, Qt.AspectRatioMode.KeepAspectRatio)
+        finally:
+            self._restoring_view = False
+
+    def _save_view_state(self):
+        center = self.mapToScene(self.viewport().rect().center())
+        self._preferences.video_viewer_zoom = float(self.transform().m11())
+        self._preferences.video_viewer_center_x = float(center.x())
+        self._preferences.video_viewer_center_y = float(center.y())
+
+    def _on_view_panned(self, _value):
+        if not self._restoring_view:
+            self._view_state_timer.start()
+
+    def wheelEvent(self, event):
+        factor = (ZOOM_STEP_FACTOR if event.angleDelta().y() > 0
+                  else 1.0 / ZOOM_STEP_FACTOR)
+        self.scale(factor, factor)
+        self._view_state_timer.start()
+        event.accept()
+
+    def _on_fit_requested(self, event):
+        """Fit the frame and forget the persisted framing (the escape
+        hatch when a warp has been panned/zoomed out of sight)."""
+        self._preferences.video_viewer_zoom = 0.0
+        self._apply_view()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        # Only refit automatically while no user framing is persisted.
+        if (self._preferences.video_viewer_zoom == 0
+                and not self._video_item.sceneBoundingRect().isEmpty()):
+            self._restore_view_state(self._video_item.sceneBoundingRect())
+
+    # ------------------------------------------------------------------ #
+    # Region of interest: overlay + rubber-band editing                    #
+    # ------------------------------------------------------------------ #
+    def _on_active_roi_changed(self, event):
+        region = self._model.active_roi
+        if region:
+            self._roi_item.setRect(QRectF(*region))
+            self._roi_item.setVisible(True)
+        else:
+            self._roi_item.setVisible(False)
+
+    def _on_roi_edit_mode_changed(self, event):
+        # Rubber-banding needs the drag, panning otherwise.
+        self.setDragMode(QGraphicsView.DragMode.NoDrag if event.new
+                         else QGraphicsView.DragMode.ScrollHandDrag)
+
+    def mousePressEvent(self, event):
+        if self._model.roi_edit_mode and event.button() == Qt.LeftButton:
+            self._roi_drag_origin = self.mapToScene(event.position().toPoint())
+            self._roi_item.setRect(QRectF(self._roi_drag_origin,
+                                          self._roi_drag_origin))
+            self._roi_item.setVisible(True)
+            event.accept()
+            return
+        super().mousePressEvent(event)
+
+    def mouseMoveEvent(self, event):
+        if self._roi_drag_origin is not None:
+            current = self.mapToScene(event.position().toPoint())
+            self._roi_item.setRect(
+                QRectF(self._roi_drag_origin, current).normalized())
+            event.accept()
+            return
+        super().mouseMoveEvent(event)
+
+    def mouseReleaseEvent(self, event):
+        if self._roi_drag_origin is not None:
+            region = self._roi_item.rect().normalized()
+            self._roi_drag_origin = None
+            if (region.width() >= MIN_ROI_SIZE
+                    and region.height() >= MIN_ROI_SIZE):
+                # Keyframe the region at the CURRENT playback position —
+                # drawing at different times makes the crop dynamic.
+                self._model.set_roi_keyframe(
+                    self._model.position_ms,
+                    (region.x(), region.y(), region.width(), region.height()))
+            else:
+                self._on_active_roi_changed(None)   # stray click: restore
+            event.accept()
+            return
+        super().mouseReleaseEvent(event)
+
+
+def video_canvas_factory(parent, editor):
+    """TraitsUI CustomEditor factory: the editor's object is the model."""
+    return VideoPlaybackCanvas(editor.object)

--- a/device_viewer/views/video_viewer/video_canvas.py
+++ b/device_viewer/views/video_viewer/video_canvas.py
@@ -111,7 +111,13 @@ class VideoPlaybackCanvas(QGraphicsView):
         self._apply_view()
 
     def _on_aligned_changed(self, event):
+        # Applying/unapplying the alignment transform changes the frame's
+        # size and position, so the persisted framing no longer fits:
+        # refit to the pane on every flip (like the Fit View button).
+        self._preferences.video_viewer_zoom = 0.0
         self._apply_view()
+        # The ROI overlay only makes sense in the space it was drawn in.
+        self._on_active_roi_changed()
 
     def _on_playing_changed(self, event):
         if event.new:
@@ -250,9 +256,11 @@ class VideoPlaybackCanvas(QGraphicsView):
     # ------------------------------------------------------------------ #
     # Region of interest: overlay + rubber-band editing                    #
     # ------------------------------------------------------------------ #
-    def _on_active_roi_changed(self, event):
+    def _on_active_roi_changed(self, event=None):
         region = self._model.active_roi
-        if region:
+        # Regions live in the coordinates of the view they were drawn in —
+        # only overlay them while that view is the one displayed.
+        if region and self._model.roi_aligned == self._model.aligned:
             self._roi_item.setRect(QRectF(*region))
             self._roi_item.setVisible(True)
         else:
@@ -289,10 +297,12 @@ class VideoPlaybackCanvas(QGraphicsView):
             if (region.width() >= MIN_ROI_SIZE
                     and region.height() >= MIN_ROI_SIZE):
                 # Keyframe the region at the CURRENT playback position —
-                # drawing at different times makes the crop dynamic.
+                # drawing at different times makes the crop dynamic. The
+                # region is recorded in the displayed view's space.
                 self._model.set_roi_keyframe(
                     self._model.position_ms,
-                    (region.x(), region.y(), region.width(), region.height()))
+                    (region.x(), region.y(), region.width(), region.height()),
+                    aligned=self._model.aligned)
             else:
                 self._on_active_roi_changed(None)   # stray click: restore
             event.accept()

--- a/device_viewer/views/video_viewer/video_export.py
+++ b/device_viewer/views/video_viewer/video_export.py
@@ -1,11 +1,11 @@
-"""Offline export of a recording's device-aligned rendition.
+"""Offline export of a recording's device-aligned and/or cropped rendition.
 
-Decodes the raw recording with ffmpeg, warps every frame through the
-sidecar's alignment transform (the same ``get_transformed_frame`` the
-live pipeline used), crops to the model's region-of-interest keyframes
-(stepwise over playback time, so the crop can follow the action), and
-re-encodes. Runs on a background thread; the GUI only receives progress
-strings.
+Decodes the recording with ffmpeg, optionally warps every frame through
+the sidecar's alignment transform (the same ``get_transformed_frame`` the
+live pipeline used — skipped for raw-space exports and recordings with no
+sidecar), crops to the model's region-of-interest keyframes (stepwise
+over playback time, so the crop can follow the action), and re-encodes.
+Runs on a background thread; the GUI only receives progress strings.
 """
 import json
 import re
@@ -26,8 +26,9 @@ logger = get_logger(__name__)
 #: Used when the container doesn't report a frame rate.
 FALLBACK_EXPORT_FPS = 30.0
 
-#: Suffix of the exported file, next to the source recording.
+#: Suffixes of the exported file, next to the source recording.
 ALIGNED_EXPORT_SUFFIX = "_aligned.mkv"
+CROPPED_EXPORT_SUFFIX = "_cropped.mkv"
 
 
 def roi_at(roi_keyframes, position_ms):
@@ -51,18 +52,24 @@ def _even(value):
 
 
 class AlignedVideoExporter(QObject):
-    """One export job: input recording + sidecar + ROI keyframes -> the
-    aligned (and cropped) video next to the source."""
+    """One export job: input recording (+ sidecar when aligned) + ROI
+    keyframes -> the aligned and/or cropped video next to the source.
+    ``aligned`` says which space the rendition (and its regions) live in:
+    the device-aligned scene (warps every frame through the sidecar's
+    transform) or the raw frame (no warp — works for ANY video)."""
 
     progress = Signal(str)
     finished = Signal(str)
     failed = Signal(str)
 
-    def __init__(self, input_path, sidecar, roi_keyframes,
+    def __init__(self, input_path, sidecar, roi_keyframes, aligned=True,
                  ffmpeg_binary="ffmpeg", parent=None):
         super().__init__(parent)
         self._input_path = str(input_path)
-        self._output_path = str(Path(input_path).with_suffix("")) + ALIGNED_EXPORT_SUFFIX
+        self._aligned = bool(aligned) and sidecar is not None
+        suffix = (ALIGNED_EXPORT_SUFFIX if self._aligned
+                  else CROPPED_EXPORT_SUFFIX)
+        self._output_path = str(Path(input_path).with_suffix("")) + suffix
         self._sidecar = sidecar
         self._roi_keyframes = sorted(roi_keyframes, key=lambda kf: kf[0])
         self._ffmpeg = ffmpeg_binary
@@ -109,22 +116,28 @@ class AlignedVideoExporter(QObject):
         decode = encode = None
         try:
             width, height, fps = self._probe()
-            transform = qtransform_deserialize(
-                json.dumps(self._sidecar["transform"]))
-            scene = self._sidecar["scene_bounding_rect"]
-            bounding = QRectF(*self._sidecar["bounding_rect"])
-            scene_rect = QRectF(*scene)
-
-            # Warp canvas at 1:1 scene scale, so ROI scene coordinates map
-            # directly onto warped pixels (minus the scene origin).
-            warp_size = (_even(scene_rect.width()), _even(scene_rect.height()))
+            if self._aligned:
+                transform = qtransform_deserialize(
+                    json.dumps(self._sidecar["transform"]))
+                bounding = QRectF(*self._sidecar["bounding_rect"])
+                scene_rect = QRectF(*self._sidecar["scene_bounding_rect"])
+                # Warp canvas at 1:1 scene scale, so ROI scene coordinates
+                # map directly onto warped pixels (minus the scene origin).
+                warp_size = (_even(scene_rect.width()),
+                             _even(scene_rect.height()))
+            else:
+                # Raw space: no warp — regions are in frame pixels, the
+                # "warp" IS the decoded frame.
+                transform = bounding = None
+                scene_rect = QRectF(0, 0, width, height)
+                warp_size = (width, height)
             # Constant output size (a video can't change resolution):
-            # the FIRST region's size, or the full warp when no regions.
+            # the FIRST region's size, or the full frame when no regions.
             if self._roi_keyframes:
                 first_region = self._roi_keyframes[0][1]
                 output_size = (_even(first_region[2]), _even(first_region[3]))
             else:
-                output_size = warp_size
+                output_size = (_even(warp_size[0]), _even(warp_size[1]))
 
             decode = subprocess.Popen(
                 [self._ffmpeg, "-hide_banner", "-loglevel", "error",
@@ -153,8 +166,11 @@ class AlignedVideoExporter(QObject):
                     break
                 source = QImage(chunk, width, height,
                                 QImage.Format_RGBA8888)
-                warped = get_transformed_frame(
-                    source, scene_rect, bounding, transform, warp_size)
+                if self._aligned:
+                    warped = get_transformed_frame(
+                        source, scene_rect, bounding, transform, warp_size)
+                else:
+                    warped = source
                 frame = self._crop_frame(warped, scene_rect, warp_size,
                                          output_size,
                                          frame_index * 1000.0 / fps)
@@ -193,7 +209,7 @@ class AlignedVideoExporter(QObject):
                 _, err = encode.communicate()
                 raise RuntimeError(err.decode("utf-8", errors="ignore")
                                    or "ffmpeg encode failed")
-            logger.info(f"Aligned export complete: {self._output_path}")
+            logger.info(f"Export complete: {self._output_path}")
             self.finished.emit(self._output_path)
         except Exception as e:
             logger.error(f"Aligned export failed: {e}", exc_info=True)

--- a/device_viewer/views/video_viewer/video_export.py
+++ b/device_viewer/views/video_viewer/video_export.py
@@ -1,0 +1,236 @@
+"""Offline export of a recording's device-aligned rendition.
+
+Decodes the raw recording with ffmpeg, warps every frame through the
+sidecar's alignment transform (the same ``get_transformed_frame`` the
+live pipeline used), crops to the model's region-of-interest keyframes
+(stepwise over playback time, so the crop can follow the action), and
+re-encodes. Runs on a background thread; the GUI only receives progress
+strings.
+"""
+import json
+import re
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+
+from PySide6.QtCore import QObject, QRect, QRectF, Qt, Signal
+from PySide6.QtGui import QImage
+
+from logger.logger_service import get_logger
+
+from ...utils.camera import get_transformed_frame, qtransform_deserialize
+
+logger = get_logger(__name__)
+
+#: Used when the container doesn't report a frame rate.
+FALLBACK_EXPORT_FPS = 30.0
+
+#: Suffix of the exported file, next to the source recording.
+ALIGNED_EXPORT_SUFFIX = "_aligned.mkv"
+
+
+def roi_at(roi_keyframes, position_ms):
+    """The region holding at ``position_ms`` (stepwise: latest keyframe at
+    or before it; times before the first keyframe use the first keyframe's
+    region). Mirrors VideoViewerModel.roi_at for use off the GUI thread."""
+    if not roi_keyframes:
+        return None
+    active = roi_keyframes[0][1]
+    for keyframe_ms, region in roi_keyframes:
+        if keyframe_ms > position_ms:
+            break
+        active = region
+    return active
+
+
+def _even(value):
+    """libx264 requires even dimensions."""
+    value = max(2, int(round(value)))
+    return value - (value % 2)
+
+
+class AlignedVideoExporter(QObject):
+    """One export job: input recording + sidecar + ROI keyframes -> the
+    aligned (and cropped) video next to the source."""
+
+    progress = Signal(str)
+    finished = Signal(str)
+    failed = Signal(str)
+
+    def __init__(self, input_path, sidecar, roi_keyframes,
+                 ffmpeg_binary="ffmpeg", parent=None):
+        super().__init__(parent)
+        self._input_path = str(input_path)
+        self._output_path = str(Path(input_path).with_suffix("")) + ALIGNED_EXPORT_SUFFIX
+        self._sidecar = sidecar
+        self._roi_keyframes = sorted(roi_keyframes, key=lambda kf: kf[0])
+        self._ffmpeg = ffmpeg_binary
+
+    def start(self):
+        if not shutil.which(self._ffmpeg):
+            self.failed.emit("FFmpeg binary not found.")
+            return
+        threading.Thread(target=self._run, daemon=True,
+                         name="aligned-video-export").start()
+
+    # ------------------------------------------------------------------ #
+    # Worker thread                                                        #
+    # ------------------------------------------------------------------ #
+    def _probe(self):
+        """(width, height, fps) — fps is the TRUE average (exact decoded
+        frame count / duration). Qt's recorder muxes variable-frame-rate
+        streams whose container rate hints are wrong (a 30 fps recording
+        advertises 62.5), so any header-derived rate mistimes the output;
+        pairing this true average with a passthrough decode keeps the
+        export's duration equal to the source's."""
+        ffprobe = str(Path(shutil.which(self._ffmpeg)).with_name("ffprobe"))
+        result = subprocess.run(
+            [ffprobe, "-v", "error", "-select_streams", "v:0",
+             "-count_frames", "-show_entries",
+             "stream=width,height,nb_read_frames : format=duration",
+             "-of", "default=noprint_wrappers=1", self._input_path],
+            capture_output=True, text=True)
+        values = dict(line.split("=", 1)
+                      for line in result.stdout.splitlines() if "=" in line)
+        try:
+            width = int(values["width"])
+            height = int(values["height"])
+            frame_count = int(values["nb_read_frames"])
+            duration_s = float(values["duration"])
+        except (KeyError, ValueError) as e:
+            raise RuntimeError(
+                f"Could not probe the recording ({e}): {result.stderr.strip()}")
+        fps = (frame_count / duration_s if duration_s > 0
+               else FALLBACK_EXPORT_FPS)
+        return width, height, fps
+
+    def _run(self):
+        decode = encode = None
+        try:
+            width, height, fps = self._probe()
+            transform = qtransform_deserialize(
+                json.dumps(self._sidecar["transform"]))
+            scene = self._sidecar["scene_bounding_rect"]
+            bounding = QRectF(*self._sidecar["bounding_rect"])
+            scene_rect = QRectF(*scene)
+
+            # Warp canvas at 1:1 scene scale, so ROI scene coordinates map
+            # directly onto warped pixels (minus the scene origin).
+            warp_size = (_even(scene_rect.width()), _even(scene_rect.height()))
+            # Constant output size (a video can't change resolution):
+            # the FIRST region's size, or the full warp when no regions.
+            if self._roi_keyframes:
+                first_region = self._roi_keyframes[0][1]
+                output_size = (_even(first_region[2]), _even(first_region[3]))
+            else:
+                output_size = warp_size
+
+            decode = subprocess.Popen(
+                [self._ffmpeg, "-hide_banner", "-loglevel", "error",
+                 "-i", self._input_path,
+                 # Emit each REAL frame exactly once: without passthrough,
+                 # ffmpeg pads the VFR stream up to its (wrong) container
+                 # rate hint with duplicates, stretching the export.
+                 "-fps_mode", "passthrough",
+                 "-f", "rawvideo", "-pix_fmt", "rgba", "-"],
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+            encode = subprocess.Popen(
+                [self._ffmpeg, "-y", "-hide_banner", "-loglevel", "error",
+                 "-f", "rawvideo", "-vcodec", "rawvideo",
+                 "-s", f"{output_size[0]}x{output_size[1]}",
+                 "-pix_fmt", "rgba", "-r", f"{fps}", "-i", "-",
+                 "-c:v", "libx264", "-pix_fmt", "yuv420p",
+                 "-preset", "medium", "-crf", "18", self._output_path],
+                stdin=subprocess.PIPE, stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE)
+
+            frame_bytes = width * height * 4
+            frame_index = 0
+            while True:
+                chunk = decode.stdout.read(frame_bytes)
+                if len(chunk) < frame_bytes:
+                    break
+                source = QImage(chunk, width, height,
+                                QImage.Format_RGBA8888)
+                warped = get_transformed_frame(
+                    source, scene_rect, bounding, transform, warp_size)
+                frame = self._crop_frame(warped, scene_rect, warp_size,
+                                         output_size,
+                                         frame_index * 1000.0 / fps)
+                frame_data = frame.constBits()
+                expected_bytes = output_size[0] * output_size[1] * 4
+                if frame_data is None or len(frame_data) != expected_bytes:
+                    raise RuntimeError(
+                        f"Frame {frame_index} produced "
+                        f"{0 if frame_data is None else len(frame_data)} "
+                        f"bytes (expected {expected_bytes})")
+                try:
+                    encode.stdin.write(frame_data)
+                except OSError:
+                    # Windows reports a dead encoder pipe as EINVAL —
+                    # surface ffmpeg's actual complaint instead.
+                    try:
+                        encode.stdin.close()
+                        _, err = encode.communicate(timeout=5)
+                        detail = err.decode("utf-8", errors="ignore").strip()
+                    except Exception:
+                        encode.kill()
+                        detail = ""
+                    raise RuntimeError(
+                        f"Encoder exited at frame {frame_index}"
+                        + (f": {detail}" if detail
+                           else " (no error output captured)"))
+                frame_index += 1
+                if frame_index % 60 == 0:
+                    self.progress.emit(
+                        f"Exporting… {frame_index / fps:.0f}s processed")
+
+            decode.stdout.close()
+            encode.stdin.close()
+            encode.wait()
+            if encode.returncode != 0:
+                _, err = encode.communicate()
+                raise RuntimeError(err.decode("utf-8", errors="ignore")
+                                   or "ffmpeg encode failed")
+            logger.info(f"Aligned export complete: {self._output_path}")
+            self.finished.emit(self._output_path)
+        except Exception as e:
+            logger.error(f"Aligned export failed: {e}", exc_info=True)
+            self.failed.emit(str(e))
+        finally:
+            for process in (decode, encode):
+                if process is not None and process.poll() is None:
+                    process.kill()
+
+    def _crop_frame(self, warped, scene_rect, warp_size, output_size,
+                    position_ms):
+        """Crop the warped frame to the region holding at ``position_ms``
+        (scene coords -> warp pixels), scaled to the constant output size."""
+        region = roi_at(self._roi_keyframes, position_ms)
+        if region is None:
+            frame = warped
+        else:
+            scale_x = warp_size[0] / scene_rect.width()
+            scale_y = warp_size[1] / scene_rect.height()
+            pixel_rect = QRect(
+                int((region[0] - scene_rect.x()) * scale_x),
+                int((region[1] - scene_rect.y()) * scale_y),
+                max(1, int(region[2] * scale_x)),
+                max(1, int(region[3] * scale_y)),
+            ).intersected(QRect(0, 0, warp_size[0], warp_size[1]))
+            if pixel_rect.isEmpty():
+                # A region entirely outside the frame must not silently
+                # become "everything": QImage.copy(emptyRect) copies the
+                # WHOLE image.
+                raise RuntimeError(
+                    f"Region of interest {tuple(region)} lies outside the "
+                    "aligned frame — redraw it in the viewer")
+            frame = warped.copy(pixel_rect)
+        if (frame.width(), frame.height()) != output_size:
+            frame = frame.scaled(output_size[0], output_size[1],
+                                 Qt.AspectRatioMode.IgnoreAspectRatio,
+                                 Qt.TransformationMode.SmoothTransformation)
+        if frame.format() != QImage.Format_RGBA8888:
+            frame = frame.convertToFormat(QImage.Format_RGBA8888)
+        return frame

--- a/examples/demos/high_performance_video_recording_test.py
+++ b/examples/demos/high_performance_video_recording_test.py
@@ -22,7 +22,7 @@ from PySide6.QtMultimediaWidgets import QGraphicsVideoItem
 from PySide6.QtCore import Qt, QSizeF, Slot, QUrl
 from PySide6.QtGui import QBrush
 
-from device_viewer.utils.camera import VideoRecorder
+from device_viewer.utils.camera import RawFFMPEGVideoRecorder
 
 # --- Logging Setup ---
 from logger.logger_service import get_logger, init_logger
@@ -68,7 +68,7 @@ class CameraRunner(QMainWindow):
         )
         layout.addWidget(self.record_btn)
 
-        self.recorder = VideoRecorder(self.video_item)
+        self.recorder = RawFFMPEGVideoRecorder(self.video_item)
 
         self.init_camera()
 

--- a/microdrop_application/menus.py
+++ b/microdrop_application/menus.py
@@ -13,7 +13,15 @@ app_globals = get_microdrop_redis_globals_manager()
 
 
 def is_advanced_mode():
-    return app_globals.get("microdrop.advanced_mode", False)
+    # Tolerate no-Redis (tests / headless imports): this runs at CLASS
+    # DEFINITION time below, so a connect error here used to make ANY
+    # import of this module (e.g. via device_viewer.preferences) require
+    # a live Redis server.
+    try:
+        return app_globals.get("microdrop.advanced_mode", False)
+    except Exception as e:
+        logger.debug(f"Advanced-mode flag unavailable (no Redis?): {e}")
+        return False
 
 
 class AdvancedModeAction(Action):

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -39,3 +39,11 @@ ICON_DROP_EC         = "\uf875" # droplet with bolt
 ICON_STAIRS          = "\uf46c" # stairs
 ICON_JOYSTICK        = "\uf5ee" # joystick (gamepad connection indicator)
 ICON_MODE_HEAT       = "\uf16a" # mode_heat (heater status indicator)
+
+# Recording viewer (ligature names \u2014 the Material Symbols font resolves
+# them like "home"/"play_arrow" above)
+ICON_FIT_SCREEN      = "fit_screen"  # refit content to the view
+ICON_TRANSFORM       = "transform"   # device-aligned (warped) view
+ICON_CROP            = "crop"        # region-of-interest edit mode
+ICON_DELETE          = "delete"      # clear regions
+ICON_SAVE            = "save"        # export/save

--- a/video_protocol_controls/protocol_columns/record_column.py
+++ b/video_protocol_controls/protocol_columns/record_column.py
@@ -130,7 +130,7 @@ class RecordHandler(BaseColumnHandler):
                 "directory": ctx.protocol.scratch.get(
                     EXPERIMENT_DIR_SCRATCH_KEY, ""),
                 "step_description": row.name,
-                "step_id": row.uuid,
+                "step_id": row.dotted_path(),
                 "show_dialog": False,
             }
             publish_message(


### PR DESCRIPTION
## Summary

Native hardware video recording with an offline Recording Viewer, now driven end-to-end by user preferences.

### Recording pipeline
- **Native hardware recording** through Qt's QMediaRecorder (platform encoding pipeline, zero per-frame Python work) with the device-alignment geometry saved to a `.transform.json` sidecar instead of baked in.
- **Recording Viewer dock pane** reproduces the aligned view offline from the sidecar.
- **Interchangeable recorders**: `VideoRecorderBase` gives `NativeVideoRecorder` and `RawFFMPEGVideoRecorder` one surface (start/stop, `is_recording`, signals, shared sidecar+cache finalization) — swapping backends is a single construction site.
- **Raw ffmpeg recorder hardening**: single-copy-per-plane frame path (was ~3x frame size in copies), stderr to a temp file (a filling pipe can no longer stall the encoder or deadlock stop), prompt sentinel-based shutdown.

### Recording preferences (new "Video Recording" group)
- Recording engine: **Qt MediaRecorder (hardware)** or **FFmpeg process**.
- FFmpeg: container, codec, preset, CRF, extra output args (fps/resolution/pixel format stay camera-derived).
- Qt: **MP4/MKV** with pros/cons tooltips; **video codec dropdown queried live** from the backend per container (`supportedVideoCodecs(Encode)`); **MKV quality tiers** (Auto/Low/Medium/High/Ultra) per resolution class, each entry showing bitrate + per-minute file size.
- Recorder is rebuilt from preferences at every recording start — changes apply without restart; bitrate class matched from the actual camera resolution/fps; MKV bitrates apply via `AverageBitRateEncoding`, otherwise quality-driven encoding is pinned at the top tier.
- Applied settings are read back from the recorder and logged at start as confirmation.

### Fixes
- Alpha settings stay adjustable while a protocol runs (they were being reverted by the not-editable undo guard; alphas are global display preferences, not step state).
- Protocol recordings are named with the step's dotted display path instead of its uuid.

### Recording Viewer editing
- Camera/recording preferences move to their own **Video Settings** preferences tab.
- **Crop/export works for every video** — raw or aligned view, transform sidecar or not: regions remember the view they were drawn in, raw exports crop without warping (`_cropped.mkv` vs `_aligned.mkv`), and the ROI sidecar stores the space (legacy sidecars still load).
- Flipping Device-Aligned **auto-refits the canvas** (the transform changes the frame geometry, which could leave it off-screen).

## Test plan
- [ ] Record with Qt backend (MP4 and MKV), confirm container/codec/bitrate in the "applied settings" log line and in the output file.
- [ ] Record with FFmpeg backend, confirm codec/preset/CRF in the pipeline log.
- [ ] Flip MP4/MKV in preferences and confirm the codec dropdown repopulates; saved codec survives dialog reopen.
- [ ] Run a protocol with the Record column and confirm recording start/stop and dotted-path filenames.
- [ ] Change alphas mid-run and confirm they stick.
- [ ] Open a recording in the Recording Viewer and confirm the aligned view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)