### PR TITLE
fix: no shorts notification (#535)

### DIFF
--- a/MESSAGES.md
+++ b/MESSAGES.md
@@ -158,3 +158,24 @@ live route sync so step cells only mutate on deliberate user action.
 - The grid → DV publish on `PROTOCOL_GRID_DISPLAY_STATE` carries the target step's params in `DeviceViewerMessageModel.execution_params`; the tree → DV publish on `PROTOCOL_TREE_DISPLAY_STATE` carries the same dict in `ProtocolTreeDisplayMessage.execution_params` (None in free mode → commit button disabled). The DV applies them on `step_id` transition (`device_view_dock_pane._apply_step_transition`), then baselines the sidebar for dirty tracking; a same-step refresh carrying params re-applies + rebaselines silently when no protocol is running.
 - The tree publishes that same-step refresh in two cases: the post-commit echo (above), and any tree-originated edit to an execution-param cell on the selected step (`_republish_on_param_cell_change`, gated on `DV_EXECUTION_PARAM_COL_IDS`) — protocol values supersede the sidebar, including uncommitted sidebar edits.
 
+### Backend → Microdrop task: shorts detected
+
+One topic carries both the spontaneous hardware shorts signal and the answer to an explicit user check, so the payload has to say which one it is: an empty channel list means "no shorts", and only the publisher knows whether the user is waiting to hear that.
+
+**Topic**
+- `SHORTS_DETECTED = "dropbot/signals/shorts_detected"` — defined in `dropbot_controller/consts.py`.
+
+**Payload schema**
+- Pydantic `ShortsDetectedSignal` at `dropbot_controller/models/shorts.py`.
+- Fields: `shorted_channels: list[int]` (empty means none found), `show_window: bool` (force a dialog even with no shorts).
+- Published through the `shorts_detected_publisher` singleton in `dropbot_controller/consts.py` — never hand-rolled `json.dumps`.
+
+**Publisher side (dropbot_controller)**
+- `dropbot_controller_base._shorts_detected_wrapper` — the proxy's `shorts-detected` signal; `show_window=False`, nobody asked, so no shorts means stay silent.
+- `dropbot_controller_base.on_detect_shorts_request` and `services/dropbot_self_tests_mixin_service` (the `test_shorts` branch) — both answer an explicit user request, so `show_window=True`.
+- `mock_dropbot_controller/mock_controller.py` mirrors both cases (`on_detect_shorts_request`, `simulate_shorts`).
+
+**Subscriber side (microdrop_application)**
+- `task._on_shorts_detected_triggered` validates the payload and hands off to the UI thread.
+- `task._on_shorts_detected_dialog`: with shorts → a `confirm` offering to keep the channels enabled; declining publishes them via `disabled_channels_changed_publisher`. Without shorts → the "No Shorts Detected" info dialog, unconditionally when `show_window` is set, otherwise only when the `suppress_no_shorts_information` preference is unset (that dialog carries the "do not show again" checkbox which writes the preference).
+

--- a/dropbot_controller/consts.py
+++ b/dropbot_controller/consts.py
@@ -87,3 +87,9 @@ HARDWARE_DEFAULT_FREQUENCY = 10_000  # Hz
 # Known hardware minimum limits for DropBot DB3-120
 HARDWARE_MIN_VOLTAGE = 30    # V
 HARDWARE_MIN_FREQUENCY = 100  # Hz
+
+# Convenience publisher singleton, so call sites can do:
+#   from dropbot_controller.consts import shorts_detected_publisher
+#   shorts_detected_publisher.publish(shorted_channels=[...], show_window=True)
+from dropbot_controller.models.shorts import ShortsDetectedPublisher
+shorts_detected_publisher = ShortsDetectedPublisher(topic=SHORTS_DETECTED)

--- a/dropbot_controller/dropbot_controller_base.py
+++ b/dropbot_controller/dropbot_controller_base.py
@@ -14,8 +14,8 @@ from microdrop_utils.ureg_helpers import ureg
 from microdrop_utils.dramatiq_controller_base import generate_class_method_dramatiq_listener_actor, invoke_class_method, TimestampedMessage
 
 from .consts import (CHIP_INSERTED, CAPACITANCE_UPDATED, HALTED, HALT, START_DEVICE_MONITORING,
-                     RETRY_CONNECTION, OUTPUT_ENABLE_PIN, SHORTS_DETECTED, PKG, SELF_TEST_CANCEL, CHANGE_SETTINGS,
-                     SET_REALTIME_MODE, DROPBOT_CONNECTION_STATE_KEY)
+                     RETRY_CONNECTION, OUTPUT_ENABLE_PIN, PKG, SELF_TEST_CANCEL, CHANGE_SETTINGS,
+                     SET_REALTIME_MODE, DROPBOT_CONNECTION_STATE_KEY, shorts_detected_publisher)
 
 from .interfaces.i_dropbot_controller_base import IDropbotControllerBase
 
