### PR TITLE
feat: keep horizontal scroll when switching protocol steps

### DIFF
--- a/pluggable_protocol_tree/tests/test_horizontal_scroll_preservation.py
+++ b/pluggable_protocol_tree/tests/test_horizontal_scroll_preservation.py
@@ -1,0 +1,49 @@
+"""Switching steps must keep the tree's horizontal scroll position (#516).
+
+With many columns the user often works scrolled right; the running-protocol
+highlight and manual step navigation should track the active step
+vertically without snapping the view back to the first column.
+"""
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.trail_length_column import (
+    make_trail_length_column,
+)
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.services.preferences import ProtocolPreferences
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+def _widget_scrolled_right(qapp):
+    """A widget narrow enough (and columns wide enough) that the horizontal
+    scrollbar has range, scrolled fully right."""
+    manager = RowManager(
+        columns=[make_name_column(), make_trail_length_column()])
+    for i in range(12):
+        manager.add_step(values={"name": f"S{i}"})
+    widget = ProtocolTreeWidget(manager, preferences=ProtocolPreferences())
+    widget.resize(150, 300)
+    widget.show()
+    header = widget.tree.header()
+    header.resizeSection(0, 400)
+    header.resizeSection(1, 400)
+    qapp.processEvents()
+    hbar = widget.tree.horizontalScrollBar()
+    assert hbar.maximum() > 0, "test needs a real horizontal scroll range"
+    hbar.setValue(hbar.maximum())
+    return widget, manager, hbar
+
+
+def test_set_current_row_keeps_horizontal_scroll(qapp):
+    widget, manager, hbar = _widget_scrolled_right(qapp)
+    saved = hbar.value()
+    widget.set_current_row(manager.get_row((10,)))
+    assert hbar.value() == saved
+    # Vertical tracking still happened: the current index is the target row.
+    assert widget.index_to_path(widget.tree.currentIndex()) == (10,)
+
+
+def test_highlight_active_row_keeps_horizontal_scroll(qapp):
+    widget, manager, hbar = _widget_scrolled_right(qapp)
+    saved = hbar.value()
+    widget.highlight_active_row(manager.get_row((2,)))
+    assert hbar.value() == saved

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -1,6 +1,8 @@
 """Qt widget: QTreeView over a RowManager, with context menu for add /
 remove / copy / cut / paste / group."""
 
+from contextlib import contextmanager
+
 from pyface.qt.QtCore import (
     Qt, QItemSelectionModel, QModelIndex, Signal,
 )
@@ -164,6 +166,20 @@ class ProtocolTreeWidget(QWidget):
 
     # --- active-row highlight + scroll (called by the executor wiring) ---
 
+    @contextmanager
+    def _keep_horizontal_scroll(self):
+        """Preserve the tree's horizontal scroll position across a step
+        switch. Both ``scrollTo`` and ``setCurrentIndex`` (which auto-scrolls
+        to the current index) otherwise snap the view back to the first
+        column; the user working scrolled-right expects only vertical
+        tracking to the active step (#516)."""
+        hbar = self.tree.horizontalScrollBar()
+        saved = hbar.value()
+        try:
+            yield
+        finally:
+            hbar.setValue(saved)
+
     def highlight_active_row(self, node):
         """Mark `node` as the currently-active step and scroll to it.
 
@@ -174,7 +190,8 @@ class ProtocolTreeWidget(QWidget):
             return
         idx = self._node_to_index(node)
         if idx.isValid():
-            self.tree.scrollTo(idx, QTreeView.PositionAtCenter)
+            with self._keep_horizontal_scroll():
+                self.tree.scrollTo(idx, QTreeView.PositionAtCenter)
             self._expand_ancestors(idx)
 
     def set_current_row(self, row):
@@ -185,8 +202,9 @@ class ProtocolTreeWidget(QWidget):
         if not idx.isValid():
             return
         self._expand_ancestors(idx)
-        self.tree.setCurrentIndex(idx)
-        self.tree.scrollTo(idx)
+        with self._keep_horizontal_scroll():
+            self.tree.setCurrentIndex(idx)
+            self.tree.scrollTo(idx)
 
     def set_editable(self, editable: bool, structural: bool = None):
         """Lock/unlock cell editing and (separately) the structural context


### PR DESCRIPTION
Implements #516. Switching steps snapped the tree back to the first column, losing the user's horizontal scroll position — on every executor step-advance during a run and on every manual step navigation. With many columns (voltage/frequency/force + magnet + heater + fluorescence + capture) you often work scrolled right, so this happened constantly.

Both step-switch paths in `views/tree_widget.py` reset the horizontal scrollbar: `highlight_active_row` via `scrollTo`, and `set_current_row` via both `setCurrentIndex` (Qt auto-scrolls to the current index) and `scrollTo`. A `_keep_horizontal_scroll()` context manager saves the horizontal scrollbar value before and restores it after, so the active step still tracks **vertically** while the horizontal position is held.

Tests build a narrow widget with wide columns (real horizontal scroll range), scroll fully right, and assert both paths preserve the position while still moving the current index to the target row.

Follow-up noted in #516: Qt's own keyboard-navigation scroll may want the same treatment; this PR covers the two reported paths (running highlight + manual nav).

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)