### PR TITLE
feat(plugin_management): read plugin docs URL from distribution metadata

### DIFF
--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -133,6 +133,35 @@ def installed_plugin_dists() -> dict[str, str]:
     return dists
 
 
+#: Project-URL labels we surface as a plugin's "Documentation" link, in
+#: preference order: a dedicated docs site if the package declares one, else
+#: its homepage (repo landing page). Matched case-insensitively against the
+#: labels in the installed distribution's core metadata (PEP 621
+#: `[project.urls]` -> `Project-URL: <label>, <url>`).
+DOCUMENTATION_URL_LABELS = ("documentation", "homepage")
+
+
+def documentation_url(dist_name) -> str:
+    """The best documentation link for an installed distribution, or "" if it
+    declares none. Reads the standard `Project-URL` metadata (populated from
+    `[project.urls]`), preferring a Documentation URL and falling back to the
+    Homepage — so no MicroDrop-specific manifest field is needed and the same
+    data serves PyPI, IDEs, and other package managers."""
+    try:
+        metadata = importlib.metadata.metadata(dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        return ""
+    urls = {}
+    for entry in metadata.get_all("Project-URL") or ():
+        label, _, url = entry.partition(",")
+        urls[label.strip().lower()] = url.strip()
+    for label in DOCUMENTATION_URL_LABELS:
+        if urls.get(label):
+            return urls[label]
+    # Legacy core-metadata field, emitted by older tools for Homepage.
+    return (metadata.get("Home-page") or "").strip()
+
+
 def uninstall_package(name, *, cwd=None) -> None:
     """`pixi remove <name>`. Best-effort; logs on failure."""
     cwd = Path(cwd or WORKSPACE_DIR)


### PR DESCRIPTION
## Summary
Adds `documentation_url(dist_name)` to `plugin_management/package_installer.py`. It reads the standard **`Project-URL`** core metadata of an installed plugin distribution (populated from the package's PEP 621 `[project.urls]` table) and returns:

1. a **Documentation** URL if declared, else
2. the **Homepage**, else
3. the legacy `Home-page` metadata field, else `""`.

This is the retrieval side of the "Documentation" link planned for the installed-plugins table in #532 — done the standards way (no MicroDrop-specific manifest field), so the same URLs also surface on PyPI, conda, and in IDEs.

## Companion changes (already on `main` in the plugin repos)
Each bundled plugin now declares its repo via `[project.urls] Homepage` (pushed directly as `chore:` commits, so no auto-release was triggered):
- heater-microdrop-plugin-py
- magnet-microdrop-plugin-py
- fluorescence-microdrop-plugin-py

## Notes
- Label matching is case-insensitive; prefers `Documentation` over `Homepage`.
- No caller yet — `#532`'s table will call it with the `dist_name` it already has per row.
- Verified: preference/fallback logic unit-checked (Documentation > Homepage > legacy Home-page > empty); module byte-compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)