### PR TITLE
feat(pluggable_protocol_tree): add Unfold Group action + grouping shortcuts

### DIFF
--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -218,6 +218,70 @@ class RowManager(HasTraits):
         self.rows_changed = True
         return parent_path + (anchor_index,)
 
+    def _group_path_for_unfold(self, path: Path) -> Optional[Path]:
+        """The group that unfolding ``path`` would dissolve: the row itself
+        when it is a group, else its containing group. None when that resolves
+        to the root (a top-level step has no enclosing group to unfold)."""
+        path = tuple(path)
+        row = self.get_row(path)
+        if isinstance(row, GroupRow):
+            return path
+        parent_path = path[:-1]
+        return parent_path or None
+
+    def _resolve_unfold_group(self, paths: List[Path]) -> Optional[Path]:
+        """The single group the selection agrees on unfolding, or None when the
+        selection is empty, targets no group (top-level steps), or spans more
+        than one group (ambiguous). Drives ``can_unfold_group``."""
+        candidates = set()
+        for p in paths:
+            try:
+                group_path = self._group_path_for_unfold(p)
+            except IndexError:
+                return None
+            if group_path is None:
+                return None
+            candidates.add(group_path)
+        if len(candidates) != 1:
+            return None
+        return next(iter(candidates))
+
+    def can_unfold_group(self, paths: List[Path]) -> bool:
+        """True when ``unfold_group(paths)`` would act (the selection targets a
+        single group, directly or via a row inside it). Drives the context-menu
+        entry's enabled state."""
+        return self._resolve_unfold_group(paths) is not None
+
+    def unfold_group(self, paths: List[Path]) -> Optional[List[Path]]:
+        """Dissolve the group the selection targets: move its children up into
+        the group's parent at the group's position, preserving their order and
+        identity, then remove the now-empty group. The inverse of
+        ``fold_into_group``.
+
+        Re-parents the live row objects (like ``move``/``fold_into_group``), NOT
+        a serialize + rebuild, so per-step references — capture recordings, the
+        fluorescence pane's live-tracked step — survive the unfold.
+
+        Returns the new paths of the moved children (empty list if the group
+        had none), or None when the selection targets no single unfoldable
+        group (see ``_resolve_unfold_group``)."""
+        group_path = self._resolve_unfold_group(paths)
+        if group_path is None:
+            return None
+        group = self.get_row(group_path)
+        parent = group.parent
+        parent_path = group_path[:-1]
+        anchor_index = group_path[-1]
+        # Snapshot children before mutating; the objects stay valid across the
+        # re-parent, so the shifting indices don't matter.
+        children = list(group.children)
+        for offset, row in enumerate(children):
+            group.remove_row(row)
+            parent.insert_row(anchor_index + offset, row)
+        parent.remove_row(group)
+        self.rows_changed = True
+        return [parent_path + (anchor_index + i,) for i in range(len(children))]
+
     # --- selection ---
 
     def select(self, paths: List[Path], mode: str = "set") -> None:

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -128,6 +128,10 @@ class ProtocolTreeWidget(QWidget):
             (QKeySequence.Copy,  self._copy),
             (QKeySequence.Cut,   self._cut),
             (QKeySequence.Paste, self._paste),
+            # Structural grouping (#529). Guarded so they honor the run-lock
+            # (#471) the same way the context-menu entries do.
+            (QKeySequence("Ctrl+G"),       self._fold_shortcut),
+            (QKeySequence("Ctrl+Shift+G"), self._unfold_shortcut),
         ):
             sc = QShortcut(seq, self.tree)
             sc.setContext(Qt.WidgetWithChildrenShortcut)
@@ -289,6 +293,9 @@ class ProtocolTreeWidget(QWidget):
         fold = menu.addAction("Fold into Group", self._fold_into_group)
         fold.setEnabled(
             self._manager.can_fold_into_group(self._manager.selection))
+        unfold = menu.addAction("Unfold Group", self._unfold_group)
+        unfold.setEnabled(
+            self._manager.can_unfold_group(self._manager.selection))
         menu.addSeparator()
         menu.addAction("Copy", self._copy)
         menu.addAction("Cut", self._cut)
@@ -401,6 +408,16 @@ class ProtocolTreeWidget(QWidget):
         parent_path = self._parent_path_for_anchor(idx)
         self._manager.add_group(parent_path=parent_path)
 
