### PR TITLE
fix(video-protocol): capture step_id uses dotted path to match recording scheme

### DIFF
--- a/video_protocol_controls/protocol_columns/capture_column.py
+++ b/video_protocol_controls/protocol_columns/capture_column.py
@@ -143,7 +143,7 @@ class CaptureHandler(BaseCompoundColumnHandler):
         payload = {
             "directory": ctx.protocol.scratch.get(EXPERIMENT_DIR_SCRATCH_KEY, ""),
             "step_description": row.name,
-            "step_id": row.uuid,
+            "step_id": row.dotted_path(),
             "show_dialog": False,
         }
         publish_message(


### PR DESCRIPTION
Image-capture filenames embedded the row uuid as `step_id` while the recording column embeds the row's dotted path; use `dotted_path()` for captures too so both media types name steps the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)