### PR TITLE
feat: capture threading, ctx.sleep, tree cell sync, compound hook fix

### DIFF
--- a/device_viewer/utils/camera.py
+++ b/device_viewer/utils/camera.py
@@ -81,29 +81,38 @@ def get_transformed_frame(src_image: QImage,
 
 
 class SaveSignals(QObject):
-    # Signal sends the (media_type, save_path)
+    # Both signals send the save_path.
     save_complete = Signal(str)
+    save_failed = Signal(str)
 
 
 class ImageSaver(QRunnable):
+    """PNG-encode + write ``image`` to ``save_path``; run it on a QThreadPool
+    (encoding a full-resolution frame takes long enough to visibly freeze the
+    GUI when run inline). Callers must hand over an image they will not paint
+    into afterwards (pass ``image.copy()`` if unsure) — QImage is implicitly
+    shared, so holding the reference is enough and copying here would put a
+    second full-frame memcpy on the caller's (GUI) thread."""
+
     def __init__(self, image, save_path):
         super().__init__()
-        # Copy image to ensure it doesn't change while we save
-        self.image = image.copy()
+        self.image = image
         self.save_path = save_path
         self.signals = SaveSignals()
 
     def run(self):
         try:
-            # 1. Heavy I/O happens here
-            self.image.save(self.save_path, "PNG")
-            logger.info(f"Saved image to: {self.save_path}")
-
-            # 2. Tell the UI we are done
-            self.signals.save_complete.emit(self.save_path)
-
+            # 1. Heavy PNG encode + disk I/O happens here.
+            if self.image.save(self.save_path, "PNG"):
+                logger.info(f"Saved image to: {self.save_path}")
+                # 2. Tell the UI we are done (queued back to the GUI thread).
+                self.signals.save_complete.emit(self.save_path)
+            else:
+                logger.error(f"Failed to save image: {self.save_path}")
+                self.signals.save_failed.emit(self.save_path)
         except Exception as e:
-            logger.error(f"Failed to save image: {e}")
+            logger.error(f"Failed to save image {self.save_path}: {e}")
+            self.signals.save_failed.emit(self.save_path)
 
 
 class VideoRecorderBase(QObject):

--- a/device_viewer/views/camera_control_view/widget.py
+++ b/device_viewer/views/camera_control_view/widget.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from PySide6.QtCore import (
     Signal,
     Slot,
+    QThreadPool,
     QTimer,
 )
 from PySide6.QtGui import QImage
@@ -111,6 +112,10 @@ class CameraControlWidget(QWidget):
         self.available_cameras = None
         self.available_formats = None
         self.show_media_capture_dialog_for_video = True
+        # In-flight ImageSaver workers, referenced so a pool worker (and its
+        # signals QObject) cannot be garbage-collected before its completion
+        # signal is delivered back to the GUI thread.
+        self._pending_image_savers = set()
 
         self.scene.addItem(self.video_item)
         # The session delivers to our own sink at full camera rate; frames
@@ -814,24 +819,35 @@ class CameraControlWidget(QWidget):
 
         # Provider feeds (ASI) supply the unprocessed sensor frame (16-bit):
         # that IS the capture — an 8-bit display grab adds nothing next to
-        # it, so it is skipped.
+        # it, so it is skipped. The frame is snapshotted here, synchronously;
+        # only the PNG encode + disk write are deferred to the thread pool.
         raw_getter = getattr(self._active_feed, "raw_frame", None)
         raw_image = raw_getter() if raw_getter is not None else None
         if raw_image is not None and not raw_image.isNull():
             raw_path = (save_path.parent / RAW_CAPTURES_SUBDIR
                         / f"{save_path.stem}_raw.png")
             raw_path.parent.mkdir(parents=True, exist_ok=True)
-            if raw_image.save(str(raw_path)):
-                _cache_media_capture(MediaType.IMAGE, str(raw_path))
-                media_capture_event_model.captured = str(raw_path)
-                logger.info(f"Raw sensor frame saved: {raw_path}")
+
+            def _on_raw_saved(saved_path):
+                _cache_media_capture(MediaType.IMAGE, saved_path)
+                media_capture_event_model.captured = saved_path
+                logger.info(f"Raw sensor frame saved: {saved_path}")
                 if show_dialog:
                     _show_media_capture_dialog(
-                        MediaType.IMAGE, str(raw_path), self.status_bar_manager)
-                return
-            logger.error(f"Failed to save raw sensor frame: {raw_path}; "
-                         "falling back to a display capture")
+                        MediaType.IMAGE, saved_path, self.status_bar_manager)
 