@@ -218,6 +218,9 @@ class DropbotControllerBase(HasTraits):
             # Publish disabled channels state so the device viewer syncs with the (now reset) hardware
             self._publish_disabled_channels_from_mask()
 
+            # Manual call because on boot, shorts-detected event may not be triggered.
+            self.proxy.detect_shorts()
+
             logger.info("Enhanced proxy connection setup completed successfully")
 
             return True
@@ -249,9 +252,7 @@ class DropbotControllerBase(HasTraits):
 
     @staticmethod
     def _shorts_detected_wrapper(signal: dict[str, str]):
-        shorts_list = signal.get('values')
-        shorts_dict = {'Shorts_detected': shorts_list}
-        publish_message(topic=SHORTS_DETECTED, message=json.dumps(shorts_dict))
+        shorts_detected_publisher.publish(shorted_channels=signal.get('values', []))
 
     @staticmethod
     def _halted_event_wrapper(signal):
@@ -308,9 +309,10 @@ class DropbotControllerBase(HasTraits):
         if self.proxy is not None:
             if self.proxy.monitor is not None:
                 shorts_list = self.proxy.detect_shorts()
-                shorts_dict = {'Shorts_detected': shorts_list}
-                logger.info(f"Detected shorts: {shorts_dict}")
-                publish_message(topic=SHORTS_DETECTED, message=json.dumps(shorts_dict))
+                logger.info(f"Detected shorts: {shorts_list}")
+                # The request came from the user, so always report back — even
+                # when there is nothing to report.
+                shorts_detected_publisher.publish(shorted_channels=shorts_list, show_window=True)
 
     def on_halt_request(self, message):
         message = json.loads(message)

--- a/dropbot_controller/models/shorts.py
+++ b/dropbot_controller/models/shorts.py
@@ -1,0 +1,50 @@
+"""Message schema for the SHORTS_DETECTED topic.
+
+The dropbot controller owns the topic; the frontend task and the mock
+controller import these as the pub/sub payload contract (sanctioned
+cross-plugin message-schema import).
+"""
+from pydantic import BaseModel, StrictBool, StrictInt
+
+from microdrop_utils.dramatiq_pub_sub_helpers import ValidatedTopicPublisher
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+
+class ShortsDetectedSignal(BaseModel):
+    """Payload for a shorts-detected signal.
+
+    Attributes
+    ----------
+    shorted_channels : list[int]
+        Channel numbers reported as shorted. Empty means no shorts were
+        found.
+    show_window : bool
+        Whether the frontend must surface a dialog even when
+        ``shorted_channels`` is empty. Set by publishers that act on an
+        explicit user request (a detect-shorts request, the shorts self
+        test), so the user always gets an answer. Spontaneous hardware
+        signals leave it False, letting a no-shorts result fall back to
+        the user's suppress-no-shorts preference.
+    """
+    shorted_channels: list[StrictInt] = []
+    show_window: StrictBool = False
+
+
+class ShortsDetectedPublisher(ValidatedTopicPublisher):
+    """Validated publisher for the ``SHORTS_DETECTED`` topic."""
+    validator_class = ShortsDetectedSignal
+
+    def publish(self, shorted_channels, show_window: bool = False, **kwargs):
+        """Construct the payload from the shorted channels and the forced
+        show-window flag.
+
+        `shorted_channels` values are coerced to `int` because the DropBot
+        proxy reports them as numpy integers, which StrictInt rejects.
+        """
+        logger.info(f"ShortsDetectedPublisher: {shorted_channels}")
+        super().publish({
+            "shorted_channels": [int(channel) for channel in shorted_channels],
+            "show_window": show_window,
+        }, **kwargs)

