### PR TITLE
feat(device_viewer): inline text-editor channel labels

### DIFF
--- a/device_viewer/services/electrode_interaction_service.py
+++ b/device_viewer/services/electrode_interaction_service.py
@@ -41,21 +41,9 @@ from ..views.electrode_view.scale_edit_view import ScaleEditViewController
 
 logger = get_logger(__name__)
 
-###### Channel edit helper methods #################
-def remove_last_digit(number: int | None) -> int | None:
-    if number == None: return None
-
-    string = str(number)[:-1]
-    if string == "":
-        return None
-    else:
-        return int(string)
-
-def add_digit(number: int | None, digit: str) -> int:
-    if number == None:
-        return int(digit)
-    else:
-        return int(str(number) + digit)
+# Sentinel returned by channel-text parsing when the edit should be reverted
+# (kept distinct from None, which means "unassign the channel").
+_CHANNEL_REVERT = object()
 
 class ElectrodeInteractionControllerService(HasTraits):
     """Service to handle electrode interactions. Converts complicated Qt-events into more application specific events.
@@ -1514,6 +1502,85 @@ class ElectrodeInteractionControllerService(HasTraits):
     def handle_electrode_channel_editing(self, electrode: Electrode):
         self.model.electrodes.electrode_editing = electrode
 
+    def handle_channel_label_press(self, event) -> bool:
+        """In channel-edit mode, a left-click on an electrode enters (or
+        switches to) inline label editing.
+
+        Returns True when a NEW edit is started — the caller consumes the press
+        so the whole value stays selected (type to replace). Returns False for
+        clicks inside the field already being edited, letting Qt place the caret
+        or start a drag-selection."""
+        if self.model.mode != "channel-edit" or event.button() != Qt.LeftButton:
+            return False
+        electrode_view = self.get_electrode_view_for_scene_pos(event.scenePos())
+        if electrode_view is None:
+            return False
+        if getattr(self, "_editing_view", None) is electrode_view:
+            return False  # already editing this label — in-field click
+        self._begin_channel_label_edit(electrode_view)
+        return True
+
+    def _begin_channel_label_edit(self, electrode_view):
+        # Commit and close any editor already open before opening the new one —
+        # only one label edits at a time. Done explicitly (not via focus-out) so
+        # the switch is deterministic regardless of focus event ordering.
+        if getattr(self, "_editing_view", None) is not None:
+            self._on_channel_label_committed()
+
+        self.model.electrodes.electrode_editing = electrode_view.electrode  # highlight
+        self._editing_view = electrode_view
+
+        text_item = electrode_view.text_path
+        text_item.editing_committed.connect(self._on_channel_label_committed)
+        text_item.editing_cancelled.connect(self._on_channel_label_cancelled)
+        electrode_view.enter_label_edit()
+
+    def _end_channel_label_edit(self):
+        electrode_view = getattr(self, "_editing_view", None)
+        if electrode_view is None:
+            return
+        text_item = electrode_view.text_path
+        try:
+            text_item.editing_committed.disconnect(self._on_channel_label_committed)
+            text_item.editing_cancelled.disconnect(self._on_channel_label_cancelled)
+        except (RuntimeError, TypeError):
+            pass  # already disconnected
+        electrode_view.exit_label_edit()
+        self._editing_view = None
+        # Snap the label back to the model value: on commit this repaints the
+        # committed number; on cancel/revert it discards the typed text.
+        self.electrode_view_layer.redraw_electrode_labels(self.model)
+
+    def _on_channel_label_committed(self):
+        electrode_view = getattr(self, "_editing_view", None)
+        if electrode_view is None:
+            return
+        new_channel = self._parse_channel_text(electrode_view.text_path.toPlainText())
+        if new_channel is not _CHANNEL_REVERT:
+            # Writing the channel fires the label-redraw observer; we still tear
+            # down below to reset interaction state.
+            electrode_view.electrode.channel = new_channel
+        self._end_channel_label_edit()
+
+    def _on_channel_label_cancelled(self):
+        self._end_channel_label_edit()
+
+    def _parse_channel_text(self, text):
+        """Map raw field text to a channel value: '' -> None (unassign), an
+        in-range int -> that int, anything else -> _CHANNEL_REVERT (keep the
+        prior value)."""
+        text = text.strip()
+        if text == "":
+            return None
+        try:
+            value = int(text)
+        except ValueError:
+            return _CHANNEL_REVERT  # digits are blocked live, so unexpected
+        n_channels = self.device_viewer_preferences.NUMBER_OF_CHANNELS
+        if 0 <= value < n_channels:
+            return value
+        return _CHANNEL_REVERT
+
     def handle_electrode_click(self, electrode_id: Str):
         """Handle an electrode click event."""
         if self.model.mode == "channel-edit":
@@ -1603,24 +1670,6 @@ class ElectrodeInteractionControllerService(HasTraits):
     # Key handlers
     #######################################################################################################
 
-    def handle_digit_input(self, digit: str):
-        if self.model.mode == "channel-edit":
-            n_channels = self.device_viewer_preferences.NUMBER_OF_CHANNELS
-            new_channel = add_digit(self.model.electrodes.electrode_editing.channel, digit)
-            if new_channel == None or 0 <= new_channel < n_channels:
-                self.model.electrodes.electrode_editing.channel = new_channel
-
-            self.electrode_view_layer.redraw_electrode_tooltip(self.model.electrodes.electrode_editing.id)
-
-    def handle_backspace(self):
-        if self.model.mode == "channel-edit":
-            n_channels = self.device_viewer_preferences.NUMBER_OF_CHANNELS
-            new_channel = remove_last_digit(self.model.electrodes.electrode_editing.channel)
-            if new_channel == None or 0 <= new_channel < n_channels:
-                self.model.electrodes.electrode_editing.channel = new_channel
-
-            self.electrode_view_layer.redraw_electrode_tooltip(self.model.electrodes.electrode_editing.id)
-
     def handle_ctrl_key_left(self):
         self.model.camera_perspective.rotate_output(-90)
 
@@ -1657,14 +1706,7 @@ class ElectrodeInteractionControllerService(HasTraits):
     ##########################################################################################
 
     def handle_key_press_event(self, event: QKeyEvent):
-        char = event.text()
         key = event.key()
-
-        if char.isprintable() and char.isdigit():  # If an actual char digit was inputted
-            self.handle_digit_input(char)
-
-        elif key == Qt.Key_Backspace:
-            self.handle_backspace()
 
         # Arrow-key stepping (keyboard).
         # Only when Ctrl/Alt are NOT held to avoid conflicts with existing shortcuts.
@@ -1929,6 +1971,13 @@ class ElectrodeInteractionControllerService(HasTraits):
                 self.model,
                 self.electrode_hovered,
             )
+
+    @observe("model.electrodes.electrode_editing")
+    def _teardown_label_edit_on_deselect(self, event):
+        # Leaving channel-edit mode clears electrode_editing (main_model), so an
+        # open editor is cancelled and reset along with the deselection.
+        if event.new is None and getattr(self, "_editing_view", None) is not None:
+            self._end_channel_label_edit()
 
     @observe("model.electrodes.actuated_channels.items")
     @observe("model.electrodes.disabled_channels.items")

--- a/device_viewer/views/electrode_view/electrode_scene.py
+++ b/device_viewer/views/electrode_view/electrode_scene.py
@@ -4,6 +4,7 @@ from PySide6.QtWidgets import QGraphicsScene, QGraphicsSceneContextMenuEvent
 
 from logger.logger_service import get_logger
 from ...services.electrode_interaction_service import ElectrodeInteractionControllerService
+from .electrodes_view_base import EditableChannelTextItem
 
 logger = get_logger(__name__)
 
@@ -39,12 +40,27 @@ class ElectrodeScene(QGraphicsScene):
         return None
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
+        # While a channel label is being edited, let the focused text item
+        # consume keys instead of the global electrode key handler (which would
+        # otherwise step electrodes, toggle pan on Space, etc.).
+        focus_item = self.focusItem()
+        if isinstance(focus_item, EditableChannelTextItem) and focus_item.editing:
+            super().keyPressEvent(event)
+            return
         self.interaction_service.handle_key_press_event(event)
         super().keyPressEvent(event)
 
     def mousePressEvent(self, event):
         """Handle the start of a mouse click event."""
+        # In channel-edit mode a click on an electrode enters inline label
+        # editing. When it starts a fresh edit the press is consumed, so the
+        # whole-value selection isn't cleared by caret placement; clicks inside
+        # the field already being edited fall through to Qt for caret/drag.
+        started_edit = self.interaction_service.handle_channel_label_press(event)
         self.interaction_service.handle_mouse_press_event(event)
+        if started_edit:
+            event.accept()
+            return
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):

--- a/device_viewer/views/electrode_view/electrodes_view_base.py
+++ b/device_viewer/views/electrode_view/electrodes_view_base.py
@@ -11,9 +11,9 @@ from logger.logger_service import get_logger, debug_throttled
 
 # enthought imports
 from traits.api import Instance, Array, Str
-from pyface.qt.QtCore import Qt, QPointF
+from pyface.qt.QtCore import Qt, QPointF, Signal
 from pyface.qt.QtGui import (QColor, QPen, QBrush, QFont, QPainterPath, QGraphicsPathItem, QGraphicsTextItem,
-                             QGraphicsItem)
+                             QGraphicsItem, QTextCursor)
 
 from microdrop_utils.decorators import debounce
 from ...default_settings import ELECTRODE_OFF, ELECTRODE_ON, ELECTRODE_NO_CHANNEL, ELECTRODE_LINE, ELECTRODE_TEXT_COLOR, \
@@ -150,6 +150,91 @@ class ElectrodeEndpointItem(QGraphicsPathItem):
         self.setBrush(Qt.NoBrush)
 
 
+class EditableChannelTextItem(QGraphicsTextItem):
+    """Electrode channel label that doubles as an inline, text-editor-style field.
+
+    Display-only until ``begin_edit`` flips it into Qt's native
+    ``TextEditorInteraction`` — which supplies the blinking caret, drag- and
+    shift-selection, and bulk select-then-replace for free. Input is constrained
+    to digits, and the commit/cancel gestures are surfaced as signals so the
+    controller (not this view) writes the model.
+    """
+
+    #: Emitted on Enter or focus-out (click-away); the controller reads the
+    #: field text and writes the model.
+    editing_committed = Signal()
+    #: Emitted on Escape — the edit is abandoned, the model left untouched.
+    editing_cancelled = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._editing = False
+
+    @property
+    def editing(self) -> bool:
+        return self._editing
+
+    def begin_edit(self):
+        """Turn the static label into a focused, fully-selected edit field."""
+        self._editing = True
+        # The device-coordinate cache would freeze the blinking caret, so edit
+        # uncached and restore the cache in end_edit.
+        self.setCacheMode(QGraphicsItem.CacheMode.NoCache)
+        self.setTextInteractionFlags(Qt.TextEditorInteraction)
+        self.setFocus(Qt.MouseFocusReason)
+        # Select the whole value so the first digit typed replaces it.
+        cursor = self.textCursor()
+        cursor.select(QTextCursor.Document)
+        self.setTextCursor(cursor)
+
+    def end_edit(self):
+        """Return to a static, cached, non-interactive label."""
+        self._editing = False
+        cursor = self.textCursor()
+        cursor.clearSelection()
+        self.setTextCursor(cursor)
+        self.setTextInteractionFlags(Qt.NoTextInteraction)
+        self.clearFocus()
+        self.setCacheMode(QGraphicsItem.CacheMode.DeviceCoordinateCache)
+
+    def keyPressEvent(self, event):
+        if not self._editing:
+            return
+
+        key = event.key()
+        if key in (Qt.Key_Return, Qt.Key_Enter):
+            self.editing_committed.emit()
+            event.accept()
+            return
+        if key == Qt.Key_Escape:
+            self.editing_cancelled.emit()
+            event.accept()
+            return
+
+        # Block printable non-digits; let navigation/editing keys (arrows,
+        # Home/End, Backspace, Delete, Ctrl+A/C/X, ...) reach the editor.
+        text = event.text()
+        if text and text.isprintable() and not text.isdigit():
+            event.accept()
+            return
+
+        super().keyPressEvent(event)
+
+    def insertFromMimeData(self, source):
+        # Paste digits only — silently drop everything else.
+        digits = "".join(ch for ch in source.text() if ch.isdigit())
+        if digits:
+            cursor = self.textCursor()
+            cursor.insertText(digits)
+            self.setTextCursor(cursor)
+
+    def focusOutEvent(self, event):
+        # Click-away commits whatever is currently in the field.
+        if self._editing:
+            self.editing_committed.emit()
+        super().focusOutEvent(event)
+
+
 # electrode polygons
 class ElectrodeView(QGraphicsPathItem):
     """