+            def _on_raw_save_failed(saved_path):
+                logger.error(f"Failed to save raw sensor frame: {saved_path}; "
+                             "falling back to a display capture")
+                self._capture_display_image(save_path, show_dialog)
+
+            self._start_image_saver(
+                raw_image, str(raw_path), _on_raw_saved, _on_raw_save_failed)
+            return
+
+        self._capture_display_image(save_path, show_dialog)
+
+    def _capture_display_image(self, save_path, show_dialog):
         # Capture Pixels (Must happen on UI thread)
         image = self.get_screen_shot()
 
@@ -839,18 +855,37 @@ class CameraControlWidget(QWidget):
             return
 
         save_path.parent.mkdir(parents=True, exist_ok=True)
-        worker = ImageSaver(image.copy(), str(save_path))
 
-        def _post_image_capture():
-            _cache_media_capture(MediaType.IMAGE, str(save_path))
-            media_capture_event_model.captured = str(save_path)
+        def _post_image_capture(saved_path):
+            _cache_media_capture(MediaType.IMAGE, saved_path)
+            media_capture_event_model.captured = saved_path
             if show_dialog:
-                _show_media_capture_dialog(MediaType.IMAGE, str(save_path), self.status_bar_manager)
+                _show_media_capture_dialog(
+                    MediaType.IMAGE, saved_path, self.status_bar_manager)
 
-        worker.signals.save_complete.connect(_post_image_capture)
+        # get_screen_shot may return the recorder's live current_image, which
+        # the recorder keeps painting into — snapshot it before handing off.
+        self._start_image_saver(image.copy(), str(save_path), _post_image_capture)
 
-        # FIXME: this could be run in a separate thread for more performance if needed. Its a QRunnable...
-        worker.run()
+    def _start_image_saver(self, image, save_path, on_saved, on_failed=None):
+        """Run an ImageSaver on the global thread pool — PNG-encoding a
+        full-resolution frame inline visibly freezes the GUI. The worker is
+        kept referenced until one of its completion signals (delivered queued
+        on the GUI thread) has fired; ``on_saved``/``on_failed`` then run on
+        the GUI thread."""
+        worker = ImageSaver(image, save_path)
+        self._pending_image_savers.add(worker)
+
+        def _finish(saved_path, callback):
+            self._pending_image_savers.discard(worker)
+            if callback is not None:
+                callback(saved_path)
+
+        worker.signals.save_complete.connect(
+            lambda saved_path: _finish(saved_path, on_saved))
+        worker.signals.save_failed.connect(
+            lambda saved_path: _finish(saved_path, on_failed))
+        QThreadPool.globalInstance().start(worker)
 
     def _capture_image_and_close(self, capture_data):
         self._capture_image_routine(capture_data)

--- a/pluggable_protocol_tree/consts.py
+++ b/pluggable_protocol_tree/consts.py
@@ -14,6 +14,10 @@ from microdrop_application.consts import ADVANCED_MODE_CHANGE
 
 from electrode_controller.consts import ELECTRODES_STATE_CHANGE, ELECTRODES_STATE_APPLIED
 
+from pluggable_protocol_tree.models.cell_sync import (
+    ProtocolTreeRowSelectedPublisher, ProtocolTreeSetCellPublisher,
+)
+
 PKG = ".".join(__name__.split(".")[:-1])
 PKG_name = PKG.title().replace("_", " ")
 
@@ -86,6 +90,18 @@ PROTOCOL_TOPIC_PREFIX = "microdrop/protocol_tree"
 # PPT-10.2: tree -> DV slim display message
 PROTOCOL_TREE_DISPLAY_STATE = "ui/protocol_tree_display_state"
 
