### PR TITLE
feat: Fold into Group context-menu action

### DIFF
--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -167,6 +167,57 @@ class RowManager(HasTraits):
             target.insert_row(target_index + offset, row)
         self.rows_changed = True
 
+    def _normalize_fold_paths(self, paths: List[Path]) -> Optional[List[Path]]:
+        """The subset of ``paths`` that ``fold_into_group`` would wrap:
+        descendants of another selected path dropped (their group folds in
+        whole). Returns the cleaned list, or None when it is empty or spans
+        more than one parent (the v1 single-parent restriction)."""
+        paths = [tuple(p) for p in paths]
+        paths = [p for p in paths
+                 if not any(self._is_ancestor(a, p) for a in paths if a != p)]
+        if not paths:
+            return None
+        parent_path = paths[0][:-1]
+        if any(p[:-1] != parent_path for p in paths):
+            return None
+        return paths
+
+    def can_fold_into_group(self, paths: List[Path]) -> bool:
+        """True when ``fold_into_group(paths)`` would act (>=1 row, all
+        sharing one parent). Drives the context-menu entry's enabled state."""
+        return self._normalize_fold_paths(paths) is not None
+
+    def fold_into_group(self, paths: List[Path],
+                        name: str = "Group") -> Optional[Path]:
+        """Wrap the rows at ``paths`` in a new group at the position of the
+        first selected row, preserving their order, identity (uuids, names,
+        column values), and any group children.
+
+        All paths must share one parent (v1 restriction); returns None
+        otherwise (see ``_normalize_fold_paths``).
+
+        Re-parents the live row objects (like ``move``), NOT a serialize +
+        rebuild, so per-step references — capture recordings, the
+        fluorescence pane's live-tracked step — survive the fold."""
+        normalized = self._normalize_fold_paths(paths)
+        if normalized is None:
+            return None
+        parent_path = normalized[0][:-1]
+        # Collect the row objects (in tree order) BEFORE mutating, and the
+        # anchor position (the first selected row). The objects stay valid
+        # across the group insert, so the shifted indices don't matter.
+        rows = [self.get_row(p) for p in sorted(normalized)]
+        anchor_index = min(p[-1] for p in normalized)
+        parent = self._parent_for_path(parent_path)
+        group = self.group_type(name=name)
+        parent.insert_row(anchor_index, group)
+        for row in rows:
+            if row.parent is not None:
+                row.parent.remove_row(row)
+            group.insert_row(len(group.children), row)
+        self.rows_changed = True
+        return parent_path + (anchor_index,)
+
     # --- selection ---
 
     def select(self, paths: List[Path], mode: str = "set") -> None:

--- a/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
+++ b/pluggable_protocol_tree/tests/test_protocol_tree_pane.py
@@ -704,6 +704,31 @@ def test_delete_all_steps_goes_to_free_mode(qapp):
     assert not pane.widget.tree.currentIndex().isValid()
 
 
+def test_fold_into_group_wraps_selection_and_selects_group(qapp):
+    """The tree widget's Fold into Group action folds the manager's
+    selection into a new group and makes that group the current row (#518)."""
+    from pluggable_protocol_tree.views.protocol_tree_pane import (
+        ProtocolTreePane,
+    )
+    from pluggable_protocol_tree.builtins.name_column import (
+        make_name_column,
+    )
+    from pluggable_protocol_tree.models.row import GroupRow
+    pane = ProtocolTreePane([make_name_column()])
+    for n in ["A", "B", "C"]:
+        pane.manager.add_step(values={"name": n})
+    pane.manager.select([(1,), (2,)], mode="set")
+
+    pane.widget._fold_into_group()
+
+    assert [r.name for r in pane.manager.root.children] == ["A", "Group"]
+    group = pane.manager.get_row((1,))
+    assert isinstance(group, GroupRow)
+    assert [r.name for r in group.children] == ["B", "C"]
+    # The new group is current so the user can rename it / act on it.
+    assert pane.widget.index_to_path(pane.widget.tree.currentIndex()) == (1,)
+
+
 def test_clear_highlights_suppresses_sync_publish(qapp):
     """clear_highlights also moves selection programmatically; same
     guard requirement."""

--- a/pluggable_protocol_tree/tests/test_row_manager.py
+++ b/pluggable_protocol_tree/tests/test_row_manager.py
@@ -106,6 +106,64 @@ def test_move_reparents_into_group(manager):
     assert new_group.children[0].name == "S"
 
 