@@ -187,7 +272,7 @@ class ElectrodeView(QGraphicsPathItem):
         self.update_line_alpha(default_alphas.get(electrode_outline_key,1.0))
 
         # Text item
-        self.text_path = QGraphicsTextItem(parent=self)
+        self.text_path = EditableChannelTextItem(parent=self)
         self.text_color = QColor(ELECTRODE_TEXT_COLOR)
         self.text_path.setDefaultTextColor(self.text_color)
         # Pole of inaccessibility + inscribed diameter: keeps the label
@@ -276,6 +361,14 @@ class ElectrodeView(QGraphicsPathItem):
     def rotate_electrode_text(self, angle=0):
         self.text_path.setTransformOriginPoint(self.text_path.boundingRect().center())
         self.text_path.setRotation(self.text_path.rotation() + angle)
+
+    def enter_label_edit(self):
+        """Begin inline editing of this electrode's channel label."""
+        self.text_path.begin_edit()
+
+    def exit_label_edit(self):
+        """End inline editing and restore the static label."""
+        self.text_path.end_edit()
 
     ##################################################################################
     # Public electrode view update methods


### PR DESCRIPTION
Resolves #509.

## What

In **channel-edit** mode, the electrode channel label is now a proper inline text field. Single-click an electrode and the caret drops into its label with the whole value pre-selected — you get a blinking cursor, drag/shift selection, and bulk select-then-replace, just like a text-editor field. This replaces the old append-digit / backspace character handling.