--- a/dropbot_controller/services/dropbot_self_tests_mixin_service.py
+++ b/dropbot_controller/services/dropbot_self_tests_mixin_service.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from functools import wraps
 
@@ -20,7 +19,7 @@ from microdrop_utils.datetime_helpers import get_current_utc_datetime
 from microdrop_utils.file_handler import open_html_in_browser
 from logger.logger_service import get_logger
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
-from dropbot_controller.consts import SHORTS_DETECTED
+from dropbot_controller.consts import shorts_detected_publisher
 
 from ..consts import SELF_TESTS_PROGRESS
 from ..models.self_tests import TestEvent, create_test_progress_message
@@ -161,10 +160,10 @@ class DropbotSelfTestsMixinService(HasTraits):
                                                     failed_channels=failed_channels if test_name == "test_channels" else None)
                     GUI.invoke_later(show_results_dialog)
                 else:
-                    shorts_dict = {'Shorts_detected': result[test_name]['shorts'], 
-                                   'Show_window': True}
-                    publish_message(topic=SHORTS_DETECTED, message=json.dumps(shorts_dict))
-                    pass
+                    # The user ran the shorts test, so always report back —
+                    # even when there is nothing to report.
+                    shorts_detected_publisher.publish(shorted_channels=result[test_name]['shorts'],
+                                                      show_window=True)
 
             # do whatever else is defined in func
             func(self, report_generation_directory)  

--- a/microdrop_application/plugin.py
+++ b/microdrop_application/plugin.py
@@ -55,9 +55,9 @@ class MicrodropPlugin(Plugin):
         return [f"file://{filename}"]
 
     def _preferences_panes_default(self):
-        from .preferences import MicrodropPreferencesPane, MicrodropDialogsPreferencesPane
+        from .preferences import MicrodropPreferencesPane
 
-        return [MicrodropPreferencesPane, MicrodropDialogsPreferencesPane]
+        return [MicrodropPreferencesPane]
 
     def _preferences_categories_default(self):
         from .preferences import microdrop_tab

--- a/microdrop_application/preferences.py
+++ b/microdrop_application/preferences.py
@@ -112,6 +112,13 @@ class MicrodropPreferencesPane(PreferencesPane):
             style_sheet=preferences_group_style_sheet,
         ),
 
+    dialog_settings = Group(
+            Item("suppress_no_shorts_information"),
+            label="Dialog Settings",
+            show_border=True,
+            style_sheet=preferences_group_style_sheet,
+        ),
+
     view = View(
 
         Item("_"), # Separator
@@ -122,41 +129,11 @@ class MicrodropPreferencesPane(PreferencesPane):
 
         canvas_settings,
 
+        Item("_"),
+
+        dialog_settings,
+
         Item("_"),  # ensure other contributed pane groups are spaced out from this pane's group.
 
         resizable=True,
     )
-
-
-class MicrodropDialogsPreferencesPane(PreferencesPane):
-    """Microdrop General preferences pane — 'Dialog Settings' group.
-
-    Contributes to the same `microdrop.app.general_settings` tab as
-    MicrodropPreferencesPane but in a separate group so the dialog-related
-    toggles can live independently of the canvas/startup controls.
-    """
-
-    #### 'PreferencesPane' interface ##########################################
-
-    # The factory to use for creating the preferences model object.
-    model_factory = MicrodropPreferences
-
-    category = microdrop_tab.id
-
-    ########################################################################################
-
-    view = View(
-        Item("_"),  # Separator
-        Group(
-            Item("suppress_no_shorts_information"),
-            label="Dialog Settings",
-            show_border=True,
-            style_sheet=preferences_group_style_sheet,
-        ),
-        Item("_"),  # Separator
-        resizable=True,
-    )
-
-    def apply(self, info=None):
-        # super().apply(info)
-        pass