+# --- fold into group (#518) ---
+
+def _names(rows):
+    return [r.name for r in rows]
+
+
+def test_fold_contiguous_wraps_selection_in_new_group(manager):
+    for n in ["A", "B", "C", "D", "E"]:
+        manager.add_step(values={"name": n})
+    group_path = manager.fold_into_group([(1,), (2,), (3,)], name="G")
+    assert group_path == (1,)
+    assert _names(manager.root.children) == ["A", "G", "E"]
+    group = manager.get_row((1,))
+    assert isinstance(group, GroupRow)
+    assert _names(group.children) == ["B", "C", "D"]
+
+
+def test_fold_preserves_row_identity(manager):
+    for n in ["A", "B", "C"]:
+        manager.add_step(values={"name": n})
+    b_uuid = manager.get_row((1,)).uuid
+    manager.fold_into_group([(1,), (2,)])
+    # B is re-parented, not rebuilt: same uuid survives (capture recordings,
+    # fluorescence live-tracking depend on this).
+    assert manager.get_row((1, 0)).uuid == b_uuid
+
+
+def test_fold_non_contiguous_closes_ranks(manager):
+    for n in ["A", "B", "C", "D"]:
+        manager.add_step(values={"name": n})
+    manager.fold_into_group([(0,), (2,)], name="G")
+    assert _names(manager.root.children) == ["G", "B", "D"]
+    assert _names(manager.get_row((0,)).children) == ["A", "C"]
+
+
+def test_fold_includes_selected_group_with_its_children(manager):
+    for n in ["A", "B", "C", "D"]:
+        manager.add_step(values={"name": n})
+    manager.fold_into_group([(1,), (2,)], name="Inner")  # [A, Inner(B,C), D]
+    manager.fold_into_group([(1,), (2,)], name="Outer")  # [A, Outer(Inner,D)]
+    assert _names(manager.root.children) == ["A", "Outer"]
+    outer = manager.get_row((1,))
+    assert _names(outer.children) == ["Inner", "D"]
+    assert _names(manager.get_row((1, 0)).children) == ["B", "C"]
+
+
+def test_fold_rejects_multi_parent_and_empty(manager):
+    for n in ["A", "B", "C"]:
+        manager.add_step(values={"name": n})
+    manager.fold_into_group([(1,), (2,)], name="G")  # [A, G(B,C)]
+    # A is at the root, (1, 0) is inside G — different parents.
+    assert manager.fold_into_group([(0,), (1, 0)]) is None
+    assert manager.fold_into_group([]) is None
+    assert not manager.can_fold_into_group([(0,), (1, 0)])
+    assert not manager.can_fold_into_group([])
+    assert manager.can_fold_into_group([(0,)])
+
+
 # --- selection ---
 
 def test_select_set_replaces_selection(manager):

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -255,6 +255,9 @@ class ProtocolTreeWidget(QWidget):
         menu = QMenu()
         menu.addAction("Add Step", lambda: self._add_step_at(idx))
         menu.addAction("Add Group", lambda: self._add_group_at(idx))
+        fold = menu.addAction("Fold into Group", self._fold_into_group)
+        fold.setEnabled(
+            self._manager.can_fold_into_group(self._manager.selection))
         menu.addSeparator()
         menu.addAction("Copy", self._copy)
         menu.addAction("Cut", self._cut)
@@ -366,6 +369,26 @@ class ProtocolTreeWidget(QWidget):
     def _add_group_at(self, idx):
         parent_path = self._parent_path_for_anchor(idx)
         self._manager.add_group(parent_path=parent_path)
+
+    def _fold_into_group(self):
+        """Wrap the selected rows in a new group at the first row's
+        position (#518), then select the new group so the user can rename
+        it (F2 / double-click) and subsequent actions target it."""
+        try:
+            group_path = self._manager.fold_into_group(
+                [tuple(p) for p in self._manager.selection])
+            if group_path is None:
+                return
+            idx = self._node_to_index(self._manager.get_row(group_path))
+            if idx.isValid():
+                self._expand_ancestors(idx)
+                self.tree.selectionModel().setCurrentIndex(
+                    idx,
+                    (QItemSelectionModel.SelectionFlag.ClearAndSelect
+                     | QItemSelectionModel.SelectionFlag.Rows),
+                )
+        except Exception:
+            logger.exception("Fold into group failed")
 
     def _parent_path_for_anchor(self, idx):
         """If anchored on a group --> insert inside. On a step --> insert as


### PR DESCRIPTION
Implements #518. Select steps and/or groups in the protocol tree, right-click → **Fold into Group**, and the selection is wrapped in one new group at the position of the first selected row, preserving order and any group children. Previously that meant Add Group, then cut/paste each batch by hand.

## Design

`RowManager.fold_into_group(paths)` re-parents the **live row objects** (the same mechanism as `move()`), not a serialize + rebuild — so uuids, names, column values, and any group's children survive, and per-step references (capture recordings' `step_id`, the fluorescence pane's live-tracked step) stay valid. `can_fold_into_group(paths)` drives the context-menu entry's enabled state; both share `_normalize_fold_paths`.

The tree widget's `_fold_into_group` folds the manager's current selection and makes the new group the current row so it can be renamed (F2 / double-click) and subsequent actions target it.

## v1 scope (per the issue)

- **Single-parent selections only** — mixed-parent selections grey the menu entry out (`_normalize_fold_paths` returns None).
- A **selected group folds in whole** with its children (descendants of a selected path are dropped from the fold set).
- **Non-contiguous** selections close ranks under the new group at the first row's position.

Natural follow-up (separate issue material): an "Unfold group" that dissolves a group in place.

## Tests

RowManager: contiguous / non-contiguous / nested-group folds, identity (uuid) preservation, and the multi-parent/empty guards + predicate. Widget: the action folds the selection and selects the new group.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)