### PR TITLE
fix(plugin_management): restore saved layout after hot-loaded panes mount

### DIFF
--- a/microdrop_utils/tasks_runtime_helpers.py
+++ b/microdrop_utils/tasks_runtime_helpers.py
@@ -93,6 +93,47 @@ def remove_dock_pane_live(window, pane_id):
     return pane
 
 
+def restore_saved_task_layout(window, application):
+    """Re-apply the dock-pane layout envisage saved at the last exit.
+
+    Envisage restores the saved layout exactly once, at window creation
+    (``TasksApplication._create_windows``). A dock pane whose plugin is
+    hot-loaded afterwards (the plugin-group launch restore) does not exist at
+    that point, so pyface drops its saved ``PaneItem`` ("Cannot retrieve dock
+    widget for pane") and the pane is later mounted at its default dock area.
+    Calling this after the hot-loaded panes are mounted re-applies the saved
+    layout against the now-complete pane set. Saved panes that no longer exist
+    are still skipped by pyface with a warning; live panes without a saved
+    placement fall back to their default dock area.
+
+    Returns True if a saved layout was found and applied.
+    """
+    if getattr(application, "always_use_default_layout", False):
+        logger.debug(
+            "restore_saved_task_layout: skipped (always_use_default_layout)")
+        return False
+
+    # The envisage TasksApplicationState loaded from the application_memento
+    # pickle — kept on the application for its lifetime, no public accessor.
+    saved_application_state = getattr(application, "_state", None)
+    task = window.active_task
+    if saved_application_state is None or task is None:
+        return False
+
+    saved_task_layout = saved_application_state.get_task_layout(task.id)
+    if saved_task_layout is None:
+        logger.debug(
+            f"restore_saved_task_layout: no saved layout for task '{task.id}'")
+        return False
+
+    # Clone so the live window's subsequent layout mutations cannot corrupt
+    # the state object that gets pickled back at exit.
+    window._window_backend.set_layout(saved_task_layout.clone_traits())
+    logger.info(
+        f"restore_saved_task_layout: re-applied saved layout for task '{task.id}'")
+    return True
+
+
 def rebuild_menu_bar_live(window, task, application):
     """Rebuild a live ``TaskWindow``'s menu bar from the CURRENT started
     plugins' TaskExtension actions.

--- a/plugin_management/live_task_extensions.py
+++ b/plugin_management/live_task_extensions.py
@@ -23,7 +23,7 @@ neither defer nor coalesce. ``GUI.invoke_later`` is the deferral primitive.)
 """
 
 from pyface.api import GUI
-from traits.api import Any, Bool, Dict, HasTraits, List
+from traits.api import Any, Bool, Dict, HasTraits, List, Property
 
 from microdrop_utils.tasks_runtime_helpers import (
     add_dock_pane_live, rebuild_menu_bar_live, remove_dock_pane_live,
@@ -52,6 +52,13 @@ class LiveTaskExtensionsController(HasTraits):
     #: True once a reconcile is queued on the UI loop — coalesces a burst of
     #: TASK_EXTENSIONS changes into one reconcile.
     _scheduled = Bool(False)
+
+    has_mounted_panes = Property(Bool)
+
+    def _get_has_mounted_panes(self):
+        """True while at least one dock pane this controller hot-mounted is
+        still mounted (entries are dropped again on unmount)."""
+        return bool(self._pane_id_by_factory)
 
     def on_changed(self, added, removed):
         """Record a TASK_EXTENSIONS delta and schedule one deferred reconcile."""

--- a/plugin_management/plugin.py
+++ b/plugin_management/plugin.py
@@ -18,6 +18,7 @@ from pyface.api import GUI
 from traits.api import Any, Bool, List, Str, observe
 
 from microdrop_application.consts import PKG as microdrop_application_PKG
+from microdrop_utils.tasks_runtime_helpers import restore_saved_task_layout
 
 from .consts import PKG, PKG_name
 from .i_plugin_group_manager import IPluginGroupManager
@@ -148,7 +149,30 @@ class PluginManagementPlugin(Plugin):
         except Exception:
             logger.exception("plugin-group launch restore failed")
 
+        # The reactive pane mount for any group enabled above is already
+        # queued on the UI loop (LiveTaskExtensionsController defers its
+        # reconcile with invoke_later), so queue the saved-layout re-apply
+        # behind it: at window creation those panes did not exist yet, so
+        # envisage dropped their saved placement (restore_saved_task_layout).
+        GUI.invoke_later(self._reapply_saved_layout_after_launch_restore)
+
         self.application.extra_plugins_loaded = True
+
+    def _reapply_saved_layout_after_launch_restore(self):
+        """Give the user back their saved window layout when the enabled
+        plugin set is unchanged from the previous session. Only re-applies
+        when the launch restore actually hot-mounted panes — a mid-session
+        Manage Plugins toggle never re-runs this, so it cannot stomp a live
+        arrangement."""
+        if self._live_task_exts is None or not self._live_task_exts.has_mounted_panes:
+            return
+        window = self.application.active_window
+        if window is None:
+            return
+        try:
+            restore_saved_task_layout(window, self.application)
+        except Exception:
+            logger.exception("saved-layout re-apply after launch restore failed")
 
     #: True once the launch update check has started (runs exactly once).
     _update_check_started = Bool(False)


### PR DESCRIPTION
## Problem
Saved window layouts never survived a restart when a hot-loadable plugin group (e.g. fluorescence) was enabled. Envisage applies the saved layout exactly once, at window creation — before the plugin-group launch restore runs at `application_initialized`. The hot-loaded group's dock panes don't exist yet, so pyface drops their saved `PaneItem`s ("Cannot retrieve dock widget for pane") and `add_dock_pane_live` later mounts them at their default dock area, perturbing the whole arrangement every session.

## Fix
- `microdrop_utils/tasks_runtime_helpers.py`: new `restore_saved_task_layout(window, application)` — re-applies the memento's saved `TaskLayout` via the pyface window backend against the now-complete pane set (hot-mounted panes are found because `add_dock_pane_live` registers them in `state.dock_panes`). Skips when there is no saved layout or `always_use_default_layout` is set.
- `plugin_management/live_task_extensions.py`: `has_mounted_panes` Property so the plugin can tell whether the launch restore actually hot-mounted panes.
- `plugin_management/plugin.py`: after `restore_persisted`, queue a one-shot re-apply with `GUI.invoke_later` — FIFO ordering puts it behind the already-queued pane-mount reconcile. Runs only at launch and only when panes were hot-mounted, so mid-session Manage Plugins toggles never stomp a live arrangement.

## Behavior
- Enabled plugin set unchanged between sessions → full layout restore.
- Changed set / crash before save / first run → graceful degradation (missing panes skipped with a warning, new panes at default spots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)