--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -13,6 +13,7 @@ from electrode_controller.consts import disabled_channels_changed_publisher
 # Local imports.
 from .consts import PKG
 from dropbot_controller.models.self_tests import TestEvent
+from dropbot_controller.models.shorts import ShortsDetectedSignal
 
 from microdrop_utils.dramatiq_controller_base import (generate_class_method_dramatiq_listener_actor,
                                                       basic_listener_actor_routine)
@@ -205,17 +206,23 @@ class MicrodropTask(Task):
         Handle shorts-detected messages. Parse the shorted channels and emit
         a Qt signal so the UI thread can show a confirmation dialog.
         """
-        data = json.loads(message)
-        shorts = data.get("Shorts_detected", [])
+        signal = ShortsDetectedSignal.model_validate_json(message)
+        shorts = signal.shorted_channels
         if shorts:
             logger.info(f"Shorts detected on channels: {shorts}")
         else:
             logger.info(f"No Shorts detected")
 
-        GUI.invoke_later(lambda: self._handle_shorts_detected_dialog_user_input(self._on_shorts_detected_dialog(shorts), shorts))
+        GUI.invoke_later(lambda: self._handle_shorts_detected_dialog_user_input(
+            self._on_shorts_detected_dialog(shorts, signal.show_window), shorts))
 
-    def _on_shorts_detected_dialog(self, shorted_channels: list):
-        """Offer the user the option to disable shorted channels (runs in UI thread)."""
+    def _on_shorts_detected_dialog(self, shorted_channels: list, show_window: bool):
+        """Offer the user the option to disable shorted channels (runs in UI thread).
+
+        A no-shorts result is always reported when the publisher forced
+        `show_window` — the user asked for the check, so the suppress
+        preference does not apply. Spontaneous signals honour it.
+        """
 
         if shorted_channels:
             channels_str = ", ".join(str(ch) for ch in shorted_channels)
@@ -228,12 +235,15 @@ class MicrodropTask(Task):
                 ),
             )
 
-        else:
-            if not self.microdrop_preferences.suppress_no_shorts_information:
-                _, checked = information(None, title="No Shorts Detected", message="No shorts were detected.",
-                                         checkbox_text="Do not show again (can be undone from preferences)")
+        elif show_window:
+            information(None, title="No Shorts Detected", message="No shorts were detected.")
+            return None
 
-                self.microdrop_preferences.suppress_no_shorts_information = checked
+        elif not self.microdrop_preferences.suppress_no_shorts_information:
+            _, checked = information(None, title="No Shorts Detected", message="No shorts were detected.",
+                                     checkbox_text="Do not show again (can be undone from preferences)")
+
+            self.microdrop_preferences.suppress_no_shorts_information = checked
 
             return None
 

--- a/mock_dropbot_controller/consts.py
+++ b/mock_dropbot_controller/consts.py
@@ -12,6 +12,7 @@ from dropbot_controller.consts import (
     TEST_ON_BOARD_FEEDBACK_CALIBRATION, TEST_SHORTS, TEST_CHANNELS,
     CHIP_CHECK, SELF_TEST_CANCEL, DETECT_DROPLETS, CHANGE_SETTINGS,
     HARDWARE_DEFAULT_VOLTAGE, HARDWARE_DEFAULT_FREQUENCY,
+    shorts_detected_publisher,
 )
 from dropbot_controller.models.self_tests import (
     TestEvent, create_test_progress_message,

--- a/mock_dropbot_controller/mock_controller.py
+++ b/mock_dropbot_controller/mock_controller.py
@@ -17,7 +17,7 @@ from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from logger.logger_service import get_logger
 
 from .consts import (
-    PKG, CHIP_INSERTED, CAPACITANCE_UPDATED, HALTED, SHORTS_DETECTED,
+    PKG, CHIP_INSERTED, CAPACITANCE_UPDATED, HALTED, shorts_detected_publisher,
     DROPBOT_CONNECTED, DROPBOT_DISCONNECTED, DROPLETS_DETECTED,
     REALTIME_MODE_UPDATED, SELF_TESTS_PROGRESS,
     START_DEVICE_MONITORING, RETRY_CONNECTION, CHANGE_SETTINGS,
@@ -219,10 +219,7 @@ class MockDropbotController(HasTraits):
         publish_message(str(len(self.actuated_channels)), topic=ELECTRODES_STATE_APPLIED)
 
     def on_detect_shorts_request(self, message):
-        publish_message(
-            topic=SHORTS_DETECTED,
-            message=json.dumps({"Shorts_detected": []}),
-        )
+        shorts_detected_publisher.publish(shorted_channels=[], show_window=True)
         logger.info("Mock: No shorts detected (mock)")
 
     def on_detect_droplets_request(self, message):
@@ -383,10 +380,7 @@ class MockDropbotController(HasTraits):
         logger.info(f"Mock: Chip {'inserted' if inserted else 'removed'}")
 
     def simulate_shorts(self, channels: list):
-        publish_message(
-            topic=SHORTS_DETECTED,
-            message=json.dumps({"Shorts_detected": channels, "Show_window": True}),
-        )
+        shorts_detected_publisher.publish(shorted_channels=channels, show_window=True)
         logger.info(f"Mock: Simulated shorts on channels {channels}")
 
     def simulate_halt(self, error_name: str = "output-current-exceeded"):

--- a/mock_dropbot_status/message_handler.py
+++ b/mock_dropbot_status/message_handler.py
@@ -2,6 +2,7 @@ import json
 
 from traits.api import Instance
 
+from dropbot_controller.models.shorts import ShortsDetectedSignal
 from logger.logger_service import get_logger
 from microdrop_utils.datetime_helpers import TimestampedMessage
 from microdrop_utils.decorators import timestamped_value
@@ -50,8 +51,7 @@ class MockDropbotMessageHandler(BaseMessageHandler):
         logger.info(f"Mock status: Drops detected on channels {channels}")
 
     def _on_shorts_detected_triggered(self, body):
-        data = json.loads(body)
-        shorts = data.get("Shorts_detected", [])
+        shorts = ShortsDetectedSignal.model_validate_json(body).shorted_channels
         logger.info(f"Mock status: Shorts on channels {shorts}")
 
     # ---- Mock-specific signal handlers (from backend via pub/sub) ----


### PR DESCRIPTION
Fixes #535

## The two bugs

**The preference could not be turned off.** The "Dialog Settings" group lived on a second preferences pane, `MicrodropDialogsPreferencesPane`, whose `apply()` was overridden to `pass`. Toggling `suppress_no_shorts_information` therefore never reached the preferences node, so Apply → OK → reopen always read back the old value. The group is now folded into `MicrodropPreferencesPane`, which inherits the real `apply()`, and the empty second pane is gone.

**A requested check gave no feedback.** The no-shorts dialog was gated solely on that preference, so once it was set, `Tools → Dropbot → On board self test → Detect shorted channels` silently reported nothing. Publishers now say whether a user is waiting on the answer, and that bypasses the preference.

## How the second fix works

`SHORTS_DETECTED` carries both the spontaneous hardware signal and the answer to an explicit user check, and an empty channel list means "no shorts" in either case — only the publisher knows which. The payload now says so, via a `show_window` flag:

- proxy `shorts-detected` signal → `show_window=False`; a no-shorts result honours the suppress preference.
- detect-shorts request and the shorts self test → `show_window=True`; the dialog always shows.

## Also in this PR

The topic moves onto the validated-publisher pattern used by `ssh_controls` and `electrode_controller`, which is what carries the new flag:

- **`dropbot_controller/models/shorts.py`** (new) — `ShortsDetectedSignal` (`shorted_channels: list[StrictInt]`, `show_window: bool`) + `ShortsDetectedPublisher`. Channels are coerced to `int` since the proxy reports numpy integers.
- **`dropbot_controller/consts.py`** — `shorts_detected_publisher` singleton.
- All five publish sites and both consumers drop their hand-rolled `json.dumps` / `data.get("Shorts_detected")` in favour of the model.
- `MESSAGES.md` gains a Detailed Flows subsection for the contract.

## Verification

Pydantic round-trip (numpy coercion included) checked; all touched modules import, and the plugin now contributes the single preferences pane. The preference persistence and the dialogs were not exercised in a running GUI, and nothing was tested against hardware — worth a manual pass through the repro steps in #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)