+    def _fold_shortcut(self):
+        # Keyboard path for "Fold into Group"; run-locked like the menu entry.
+        if self._structural_editable:
+            self._fold_into_group()
+
+    def _unfold_shortcut(self):
+        # Keyboard path for "Unfold Group"; run-locked like the menu entry.
+        if self._structural_editable:
+            self._unfold_group()
+
     def _fold_into_group(self):
         """Wrap the selected rows in a new group at the first row's
         position (#518), then select the new group so the user can rename
@@ -420,6 +437,39 @@ class ProtocolTreeWidget(QWidget):
                 )
         except Exception:
             logger.exception("Fold into group failed")
+
+    def _unfold_group(self):
+        """Dissolve the selected group, moving its children up into the parent
+        at the group's position (#529), then select all the unfolded rows."""
+        try:
+            child_paths = self._manager.unfold_group(
+                [tuple(p) for p in self._manager.selection])
+            if not child_paths:
+                return
+            indexes = [
+                idx for idx in (
+                    self._node_to_index(self._manager.get_row(p))
+                    for p in child_paths
+                )
+                if idx.isValid()
+            ]
+            if not indexes:
+                return
+            sm = self.tree.selectionModel()
+            self._expand_ancestors(indexes[0])
+            sm.setCurrentIndex(
+                indexes[0],
+                (QItemSelectionModel.SelectionFlag.ClearAndSelect
+                 | QItemSelectionModel.SelectionFlag.Rows),
+            )
+            for idx in indexes[1:]:
+                sm.select(
+                    idx,
+                    (QItemSelectionModel.SelectionFlag.Select
+                     | QItemSelectionModel.SelectionFlag.Rows),
+                )
+        except Exception:
+            logger.exception("Unfold group failed")
 
     def _parent_path_for_anchor(self, idx):
         """If anchored on a group --> insert inside. On a step --> insert as

--- a/protocol_quick_action_tools/quick_actions/add_group.py
+++ b/protocol_quick_action_tools/quick_actions/add_group.py
@@ -19,5 +19,7 @@ def make_add_group_action() -> _AddGroupAction:
         icon_text="playlist_add",
         tooltip="Add group",
         priority=30,
-        shortcut="Ctrl+Shift+G",
+        # Ctrl+Shift+Return (main Enter, mirroring add_step's Ctrl+Return) frees
+        # Ctrl+Shift+G for the tree's Unfold Group shortcut (#529).
+        shortcut="Ctrl+Shift+Return",
     )


### PR DESCRIPTION
Resolves #529.

## What

Adds the inverse of **Fold into Group** to the pluggable protocol tree: an **Unfold Group** operation that dissolves a group — moving its children up into the parent at the group's position, preserving order and identity — then deletes the now-empty group. Also wires keyboard shortcuts for both grouping operations.

## Behavior

- **Right-click** a group (or a row inside one) → **Unfold Group** → its children pop up into the parent at the group's spot, the empty group is deleted, and the freed rows come out **selected**.
- Nested groups unfold into their parent group; top-level groups unfold into the root.
- **Disabled** for top-level steps (no enclosing group) and multi-group selections (ambiguous).
- Structural run-lock (#471) is respected — no unfolding mid-run.

## Keyboard shortcuts

| Action | Shortcut |
|---|---|
| Fold into Group | `Ctrl+G` |
| Unfold Group | `Ctrl+Shift+G` |
| New Group *(retuned)* | `Ctrl+Shift+Return` (was `Ctrl+Shift+G`) |

The New Group quick-action moves off `Ctrl+Shift+G` to free it for Unfold; `Ctrl+Shift+Return` (main Enter) mirrors `add_step`'s existing `Ctrl+Return`. Fold/unfold shortcuts are tree-scoped (like Copy/Cut/Paste) and run-locked like their menu entries.

## How

- `RowManager.can_unfold_group` / `unfold_group` (+ a private resolver) mirror the fold API. `unfold_group` **re-parents the live row objects** rather than serialize+rebuild, so per-step references (capture recordings, the fluorescence pane's live-tracked step) survive; it returns the new paths of all moved children.
- `TreeWidget` gets the `Unfold Group` menu entry, the `_unfold_group` handler (selects all unfolded rows), and the two grouping `QShortcut`s.
- `add_group` quick-action shortcut retuned to `Ctrl+Shift+Return`.

## Commits

1. `feat(pluggable_protocol_tree): add Unfold Group action and grouping shortcuts`
2. `refactor(protocol_quick_action_tools): move New Group shortcut to Ctrl+Shift+Return`

## Testing

Manual — right-click groups / rows-inside-groups and unfold (incl. nested and top-level groups); verify enablement for steps and multi-group selections; exercise `Ctrl+G` / `Ctrl+Shift+G` / `Ctrl+Shift+Return`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)