## Behavior

- **Single-click** an electrode → enter editing with the value selected (type to replace).
- **Click again inside the field** → place caret / drag-select (native).
- **Enter** or **click-away** commit; **Escape** reverts.
- Input is constrained to **digits** (live and on paste); out-of-range (≥ `NUMBER_OF_CHANNELS`) reverts; empty **unassigns** the channel.
- **Switching electrodes** commits the current edit first (done explicitly, so it's deterministic regardless of focus-event ordering).
- Leaving channel-edit mode discards a partial edit.
- The teal "editing" highlight is unchanged (still driven by `electrode_editing`).

## How

- `EditableChannelTextItem` (new, in `electrodes_view_base.py`) wraps the label in Qt's native `TextEditorInteraction`, filters non-digits, and surfaces commit/cancel via signals so the **controller** (not the view) writes the model — keeping MVC separation.
- `electrode_scene.py` routes keys to the focused field while editing and consumes the entry click so the whole-value selection survives.
- `electrode_interaction_service.py` handles entry (`handle_channel_label_press`), validation, commit/cancel, and teardown; removes the now-dead `add_digit` / `remove_last_digit` path.

## Testing

Manual — run `examples/run_device_viewer_pluggable.py`, enter channel-edit mode, and edit labels (type, select-replace, Enter/Escape/click-away, empty, out-of-range, switch electrodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)