+# Generic per-cell sync between the tree and column-owning plugin panes
+# (payload contracts + publishers in models/cell_sync.py): row_selected
+# broadcasts the selected step's uuid + every column's serialized value;
+# set_cell writes one value back into a step's cell.
+PROTOCOL_TREE_ROW_SELECTED = "ui/protocol_tree/row_selected"
+PROTOCOL_TREE_SET_CELL = "ui/protocol_tree/set_cell"
+
+protocol_tree_row_selected_publisher = ProtocolTreeRowSelectedPublisher(
+    topic=PROTOCOL_TREE_ROW_SELECTED)
+protocol_tree_set_cell_publisher = ProtocolTreeSetCellPublisher(
+    topic=PROTOCOL_TREE_SET_CELL)
+
 SYNC_LISTENER_NAME = "protocol_tree_dv_sync_listener"
 EXECUTOR_LISTENER_NAME = "pluggable_protocol_tree_executor_listener"
 LOGGING_LISTENER_NAME = "protocol_tree_logging_listener"
@@ -98,6 +114,7 @@ ACTOR_TOPIC_DICT = {
         REALTIME_MODE_UPDATED,
         STEP_PARAMS_COMMIT,
         ADVANCED_MODE_CHANGE,
+        PROTOCOL_TREE_SET_CELL,
     ],
 
     LOGGING_LISTENER_NAME: [

--- a/pluggable_protocol_tree/execution/step_context.py
+++ b/pluggable_protocol_tree/execution/step_context.py
@@ -284,6 +284,29 @@ class ProtocolContext(HasTraits):
                 f"Timed out after {timeout}s wait"
             ) from None
 
