### PR TITLE
fix: don't force-show hot-mounted dock panes

### DIFF
--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -2,15 +2,14 @@
 import json
 import dramatiq
 from PySide6.QtCore import QTimer
-from apptools.preferences.preferences_helper import PreferencesHelper
 
 # Enthought library imports.
 from pyface.tasks.action.api import SMenu, SMenuBar, TaskToggleGroup
-from pyface.tasks.api import PaneItem, Task, TaskLayout, HSplitter, VSplitter
+from pyface.tasks.api import PaneItem, Task, TaskLayout, VSplitter
 from pyface.api import GUI
 from traits.api import Instance, provides
 
-from electrode_controller.consts import electrode_disable_request_publisher, disabled_channels_changed_publisher
+from electrode_controller.consts import disabled_channels_changed_publisher
 # Local imports.
 from .consts import PKG
 from dropbot_controller.models.self_tests import TestEvent

--- a/microdrop_utils/tasks_runtime_helpers.py
+++ b/microdrop_utils/tasks_runtime_helpers.py
@@ -24,9 +24,12 @@ def add_dock_pane_live(window, task, factory, area=None):
     """Create ``factory`` and dock it onto the live ``window`` at runtime.
 
     Mirrors ``TaskWindowBackend._layout_state``: create the QDockWidget,
-    ``addDockWidget`` it onto the QMainWindow (``window.control``), show it,
-    and register it in both the active ``TaskState`` and the window so
-    ``window.get_dock_pane(id)`` and the View-menu toggle group see it.
+    ``addDockWidget`` it onto the QMainWindow (``window.control``), and
+    register it in both the active ``TaskState`` and the window so
+    ``window.get_dock_pane(id)`` and the View-menu toggle group see it. The
+    pane is NOT force-shown — it keeps its own ``visible`` state / the
+    restored saved layout — so a plugin group contributing several panes
+    doesn't crowd the window (which was clipping the status bar, #520).
 
     ``area`` overrides the pane's own ``dock_area`` ('left'/'right'/'top'/
     'bottom'); pass None to honour the pane default. Returns the pane.
@@ -42,8 +45,6 @@ def add_dock_pane_live(window, task, factory, area=None):
     pane.create(main_window)
 
     main_window.addDockWidget(AREA_MAP[area or pane.dock_area], pane.control)
-    pane.visible = True
-    pane.control.show()
 
     state.dock_panes = state.dock_panes + [pane]
     window.dock_panes = state.dock_panes


### PR DESCRIPTION
Closes #520.

## Root cause

`add_dock_pane_live` (`microdrop_utils/tasks_runtime_helpers.py`) force-showed every hot-mounted dock pane:

```python
pane.visible = True
pane.control.show()
```

When a plugin group contributes **several** dock panes — the fluorescence group mounts three (main controls, image viewer, advanced camera) — they were all shown at once, crowding the window enough that the status bar got clipped to zero height until a manual resize. (Earlier theories about layout-restore timing were a red herring; it reproduces on plain enable of the group.)

## Fix

Drop the forced show. A hot-mounted pane now keeps its own `visible` state / the restored saved layout, so a group's extra panes don't all pop open and crowd the window. Panes that were visible last session are still restored by the saved-layout re-apply.

Also removes a few unused imports in `microdrop_application/task.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)