+    def sleep(self, seconds: float):
+        """Stop-aware settle wait that keeps the status timers honest.
+
+        For fixed hardware settle times (LED stabilization, stage motion):
+        blocks the worker thread for ``seconds`` under the same ref-counted
+        ack-wait freeze as :meth:`StepContext.wait_for`, so the settle is
+        excluded from the step/phase/protocol timers instead of being
+        misreported as step time — without entering the operator Paused
+        state (no pause_event, no "Paused" UI). Use this instead of
+        ``time.sleep`` in column handlers.
+
+        Raises ``AbortError`` if the protocol's ``stop_event`` fires during
+        the wait, so Stop aborts the settle immediately.
+        """
+        if self.signals is not None:
+            self.signals.ack_wait_started = True
+        try:
+            if self.stop_event.wait(max(0.0, float(seconds))):
+                raise AbortError("stop_event fired while settling")
+        finally:
+            if self.signals is not None:
+                self.signals.ack_wait_finished = True
+
     def prompt_gui(self, gui_callable: Callable, *,
                    timeout: float = float("inf")):
         """Run ``gui_callable`` on the GUI thread, paused, and return its result.
@@ -494,6 +517,9 @@ class StepContext(HasTraits):
 
     def wait(self, *args, **kwargs):
         return self.protocol.wait(*args, **kwargs)
+
+    def sleep(self, *args, **kwargs):
+        return self.protocol.sleep(*args, **kwargs)
 
     def prompt_gui(self, *args, **kwargs):
         # Must return: ProtocolContext.prompt_gui hands back the dialog's

--- a/pluggable_protocol_tree/models/_compound_adapters.py
+++ b/pluggable_protocol_tree/models/_compound_adapters.py
@@ -85,6 +85,10 @@ class _CompoundFieldHandlerAdapter(BaseColumnHandler):
             row, self.compound_model, self.field_id, value,
         )
 
+    def on_pre_protocol_start(self, ctx):
+        if self.is_owner:
+            self.compound_handler.on_pre_protocol_start(ctx)
+
     def on_protocol_start(self, ctx):
         if self.is_owner:
             self.compound_handler.on_protocol_start(ctx)
@@ -104,6 +108,10 @@ class _CompoundFieldHandlerAdapter(BaseColumnHandler):
     def on_protocol_end(self, ctx):
         if self.is_owner:
             self.compound_handler.on_protocol_end(ctx)
+
+    def on_post_protocol_end(self, ctx):
+        if self.is_owner:
+            self.compound_handler.on_post_protocol_end(ctx)
 
 
 from .column import Column  # noqa: E402 — after class definitions to avoid circular

--- a/pluggable_protocol_tree/models/cell_sync.py
+++ b/pluggable_protocol_tree/models/cell_sync.py
@@ -1,0 +1,69 @@
+"""Pydantic contracts for the tree's generic per-cell sync topics.
+
+``PROTOCOL_TREE_ROW_SELECTED`` — broadcast by the tree's sync controller
+on every selection change, and again on any cell edit of the selected
+step: the selected step's uuid plus EVERY column's serialized value.
+Column-owning plugins (fluorescence, magnet, ...) live-track the selected
+step through this without reaching into the tree. ``step_id`` None = no
+step selected (free mode / group row).
+
+``PROTOCOL_TREE_SET_CELL`` — request handled by the sync controller:
+write ``value`` (the column's serialized form) into one step's cell,
+equality-skipped and fired through ``cell_changed`` like a manual edit.
+``only_if_set`` restricts the write to cells that currently hold a value,
+so a pane edit never populates an unchecked step. Ignored while a
+protocol runs — the executor owns the rows then.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from microdrop_utils.dramatiq_pub_sub_helpers import ValidatedTopicPublisher
+
+
+class ProtocolTreeRowSelectedMessage(BaseModel):
+    step_id: str | None = None
+    cells: dict[str, Any] = {}
+
+    def serialize(self) -> str:
+        return self.model_dump_json()
+
+    @classmethod
+    def deserialize(cls, json_str: str) -> "ProtocolTreeRowSelectedMessage":
+        return cls.model_validate_json(json_str)
+
+
+class ProtocolTreeSetCellMessage(BaseModel):
+    step_id: str
+    col_id: str
+    value: Any = None
+    only_if_set: bool = False
+
+    def serialize(self) -> str:
+        return self.model_dump_json()
+
+    @classmethod
+    def deserialize(cls, json_str: str) -> "ProtocolTreeSetCellMessage":
+        return cls.model_validate_json(json_str)
+
+
+class ProtocolTreeRowSelectedPublisher(ValidatedTopicPublisher):
+    """Validated publisher for ``PROTOCOL_TREE_ROW_SELECTED``."""
+    validator_class = ProtocolTreeRowSelectedMessage
+
+    def publish(self, *, step_id, cells, **kw):
+        super().publish({"step_id": step_id, "cells": cells}, **kw)
+
+
+class ProtocolTreeSetCellPublisher(ValidatedTopicPublisher):
+    """Validated publisher for ``PROTOCOL_TREE_SET_CELL``."""
+    validator_class = ProtocolTreeSetCellMessage
+
+    def publish(self, *, step_id, col_id, value, only_if_set=False, **kw):
+        super().publish({
+            "step_id": step_id,
+            "col_id": col_id,
+            "value": value,
+            "only_if_set": only_if_set,
+        }, **kw)

--- a/pluggable_protocol_tree/models/compound_column.py
+++ b/pluggable_protocol_tree/models/compound_column.py
@@ -90,11 +90,13 @@ class BaseCompoundColumnHandler(HasTraits):
     def on_interact(self, row, model, field_id, value):
         return model.set_value(row, field_id, value)
 
+    def on_pre_protocol_start(self, ctx): pass
     def on_protocol_start(self, ctx): pass
     def on_pre_step(self, row, ctx): pass
     def on_step(self, row, ctx): pass
     def on_post_step(self, row, ctx): pass
     def on_protocol_end(self, ctx): pass
+    def on_post_protocol_end(self, ctx): pass
 
 
 @provides(ICompoundColumn)

--- a/pluggable_protocol_tree/services/device_viewer_sync.py
+++ b/pluggable_protocol_tree/services/device_viewer_sync.py
@@ -50,8 +50,10 @@ from microdrop_application.menus import is_advanced_mode
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from pluggable_protocol_tree.consts import (
     DV_EXECUTION_PARAM_COL_IDS, ELECTRODE_TO_CHANNEL_KEY,
-    PROTOCOL_TREE_DISPLAY_STATE, SYNC_LISTENER_NAME,
+    PROTOCOL_TREE_DISPLAY_STATE, PROTOCOL_TREE_SET_CELL, SYNC_LISTENER_NAME,
+    protocol_tree_row_selected_publisher,
 )
+from pluggable_protocol_tree.models.cell_sync import ProtocolTreeSetCellMessage
 from pluggable_protocol_tree.models.display_state import (
     ProtocolTreeDisplayMessage,
 )
@@ -166,6 +168,7 @@ class DeviceViewerSyncController(HasTraits):
     _dv_state_changed_event       = Event(Str)
     _protocol_running_changed_event = Event(Bool)
     _step_params_committed_event  = Event(Str)
+    _set_cell_request_event       = Event(Str)
 
     def _advanced_mode_default(self):
         return bool(is_advanced_mode())
@@ -217,24 +220,27 @@ class DeviceViewerSyncController(HasTraits):
 
     @observe("row_manager:cell_changed")
     def _republish_on_param_cell_change(self, event):
-        """Tree-originated edits to an execution-param cell on the selected
-        step republish display state so the DV sidebar reloads + rebaselines
-        - protocol values supersede whatever the sidebar holds. DV-originated
-        writes (the commit handler) suppress this and publish once at the
-        end instead."""
-        if event.new.get("col_id") not in DV_EXECUTION_PARAM_COL_IDS:
-            return
+        """Cell edits on the selected step rebroadcast row_selected so
+        column-owning panes tracking the selection stay current (e.g. the
+        fluorescence cell checked/unchecked mid-selection). Edits to an
+        execution-param cell additionally republish display state so the
+        DV sidebar reloads + rebaselines - protocol values supersede
+        whatever the sidebar holds. DV-originated writes (the commit
+        handler) suppress this and publish once at the end instead."""
         if self._suppress_publish or not self._last_selected_uuid:
-            return
-        if self._free_mode_stash is not None:
-            # Never let a cell edit trigger the leave-free-mode prompt
-            # inside _publish_for_row; the next selection change handles it.
             return
         try:
             row = self.row_manager.get_row(tuple(event.new["path"]))
         except (IndexError, AttributeError):
             return
         if isinstance(row, GroupRow) or row.uuid != self._last_selected_uuid:
+            return
+        self._publish_row_selected(row)
+        if event.new.get("col_id") not in DV_EXECUTION_PARAM_COL_IDS:
+            return
+        if self._free_mode_stash is not None:
+            # Never let a cell edit trigger the leave-free-mode prompt
+            # inside _publish_for_row; the next selection change handles it.
             return
         self._publish_for_row(row)
 
@@ -289,6 +295,8 @@ class DeviceViewerSyncController(HasTraits):
             self._protocol_running_changed_event = (message.casefold() == "true")
         elif topic == STEP_PARAMS_COMMIT:
             self._step_params_committed_event = message
+        elif topic == PROTOCOL_TREE_SET_CELL:
+            self._set_cell_request_event = message
         elif topic == REALTIME_MODE_UPDATED:
             self.realtime_mode = True
         elif topic == ADVANCED_MODE_CHANGE:
@@ -438,6 +446,62 @@ class DeviceViewerSyncController(HasTraits):
         if row.uuid == self._last_selected_uuid:
             self._publish_for_row(row)
 
+    @observe("_set_cell_request_event", dispatch="ui")
+    def _on_set_cell_request(self, event) -> None:
+        """PROTOCOL_TREE_SET_CELL: a column-owning pane writes one value
+        into the step that owns it (e.g. the fluorescence pane's
+        live-tracking write-back). dispatch="ui" — it mutates rows.
+        Ignored during a run: the executor owns the rows then, and pane
+        edits are display-only."""
+        try:
+            set_cell_msg = ProtocolTreeSetCellMessage.deserialize(event.new)
+        except Exception as e:
+            logger.warning(f"failed to parse set-cell request: {e}")
+            return
+        if self._protocol_running:
+            logger.info(
+                f"set-cell for {set_cell_msg.col_id!r} ignored during a run")
+            return
+        row = self.row_manager.get_row_by_uuid(set_cell_msg.step_id)
+        if row is None or isinstance(row, GroupRow):
+            logger.warning(
+                f"set-cell for unknown step {set_cell_msg.step_id!r} dropped")
+            return
+        try:
+            column = self.row_manager._column_by_id(set_cell_msg.col_id)
+        except KeyError:
+            logger.warning(
+                f"set-cell for unknown column {set_cell_msg.col_id!r} dropped")
+            return
+        value = column.model.deserialize(set_cell_msg.value)
+        current = column.model.get_value(row)
+        if set_cell_msg.only_if_set and current is None:
+            return
+        if current == value:
+            return
+        # set_value fires cell_changed, so the edit flows through the same
+        # dirty tracking + rebroadcast path as a manual cell edit.
+        self.row_manager.set_value(tuple(row.path), set_cell_msg.col_id, value)
+        logger.info(f"set-cell applied to Step {row.dotted_path()} "
+                    f"column {set_cell_msg.col_id!r}")
+
+    def _publish_row_selected(self, row) -> None:
+        """Broadcast PROTOCOL_TREE_ROW_SELECTED: the selected step's uuid
+        plus every column's serialized value (step_id None for free mode /
+        group selection). Column-owning panes (fluorescence) live-track
+        the selected step through this without reaching into the tree."""
+        if row is None:
+            protocol_tree_row_selected_publisher.publish(step_id=None,
+                                                         cells={})
+            return
+        cells = {
+            column.model.col_id:
+                column.model.serialize(column.model.get_value(row))
+            for column in self.row_manager.columns
+        }
+        protocol_tree_row_selected_publisher.publish(step_id=row.uuid,
+                                                     cells=cells)
+
     def _publish_for_row(self, row) -> None:
         """Publish PROTOCOL_TREE_DISPLAY_STATE for the given row (or
         free-mode payload if row is None / a group). Gated only on the
@@ -508,6 +572,8 @@ class DeviceViewerSyncController(HasTraits):
             topic=PROTOCOL_TREE_DISPLAY_STATE,
             message=msg.serialize(),
         )
+        self._publish_row_selected(
+            None if row is None or isinstance(row, GroupRow) else row)
 
     def _insert_free_mode_as_new_step(self) -> None:
         """Reentrancy-guarded RowManager.add_step for the free-mode capture.


### PR DESCRIPTION
Four related pieces supporting the fluorescence plugin's protocol integration (fluorescence-microdrop-plugin-py PR #4):

## perf: capture PNG saves off the GUI thread
Full-resolution 16-bit ASI frame PNG encode+write ran on the GUI thread and froze the UI on every capture. Saves now dispatch through `QThreadPool` (`ImageSaver` QRunnable), with save-failure reporting (previously an unchecked `QImage.save()` bool) and a display-image fallback.

## feat: stop-aware `ctx.sleep` with timer freeze
`ProtocolContext.sleep(seconds)` — a settle primitive for column handlers: pause-aware (runs under the ack-wait timer freeze so step timing is not misreported), and stop-aware (`stop_event` aborts it immediately via `AbortError`). No caller in-tree yet; peripheral columns can use it for fire-and-forget settles.

## feat: generic row_selected / set_cell cell sync
Lets column-owning plugin panes live-track the tree's selected step without reaching into the tree (device-viewer semantics):
- `PROTOCOL_TREE_ROW_SELECTED` — broadcast on selection change and on any cell edit of the selected step: step uuid + every column's serialized value.
- `PROTOCOL_TREE_SET_CELL` — write one value into a step's cell by uuid: equality-skipped, `only_if_set` guard, fires `cell_changed` like a manual edit, ignored during runs.
- Pydantic contracts + `ValidatedTopicPublisher`s in `models/cell_sync.py`; handled in `DeviceViewerSyncController`.

First consumer: the fluorescence controls pane (snapshot live-tracking).

## fix: run-bracket hooks never reached compound handlers
`_CompoundFieldHandlerAdapter` did not forward `on_pre_protocol_start` / `on_post_protocol_end`, so a compound column's once-per-run hooks silently never ran (bit the heater's new end-of-run stream stop and the fluorescence lights-out). Now declared on `BaseCompoundColumnHandler` and forwarded owner-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)