### PR TITLE
feat(plugin_management): hot-load plugin changes without relaunch

### DIFF
--- a/docs/superpowers/plans/2026-07-16-plugin-hot-load.md
+++ b/docs/superpowers/plans/2026-07-16-plugin-hot-load.md
@@ -1,0 +1,1117 @@
+# Plugin Hot-Load Without Relaunch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a plugin package is installed, decide from a `pixi list --json` diff whether the change is safe to apply to the live interpreter; when it is, re-discover entry points and enable the new plugin's groups so its dock panes appear immediately — no relaunch.
+
+**Architecture:** `package_installer.py` gains an env snapshot/diff and returns an honest `EnvChangeResult`. A new `hot_load.py` owns the gate plus the import/Envisage surgery (`invalidate_caches` → `discover_entry_point_manifests` → `sys.modules` guard → `register_manifest` → `apply`). `relaunch.py` gains a `finish_change()` helper that either shows a confirmation or falls back to today's relaunch prompt. pixi subprocesses run on a worker thread; the hot-load runs on the GUI thread via `run_with_wait`'s `on_success`.
+
+**Tech Stack:** Python 3.13 (pixi default env), Traits/TraitsUI, Envisage, PySide6, pytest, pixi.
+
+**Spec:** `docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md` (read it first — it explains *why* the gate is shaped this way).
+
+## Global Constraints
+
+- **Branch:** work on `feat/plugin-hot-load-spec` in the `microdrop-py/src` submodule. **Never commit to `main`.**
+- **Baseline:** this plan builds on two commits that landed just before it — `a303f235` (the `_run(["install"])` calls in `install_from_channel` / `uninstall_package`) and `5be1f242` (`relaunch.py`'s `pixi run microdrop` task form). Do not revert either. The working tree is clean at the start of Task 1; keep it that way by staging only the files each Commit step names — never `git add -A`.
+- **f-strings everywhere**, including log messages. Never `%s`, `%r`, or `.format()`.
+- **Dialogs** only via `microdrop_application.dialogs.pyface_wrapper`. Never raw `QMessageBox` or `pyface.api` directly.
+- **Logging:** `from logger.logger_service import get_logger` then `logger = get_logger(__name__)`.
+- **Commits:** Conventional Commits — `type(scope): subject`, imperative, ~50 chars including the prefix. Scope is `plugin_management`.
+- **Never mint a new name when an existing one expresses it.** Reuse `_norm_dist`, `apply()`, `run_with_wait`, `confirm_and_relaunch`.
+- **DO NOT RUN ANY TESTS.** Not pytest, not the app. The project owner runs
+  every test manually and has explicitly asked that agents never invoke them.
+  Write the test code exactly as specified, commit it, and move on. Never
+  `pixi run pytest`, `python -m pytest`, or launch `pixi run microdrop`.
+- **Consequence to respect, not paper over:** because nothing is executed, no
+  task's tests are verified. Do not write "tests pass", "verified", or
+  "working" in any commit message, summary, or report. Say what you wrote and
+  that it is unrun. The only real gate is Task 5, which the owner performs.
+- **Syntax check instead** (this is not a test run, and is the one command you
+  may use to catch typos):
+  ```bash
+  cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile <files you touched>
+  ```
+  `py_compile` works with a bare `python` because it never imports numpy. Any
+  *real* execution would need `pixi run` — but you are not doing any.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `plugin_management/package_installer.py` (modify) | pixi subprocess layer. Gains `EnvDiff`, `env_snapshot`, `diff_snapshots`, `_parse_list_json`; `InstallResult` → `EnvChangeResult`. Stays Qt-free and knows nothing about plugins or groups. |
+| `plugin_management/hot_load.py` (create) | The gate + import/Envisage surgery. Knows nothing about pixi or Qt. |
+| `plugin_management/i_plugin_group_manager.py` (modify) | Add `register_manifest` to the service interface. |
+| `plugin_management/relaunch.py` (modify) | Add `finish_change(task, msg_html, ok)`. |
+| `plugin_management/browse_controller.py` (modify) | Install flow — the path that actually takes the fast lane. |
+| `plugin_management/manage_controller.py` (modify) | Install-version / upgrade / uninstall flows. |
+| `plugin_management/manage_model.py` (modify) | Return the `EnvChangeResult` from the three worker methods. |
+| `plugin_management/tests/test_env_diff.py` (create) | Snapshot + diff unit tests. |
+| `plugin_management/tests/test_hot_load.py` (create) | Gate, guard, and orchestration tests. |
+| `plugin_management/tests/test_relaunch.py` (create) | `finish_change` branch tests. |
+| `plugin_management/tests/test_package_installer.py` (modify) | Drive `requires_relaunch` off a mocked diff. |
+
+`update_controller.py` / `update_model.py` are **deliberately untouched** — `do_update_all` returns `(succeeded, failed)` name lists across many packages, and update-all only ever touches already-installed plugins, so its diff always contains `changed` and it can never take the fast path.
+
+---
+
+### Task 1: Env snapshot and diff
+
+**Files:**
+- Modify: `plugin_management/package_installer.py`
+- Test: `plugin_management/tests/test_env_diff.py` (create)
+
+**Interfaces:**
+- Consumes: `package_installer._run(args, cwd=None)` (existing; raises `InstallError` on non-zero exit), `package_installer.InstallError` (existing).
+- Produces:
+  - `EnvDiff(added: dict, changed: dict, removed: dict)` — frozen dataclass. `added`/`removed` map `name -> version`; `changed` maps `name -> (old_version, new_version)`. Properties `is_pure_addition` and `is_pure_removal` (both `bool`).
+  - `env_snapshot(*, cwd=None) -> dict` — `{name: (version, build, kind)}`.
+  - `diff_snapshots(before: dict, after: dict) -> EnvDiff`.
+  - `_parse_list_json(stdout: str) -> list[dict]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugin_management/tests/test_env_diff.py`:
+
+```python
+"""Tests for the pixi environment snapshot + diff that gates hot-loading."""
+import json
+
+import pytest
+from types import SimpleNamespace
+
+from plugin_management import package_installer
+from plugin_management.package_installer import (
+    EnvDiff, diff_snapshots, env_snapshot)
+
+
+def _snap(**pkgs):
+    """{name: (version, build, kind)} from name="version" kwargs."""
+    return {n: (v, "b0", "conda") for n, v in pkgs.items()}
+
+
+def test_diff_detects_added():
+    d = diff_snapshots(_snap(a="1.0"), _snap(a="1.0", b="2.0"))
+    assert d.added == {"b": "2.0"}
+    assert d.changed == {} and d.removed == {}
+
+
+def test_diff_detects_removed():
+    d = diff_snapshots(_snap(a="1.0", b="2.0"), _snap(a="1.0"))
+    assert d.removed == {"b": "2.0"}
+    assert d.added == {} and d.changed == {}
+
+
+def test_diff_detects_changed_version():
+    d = diff_snapshots(_snap(a="1.0"), _snap(a="1.1"))
+    assert d.changed == {"a": ("1.0", "1.1")}
+
+
+def test_diff_build_only_change_counts_as_changed():
+    """A same-version rebuild replaces files on disk under live modules."""
+    before = {"a": ("1.0", "b0", "conda")}
+    after = {"a": ("1.0", "b1", "conda")}
+    assert diff_snapshots(before, after).changed == {"a": ("1.0", "1.0")}
+
+
+def test_diff_kind_change_counts_as_changed():
+    before = {"a": ("1.0", "b0", "conda")}
+    after = {"a": ("1.0", "b0", "pypi")}
+    assert diff_snapshots(before, after).changed == {"a": ("1.0", "1.0")}
+
+
+def test_is_pure_addition_only_when_nothing_else_moved():
+    assert EnvDiff({"b": "1"}, {}, {}).is_pure_addition is True
+    assert EnvDiff({"b": "1"}, {"a": ("1", "2")}, {}).is_pure_addition is False
+    assert EnvDiff({"b": "1"}, {}, {"c": "1"}).is_pure_addition is False
+
+
+def test_is_pure_removal_only_when_nothing_else_moved():
+    assert EnvDiff({}, {}, {"c": "1"}).is_pure_removal is True
+    assert EnvDiff({"b": "1"}, {}, {"c": "1"}).is_pure_removal is False
+    assert EnvDiff({}, {"a": ("1", "2")}, {"c": "1"}).is_pure_removal is False
+
+
+def test_env_snapshot_parses_records(monkeypatch):
+    payload = [{"name": "numpy", "version": "2.1.0", "build": "py313h0",
+                "kind": "conda"}]
+    monkeypatch.setattr(package_installer, "_run",
+                        lambda a, cwd=None: SimpleNamespace(
+                            stdout=json.dumps(payload)))
+    assert env_snapshot() == {"numpy": ("2.1.0", "py313h0", "conda")}
+
+
+def test_env_snapshot_tolerates_leading_warnings(monkeypatch):
+    """pixi prints warnings before the JSON, exactly as `search` does."""
+    payload = [{"name": "numpy", "version": "2.1.0", "build": "b0",
+                "kind": "conda"}]
+    stdout = f" WARN something deprecated\n{json.dumps(payload)}"
+    monkeypatch.setattr(package_installer, "_run",
+                        lambda a, cwd=None: SimpleNamespace(stdout=stdout))
+    assert env_snapshot()["numpy"][0] == "2.1.0"
+
+
+def test_parse_list_json_without_array_raises():
+    with pytest.raises(package_installer.InstallError):
+        package_installer._parse_list_json("no json here")
+```
+
+- [ ] **Step 2: Do not run the tests**
+
+Skip execution (see Global Constraints). For reference, were they run now they
+would fail collection with `ImportError: cannot import name 'EnvDiff' from
+'plugin_management.package_installer'` — that is the shape of failure the
+implementation in Step 3 resolves.
+
+- [ ] **Step 3: Implement**
+
+In `plugin_management/package_installer.py`, add `field`-free dataclass imports if needed (`from dataclasses import dataclass` is already imported) and insert after the existing `InstallResult` dataclass:
+
+```python
+@dataclass(frozen=True)
+class EnvDiff:
+    """What a pixi command did to the environment, keyed by package name.
+
+    ``added``/``removed`` map name -> version; ``changed`` maps
+    name -> (old_version, new_version)."""
+
+    added: dict
+    changed: dict
+    removed: dict
+
+    @property
+    def is_pure_addition(self):
+        """True when packages were only ADDED — nothing upgraded, downgraded,
+        rebuilt or removed. The only shape safe to import into a live
+        interpreter."""
+        return not self.changed and not self.removed
+
+    @property
+    def is_pure_removal(self):
+        """True when packages were only REMOVED. Safe after pre_uninstall has
+        already disabled the affected groups."""
+        return not self.changed and not self.added
+```
+
+Add near `_parse_search_json`:
+
+```python
+def _parse_list_json(stdout: str) -> list[dict]:
+    """Parse `pixi list --json` stdout (which may be preceded by warning
+    lines) into the package record list."""
+    start = stdout.find("[")
+    if start == -1:
+        raise InstallError("no JSON array in pixi list output")
+    try:
+        return json.loads(stdout[start:])
+    except ValueError as e:
+        raise InstallError(f"could not parse pixi list JSON: {e}") from e
+
+
+def env_snapshot(*, cwd=None) -> dict:
+    """{name: (version, build, kind)} for every package in the workspace env.
+
+    `pixi list` defaults to the platform best matching this machine — the
+    same platform, and the same prefix, the running interpreter uses."""
+    proc = _run(["list", "--json"], cwd=cwd)
+    return {r["name"]: (r["version"], r["build"], r["kind"])
+            for r in _parse_list_json(proc.stdout)}
+
+
+def diff_snapshots(before, after) -> EnvDiff:
+    """Classify per-package differences between two env_snapshot() results.
+
+    Compares the FULL (version, build, kind) record, so a same-version
+    rebuild counts as changed — it still replaces files on disk underneath
+    whatever is already imported."""
+    added = {n: rec[0] for n, rec in after.items() if n not in before}
+    removed = {n: rec[0] for n, rec in before.items() if n not in after}
+    changed = {n: (before[n][0], after[n][0])
+               for n in before.keys() & after.keys()
+               if before[n] != after[n]}
+    return EnvDiff(added=added, changed=changed, removed=removed)
+```
+
+- [ ] **Step 4: Syntax-check only**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/package_installer.py plugin_management/tests/test_env_diff.py
+```
+Expected: no output. Do **not** run pytest.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin_management/package_installer.py plugin_management/tests/test_env_diff.py
+git commit -m "feat(plugin_management): add pixi env snapshot and diff"
+```
+
+---
+
+### Task 2: EnvChangeResult and installer wiring
+
+**Files:**
+- Modify: `plugin_management/package_installer.py`
+- Test: `plugin_management/tests/test_package_installer.py`
+
+**Interfaces:**
+- Consumes: `EnvDiff`, `env_snapshot`, `diff_snapshots` (Task 1).
+- Produces:
+  - `EnvChangeResult(name: str, diff: EnvDiff | None, requires_relaunch: bool)` — replaces `InstallResult`.
+  - `install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None, version=None) -> EnvChangeResult`
+  - `upgrade_package(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None) -> EnvChangeResult`
+  - `uninstall_package(name, *, cwd=None) -> EnvChangeResult` (previously returned `None`)
+
+- [ ] **Step 1: Write the failing tests**
+
+In `plugin_management/tests/test_package_installer.py`, add to the imports at the top:
+
+```python
+from types import SimpleNamespace
+```
+
+Then append these tests to the file:
+
+```python
+def _rec(name, version, build="b0", kind="conda"):
+    return {"name": name, "version": version, "build": build, "kind": kind}
+
+
+class _FakeRun:
+    """Stands in for package_installer._run.
+
+    Serves a different `pixi list --json` payload on each successive `list`
+    call, so an install can be made to look purely additive or not."""
+
+    def __init__(self, *list_payloads):
+        self.payloads = list(list_payloads)
+        self.calls = []
+
+    def __call__(self, args, cwd=None):
+        self.calls.append(list(args))
+        if args[:1] == ["list"]:
+            return SimpleNamespace(stdout=json.dumps(self.payloads.pop(0)))
+        return None
+
+
+def test_install_pure_addition_does_not_require_relaunch(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+    fake = _FakeRun([_rec("numpy", "2.1.0")],
+                    [_rec("numpy", "2.1.0"), _rec("my-plugin", "1.0.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.requires_relaunch is False
+    assert result.diff.added == {"my-plugin": "1.0.0"}
+
+
+def test_install_that_bumps_a_dep_requires_relaunch(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+    fake = _FakeRun([_rec("numpy", "2.1.0")],
+                    [_rec("numpy", "2.2.0"), _rec("my-plugin", "1.0.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.requires_relaunch is True
+    assert result.diff.changed == {"numpy": ("2.1.0", "2.2.0")}
+
+
+def test_install_snapshot_failure_still_installs_and_asks_relaunch(
+        tmp_path, monkeypatch):
+    """A broken `pixi list` must never break the install — it degrades to the
+    relaunch prompt."""
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+
+    def fake_run(args, cwd=None):
+        if args[:1] == ["list"]:
+            raise package_installer.InstallError("list exploded")
+        return None
+    monkeypatch.setattr(package_installer, "_run", fake_run)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.name == "my-plugin"
+    assert result.diff is None
+    assert result.requires_relaunch is True
+
+
+def test_uninstall_pure_removal_does_not_require_relaunch(tmp_path, monkeypatch):
+    fake = _FakeRun([_rec("numpy", "2.1.0"), _rec("my-plugin", "1.0.0")],
+                    [_rec("numpy", "2.1.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.uninstall_package("my-plugin", cwd=tmp_path)
+
+    assert result.requires_relaunch is False
+    assert result.diff.removed == {"my-plugin": "1.0.0"}
+
+
+def test_uninstall_failure_requires_relaunch(tmp_path, monkeypatch):
+    """`pixi remove` failing is swallowed (existing contract) but must never
+    claim the hot path."""
+    def fake_run(args, cwd=None):
+        if args[:1] == ["remove"]:
+            raise package_installer.InstallError("boom")
+        return SimpleNamespace(stdout=json.dumps([_rec("numpy", "2.1.0")]))
+    monkeypatch.setattr(package_installer, "_run", fake_run)
+
+    result = package_installer.uninstall_package("my-plugin", cwd=tmp_path)
+
+    assert result.diff is None
+    assert result.requires_relaunch is True
+```
+
+Also update the existing `test_install_from_channel_adds_and_returns` — its `_run` fake returns `None`, so the snapshot fails and `requires_relaunch` stays `True` for the *right* reason now. Make that explicit by replacing its final assertion block with:
+
+```python
+    assert ["add", "scipy_analysis"] in calls
+    assert result.name == "scipy_analysis"
+    # The fake _run returns None, so snapshotting fails -> unknown -> relaunch.
+    assert result.diff is None
+    assert result.requires_relaunch is True
+```
+
+- [ ] **Step 2: Do not run the tests**
+
+Skip execution (see Global Constraints). For reference: the five new tests
+would fail with `AttributeError: 'NoneType' object has no attribute
+'requires_relaunch'` from `uninstall_package`, and `assert True is False` on
+the pure-addition tests, since the current code hardcodes
+`requires_relaunch=True`.
+
+- [ ] **Step 3: Implement**
+
+In `plugin_management/package_installer.py`, replace the `InstallResult` dataclass with:
+
+```python
+@dataclass
+class EnvChangeResult:
+    """The outcome of an env-mutating pixi command.
+
+    ``diff`` is None when the environment could not be snapshotted; callers
+    must treat that as 'unknown' and relaunch."""
+
+    name: str
+    diff: EnvDiff | None
+    requires_relaunch: bool
+```
+
+Add these helpers below `diff_snapshots`:
+
+```python
+def _try_snapshot(cwd):
+    """env_snapshot() or None. Snapshotting must never break an install: it
+    runs through _run, which raises InstallError on a non-zero exit."""
+    try:
+        return env_snapshot(cwd=cwd)
+    except Exception as e:
+        logger.warning(f"could not snapshot the pixi environment: {e}")
+        return None
+
+
+def _diff_or_none(before, after):
+    """EnvDiff, or None when either snapshot is missing."""
+    if before is None or after is None:
+        return None
+    return diff_snapshots(before, after)
+```
+
+Replace the body of `install_from_channel` (keep its existing docstring's first paragraph, updated) with:
+
+```python
+def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
+                         version=None) -> EnvChangeResult:
+    """Register the channel and `pixi add <name>` so the solver resolves the
+    package + its deps. When ``version`` is given, pin it (`pixi add
+    <name>==<version>`) to install that specific version (down/upgrade).
+    Snapshot/restore pyproject + lock on any failure.
+
+    Snapshots the environment either side of the install so the caller can
+    tell a purely-additive change (hot-loadable) from one that moved a
+    package already imported by this interpreter (needs a relaunch)."""
+    cwd = Path(cwd or WORKSPACE_DIR)
+    snapshot = _snapshot(cwd)
+    before = _try_snapshot(cwd)
+    spec = f"{name}=={version}" if version else name
+    try:
+        _ensure_channel_registered(channel_url, cwd)
+        _run(["add", spec], cwd=cwd)
+        _run(["install"], cwd=cwd)
+    except Exception:
+        _restore(cwd, snapshot)
+        raise
+    diff = _diff_or_none(before, _try_snapshot(cwd))
+    logger.info(f"installed plugin '{spec}' from {channel_url}")
+    return EnvChangeResult(
+        name=name, diff=diff,
+        requires_relaunch=diff is None or not diff.is_pure_addition)
+```
+
+Update `upgrade_package`'s return annotation to `-> EnvChangeResult` (body unchanged).
+
+Replace `uninstall_package` with:
+
+```python
+def uninstall_package(name, *, cwd=None) -> EnvChangeResult:
+    """`pixi remove <name>` + `pixi install`. Best-effort: a failure is logged,
+    not raised, and reports requires_relaunch=True so a failed removal never
+    claims the hot path."""
+    cwd = Path(cwd or WORKSPACE_DIR)
+    before = _try_snapshot(cwd)
+    try:
+        _run(["remove", name], cwd=cwd)
+        _run(["install"], cwd=cwd)
+    except InstallError as e:
+        logger.warning(f"`pixi remove {name}` failed: {e}")
+        return EnvChangeResult(name=name, diff=None, requires_relaunch=True)
+    diff = _diff_or_none(before, _try_snapshot(cwd))
+    return EnvChangeResult(
+        name=name, diff=diff,
+        requires_relaunch=diff is None or not diff.is_pure_removal)
+```
+
+- [ ] **Step 4: Syntax-check only**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/package_installer.py plugin_management/tests/test_package_installer.py
+```
+Expected: no output. Do **not** run pytest.
+
+For the owner's later manual run: `test_install_from_channel_rolls_back`
+should still pass unchanged — its fake `_run` returns `None` for the `list`
+call, `_try_snapshot` swallows the resulting `AttributeError`, and the `add`
+call still raises, so the rollback assertion holds.
+
+- [ ] **Step 5: Verify no stale references to the old name**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && grep -rn "InstallResult" --include=*.py .
+```
+Expected: no output. If anything matches, update it to `EnvChangeResult`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add plugin_management/package_installer.py plugin_management/tests/test_package_installer.py
+git commit -m "feat(plugin_management): compute requires_relaunch from diff"
+```
+
+---
+
+### Task 3: The hot-load gate and guard
+
+**Files:**
+- Create: `plugin_management/hot_load.py`
+- Modify: `plugin_management/i_plugin_group_manager.py`
+- Test: `plugin_management/tests/test_hot_load.py` (create)
+
+**Interfaces:**
+- Consumes: `EnvDiff` (Task 1); `entry_point_discovery.discover_entry_point_manifests() -> [(PluginManifest, dist_name)]`; `PluginGroupManager._norm_dist(name) -> str`; `PluginGroupManager.register_manifest(manifest, dist_name="")`; `PluginGroupManager.apply(application, desired)`; `PluginGroupManager.is_loaded(group_name) -> bool`; `PluginManifest.groups -> [PluginGroupSpec]`; `PluginGroupSpec.name`, `PluginGroupSpec.plugins -> ["module.path:ClassName"]`.
+- Produces:
+  - `hot_load.hot_load_installed(application, manager, dist_name, diff) -> bool` — True when the plugin is live; False means the caller must offer the relaunch prompt. **GUI thread only.**
+  - `hot_load._live_modules(manifest) -> generator[str]`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `plugin_management/tests/test_hot_load.py`:
+
+```python
+"""Tests for the hot-load gate: when may a just-installed plugin be applied
+to the LIVE app instead of relaunching?"""
+import sys
+
+import pytest
+
+from plugin_management import group_manager, hot_load
+from plugin_management.group_manager import PluginGroupManager
+from plugin_management.manifest import manifest_from_dict
+from plugin_management.package_installer import EnvDiff
+from plugin_management.tests.test_group_manager_adoption import FakeApp
+
+PURE_ADDITION = EnvDiff(added={"my-plugin": "1.0"}, changed={}, removed={})
+BUMPED_DEP = EnvDiff(added={"my-plugin": "1.0"},
+                     changed={"numpy": ("2.1", "2.2")}, removed={})
+
+DIST = "my-microdrop-plugin"
+
+
+@pytest.fixture(autouse=True)
+def isolated_preferences(monkeypatch):
+    """Keep enable/disable from writing the REAL application preferences."""
+    from apptools.preferences.api import Preferences
+    store = Preferences()
+    monkeypatch.setattr(group_manager, "get_default_preferences",
+                        lambda: store)
+    return store
+
+
+@pytest.fixture
+def dummy_module(tmp_path, monkeypatch):
+    """A real, importable, TOP-LEVEL module that is not yet in sys.modules.
+
+    The guard keys on the top-level package name, so a dummy living inside
+    `plugin_management` would always trip it — this has to be its own root."""
+    (tmp_path / "hotload_dummy_pkg.py").write_text(
+        "from envisage.plugin import Plugin\n"
+        "\n"
+        "class HotDummyPlugin(Plugin):\n"
+        "    id = 'hotload_dummy_pkg.plugin'\n",
+        encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    yield "hotload_dummy_pkg"
+    sys.modules.pop("hotload_dummy_pkg", None)
+
+
+def _manifest(module):
+    return manifest_from_dict({
+        "schema_version": 1,
+        "name": "my_plugin",
+        "packages": [module],
+        "groups": [{
+            "name": "my_group",
+            "plugins": [f"{module}:HotDummyPlugin"],
+            "enabled_key": "plugin_group_enabled.my_group",
+        }],
+    })
+
+
+def _patch_discovery(monkeypatch, manifest, dist=DIST):
+    monkeypatch.setattr(hot_load, "discover_entry_point_manifests",
+                        lambda: [(manifest, dist)])
+
+
+def test_hot_loads_and_enables_a_pure_addition(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    app, manager = FakeApp(), PluginGroupManager()
+
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is True
+    assert manager.is_loaded("my_group")
+    assert [c for c in app.calls if c[0] == "add"] == [("add", "HotDummyPlugin")]
+
+
+def test_refuses_when_diff_is_none(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(FakeApp(), manager, DIST, None) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_a_dep_was_bumped(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, BUMPED_DEP) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_nothing_was_discovered(monkeypatch):
+    monkeypatch.setattr(hot_load, "discover_entry_point_manifests", lambda: [])
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+
+
+def test_refuses_when_dist_name_does_not_match(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module), dist="someone-else")
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+
+
+def test_dist_name_match_ignores_case_and_underscores(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module),
+                     dist="My_Microdrop_Plugin")
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is True
+
+
+def test_refuses_when_the_module_is_already_imported(monkeypatch, dummy_module):
+    """Reinstall-after-uninstall: the lock diff says 'pure addition', but
+    import_module would hand back the STALE module."""
+    import importlib
+    importlib.import_module(dummy_module)          # simulate it being live
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_a_colliding_group_is_loaded(monkeypatch, dummy_module):
+    manifest = _manifest(dummy_module)
+    _patch_discovery(monkeypatch, manifest)
+    app, manager = FakeApp(), PluginGroupManager()
+    manager.register_manifest(manifest, dist_name=DIST)
+    manager.enable(app, "my_group")               # already live
+
+    assert hot_load.hot_load_installed(
+        app, manager, DIST, PURE_ADDITION) is False
+
+
+def test_refuses_when_the_plugin_cannot_be_imported(monkeypatch):
+    """A manifest pointing at a module that does not exist: enable() cannot
+    resolve it, the group never loads, and relaunch is a real remedy."""
+    _patch_discovery(monkeypatch, _manifest("hotload_missing_pkg"))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION) is False
+
+
+def test_live_modules_keys_on_the_top_level_package():
+    """`plugin_management` is always imported here, so a spec nested under it
+    must report the ROOT package, not the leaf module."""
+    manifest = _manifest("plugin_management.tests.whatever")
+    assert list(hot_load._live_modules(manifest)) == ["plugin_management"]
+```
+
+- [ ] **Step 2: Do not run the tests**
+
+Skip execution (see Global Constraints). For reference, they would fail
+collection with `ModuleNotFoundError: No module named
+'plugin_management.hot_load'`.
+
+- [ ] **Step 3: Create `plugin_management/hot_load.py`**
+
+```python
+"""Apply a freshly-installed plugin to the LIVE app instead of relaunching.
+
+``pixi install`` writes into the same site-packages the running interpreter
+imports from, so a brand-new package is importable without a restart —
+``enable()`` already imports never-before-seen plugin code every time a group
+is toggled on. What is NOT safe is upgrading or removing an already-imported
+package: modules cannot be un-imported, live objects keep their old classes,
+and on Windows a loaded .pyd/.dll cannot be replaced.
+
+Two INDEPENDENT checks gate the fast path:
+
+1. The env diff must be purely additive (``EnvDiff.is_pure_addition``).
+2. None of the modules ``enable()`` would import may already be in
+   ``sys.modules``. The diff alone reports a reinstall-after-uninstall as a
+   pure addition, but ``import_module`` would hand back the stale module and
+   silently run the old code under the new version's name.
+
+Anything unexpected returns False and the caller falls back to the relaunch
+prompt — always correct, just slower.
+"""
+import importlib
+import sys
+
+from plugin_management.entry_point_discovery import (
+    discover_entry_point_manifests)
+from plugin_management.group_manager import PluginGroupManager
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+
+def _live_modules(manifest):
+    """Top-level modules ``enable()`` would import that are ALREADY loaded.
+
+    Keys on exactly what ``group_manager._resolve_plugin_class`` imports,
+    rather than mapping package names to modules — conda names, python dist
+    names and module names all differ, and native libs map to no dist at all,
+    so any mapping-based check under-reports in the unsafe direction."""
+    for spec in manifest.groups:
+        for plugin_spec in spec.plugins:          # "module.path:ClassName"
+            top = plugin_spec.partition(":")[0].split(".")[0]
+            if top in sys.modules:
+                yield top
+
+
+def hot_load_installed(application, manager, dist_name, diff) -> bool:
+    """Register + enable a just-installed distribution's plugin groups on the
+    live application.
+
+    GUI THREAD ONLY: mutates the manager's traits and fires the
+    TASK_EXTENSIONS delta that LiveTaskExtensionsController reconciles into
+    mounted dock panes.
+
+    Returns True when the plugin is live and no relaunch is needed; False
+    means the caller must offer the relaunch prompt."""
+    try:
+        return _hot_load_installed(application, manager, dist_name, diff)
+    except Exception:
+        logger.exception(
+            f"hot-load of '{dist_name}' failed; falling back to relaunch")
+        return False
+
+
+def _hot_load_installed(application, manager, dist_name, diff):
+    if diff is None or not diff.is_pure_addition:
+        logger.info(f"hot-load refused for '{dist_name}': the env change is "
+                    f"not purely additive")
+        return False
+
+    # The metadata cache is mtime-keyed and would self-invalidate, but the
+    # FileFinder / sys.path_importer_cache layer that enable()'s
+    # import_module goes through is not.
+    importlib.invalidate_caches()
+
+    norm = PluginGroupManager._norm_dist
+    mine = [(m, d) for m, d in discover_entry_point_manifests()
+            if norm(d) == norm(dist_name)]
+    if not mine:
+        logger.warning(
+            f"hot-load refused: no manifest discovered for '{dist_name}'")
+        return False
+
+    for manifest, _ in mine:
+        live = sorted(set(_live_modules(manifest)))
+        if live:
+            logger.info(f"hot-load refused for '{dist_name}': modules already "
+                        f"imported: {live}")
+            return False
+
+    names = []
+    try:
+        for manifest, dist in mine:
+            manager.register_manifest(manifest, dist_name=dist)
+            names += [g.name for g in manifest.groups]
+    except RuntimeError as e:
+        logger.warning(f"hot-load refused for '{dist_name}': {e}")
+        return False
+
+    # apply() rather than enable(): it is the public reconcile entry point AND
+    # it persists the enabled flag, so a hot-installed plugin comes back on
+    # the next launch exactly like a toggled one.
+    manager.apply(application, {n: True for n in names})
+
+    not_loaded = [n for n in names if not manager.is_loaded(n)]
+    if not_loaded:
+        logger.warning(f"hot-load of '{dist_name}' left groups unloaded: "
+                       f"{not_loaded}; relaunch needed")
+        return False
+
+    logger.info(f"hot-loaded '{dist_name}': enabled groups {names}")
+    return True
+```
+
+- [ ] **Step 4: Add `register_manifest` to the interface**
+
+In `plugin_management/i_plugin_group_manager.py`, add after the `groups` trait and before `is_loaded`:
+
+```python
+    def register_manifest(self, manifest, dist_name="") -> None:
+        """Register a freshly-installed manifest's groups at runtime. Raises
+        if a colliding group name is currently loaded."""
+```
+
+- [ ] **Step 5: Syntax-check only**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/hot_load.py plugin_management/i_plugin_group_manager.py plugin_management/tests/test_hot_load.py
+```
+Expected: no output. Do **not** run pytest — not this file, not the suite.
+
+- [ ] **Step 6: Re-read hot_load.py against the spec**
+
+Since nothing is executed, this read is the only correctness check available.
+Confirm by eye, against
+`docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md` §3-§4:
+the gate refuses a non-pure-addition diff *before* any import work; the
+`sys.modules` guard runs *before* `register_manifest`; `apply()` is used
+rather than `enable()`; and the `is_loaded` check runs after `apply()`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add plugin_management/hot_load.py plugin_management/i_plugin_group_manager.py plugin_management/tests/test_hot_load.py
+git commit -m "feat(plugin_management): add hot-load gate and guard"
+```
+
+---
+
+### Task 4: Wire the controllers
+
+**Files:**
+- Modify: `plugin_management/relaunch.py`
+- Modify: `plugin_management/browse_controller.py:77-95`
+- Modify: `plugin_management/manage_controller.py:151-196`
+- Modify: `plugin_management/manage_model.py:174-199`
+- Test: `plugin_management/tests/test_relaunch.py` (create)
+
+**Interfaces:**
+- Consumes: `hot_load.hot_load_installed(application, manager, dist_name, diff) -> bool` (Task 3); `EnvChangeResult.diff` / `.requires_relaunch` (Task 2); `relaunch.confirm_and_relaunch(task, msg_html)` (existing); `information(parent, message, title)` from `microdrop_application.dialogs.pyface_wrapper` (existing); `IPluginGroupManager` (existing service interface).
+- Produces: `relaunch.finish_change(task, msg_html, ok) -> None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `plugin_management/tests/test_relaunch.py`:
+
+```python
+"""finish_change picks the right ending: a plain confirmation when the change
+is already live, the relaunch offer when it is not."""
+from plugin_management import relaunch
+
+
+def test_finish_change_informs_when_already_live(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(relaunch, "information",
+                        lambda **kw: seen.update(kw))
+    monkeypatch.setattr(relaunch, "confirm_and_relaunch",
+                        lambda *a: seen.update(relaunched=True))
+
+    relaunch.finish_change(None, "Installed and enabled <b>X</b>.", True)
+
+    assert seen["message"] == "Installed and enabled <b>X</b>."
+    assert "relaunched" not in seen
+
+
+def test_finish_change_offers_relaunch_when_not_live(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(relaunch, "information",
+                        lambda **kw: seen.update(informed=True))
+    monkeypatch.setattr(relaunch, "confirm_and_relaunch",
+                        lambda task, msg: seen.update(msg=msg))
+
+    relaunch.finish_change(None, "Installed <b>X</b>.", False)
+
+    assert seen["msg"] == "Installed <b>X</b>."
+    assert "informed" not in seen
+```
+
+- [ ] **Step 2: Do not run the test**
+
+Skip execution (see Global Constraints). For reference, it would fail with
+`AttributeError: module 'plugin_management.relaunch' has no attribute
+'finish_change'`.
+
+- [ ] **Step 3: Add `finish_change` to `relaunch.py`**
+
+Append to `plugin_management/relaunch.py`:
+
+```python
+def finish_change(task, msg_html, ok):
+    """Report the outcome of an env change. ``ok`` means it is already live —
+    say so and stop. Otherwise fall back to the standard relaunch offer."""
+    if ok:
+        information(parent=None, title="Plugin ready", message=msg_html)
+        return
+    confirm_and_relaunch(task, msg_html)
+```
+
+- [ ] **Step 4: Do not run the test**
+
+Skip execution. Syntax-check instead:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/relaunch.py plugin_management/tests/test_relaunch.py
+```
+Expected: no output.
+
+- [ ] **Step 5: Wire `browse_controller.py`**
+
+Replace the import on line 20:
+
+```python
+from plugin_management.hot_load import hot_load_installed
+from plugin_management.i_plugin_group_manager import IPluginGroupManager
+from plugin_management.relaunch import finish_change
+```
+
+Replace the `run_with_wait(...)` block at the end of `install_selected` with:
+
+```python
+        run_with_wait(
+            lambda: model.do_install(pkg.name, pkg.version),
+            title="Installing plugin",
+            message=f"Installing {pkg.name} {pkg.version}…",
+            on_success=lambda r: self._finish_install(pkg, r),
+            on_error=lambda e: error_dialog(
+                parent=None, title="Install failed", message=str(e)))
+```
+
+Add these two methods to `BrowsePluginsHandler`:
+
+```python
+    def _finish_install(self, pkg, result):
+        """GUI thread: try to apply the install live, then report."""
+        ok = self._hot_load(pkg.name, result)
+        name = escape_html_multiline(pkg.name)
+        version = escape_html_multiline(pkg.version)
+        verb = "Installed and enabled" if ok else "Installed"
+        finish_change(self.task, f"{verb} <b>{name}</b> {version}.", ok)
+
+    def _hot_load(self, dist_name, result):
+        """False (relaunch) whenever the live application or its group manager
+        is unreachable — e.g. the standalone installer demo."""
+        application = getattr(
+            getattr(self.task, "window", None), "application", None)
+        if application is None:
+            return False
+        manager = application.get_service(IPluginGroupManager)
+        if manager is None:
+            return False
+        return hot_load_installed(application, manager, dist_name, result.diff)
+```
+
+- [ ] **Step 6: Wire `manage_model.py`**
+
+Add `return` to the three worker methods so the controller's `on_success(r)` receives the result:
+
+```python
+    def do_install_version(self, dist_name, version):
+        """Install a specific version of a package (version dropdown select)."""
+        return package_installer.install_from_channel(dist_name, version=version)
+
+    def do_upgrade(self, dist_name):
+        """Upgrade a package to the latest channel version (upgrade button)."""
+        return package_installer.upgrade_package(dist_name)
+
+    def do_uninstall(self, dist_name):
+        """Worker-thread safe: remove the package (no trait mutation)."""
+        return package_installer.uninstall_package(dist_name)
+```
+
+- [ ] **Step 7: Wire `manage_controller.py`**
+
+Replace the import on line 35 (`from .relaunch import confirm_and_relaunch`) with:
+
+```python
+from .hot_load import hot_load_installed
+from .relaunch import finish_change
+```
+
+Replace `_after_change` (lines 204-205) with:
+
+```python
+    def _hot_load(self, dist_name, result):
+        """GUI thread: try to apply an install live. The model already holds
+        the application and the group manager."""
+        return hot_load_installed(self.model.application, self.model.manager,
+                                  dist_name, result.diff)
+```
+
+In `_prompt_install_version`, replace the `done=` callback with:
+
+```python
+                  done=lambda r: (self.model.refresh_installed(),
+                                  finish_change(
+                                      self.task,
+                                      f"Installed <b>{_esc(label)}</b> "
+                                      f"{_esc(new_version)}.",
+                                      self._hot_load(dist, r))))
+```
+
+In `_on_upgrade`, replace the `done=` callback with:
+
+```python
+                  done=lambda r: (self.model.refresh_installed(),
+                                  finish_change(
+                                      self.task,
+                                      f"Upgraded <b>{_esc(label)}</b>.",
+                                      self._hot_load(dist, r))))
+```
+
+In `_on_uninstall`, replace the `done=` callback with (no hot-load call —
+`pre_uninstall` already unloaded the groups and there is nothing to import):
+
+```python
+                  done=lambda r: (self.model.refresh_installed(),
+                                  finish_change(
+                                      self.task,
+                                      f"Uninstalled <b>{_esc(label)}</b>.",
+                                      not r.requires_relaunch)))
+```
+
+- [ ] **Step 8: Verify no stale relaunch wiring remains**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && grep -rn "confirm_and_relaunch\|_after_change" --include=*.py plugin_management/
+```
+Expected: matches ONLY in `relaunch.py` (the definition and `finish_change`'s fallback) and `update_controller.py` (deliberately untouched). No matches in `browse_controller.py` or `manage_controller.py`.
+
+- [ ] **Step 9: Syntax-check only**
+
+Run:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/relaunch.py plugin_management/browse_controller.py plugin_management/manage_controller.py plugin_management/manage_model.py plugin_management/tests/test_relaunch.py
+```
+Expected: no output. Do **not** run pytest.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add plugin_management/relaunch.py plugin_management/browse_controller.py plugin_management/manage_controller.py plugin_management/manage_model.py plugin_management/tests/test_relaunch.py
+git commit -m "feat(plugin_management): hot-load installs, skip relaunch"
+```
+
+---
+
+### Task 5: Manual verification — PERFORMED BY THE OWNER, NOT BY AN AGENT
+
+**Agents: do not execute this task.** Do not launch the app, do not run
+pytest. Stop after Task 4, report what was written and that none of it has
+been run, and hand these steps to the owner.
+
+Nothing in Tasks 1-4 has been executed, so this is the *only* correctness
+gate the change gets. The owner may also want to run the unit suite once here:
+`cd microdrop-py && pixi run bash -c "cd src && QT_QPA_PLATFORM=offscreen pytest plugin_management/tests/ -v"`.
+
+**Prerequisite:** Redis must be running (`redis-server`, or `python examples/start_redis_server.py`).
+
+- [ ] **Step 1: Launch the app**
+
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run microdrop
+```
+
+- [ ] **Step 2: Fresh install takes the fast path**
+
+Tools → Browse Plugins → select `heater-microdrop-plugin` (not currently installed) → Install → accept the consent dialog.
+
+Expected: a **"Plugin ready"** dialog reading "Installed and enabled …", **no relaunch prompt**, and the heater dock pane + menu entries appear without restarting. The log shows `hot-loaded 'heater-microdrop-plugin': enabled groups [...]`.
+
+- [ ] **Step 3: Uninstall takes the fast path**
+
+Tools → Manage Plugins → uninstall the heater plugin.
+
+Expected: **no relaunch prompt**; the pane disappears.
+
+- [ ] **Step 4: Reinstall in the same session is REFUSED (the key case)**
+
+Without restarting, Browse Plugins → install `heater-microdrop-plugin` again.
+
+Expected: **a relaunch prompt**. The log shows `hot-load refused for 'heater-microdrop-plugin': modules already imported: ['peripheral_controller']`. This proves the `sys.modules` guard — if this silently hot-loads instead, the guard is broken and the plan must not be marked complete.
+
+- [ ] **Step 5: Upgrade is REFUSED**
+
+Manage Plugins → upgrade `magnet-microdrop-plugin`.
+
+Expected: **a relaunch prompt**; the log shows the refusal naming the changed package.
+
+- [ ] **Step 6: Record the outcome**
+
+Report each step's actual result. If any step deviates, stop and report rather than marking the plan complete.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| §1 Env snapshot + diff | Task 1 |
+| §1 `EnvChangeResult` rename, uninstall failure contract, model methods return | Tasks 2, 4 |
+| §2 Gate rules (install pure-addition / uninstall pure-removal) | Tasks 2 (rules), 3 (enforcement) |
+| §3 Hot-load orchestration + `apply()` + `is_loaded` check | Task 3 |
+| §4 `sys.modules` guard | Task 3 |
+| §5 Error handling (snapshot failure, broad except, known `enable()` gap) | Tasks 2, 3 |
+| §6 Threading (worker installs, GUI-thread hot-load) | Task 4 |
+| §7 `finish_change` + controller integration; `update_controller` untouched | Task 4 |
+| §7 `register_manifest` on `IPluginGroupManager` | Task 3 |
+| Testing (unit) | Tasks 1-4 |
+| Testing (manual) | Task 5 |
+
+No spec requirement is unimplemented.
+
+**Type consistency:** `EnvDiff(added, changed, removed)` and its `is_pure_addition` / `is_pure_removal` properties are used identically in Tasks 1, 2 and 3. `EnvChangeResult(name, diff, requires_relaunch)` is produced in Task 2 and consumed as `r.diff` / `r.requires_relaunch` in Task 4. `hot_load_installed(application, manager, dist_name, diff)` is defined in Task 3 and called with that exact argument order in Task 4.

--- a/docs/superpowers/plans/2026-07-16-plugin-hot-load.md
+++ b/docs/superpowers/plans/2026-07-16-plugin-hot-load.md
@@ -19,21 +19,25 @@
 - **Logging:** `from logger.logger_service import get_logger` then `logger = get_logger(__name__)`.
 - **Commits:** Conventional Commits — `type(scope): subject`, imperative, ~50 chars including the prefix. Scope is `plugin_management`.
 - **Never mint a new name when an existing one expresses it.** Reuse `_norm_dist`, `apply()`, `run_with_wait`, `confirm_and_relaunch`.
-- **DO NOT RUN ANY TESTS.** Not pytest, not the app. The project owner runs
-  every test manually and has explicitly asked that agents never invoke them.
-  Write the test code exactly as specified, commit it, and move on. Never
-  `pixi run pytest`, `python -m pytest`, or launch `pixi run microdrop`.
-- **Consequence to respect, not paper over:** because nothing is executed, no
-  task's tests are verified. Do not write "tests pass", "verified", or
-  "working" in any commit message, summary, or report. Say what you wrote and
-  that it is unrun. The only real gate is Task 5, which the owner performs.
-- **Syntax check instead** (this is not a test run, and is the one command you
-  may use to catch typos):
+- **TEST POLICY (standing owner preference, used on the four prior features
+  in this repo):** **NEVER run pytest** and **never launch the app**
+  (`pixi run microdrop`). Write the test files exactly as specified and commit
+  them — they are deliverables the owner runs manually.
+- **Verify with py_compile + a headless logic smoke instead.** This is the
+  established pattern here and it is how you check your work:
   ```bash
+  # syntax
   cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile <files you touched>
+  # logic smoke — real execution, no pytest
+  cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c '<exercise the function, print the result>'"
   ```
-  `py_compile` works with a bare `python` because it never imports numpy. Any
-  *real* execution would need `pixi run` — but you are not doing any.
+  Always go through `pixi run` for smokes — a bare `python` crashes on
+  `import numpy` (`0xc06d007f`) because the env's DLL dirs are off PATH.
+  `py_compile` is the exception: it never imports numpy, so bare `python` is fine.
+- **Report honestly.** A smoke is not the test suite. Never write "tests
+  pass", "verified", or "all green" in a commit message or report — say what
+  the smoke printed and that pytest was not run. The committed test files are
+  **unrun**; Task 5 (owner-performed) is the real gate.
 
 ## File Structure
 
@@ -232,13 +236,33 @@ def diff_snapshots(before, after) -> EnvDiff:
     return EnvDiff(added=added, changed=changed, removed=removed)
 ```
 
-- [ ] **Step 4: Syntax-check only**
+- [ ] **Step 4: Syntax check + logic smoke (never pytest)**
 
-Run:
 ```bash
 cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/package_installer.py plugin_management/tests/test_env_diff.py
 ```
-Expected: no output. Do **not** run pytest.
+Expected: no output.
+
+Then exercise the diff for real:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c \"
+from plugin_management.package_installer import diff_snapshots
+before = {'numpy': ('2.1', 'b0', 'conda'), 'gone': ('1.0', 'b0', 'conda')}
+after  = {'numpy': ('2.1', 'b1', 'conda'), 'new': ('1.0', 'b0', 'conda')}
+d = diff_snapshots(before, after)
+print('added', d.added); print('changed', d.changed); print('removed', d.removed)
+print('pure_addition', d.is_pure_addition, 'pure_removal', d.is_pure_removal)
+\""
+```
+Expected exactly:
+```
+added {'new': '1.0'}
+changed {'numpy': ('2.1', '2.1')}
+removed {'gone': '1.0'}
+pure_addition False pure_removal False
+```
+The `changed` entry proves a build-only bump is caught. If it is absent, the
+comparison is on version alone and the gate is unsafe — fix before committing.
 
 - [ ] **Step 5: Commit**
 
@@ -803,13 +827,37 @@ In `plugin_management/i_plugin_group_manager.py`, add after the `groups` trait a
         if a colliding group name is currently loaded."""
 ```
 
-- [ ] **Step 5: Syntax-check only**
+- [ ] **Step 5: Syntax check + logic smoke (never pytest)**
 
-Run:
 ```bash
 cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py/src" && python -m py_compile plugin_management/hot_load.py plugin_management/i_plugin_group_manager.py plugin_management/tests/test_hot_load.py
 ```
-Expected: no output. Do **not** run pytest — not this file, not the suite.
+Expected: no output.
+
+Then prove the two refusal paths without any plugin installed:
+```bash
+cd "C:/Users/Info/PycharmProjects/pixi-microdrop/microdrop-py" && pixi run bash -c "cd src && python -c \"
+from plugin_management import hot_load
+from plugin_management.package_installer import EnvDiff
+from plugin_management.manifest import manifest_from_dict
+bumped = EnvDiff(added={'p': '1'}, changed={'numpy': ('2.1','2.2')}, removed={})
+print('bumped dep ->', hot_load.hot_load_installed(None, None, 'p', bumped))
+print('diff None  ->', hot_load.hot_load_installed(None, None, 'p', None))
+m = manifest_from_dict({'schema_version': 1, 'name': 'x', 'packages': ['plugin_management'],
+    'groups': [{'name': 'g', 'plugins': ['plugin_management.tests.z:C'],
+                'enabled_key': 'plugin_group_enabled.g'}]})
+print('live modules ->', list(hot_load._live_modules(m)))
+\""
+```
+Expected exactly:
+```
+bumped dep -> False
+diff None  -> False
+live modules -> ['plugin_management']
+```
+Both refusals must return before touching `application`/`manager` (both passed
+as `None` here) — if either raises `AttributeError`, the gate is checking in
+the wrong order. `live modules` proves the guard keys on the ROOT package.
 
 - [ ] **Step 6: Re-read hot_load.py against the spec**
 

--- a/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
+++ b/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
@@ -163,11 +163,25 @@ The asymmetry is deliberate:
   already disabled and deregistered the affected groups, and orphaned
   dependencies will not be re-imported by anything.
 
-**Consequence, stated plainly:** upgrade, install-version, and update-all
-will *always* relaunch, because the plugin's own version change lands in
-`changed`. The fast path realistically fires for exactly two flows — fresh
-install of a new plugin, and clean uninstall. This is a smaller win than
-"no more relaunches", and it is the intended, conservative scope.
+**Consequence, stated plainly:** install-version and update-all will
+*always* relaunch, because the plugin's own version change lands in
+`changed`. **Upgrade is different, and the reasoning is one layer thinner
+than the other two flows.** The upgrade glyph is unconditional on every row
+(`installed_table.py:48-49`) — it can fire on a plugin that is already at
+the latest channel version, in which case the unpinned `pixi add` re-resolves
+to nothing and yields an *empty* `EnvDiff`, which passes `is_pure_addition`
+(the first gate) trivially. What actually stops the fast path in that case
+is the **second, independent gate**: `PluginGroupManager.adopt_running`
+(`group_manager.py:198-201`) resolves every registered group's every plugin
+spec via `_resolve_plugin_class` (i.e. `import_module`) at launch, so by the
+time Manage is open, every installed plugin's top-level module is already
+sitting in `sys.modules` — and `_live_modules` trips, refusing the hot-load.
+The fast path realistically fires for exactly two flows — fresh install of a
+new plugin, and clean uninstall — but for upgrade specifically that is a
+genuine defense-in-depth result (two gates, not one) rather than the
+`changed`-always-populated invariant the paragraph above states for the
+other two flows. This is a smaller win than "no more relaunches", and it is
+the intended, conservative scope.
 
 ### 3. Hot-load (`hot_load.py`, new)
 
@@ -183,8 +197,10 @@ def hot_load_installed(application, manager, dist_name, diff) -> bool:
             if norm(d) == norm(dist_name)]
     if not mine:
         return False                       # discovered nothing -> be conservative
-    if any(_live_modules(m) for m, _ in mine):
-        return False                       # stale sys.modules -> relaunch
+    for manifest, _ in mine:
+        live = sorted(set(_live_modules(manifest)))
+        if live:
+            return False                   # stale sys.modules -> relaunch
     names = []
     try:
         for manifest, dist in mine:

--- a/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
+++ b/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
@@ -3,9 +3,10 @@
 **Date:** 2026-07-16
 **Scope:** `plugin_management` only — new `hot_load.py`; snapshot/diff
 helpers + `EnvChangeResult` in `package_installer.py`; `register_manifest`
-added to `i_plugin_group_manager.py`; the four `confirm_and_relaunch` call
-sites in `browse_controller.py` / `manage_controller.py` /
-`update_controller.py` routed through one `finish_change(...)` helper.
+added to `i_plugin_group_manager.py`; the three `confirm_and_relaunch` call
+sites in `browse_controller.py` / `manage_controller.py` routed through one
+`finish_change(...)` helper. `update_controller.py` is deliberately **not**
+touched (see §7).
 **Goal:** after a plugin package is installed or removed, decide from a
 `pixi list --json` diff whether the change is safe to apply to the live
 interpreter. When it is, re-discover entry points, register the new
@@ -317,12 +318,19 @@ simply fail it on the first line and cost nothing:
   returns `False` immediately and behaviour is unchanged. Routing them
   through the same code keeps one path and means a future loosening of the
   gate needs no new wiring.
-- `update_controller` — update-all; same two calls, always `changed`, always
-  relaunch.
-- `manage_controller._on_uninstall` — the one exception. `pre_uninstall`
-  still runs first, then `finish_change(task, msg, not r.requires_relaunch)`
-  with **no** `hot_load_installed` call, because uninstall imports nothing
-  and has nothing to register.
+- `manage_controller._on_uninstall` — `pre_uninstall` still runs first, then
+  `finish_change(task, msg, not r.requires_relaunch)` with **no**
+  `hot_load_installed` call, because uninstall imports nothing and has
+  nothing to register.
+
+**`update_controller` is left untouched**, and this is the one place the
+"uniform" rule does not apply. `update_model.do_update_all` loops over
+several packages and returns `(succeeded, failed)` — lists of *names*, not
+an `EnvChangeResult` — so routing it through `finish_change` would mean
+reshaping its return type. It would buy nothing: update-all only ever
+updates *already-installed* plugins, so its diff always contains `changed`
+and it can never take the fast path. It keeps calling
+`confirm_and_relaunch` directly.
 
 `register_manifest` is added to `IPluginGroupManager`
 (`i_plugin_group_manager.py`), which currently declares only `is_loaded` /

--- a/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
+++ b/docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md
@@ -1,0 +1,382 @@
+# Plugin Hot-Load Without Relaunch — Design
+
+**Date:** 2026-07-16
+**Scope:** `plugin_management` only — new `hot_load.py`; snapshot/diff
+helpers + `EnvChangeResult` in `package_installer.py`; `register_manifest`
+added to `i_plugin_group_manager.py`; the four `confirm_and_relaunch` call
+sites in `browse_controller.py` / `manage_controller.py` /
+`update_controller.py` routed through one `finish_change(...)` helper.
+**Goal:** after a plugin package is installed or removed, decide from a
+`pixi list --json` diff whether the change is safe to apply to the live
+interpreter. When it is, re-discover entry points, register the new
+manifest's groups and enable them so dock panes/menus appear immediately —
+no relaunch. When it is not, fall back to today's relaunch prompt.
+**Related:** Microdrop issue #491 (plugin-management improvements).
+
+**Baseline note:** this design assumes the *working tree* state of
+`package_installer.py`, not `HEAD`. The uncommitted `_run(["install"])`
+calls in `install_from_channel` and `uninstall_package` are load-bearing
+here (they are what makes the env on disk match the lock before we diff),
+as are the uncommitted `relaunch.py` changes to the `pixi run microdrop`
+task form.
+
+## Existing infrastructure (reused, not rebuilt)
+
+- `package_installer.install_from_channel(name, version=None)` — registers
+  the channel, `pixi add`, `pixi install`, with pyproject/lock
+  snapshot+rollback on failure.
+- `package_installer.uninstall_package(name)` — `pixi remove` + `pixi
+  install`, best-effort.
+- `package_installer._run(args, cwd=...)` — the pixi subprocess wrapper;
+  raises `InstallError` on non-zero exit.
+- `entry_point_discovery.discover_entry_point_manifests()` — pure,
+  stateless, imports no plugin code; returns `[(PluginManifest, dist_name)]`.
+  Safe to re-run at any time.
+- `PluginGroupManager.register_manifest(manifest, dist_name)` — splices a
+  freshly-installed manifest's groups into the live registry without
+  clobbering loaded ones; raises if a colliding group name is loaded.
+  **Currently has no production caller** — this design supplies it.
+- `PluginGroupManager.apply(application, desired)` — reconciles group load
+  state, calls `enable()`/`disable()`, and persists the enabled flag.
+- `PluginGroupManager._norm_dist(name)` — normalises case and `_`/`-` so
+  conda `magnet-microdrop-plugin` matches dist `magnet_microdrop_plugin`.
+- `PluginGroupManager.enable()` — resolves `"module:Class"` specs via
+  `importlib.import_module`, `add_plugin` + `start_plugin` on the live
+  application, snapshot-diffs the service registry to capture runtime
+  service ids.
+- `LiveTaskExtensionsController` — reactively mounts/unmounts dock panes and
+  rebuilds the menu bar when `TASK_EXTENSIONS` change. The hot-load path
+  never touches the view layer; this controller does it.
+- `manage_model.pre_uninstall(manifest_name)` — disables + deregisters a
+  plugin's groups *before* its package is removed.
+- `run_with_wait(work, on_success=..., on_error=...)` — worker thread for
+  `work`, callbacks marshalled to the GUI thread.
+- `relaunch.confirm_and_relaunch(task, msg_html)` — the standard
+  "relaunch now / later" popup.
+
+## Why this is possible at all
+
+`pixi install` writes into `.pixi/envs/default/Lib/site-packages`, which is
+the same prefix the running interpreter imports from when the app is
+launched via `pixi run microdrop` (the `microdrop` task in
+`pyproject.toml`). `relaunch_app` re-execs into *that same environment* — so
+the relaunch changes nothing about the env, it only obtains a fresh
+interpreter. The relaunch exists solely to dodge the in-process import
+problem.
+
+`relaunch.py`'s stated rationale ("a live interpreter can't safely import
+packages added mid-run") is too broad. Importing a *brand-new* package into
+a live interpreter is fine, and `enable()` already does exactly that today
+for never-before-imported plugin code when a group is toggled on. The
+genuinely unsafe cases are *upgrading* or *removing* an already-imported
+package: stale modules in `sys.modules`, live objects of old classes, and
+on Windows, replacement of loaded `.pyd`/`.dll` files.
+
+`importlib.metadata`'s `FastPath.lookup` is keyed on the directory's
+`st_mtime`, so a newly installed `.dist-info` self-invalidates and
+`entry_points()` would see it without help. We still call
+`importlib.invalidate_caches()` — it is needed for the `FileFinder` /
+`sys.path_importer_cache` layer that `enable()`'s `import_module` goes
+through, and it closes the same-mtime-tick gap on coarse filesystems.
+
+## Design
+
+### 1. Env snapshot + diff (`package_installer.py`)
+
+```python
+def env_snapshot(*, cwd=None) -> dict:
+    """{name: (version, build, kind)} from `pixi list --json`.
+
+    Defaults to the platform best matching this machine, which is the
+    platform the running interpreter is using."""
+    proc = _run(["list", "--json"], cwd=cwd)
+    return {r["name"]: (r["version"], r["build"], r["kind"])
+            for r in json.loads(proc.stdout)}
+```
+
+```python
+@dataclass(frozen=True)
+class EnvDiff:
+    added: dict     # name -> version
+    changed: dict   # name -> (old_version, new_version)
+    removed: dict   # name -> version
+
+    @property
+    def is_pure_addition(self):
+        return not self.changed and not self.removed
+
+    @property
+    def is_pure_removal(self):
+        return not self.changed and not self.added
+```
+
+`diff_snapshots(before, after) -> EnvDiff` compares the full
+`(version, build)` tuple, so a rebuild at the same version counts as
+`changed`.
+
+`InstallResult` is **renamed `EnvChangeResult`** — it is now returned by
+uninstall as well as install:
+
+```python
+@dataclass
+class EnvChangeResult:
+    name: str
+    diff: EnvDiff | None       # None when snapshotting failed
+    requires_relaunch: bool
+```
+
+`install_from_channel` snapshots around its existing pixi calls and returns
+`requires_relaunch = not (diff and diff.is_pure_addition)`.
+`uninstall_package` — which currently returns `None` — returns the same
+dataclass with `requires_relaunch = not (diff and diff.is_pure_removal)`.
+
+`uninstall_package` currently *swallows* `InstallError` (logs a warning and
+returns). It keeps that contract: on a failed `pixi remove` it returns
+`EnvChangeResult(name, diff=None, requires_relaunch=True)`, so a failed
+uninstall degrades to the relaunch prompt rather than silently claiming the
+fast path.
+
+Both snapshot calls are individually wrapped so a snapshot failure can never
+break the install (see §5).
+
+The three worker-thread model methods that currently discard the installer's
+return value — `manage_model.do_install_version`, `do_upgrade`, and
+`do_uninstall` — must `return` the `EnvChangeResult` so the controller's
+`on_success(r)` can read `r.diff`.
+
+### 2. The gate rules
+
+| Flow | Safe when | Rule |
+|---|---|---|
+| install / install-version / upgrade / update-all | pure additions | `not diff.is_pure_addition` → relaunch |
+| uninstall | pure removals | `not diff.is_pure_removal` → relaunch |
+
+The asymmetry is deliberate:
+
+- **`changed` is unsafe in both directions** — new files on disk underneath
+  live modules in memory.
+- **A removal during *install*** means the solver dropped a package to
+  satisfy the new plugin. Its modules may be live *and still in use by a
+  running plugin*. Unsafe.
+- **A removal during *uninstall*** is the entire point. `pre_uninstall` has
+  already disabled and deregistered the affected groups, and orphaned
+  dependencies will not be re-imported by anything.
+
+**Consequence, stated plainly:** upgrade, install-version, and update-all
+will *always* relaunch, because the plugin's own version change lands in
+`changed`. The fast path realistically fires for exactly two flows — fresh
+install of a new plugin, and clean uninstall. This is a smaller win than
+"no more relaunches", and it is the intended, conservative scope.
+
+### 3. Hot-load (`hot_load.py`, new)
+
+```python
+def hot_load_installed(application, manager, dist_name, diff) -> bool:
+    """True if the plugin was registered + enabled live.
+    False means the caller must fall back to the relaunch prompt."""
+    if diff is None or not diff.is_pure_addition:
+        return False
+    importlib.invalidate_caches()
+    norm = PluginGroupManager._norm_dist          # existing static, see below
+    mine = [(m, d) for m, d in discover_entry_point_manifests()
+            if norm(d) == norm(dist_name)]
+    if not mine:
+        return False                       # discovered nothing -> be conservative
+    if any(_live_modules(m) for m, _ in mine):
+        return False                       # stale sys.modules -> relaunch
+    names = []
+    try:
+        for manifest, dist in mine:
+            manager.register_manifest(manifest, dist_name=dist)
+            names += [g.name for g in manifest.groups]
+    except RuntimeError:                   # colliding group currently loaded
+        return False
+    manager.apply(application, {n: True for n in names})
+    if not all(manager.is_loaded(n) for n in names):
+        return False                       # imports failed -> relaunch may help
+    return True
+```
+
+It goes through `manager.apply(...)` rather than calling `enable()` directly
+because `apply()` is the existing public reconcile entry point *and* it
+persists the enabled flag — so a hot-installed plugin survives the next
+launch the same way a toggled one does.
+
+### 4. The `sys.modules` guard
+
+```python
+def _live_modules(manifest):
+    """Top-level modules enable() would import that are already loaded."""
+    for spec in manifest.groups:
+        for plugin_spec in spec.plugins:          # "module.path:ClassName"
+            top = plugin_spec.partition(":")[0].split(".")[0]
+            if top in sys.modules:
+                yield top
+```
+
+This guards *exactly* what `_resolve_plugin_class` imports, rather than
+approximating via package names (conda names, python dist names, and module
+names all differ, and native libs map to no dist at all — any mapping-based
+check would silently under-report).
+
+It is **not** redundant with the gate. Two real cases trip it, both of which
+the gate alone reports as "pure addition" and would wrongly wave through:
+
+1. **Reinstall after uninstall in the same session.** Uninstall now takes
+   the fast path and leaves the plugin's modules in `sys.modules`. A
+   subsequent reinstall is a pure addition by the lock, but
+   `import_module` would hand back the *stale* module — silently running
+   the old code while reporting the new version.
+2. **Top-level package collision.** `magnet-microdrop-plugin` ships a
+   top-level `peripheral_controller` package. A second plugin claiming that
+   name while magnet is loaded is correctly refused rather than silently
+   binding to magnet's already-imported module.
+
+### 5. Error handling
+
+Governing principle: **the gate must never break the install.** The package
+is on disk and correct by the time we diff; a failure to *reason* about it
+degrades to today's behaviour, never to a failed install.
+
+- **`env_snapshot()` fails** (pixi non-zero, unparseable JSON). Wrapped in
+  try/except at both call sites → `diff = None` → `requires_relaunch = True`
+  → relaunch prompt. This needs care: `env_snapshot` goes through `_run`,
+  which raises `InstallError`, so an unguarded *before*-snapshot would abort
+  an install that had not started yet.
+- **`hot_load_installed` raises unexpectedly.** Broad try/except inside it;
+  log and return `False` → relaunch. This matches the module's neighbours —
+  `discover_entry_point_manifests`, `enable`, and
+  `LiveTaskExtensionsController` all log-and-continue rather than propagate.
+- **Install rollback** is unchanged: `_snapshot`/`_restore` of
+  `pyproject.toml` + `pixi.lock` still fire on any pixi failure.
+
+**Known gap (accepted, out of scope).** `enable()` swallows per-plugin
+exceptions and sets `group.loaded = True` regardless, so a plugin whose
+class imports fine but whose `start()` throws reports as loaded with no
+pane. That is exactly how it behaves today when toggled on — not a
+regression, and fixing it means changing `enable()`'s contract for the
+existing toggle path. The *fully* unimportable case **is** detectable
+(`enable()` returns early without setting `loaded` when
+`_resolve_plugin_class` fails for every spec) and is caught by the
+`all(manager.is_loaded(n))` check in §3 — that is the one case where
+relaunching is a real remedy rather than superstition.
+
+### 6. Threading
+
+```
+worker thread   (run_with_wait's work fn)
+  before = env_snapshot()
+  pixi add / pixi remove ; pixi install
+  after  = env_snapshot()
+  -> EnvChangeResult(name, diff, requires_relaunch)
+
+GUI thread      (run_with_wait's on_success)
+  ok = hot_load_installed(app, manager, dist, r.diff)
+  finish_change(task, msg_html, ok)
+```
+
+The split is forced, not stylistic: pixi subprocesses must stay off the GUI
+thread, but `hot_load_installed` mutates `PluginGroupManager` traits and
+fires the `TASK_EXTENSIONS` delta that `LiveTaskExtensionsController`
+reconciles, so it must run on the GUI thread. `run_with_wait` already
+provides exactly this split (`on_success` is GUI-thread), so no new
+threading primitive is needed, and the MVC rule that the model is mutated
+only on the GUI thread is preserved.
+
+### 7. Controller integration
+
+One shared helper replaces the four current `confirm_and_relaunch` call
+sites:
+
+```python
+def finish_change(task, msg_html, ok):
+    if ok:
+        information(parent=None, title="Plugin ready", message=msg_html)
+    else:
+        confirm_and_relaunch(task, msg_html)
+```
+
+(`information` / `confirm` / `YES` come from
+`microdrop_application.dialogs.pyface_wrapper`, as `relaunch.py` already
+does — never raw QMessageBox.)
+
+Because the fast path auto-enables, the success message must say so:
+`browse_controller`'s current `"Installed <b>X</b> 1.2.3."` becomes
+`"Installed and enabled <b>X</b> 1.2.3."` on the hot-load branch. The
+relaunch branch keeps today's wording, since nothing is enabled yet.
+
+**Every install path calls `hot_load_installed` uniformly** — no
+special-casing by flow. The gate decides, and paths that can never be safe
+simply fail it on the first line and cost nothing:
+
+- `browse_controller.install_selected` — `on_success` runs
+  `hot_load_installed(...)` then `finish_change(...)`. This is the path that
+  actually takes the fast lane.
+- `manage_controller._prompt_install_version` / `_on_upgrade` — same two
+  calls. Their diffs always contain `changed`, so `hot_load_installed`
+  returns `False` immediately and behaviour is unchanged. Routing them
+  through the same code keeps one path and means a future loosening of the
+  gate needs no new wiring.
+- `update_controller` — update-all; same two calls, always `changed`, always
+  relaunch.
+- `manage_controller._on_uninstall` — the one exception. `pre_uninstall`
+  still runs first, then `finish_change(task, msg, not r.requires_relaunch)`
+  with **no** `hot_load_installed` call, because uninstall imports nothing
+  and has nothing to register.
+
+`register_manifest` is added to `IPluginGroupManager`
+(`i_plugin_group_manager.py`), which currently declares only `is_loaded` /
+`enable` / `disable` / `apply` / `adopt_running` / `restore_persisted`.
+Consumers hold the manager by protocol and cannot reach `register_manifest`
+today.
+
+## Testing
+
+Unit tests in `plugin_management/tests/` — all pure, no Qt, no Envisage, no
+real pixi:
+
+1. `diff_snapshots` classification — added / changed / removed; a
+   **build-only** change (same version, new build) must count as `changed`;
+   both `is_pure_*` properties.
+2. `env_snapshot` parsing — monkeypatch `_run` with a captured
+   `pixi list --json` fixture.
+3. The rule table — pure addition → no relaunch; removal-during-install →
+   relaunch; upgrade (`changed`) → relaunch; pure removal on uninstall → no
+   relaunch.
+4. `_live_modules` — a manifest whose plugin spec module is in `sys.modules`
+   trips the guard.
+5. `hot_load_installed` against a fake manager (reusing the fake-manager
+   pattern in `test_group_manager_adoption.py`) — asserts `register_manifest`
+   + `apply` are called on the happy path, and that each refusal branch
+   returns `False`.
+6. Snapshot failure → `diff is None` → `requires_relaunch is True`, install
+   still reports success.
+
+`test_package_installer.py` currently asserts `result.requires_relaunch is
+True` unconditionally and must be updated to drive it off a mocked diff. It
+also references `InstallResult` by name (rename to `EnvChangeResult`).
+
+**Manual verification** (the real proof — launch via `pixi run microdrop`):
+
+- Browse Plugins → install `heater-microdrop-plugin` (not currently
+  installed) → expect **no** relaunch prompt; pane appears live.
+- Uninstall it → expect **no** relaunch prompt; pane disappears.
+- Reinstall it in the same session → expect **a relaunch prompt** (module
+  guard trips). This is the case that validates the guard and is the most
+  likely to reveal a design error.
+- Upgrade `magnet-microdrop-plugin` → expect **a relaunch prompt**
+  (`changed` non-empty).
+
+## Out of scope
+
+- Loosening the gate to "only relaunch if a changed package is actually
+  imported". Rejected for now: conda names, python dist names and module
+  names diverge, and native libs map to no dist, so any mapping-based check
+  under-reports in the unsafe direction.
+- Making `enable()` report per-plugin start failures (changes the contract
+  for the existing toggle path).
+- Unloading modules on uninstall. Python cannot reliably un-import; the
+  `sys.modules` guard exists precisely because we accept this.
+- Frozen/PyInstaller builds (`src/pyinstaller.spec`): there is no pixi env
+  and `pixi` may not be on PATH, so `install_from_channel` already fails at
+  the `subprocess.run(["pixi", ...])` call. Orthogonal to this change.

--- a/examples/demos/plugin_installed_table_demo.py
+++ b/examples/demos/plugin_installed_table_demo.py
@@ -67,8 +67,8 @@ class DemoManagePluginsModel(ManagePluginsModel):
     def apply(self):
         print("[demo] apply groups:", self.desired())
 
-    def pre_uninstall(self, manifest_name):
-        print(f"[demo] pre_uninstall {manifest_name}")
+    def pre_change(self, manifest_name, dist_name=""):
+        print(f"[demo] pre_change {manifest_name}")
 
     def do_install_version(self, dist_name, version):
         print(f"[demo] would install {dist_name}=={version}")

--- a/examples/demos/plugin_installed_table_demo.py
+++ b/examples/demos/plugin_installed_table_demo.py
@@ -20,6 +20,7 @@ from plugin_management.manage_model import (
     ManagePluginsModel, GroupRow, InstalledPackageRow)
 from plugin_management.manage_view import manage_plugins_view
 from plugin_management.manage_controller import ManagePluginsController
+from plugin_management.package_installer import EnvChangeResult
 
 # Fake channel search result (feeds the version dropdowns via apply_channel_data).
 _FAKE_CHANNEL = [
@@ -71,12 +72,15 @@ class DemoManagePluginsModel(ManagePluginsModel):
 
     def do_install_version(self, dist_name, version):
         print(f"[demo] would install {dist_name}=={version}")
+        return EnvChangeResult(name=dist_name, diff=None, requires_relaunch=True)
 
     def do_upgrade(self, dist_name):
         print(f"[demo] would upgrade {dist_name}")
+        return EnvChangeResult(name=dist_name, diff=None, requires_relaunch=True)
 
     def do_uninstall(self, dist_name):
         print(f"[demo] would uninstall {dist_name}")
+        return EnvChangeResult(name=dist_name, diff=None, requires_relaunch=True)
 
     def do_search_channel(self):
         print("[demo] search channel")

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -217,6 +217,9 @@ class EnumSelectColumn(EditBlankingColumn):
     def make_cell_editor(self, object):
         return self._editor_with_reset(EnumEditor, name=self.values_name)
 
+    def _blank_if_editing(self, value, object):
+        return "" if id(object) == self._editing_id else f"{value} ⌄"
+
 ## --------------------------------------------------------
 # Range editing spinner box with custom increments
 ## --------------------------------------------------------

--- a/plugin_management/browse_controller.py
+++ b/plugin_management/browse_controller.py
@@ -17,7 +17,9 @@ from microdrop_style.button_styles import ICON_FONT_FAMILY
 from microdrop_utils.threaded_progress import run_with_wait
 from microdrop_utils.traitsui_qt_helpers import SafeCancelTableHandler
 
-from plugin_management.relaunch import confirm_and_relaunch
+from plugin_management.hot_load import hot_load_installed
+from plugin_management.i_plugin_group_manager import IPluginGroupManager
+from plugin_management.relaunch import finish_change
 
 #: Point size of the Material Symbols glyph rendered on the Refresh toolbar button.
 REFRESH_ICON_POINT_SIZE = 16
@@ -88,11 +90,29 @@ class BrowsePluginsHandler(SafeCancelTableHandler):
             lambda: model.do_install(pkg.name, pkg.version),
             title="Installing plugin",
             message=f"Installing {pkg.name} {pkg.version}…",
-            on_success=lambda r: confirm_and_relaunch(
-                self.task, f"Installed <b>{escape_html_multiline(pkg.name)}</b> "
-                           f"{escape_html_multiline(pkg.version)}."),
+            on_success=lambda r: self._finish_install(pkg, r),
             on_error=lambda e: error_dialog(
                 parent=None, title="Install failed", message=str(e)))
+
+    def _finish_install(self, pkg, result):
+        """GUI thread: try to apply the install live, then report."""
+        ok = self._hot_load(pkg.name, result)
+        name = escape_html_multiline(pkg.name)
+        version = escape_html_multiline(pkg.version)
+        verb = "Installed and enabled" if ok else "Installed"
+        finish_change(self.task, f"{verb} <b>{name}</b> {version}.", ok)
+
+    def _hot_load(self, dist_name, result):
+        """False (relaunch) whenever the live application or its group manager
+        is unreachable — e.g. the standalone installer demo."""
+        application = getattr(
+            getattr(self.task, "window", None), "application", None)
+        if application is None:
+            return False
+        manager = application.get_service(IPluginGroupManager)
+        if manager is None:
+            return False
+        return hot_load_installed(application, manager, dist_name, result.diff)
 
     def do_close(self, info):
         info.ui.dispose()

--- a/plugin_management/browse_controller.py
+++ b/plugin_management/browse_controller.py
@@ -96,24 +96,28 @@ class BrowsePluginsHandler(SafeCancelTableHandler):
 
     def _finish_install(self, pkg, model, result):
         """GUI thread: try to apply the install live, drop the now-installed
-        row, then report."""
-        ok = self._hot_load(pkg.name, result)
+        row, then report — naming the refusal reason when a relaunch is
+        still needed."""
+        reason = self._hot_load(pkg.name, result)
+        ok = reason is None
         model.drop_installed()
         name = escape_html_multiline(pkg.name)
         version = escape_html_multiline(pkg.version)
         verb = "Installed and enabled" if ok else "Installed"
-        finish_change(self.task, f"{verb} <b>{name}</b> {version}.", ok)
+        finish_change(self.task, f"{verb} <b>{name}</b> {version}.", ok,
+                      reason or "")
 
     def _hot_load(self, dist_name, result):
-        """False (relaunch) whenever the live application or its group manager
-        is unreachable — e.g. the standalone installer demo."""
+        """None when applied live; otherwise the refusal reason. Refuses
+        whenever the live application or its group manager is unreachable —
+        e.g. the standalone installer demo."""
         application = getattr(
             getattr(self.task, "window", None), "application", None)
         if application is None:
-            return False
+            return "no running application to load it into"
         manager = application.get_service(IPluginGroupManager)
         if manager is None:
-            return False
+            return "the plugin-group manager is unavailable"
         return hot_load_installed(application, manager, dist_name, result.diff)
 
     def do_close(self, info):

--- a/plugin_management/browse_controller.py
+++ b/plugin_management/browse_controller.py
@@ -90,13 +90,15 @@ class BrowsePluginsHandler(SafeCancelTableHandler):
             lambda: model.do_install(pkg.name, pkg.version),
             title="Installing plugin",
             message=f"Installing {pkg.name} {pkg.version}…",
-            on_success=lambda r: self._finish_install(pkg, r),
+            on_success=lambda r: self._finish_install(pkg, model, r),
             on_error=lambda e: error_dialog(
                 parent=None, title="Install failed", message=str(e)))
 
-    def _finish_install(self, pkg, result):
-        """GUI thread: try to apply the install live, then report."""
+    def _finish_install(self, pkg, model, result):
+        """GUI thread: try to apply the install live, drop the now-installed
+        row, then report."""
         ok = self._hot_load(pkg.name, result)
+        model.drop_installed()
         name = escape_html_multiline(pkg.name)
         version = escape_html_multiline(pkg.version)
         verb = "Installed and enabled" if ok else "Installed"

--- a/plugin_management/browse_model.py
+++ b/plugin_management/browse_model.py
@@ -122,6 +122,11 @@ class BrowsePluginsModel(HasTraits):
     details_text = Str()
     stale = Bool(False)
 
+    #: The raw channel payload behind ``packages``, kept so the rows can be
+    #: rebuilt against a CHANGED INSTALLED SET without re-fetching. An install
+    #: does not change what the channel offers, only what is already installed.
+    _channel_data = List(Dict)
+
     def fetch_data(self):
         """Worker-thread safe: return (packages, stale). Does NOT touch traits.
         Tries the channel; on failure falls back to the app-data cache."""
@@ -140,7 +145,24 @@ class BrowsePluginsModel(HasTraits):
     def set_packages(self, data, stale):
         """GUI thread: build one row per not-yet-installed package + flags."""
         self.stale = stale
+        self._channel_data = list(data)
         self.packages = self._rows_from(data)
+
+    def drop_installed(self):
+        """GUI thread: rebuild the rows against the CURRENT installed set.
+
+        Call after an install so the package just installed leaves the list.
+        Deliberately does NOT re-fetch: the channel still offers exactly what
+        it did a moment ago — the only thing that changed is what is installed,
+        and ``_rows_from`` re-reads that itself.
+
+        Re-selects by NAME rather than keeping the old object: ``_rows_from``
+        builds fresh AvailablePackage rows every call, so an identity check
+        would drop a selection that is still perfectly valid."""
+        keep = self.selected.name if self.selected else ""
+        self.packages = self._rows_from(self._channel_data)
+        self.selected = next(
+            (p for p in self.packages if p.name == keep), None)
 
     def _rows_from(self, data):
         """One AvailablePackage per channel package name, **excluding packages

--- a/plugin_management/hot_load.py
+++ b/plugin_management/hot_load.py
@@ -29,17 +29,25 @@ from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
 
-def _live_modules(manifest):
-    """Top-level modules ``enable()`` would import that are ALREADY loaded.
+def _live_modules(manifest, already_imported):
+    """Top-level modules ``enable()`` would import that were ALREADY loaded
+    before this install — i.e. stale code we cannot replace in-process.
 
     Keys on exactly what ``group_manager._resolve_plugin_class`` imports,
     rather than mapping package names to modules — conda names, python dist
     names and module names all differ, and native libs map to no dist at all,
-    so any mapping-based check under-reports in the unsafe direction."""
+    so any mapping-based check under-reports in the unsafe direction.
+
+    ``already_imported`` MUST be a snapshot of ``sys.modules`` taken before
+    discovery runs, NOT a live read. ``discover_entry_point_manifests()``
+    resolves each entry point's package data via
+    ``importlib.resources.files(ep.module)``, which *imports that module* — so
+    a live read would report the module discovery itself had just imported and
+    refuse every install. See ``_hot_load_installed``."""
     for spec in manifest.groups:
         for plugin_spec in spec.plugins:          # "module.path:ClassName"
             top = plugin_spec.partition(":")[0].split(".")[0]
-            if top in sys.modules:
+            if top in already_imported:
                 yield top
 
 
@@ -67,6 +75,14 @@ def _hot_load_installed(application, manager, dist_name, diff):
                     f"not purely additive")
         return False
 
+    # Snapshot sys.modules BEFORE discovery. discover_entry_point_manifests()
+    # reads each entry point's package-data manifest via
+    # importlib.resources.files(ep.module), which IMPORTS that module — so a
+    # guard reading sys.modules afterwards would always see the plugin's own
+    # module and refuse every install. What we need to know is what was stale
+    # *before* this install, and only a pre-discovery snapshot answers that.
+    already_imported = set(sys.modules)
+
     # The metadata cache is mtime-keyed and would self-invalidate, but the
     # FileFinder / sys.path_importer_cache layer that enable()'s
     # import_module goes through is not.
@@ -81,7 +97,7 @@ def _hot_load_installed(application, manager, dist_name, diff):
         return False
 
     for manifest, _ in mine:
-        live = sorted(set(_live_modules(manifest)))
+        live = sorted(set(_live_modules(manifest, already_imported)))
         if live:
             logger.info(f"hot-load refused for '{dist_name}': modules already "
                         f"imported: {live}")

--- a/plugin_management/hot_load.py
+++ b/plugin_management/hot_load.py
@@ -15,8 +15,10 @@ Two INDEPENDENT checks gate the fast path:
    pure addition, but ``import_module`` would hand back the stale module and
    silently run the old code under the new version's name.
 
-Anything unexpected returns False and the caller falls back to the relaunch
-prompt — always correct, just slower.
+Anything unexpected refuses, and the caller falls back to the relaunch
+prompt — always correct, just slower. A refusal returns its REASON (a short
+human-readable string, also logged) so the relaunch dialog can say why the
+change could not be applied live instead of looking like arbitrary nagging.
 """
 import importlib
 import sys
@@ -51,7 +53,7 @@ def _live_modules(manifest, already_imported):
                 yield top
 
 
-def hot_load_installed(application, manager, dist_name, diff) -> bool:
+def hot_load_installed(application, manager, dist_name, diff) -> str | None:
     """Register + enable a just-installed distribution's plugin groups on the
     live application.
 
@@ -59,21 +61,31 @@ def hot_load_installed(application, manager, dist_name, diff) -> bool:
     TASK_EXTENSIONS delta that LiveTaskExtensionsController reconciles into
     mounted dock panes.
 
-    Returns True when the plugin is live and no relaunch is needed; False
-    means the caller must offer the relaunch prompt."""
+    Returns None when the plugin is live and no relaunch is needed; otherwise
+    a short human-readable reason the fast path was refused, for the caller
+    to show alongside the relaunch prompt."""
     try:
         return _hot_load_installed(application, manager, dist_name, diff)
     except Exception:
         logger.exception(
             f"hot-load of '{dist_name}' failed; falling back to relaunch")
-        return False
+        return "an unexpected error occurred (see the log)"
+
+
+def _refuse(dist_name, reason):
+    """Log a refusal and return its reason for the relaunch dialog."""
+    logger.info(f"hot-load refused for '{dist_name}': {reason}")
+    return reason
 
 
 def _hot_load_installed(application, manager, dist_name, diff):
-    if diff is None or not diff.is_pure_addition:
-        logger.info(f"hot-load refused for '{dist_name}': the env change is "
-                    f"not purely additive")
-        return False
+    if diff is None:
+        return _refuse(dist_name,
+                       "the environment change could not be determined")
+    if not diff.is_pure_addition:
+        moved = sorted(diff.changed) + sorted(diff.removed)
+        return _refuse(dist_name, f"existing packages were changed or "
+                                  f"removed: {', '.join(moved)}")
 
     # Snapshot sys.modules BEFORE discovery. discover_entry_point_manifests()
     # reads each entry point's package-data manifest via
@@ -92,16 +104,13 @@ def _hot_load_installed(application, manager, dist_name, diff):
     mine = [(m, d) for m, d in discover_entry_point_manifests()
             if norm(d) == norm(dist_name)]
     if not mine:
-        logger.warning(
-            f"hot-load refused: no manifest discovered for '{dist_name}'")
-        return False
+        return _refuse(dist_name, "no plugin manifest was found for it")
 
     for manifest, _ in mine:
         live = sorted(set(_live_modules(manifest, already_imported)))
         if live:
-            logger.info(f"hot-load refused for '{dist_name}': modules already "
-                        f"imported: {live}")
-            return False
+            return _refuse(dist_name, f"{', '.join(live)} is already loaded "
+                                      f"from an earlier install")
 
     names = []
     try:
@@ -109,8 +118,7 @@ def _hot_load_installed(application, manager, dist_name, diff):
             manager.register_manifest(manifest, dist_name=dist)
             names += [g.name for g in manifest.groups]
     except RuntimeError as e:
-        logger.warning(f"hot-load refused for '{dist_name}': {e}")
-        return False
+        return _refuse(dist_name, str(e))
 
     # apply() rather than enable(): it is the public reconcile entry point AND
     # it persists the enabled flag, so a hot-installed plugin comes back on
@@ -119,9 +127,8 @@ def _hot_load_installed(application, manager, dist_name, diff):
 
     not_loaded = [n for n in names if not manager.is_loaded(n)]
     if not_loaded:
-        logger.warning(f"hot-load of '{dist_name}' left groups unloaded: "
-                       f"{not_loaded}; relaunch needed")
-        return False
+        return _refuse(dist_name, f"plugin groups failed to load: "
+                                  f"{', '.join(not_loaded)}")
 
     logger.info(f"hot-loaded '{dist_name}': enabled groups {names}")
-    return True
+    return None

--- a/plugin_management/hot_load.py
+++ b/plugin_management/hot_load.py
@@ -1,0 +1,111 @@
+"""Apply a freshly-installed plugin to the LIVE app instead of relaunching.
+
+``pixi install`` writes into the same site-packages the running interpreter
+imports from, so a brand-new package is importable without a restart —
+``enable()`` already imports never-before-seen plugin code every time a group
+is toggled on. What is NOT safe is upgrading or removing an already-imported
+package: modules cannot be un-imported, live objects keep their old classes,
+and on Windows a loaded .pyd/.dll cannot be replaced.
+
+Two INDEPENDENT checks gate the fast path:
+
+1. The env diff must be purely additive (``EnvDiff.is_pure_addition``).
+2. None of the modules ``enable()`` would import may already be in
+   ``sys.modules``. The diff alone reports a reinstall-after-uninstall as a
+   pure addition, but ``import_module`` would hand back the stale module and
+   silently run the old code under the new version's name.
+
+Anything unexpected returns False and the caller falls back to the relaunch
+prompt — always correct, just slower.
+"""
+import importlib
+import sys
+
+from plugin_management.entry_point_discovery import (
+    discover_entry_point_manifests)
+from plugin_management.group_manager import PluginGroupManager
+from logger.logger_service import get_logger
+
+logger = get_logger(__name__)
+
+
+def _live_modules(manifest):
+    """Top-level modules ``enable()`` would import that are ALREADY loaded.
+
+    Keys on exactly what ``group_manager._resolve_plugin_class`` imports,
+    rather than mapping package names to modules — conda names, python dist
+    names and module names all differ, and native libs map to no dist at all,
+    so any mapping-based check under-reports in the unsafe direction."""
+    for spec in manifest.groups:
+        for plugin_spec in spec.plugins:          # "module.path:ClassName"
+            top = plugin_spec.partition(":")[0].split(".")[0]
+            if top in sys.modules:
+                yield top
+
+
+def hot_load_installed(application, manager, dist_name, diff) -> bool:
+    """Register + enable a just-installed distribution's plugin groups on the
+    live application.
+
+    GUI THREAD ONLY: mutates the manager's traits and fires the
+    TASK_EXTENSIONS delta that LiveTaskExtensionsController reconciles into
+    mounted dock panes.
+
+    Returns True when the plugin is live and no relaunch is needed; False
+    means the caller must offer the relaunch prompt."""
+    try:
+        return _hot_load_installed(application, manager, dist_name, diff)
+    except Exception:
+        logger.exception(
+            f"hot-load of '{dist_name}' failed; falling back to relaunch")
+        return False
+
+
+def _hot_load_installed(application, manager, dist_name, diff):
+    if diff is None or not diff.is_pure_addition:
+        logger.info(f"hot-load refused for '{dist_name}': the env change is "
+                    f"not purely additive")
+        return False
+
+    # The metadata cache is mtime-keyed and would self-invalidate, but the
+    # FileFinder / sys.path_importer_cache layer that enable()'s
+    # import_module goes through is not.
+    importlib.invalidate_caches()
+
+    norm = PluginGroupManager._norm_dist
+    mine = [(m, d) for m, d in discover_entry_point_manifests()
+            if norm(d) == norm(dist_name)]
+    if not mine:
+        logger.warning(
+            f"hot-load refused: no manifest discovered for '{dist_name}'")
+        return False
+
+    for manifest, _ in mine:
+        live = sorted(set(_live_modules(manifest)))
+        if live:
+            logger.info(f"hot-load refused for '{dist_name}': modules already "
+                        f"imported: {live}")
+            return False
+
+    names = []
+    try:
+        for manifest, dist in mine:
+            manager.register_manifest(manifest, dist_name=dist)
+            names += [g.name for g in manifest.groups]
+    except RuntimeError as e:
+        logger.warning(f"hot-load refused for '{dist_name}': {e}")
+        return False
+
+    # apply() rather than enable(): it is the public reconcile entry point AND
+    # it persists the enabled flag, so a hot-installed plugin comes back on
+    # the next launch exactly like a toggled one.
+    manager.apply(application, {n: True for n in names})
+
+    not_loaded = [n for n in names if not manager.is_loaded(n)]
+    if not_loaded:
+        logger.warning(f"hot-load of '{dist_name}' left groups unloaded: "
+                       f"{not_loaded}; relaunch needed")
+        return False
+
+    logger.info(f"hot-loaded '{dist_name}': enabled groups {names}")
+    return True

--- a/plugin_management/hot_load.py
+++ b/plugin_management/hot_load.py
@@ -9,7 +9,10 @@ and on Windows a loaded .pyd/.dll cannot be replaced.
 
 Two INDEPENDENT checks gate the fast path:
 
-1. The env diff must be purely additive (``EnvDiff.is_pure_addition``).
+1. No package OTHER than the target dist itself may change or vanish in the
+   env diff. The target changing itself (an in-place version change) is fine
+   *because of check 2*: callers unload + ``purge_plugin_modules`` the plugin
+   first, so its fresh code is genuinely importable.
 2. None of the modules ``enable()`` would import may already be in
    ``sys.modules``. The diff alone reports a reinstall-after-uninstall as a
    pure addition, but ``import_module`` would hand back the stale module and
@@ -21,6 +24,7 @@ human-readable string, also logged) so the relaunch dialog can say why the
 change could not be applied live instead of looking like arbitrary nagging.
 """
 import importlib
+import importlib.metadata as importlib_metadata
 import sys
 
 from plugin_management.entry_point_discovery import (
@@ -31,14 +35,19 @@ from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
 
+def _top_modules(plugin_specs):
+    """The top-level module of each ``"module.path:ClassName"`` spec — exactly
+    what ``group_manager._resolve_plugin_class`` imports. Derived from the
+    specs rather than by mapping package names to modules — conda names,
+    python dist names and module names all differ, and native libs map to no
+    dist at all, so any mapping-based check under-reports in the unsafe
+    direction."""
+    return {spec.partition(":")[0].split(".")[0] for spec in plugin_specs}
+
+
 def _live_modules(manifest, already_imported):
     """Top-level modules ``enable()`` would import that were ALREADY loaded
     before this install — i.e. stale code we cannot replace in-process.
-
-    Keys on exactly what ``group_manager._resolve_plugin_class`` imports,
-    rather than mapping package names to modules — conda names, python dist
-    names and module names all differ, and native libs map to no dist at all,
-    so any mapping-based check under-reports in the unsafe direction.
 
     ``already_imported`` MUST be a snapshot of ``sys.modules`` taken before
     discovery runs, NOT a live read. ``discover_entry_point_manifests()``
@@ -46,11 +55,61 @@ def _live_modules(manifest, already_imported):
     ``importlib.resources.files(ep.module)``, which *imports that module* — so
     a live read would report the module discovery itself had just imported and
     refuse every install. See ``_hot_load_installed``."""
-    for spec in manifest.groups:
-        for plugin_spec in spec.plugins:          # "module.path:ClassName"
-            top = plugin_spec.partition(":")[0].split(".")[0]
-            if top in already_imported:
-                yield top
+    specs = [p for group in manifest.groups for p in group.plugins]
+    for top in sorted(_top_modules(specs)):
+        if top in already_imported:
+            yield top
+
+
+def _dist_top_modules(dist_name):
+    """Every top-level module the installed distribution SHIPS, from its file
+    RECORD. The group specs name only the plugin-class modules; a dist may
+    ship additional top-level helper packages those modules import — purging
+    by specs alone leaves them cached, and the fresh re-import silently binds
+    old helper code under the new version. Empty set if not installed."""
+    try:
+        dist = importlib_metadata.distribution(dist_name)
+    except importlib_metadata.PackageNotFoundError:
+        return set()
+    tops = set()
+    for f in dist.files or ():
+        first = f.parts[0] if f.parts else ""
+        if not first or first.endswith((".dist-info", ".data")):
+            continue
+        if len(f.parts) == 1:
+            if first.endswith(".py"):
+                tops.add(first[:-3])
+        else:
+            tops.add(first)
+    return tops
+
+
+def purge_plugin_modules(plugin_specs, dist_name=""):
+    """Drop the plugin's top-level modules (and all their submodules) from
+    ``sys.modules`` so a later install re-imports FRESH code from disk instead
+    of binding to the cached, now-stale module objects.
+
+    Purges the union of the spec-derived tops and — when ``dist_name`` is
+    given and still installed — every top-level module the distribution's
+    RECORD ships, so helper packages outside the specs cannot survive as
+    stale code.
+
+    Call only after the plugin's groups are disabled and deregistered. Safe
+    because MicroDrop plugins are fully isolated (decoupled via dramatiq
+    topics / app_globals, no cross-plugin imports — they can even run as
+    separate processes), so once a plugin's own instances are torn down
+    nothing else holds references into its modules. This is what lets an
+    install → uninstall → reinstall cycle, and an in-place version change,
+    hot-load instead of demanding a relaunch."""
+    tops = _top_modules(plugin_specs) | _dist_top_modules(dist_name)
+    purged = [name for name in list(sys.modules)
+              if name.split(".")[0] in tops]
+    for name in purged:
+        del sys.modules[name]
+    if purged:
+        logger.info(f"purged {len(purged)} module(s) under {sorted(tops)} "
+                    f"for reinstall")
+    return purged
 
 
 def hot_load_installed(application, manager, dist_name, diff) -> str | None:
@@ -79,13 +138,19 @@ def _refuse(dist_name, reason):
 
 
 def _hot_load_installed(application, manager, dist_name, diff):
+    norm = PluginGroupManager._norm_dist
     if diff is None:
         return _refuse(dist_name,
                        "the environment change could not be determined")
-    if not diff.is_pure_addition:
-        moved = sorted(diff.changed) + sorted(diff.removed)
+    # The target dist changing ITSELF (in-place version change) is allowed:
+    # the caller unloads + purges its modules first, and the sys.modules
+    # guard below still refuses if that didn't happen. Any OTHER package
+    # moving may be live in this interpreter — relaunch.
+    moved = sorted(diff.changed) + sorted(diff.removed)
+    blocking = [m for m in moved if norm(m) != norm(dist_name)]
+    if blocking:
         return _refuse(dist_name, f"existing packages were changed or "
-                                  f"removed: {', '.join(moved)}")
+                                  f"removed: {', '.join(blocking)}")
 
     # Snapshot sys.modules BEFORE discovery. discover_entry_point_manifests()
     # reads each entry point's package-data manifest via
@@ -100,7 +165,6 @@ def _hot_load_installed(application, manager, dist_name, diff):
     # import_module goes through is not.
     importlib.invalidate_caches()
 
-    norm = PluginGroupManager._norm_dist
     mine = [(m, d) for m, d in discover_entry_point_manifests()
             if norm(d) == norm(dist_name)]
     if not mine:

--- a/plugin_management/i_plugin_group_manager.py
+++ b/plugin_management/i_plugin_group_manager.py
@@ -13,6 +13,10 @@ class IPluginGroupManager(Interface):
     #: group name -> PluginGroup.
     groups = Dict()
 
+    def register_manifest(self, manifest, dist_name="") -> None:
+        """Register a freshly-installed manifest's groups at runtime. Raises
+        if a colliding group name is currently loaded."""
+
     def is_loaded(self, group_name) -> bool:
         """True if the named group is currently loaded."""
 

--- a/plugin_management/installed_table.py
+++ b/plugin_management/installed_table.py
@@ -5,11 +5,11 @@ Documentation / Upgrade / Uninstall as Material-glyph action columns. The
 reusable column types live in ``microdrop_utils.traitsui_qt_helpers``
 (``GlyphActionColumn`` for the click-to-fire glyphs, ``EnumSelectColumn`` for
 the version dropdown that blanks its static text while editing); only the
-docs-specific greying is defined locally.
+docs- and upgrade-specific enabled/disabled treatments are defined locally.
 """
 from traitsui.api import TableEditor
 
-from microdrop_style.colors import GREY, INFO_COLOR
+from microdrop_style.colors import GREY, INFO_COLOR, SUCCESS_COLOR
 from microdrop_style.icons.icons import ICON_DESCRIPTION, ICON_DELETE
 from microdrop_utils.traitsui_qt_helpers import (
     ObjectColumn, GlyphActionColumn, EnumSelectColumn)
@@ -39,14 +39,33 @@ class DocColumn(GlyphActionColumn):
             object.open_docs = True
 
 
+class UpgradeColumn(GlyphActionColumn):
+    """Upgrade glyph: success-green + click-to-fire when the channel offers a
+    newer version; darker grey and inert when already up to date (the same
+    disabled treatment as DocColumn)."""
+
+    def get_text_color(self, object):
+        if object.upgrade_available():
+            return SUCCESS_COLOR
+        return GREY["dark"]
+
+    def get_tooltip(self, object):
+        if object.upgrade_available():
+            return f"Upgrade to {object.available_versions[0]}"
+        return "Already up to date"
+
+    def on_click(self, object):
+        if object.upgrade_available():
+            object.upgrade = True
+
+
 installed_table_editor = TableEditor(
     columns=[
         ObjectColumn(name="name", label="", editable=False),
         DocColumn(name="doc_url", label="", glyph=ICON_DESCRIPTION),
         EnumSelectColumn(name="version", label="",
                          values_name="available_versions", width=90),
-        GlyphActionColumn(name="dist_name", label="", glyph=ICON_UPGRADE,
-                          fire="upgrade"),
+        UpgradeColumn(name="dist_name", label="", glyph=ICON_UPGRADE),
         GlyphActionColumn(name="manifest_name", label="", glyph=ICON_DELETE,
                           fire="uninstall"),
     ],

--- a/plugin_management/manage_controller.py
+++ b/plugin_management/manage_controller.py
@@ -115,6 +115,11 @@ class ManagePluginsController(SafeCancelTableController):
         model.edit_traits(view=browse_view,
                           handler=BrowsePluginsHandler(task=self.task),
                           kind="livemodal")
+        # Browse's own hot-load may have registered + enabled a new plugin
+        # live; refresh so the Installed Packages table reflects it without
+        # requiring the user to close and reopen this dialog.
+        self.model.refresh()
+        self.model.refresh_installed()
 
     # --- Refresh Versions: re-fetch the channel, update the dropdowns ---
     def refresh_versions(self, info):

--- a/plugin_management/manage_controller.py
+++ b/plugin_management/manage_controller.py
@@ -165,12 +165,9 @@ class ManagePluginsController(SafeCancelTableController):
         self._run(lambda: self.model.do_install_version(dist, new_version),
                   title="Installing version",
                   message=f"Installing {label} {new_version}…",
-                  done=lambda r: (self.model.refresh_installed(),
-                                  finish_change(
-                                      self.task,
-                                      f"Installed <b>{_esc(label)}</b> "
-                                      f"{_esc(new_version)}.",
-                                      self._hot_load(dist, r))))
+                  done=lambda r: self._finish_install_change(
+                      f"Installed <b>{_esc(label)}</b> {_esc(new_version)}.",
+                      dist, r))
 
     @observe("model:installed_rows:items:upgrade")
     def _on_upgrade(self, event):
@@ -184,11 +181,8 @@ class ManagePluginsController(SafeCancelTableController):
             return
         self._run(lambda: self.model.do_upgrade(dist),
                   title="Upgrading plugin", message=f"Upgrading {label}…",
-                  done=lambda r: (self.model.refresh_installed(),
-                                  finish_change(
-                                      self.task,
-                                      f"Upgraded <b>{_esc(label)}</b>.",
-                                      self._hot_load(dist, r))))
+                  done=lambda r: self._finish_install_change(
+                      f"Upgraded <b>{_esc(label)}</b>.", dist, r))
 
     @observe("model:installed_rows:items:uninstall")
     def _on_uninstall(self, event):
@@ -201,7 +195,8 @@ class ManagePluginsController(SafeCancelTableController):
         self.model.pre_uninstall(manifest)
         self._run(lambda: self.model.do_uninstall(dist),
                   title="Uninstalling plugin", message=f"Removing {label}…",
-                  done=lambda r: (self.model.refresh_installed(),
+                  done=lambda r: (self.model.refresh(),
+                                  self.model.refresh_installed(),
                                   finish_change(
                                       self.task,
                                       f"Uninstalled <b>{_esc(label)}</b>.",
@@ -213,11 +208,16 @@ class ManagePluginsController(SafeCancelTableController):
                       on_error=lambda e: error_dialog(
                           parent=None, title=title, message=str(e)))
 
-    def _hot_load(self, dist_name, result):
-        """GUI thread: try to apply an install live. The model already holds
-        the application and the group manager."""
-        return hot_load_installed(self.model.application, self.model.manager,
-                                  dist_name, result.diff)
+    def _finish_install_change(self, msg_html, dist_name, result):
+        """GUI thread: apply an install/upgrade live if safe, rebuild BOTH
+        tables (the hot-load may have registered + enabled new groups — a
+        stale Groups row would let a later Apply silently disable them), and
+        report, naming the refusal reason when a relaunch is still needed."""
+        reason = hot_load_installed(self.model.application, self.model.manager,
+                                    dist_name, result.diff)
+        self.model.refresh()
+        self.model.refresh_installed()
+        finish_change(self.task, msg_html, reason is None, reason or "")
 
     def _set_row_version(self, row, version):
         """Revert a cancelled dropdown selection without re-triggering the

--- a/plugin_management/manage_controller.py
+++ b/plugin_management/manage_controller.py
@@ -33,6 +33,7 @@ from .browse_model import BrowsePluginsModel
 from .browse_view import browse_view
 from .browse_controller import BrowsePluginsHandler
 from .hot_load import hot_load_installed
+from .package_installer import EnvDiff
 from .relaunch import finish_change
 
 logger = get_logger(__name__)
@@ -162,12 +163,16 @@ class ManagePluginsController(SafeCancelTableController):
             self._set_row_version(row, old_version)  # revert the dropdown
             return
         label, dist = row.label, row.dist_name
+        # Unload + purge first so the new version's code is genuinely
+        # importable — an in-place version change hot-loads like an install.
+        self.model.pre_change(row.manifest_name, dist)
         self._run(lambda: self.model.do_install_version(dist, new_version),
                   title="Installing version",
                   message=f"Installing {label} {new_version}…",
                   done=lambda r: self._finish_install_change(
                       f"Installed <b>{_esc(label)}</b> {_esc(new_version)}.",
-                      dist, r))
+                      dist, r),
+                  error=lambda e: self._reenable_from_disk(dist))
 
     @observe("model:installed_rows:items:upgrade")
     def _on_upgrade(self, event):
@@ -179,10 +184,12 @@ class ManagePluginsController(SafeCancelTableController):
                    message=f"Upgrade <b>{_esc(label)}</b> to the latest "
                            f"version{target}?", cancel=False) != YES:
             return
+        self.model.pre_change(row.manifest_name, dist)
         self._run(lambda: self.model.do_upgrade(dist),
                   title="Upgrading plugin", message=f"Upgrading {label}…",
                   done=lambda r: self._finish_install_change(
-                      f"Upgraded <b>{_esc(label)}</b>.", dist, r))
+                      f"Upgraded <b>{_esc(label)}</b>.", dist, r),
+                  error=lambda e: self._reenable_from_disk(dist))
 
     @observe("model:installed_rows:items:uninstall")
     def _on_uninstall(self, event):
@@ -192,7 +199,7 @@ class ManagePluginsController(SafeCancelTableController):
                    message=f"Uninstall <b>{_esc(label)}</b>? This removes its "
                            f"package from the environment.", cancel=False) != YES:
             return
-        self.model.pre_uninstall(manifest)
+        self.model.pre_change(manifest, dist)
         self._run(lambda: self.model.do_uninstall(dist),
                   title="Uninstalling plugin", message=f"Removing {label}…",
                   done=lambda r: (self.model.refresh(),
@@ -200,13 +207,32 @@ class ManagePluginsController(SafeCancelTableController):
                                   finish_change(
                                       self.task,
                                       f"Uninstalled <b>{_esc(label)}</b>.",
-                                      not r.requires_relaunch)))
+                                      not r.requires_relaunch)),
+                  error=lambda e: self._reenable_from_disk(dist))
 
     # --- helpers ---
-    def _run(self, work, *, title, message, done):
+    def _run(self, work, *, title, message, done, error=None):
+        """Threaded worker + wait dialog. ``error`` (GUI thread) runs before
+        the error dialog — recovery first, then tell the user what failed."""
+        def _on_error(e):
+            if error is not None:
+                error(e)
+            error_dialog(parent=None, title=title, message=str(e))
         run_with_wait(work, title=title, message=message, on_success=done,
-                      on_error=lambda e: error_dialog(
-                          parent=None, title=title, message=str(e)))
+                      on_error=_on_error)
+
+    def _reenable_from_disk(self, dist_name):
+        """GUI thread: a failed pixi step left the plugin unloaded + purged
+        while its files are still on disk (install rolls back). Re-register
+        and re-enable from disk so the failure costs only the error dialog —
+        an empty diff passes the gate, and the purge means fresh imports."""
+        reason = hot_load_installed(self.model.application, self.model.manager,
+                                    dist_name, EnvDiff({}, {}, {}))
+        if reason is not None:
+            logger.warning(f"could not re-enable '{dist_name}' after a failed "
+                           f"change: {reason}")
+        self.model.refresh()
+        self.model.refresh_installed()
 
     def _finish_install_change(self, msg_html, dist_name, result):
         """GUI thread: apply an install/upgrade live if safe, rebuild BOTH

--- a/plugin_management/manage_controller.py
+++ b/plugin_management/manage_controller.py
@@ -32,7 +32,8 @@ INSTALLED_SPLIT_GAP = 4
 from .browse_model import BrowsePluginsModel
 from .browse_view import browse_view
 from .browse_controller import BrowsePluginsHandler
-from .relaunch import confirm_and_relaunch
+from .hot_load import hot_load_installed
+from .relaunch import finish_change
 
 logger = get_logger(__name__)
 
@@ -160,9 +161,11 @@ class ManagePluginsController(SafeCancelTableController):
                   title="Installing version",
                   message=f"Installing {label} {new_version}…",
                   done=lambda r: (self.model.refresh_installed(),
-                                  self._after_change(
+                                  finish_change(
+                                      self.task,
                                       f"Installed <b>{_esc(label)}</b> "
-                                      f"{_esc(new_version)}.")))
+                                      f"{_esc(new_version)}.",
+                                      self._hot_load(dist, r))))
 
     @observe("model:installed_rows:items:upgrade")
     def _on_upgrade(self, event):
@@ -177,8 +180,10 @@ class ManagePluginsController(SafeCancelTableController):
         self._run(lambda: self.model.do_upgrade(dist),
                   title="Upgrading plugin", message=f"Upgrading {label}…",
                   done=lambda r: (self.model.refresh_installed(),
-                                  self._after_change(
-                                      f"Upgraded <b>{_esc(label)}</b>.")))
+                                  finish_change(
+                                      self.task,
+                                      f"Upgraded <b>{_esc(label)}</b>.",
+                                      self._hot_load(dist, r))))
 
     @observe("model:installed_rows:items:uninstall")
     def _on_uninstall(self, event):
@@ -192,8 +197,10 @@ class ManagePluginsController(SafeCancelTableController):
         self._run(lambda: self.model.do_uninstall(dist),
                   title="Uninstalling plugin", message=f"Removing {label}…",
                   done=lambda r: (self.model.refresh_installed(),
-                                  self._after_change(
-                                      f"Uninstalled <b>{_esc(label)}</b>.")))
+                                  finish_change(
+                                      self.task,
+                                      f"Uninstalled <b>{_esc(label)}</b>.",
+                                      not r.requires_relaunch)))
 
     # --- helpers ---
     def _run(self, work, *, title, message, done):
@@ -201,8 +208,11 @@ class ManagePluginsController(SafeCancelTableController):
                       on_error=lambda e: error_dialog(
                           parent=None, title=title, message=str(e)))
 
-    def _after_change(self, msg_html):
-        confirm_and_relaunch(self.task, msg_html)
+    def _hot_load(self, dist_name, result):
+        """GUI thread: try to apply an install live. The model already holds
+        the application and the group manager."""
+        return hot_load_installed(self.model.application, self.model.manager,
+                                  dist_name, result.diff)
 
     def _set_row_version(self, row, version):
         """Revert a cancelled dropdown selection without re-triggering the

--- a/plugin_management/manage_model.py
+++ b/plugin_management/manage_model.py
@@ -126,7 +126,16 @@ class ManagePluginsModel(HasTraits):
         self.rows = self._build_rows()
 
     def refresh_installed(self):
+        """Rebuild the Installed Packages rows, re-selecting the same package
+        by name. The rows are FRESH objects — keeping the old selection object
+        would leave the details pane rendering the previous version's
+        metadata after a version change. Re-assigning the selection fires
+        ``_update_installed_details``, so the pane follows; a package that
+        vanished (uninstall) clears the selection and blanks the pane."""
+        keep = self.installed_selected.dist_name if self.installed_selected else ""
         self.installed_rows = self._build_installed_rows()
+        self.installed_selected = next(
+            (r for r in self.installed_rows if r.dist_name == keep), None)
 
     def _build_rows(self):
         return [

--- a/plugin_management/manage_model.py
+++ b/plugin_management/manage_model.py
@@ -173,11 +173,11 @@ class ManagePluginsModel(HasTraits):
     # --- worker-thread safe ops (no trait mutation) ---
     def do_install_version(self, dist_name, version):
         """Install a specific version of a package (version dropdown select)."""
-        package_installer.install_from_channel(dist_name, version=version)
+        return package_installer.install_from_channel(dist_name, version=version)
 
     def do_upgrade(self, dist_name):
         """Upgrade a package to the latest channel version (upgrade button)."""
-        package_installer.upgrade_package(dist_name)
+        return package_installer.upgrade_package(dist_name)
 
     def do_search_channel(self):
         """Re-fetch the channel package list (Refresh Versions). Returns the
@@ -196,4 +196,4 @@ class ManagePluginsModel(HasTraits):
 
     def do_uninstall(self, dist_name):
         """Worker-thread safe: remove the package (no trait mutation)."""
-        package_installer.uninstall_package(dist_name)
+        return package_installer.uninstall_package(dist_name)

--- a/plugin_management/manage_model.py
+++ b/plugin_management/manage_model.py
@@ -8,7 +8,7 @@ import html
 
 from traits.api import Any, Bool, Event, HasTraits, Instance, List, Str, observe
 
-from . import package_installer
+from . import hot_load, package_installer
 from .browse_model import _version_key, _DETAILS_CSS
 from .group_manager import PluginGroupManager
 from logger.logger_service import get_logger
@@ -172,8 +172,10 @@ class ManagePluginsModel(HasTraits):
 
     # --- worker-thread safe ops (no trait mutation) ---
     def do_install_version(self, dist_name, version):
-        """Install a specific version of a package (version dropdown select)."""
-        return package_installer.install_from_channel(dist_name, version=version)
+        """Replace a package with a specific version (version dropdown select)
+        — a full remove + add, so nothing of the old build survives on disk."""
+        return package_installer.reinstall_from_channel(dist_name,
+                                                        version=version)
 
     def do_upgrade(self, dist_name):
         """Upgrade a package to the latest channel version (upgrade button)."""
@@ -184,15 +186,24 @@ class ManagePluginsModel(HasTraits):
         data; the controller applies it on the GUI thread."""
         return package_installer.search_channel()
 
-    def pre_uninstall(self, manifest_name):
-        """Hot-unload + deregister a plugin's groups before its package is
-        removed, so declining the relaunch doesn't leave dead groups
-        loaded/registered."""
+    def pre_change(self, manifest_name, dist_name=""):
+        """Hot-unload + deregister a plugin's groups, then purge its modules
+        from ``sys.modules``, before its package is removed or replaced.
+
+        The purge is what lets an install → uninstall → reinstall cycle and
+        an in-place version change hot-load instead of demanding a relaunch:
+        the next ``enable()`` re-imports FRESH code from disk rather than
+        binding to the cached, stale module objects. Safe because plugins are
+        fully isolated (no cross-plugin imports; they can run as separate
+        processes), so after disable() nothing else references their modules."""
+        specs = []
         for name in [n for n, g in self.manager.groups.items()
                      if g.manifest_name == manifest_name]:
+            specs += self.manager.groups[name].plugin_specs
             if self.manager.is_loaded(name):
                 self.manager.disable(self.application, name)
         self.manager.deregister_plugin(manifest_name)
+        hot_load.purge_plugin_modules(specs, dist_name)
 
     def do_uninstall(self, dist_name):
         """Worker-thread safe: remove the package (no trait mutation)."""

--- a/plugin_management/manage_model.py
+++ b/plugin_management/manage_model.py
@@ -57,6 +57,13 @@ class InstalledPackageRow(HasTraits):
     upgrade = Event()
     uninstall = Event()
 
+    def upgrade_available(self):
+        """True when the channel offers a newer version than the installed
+        one. ``available_versions`` is newest-first and always contains the
+        current version, so a differing head is exactly 'newer exists'."""
+        return (bool(self.available_versions)
+                and self.available_versions[0] != self.version)
+
 
 def format_installed_details_html(row):
     """Styled HTML details for an installed package (shown in the details pane).

--- a/plugin_management/manage_view.py
+++ b/plugin_management/manage_view.py
@@ -26,8 +26,8 @@ refresh_versions_action = Action(
 
 _INSTALLED_HELP = ("Installed plugin packages. Open docs, switch the version "
                    "(installs that build), upgrade to latest, or uninstall. "
-                   "Version changes and upgrades prompt a relaunch; a clean "
-                   "uninstall applies immediately.")
+                   "Changes apply immediately when they can; otherwise you "
+                   "are offered a relaunch, with the reason.")
 
 groups_table = TableEditor(
     columns=[

--- a/plugin_management/manage_view.py
+++ b/plugin_management/manage_view.py
@@ -26,7 +26,8 @@ refresh_versions_action = Action(
 
 _INSTALLED_HELP = ("Installed plugin packages. Open docs, switch the version "
                    "(installs that build), upgrade to latest, or uninstall. "
-                   "Version changes and uninstall prompt a relaunch.")
+                   "Version changes and upgrades prompt a relaunch; a clean "
+                   "uninstall applies immediately.")
 
 groups_table = TableEditor(
     columns=[

--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -56,7 +56,7 @@ class EnvDiff:
 
     @property
     def is_pure_removal(self):
-        """True when packages were only REMOVED. Safe after pre_uninstall has
+        """True when packages were only REMOVED. Safe after pre_change has
         already disabled the affected groups."""
         return not self.changed and not self.added
 
@@ -135,10 +135,51 @@ def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
 
 
 def upgrade_package(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None) -> EnvChangeResult:
-    """Upgrade a plugin to the latest channel version — an unpinned
-    `pixi add <name>` that re-resolves to the newest compatible build. Thin
-    wrapper over :func:`install_from_channel`."""
-    return install_from_channel(name, channel_url, cwd=cwd)
+    """Upgrade a plugin to the latest channel version via a full
+    remove + add cycle. Thin wrapper over :func:`reinstall_from_channel`."""
+    return reinstall_from_channel(name, channel_url, cwd=cwd)
+
+
+def reinstall_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
+                           version=None) -> EnvChangeResult:
+    """Replace an installed package: `pixi remove <name>` then `pixi add`
+    (pinned when ``version`` is given) then `pixi install`.
+
+    A full remove + add rather than an in-place `pixi add <name>==<version>`
+    so NOTHING of the old build survives on disk — stale ``__pycache__`` or
+    leftover dist-info from an in-place transaction can hand the import
+    system old code under the new version's name.
+
+    The env is snapshotted BEFORE the remove and diffed against the state
+    after the add — never against the post-remove trough, where a plugin-only
+    dependency that left and came back at a different version would look like
+    a harmless addition while its old version is still imported.
+
+    Rolls back pyproject + lock on failure and best-effort re-materializes
+    the env, so a failed reinstall does not leave the removed state on disk."""
+    cwd = Path(cwd or WORKSPACE_DIR)
+    snapshot = _snapshot(cwd)
+    before = _try_snapshot(cwd)
+    spec = f"{name}=={version}" if version else name
+    try:
+        _run(["remove", name], cwd=cwd)
+        _ensure_channel_registered(channel_url, cwd)
+        _run(["add", spec], cwd=cwd)
+        _run(["install"], cwd=cwd)
+    except Exception:
+        _restore(cwd, snapshot)
+        try:
+            _run(["install"], cwd=cwd)
+        except InstallError as e:
+            logger.warning(
+                f"could not re-materialize the env after a failed reinstall "
+                f"of '{name}': {e}")
+        raise
+    diff = _diff_or_none(before, _try_snapshot(cwd))
+    logger.info(f"reinstalled plugin '{spec}' from {channel_url}")
+    return EnvChangeResult(
+        name=name, diff=diff,
+        requires_relaunch=diff is None or not diff.is_pure_addition)
 
 
 def _parse_search_json(stdout: str) -> list[dict]:

--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -25,8 +25,14 @@ class InstallError(Exception):
 
 
 @dataclass
-class InstallResult:
+class EnvChangeResult:
+    """The outcome of an env-mutating pixi command.
+
+    ``diff`` is None when the environment could not be snapshotted; callers
+    must treat that as 'unknown' and relaunch."""
+
     name: str
+    diff: "EnvDiff | None"
     requires_relaunch: bool
 
 
@@ -89,14 +95,18 @@ def _ensure_channel_registered(channel_url, cwd):
 
 
 def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
-                         version=None) -> InstallResult:
+                         version=None) -> EnvChangeResult:
     """Register the channel and `pixi add <name>` so the solver resolves the
     package + its deps. When ``version`` is given, pin it (`pixi add
     <name>==<version>`) to install that specific version (down/upgrade).
-    Snapshot/restore pyproject + lock on any failure. Returns
-    InstallResult(name, requires_relaunch=True)."""
+    Snapshot/restore pyproject + lock on any failure.
+
+    Snapshots the environment either side of the install so the caller can
+    tell a purely-additive change (hot-loadable) from one that moved a
+    package already imported by this interpreter (needs a relaunch)."""
     cwd = Path(cwd or WORKSPACE_DIR)
     snapshot = _snapshot(cwd)
+    before = _try_snapshot(cwd)
     spec = f"{name}=={version}" if version else name
     try:
         _ensure_channel_registered(channel_url, cwd)
@@ -105,11 +115,14 @@ def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
     except Exception:
         _restore(cwd, snapshot)
         raise
+    diff = _diff_or_none(before, _try_snapshot(cwd))
     logger.info(f"installed plugin '{spec}' from {channel_url}")
-    return InstallResult(name=name, requires_relaunch=True)
+    return EnvChangeResult(
+        name=name, diff=diff,
+        requires_relaunch=diff is None or not diff.is_pure_addition)
 
 
-def upgrade_package(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None) -> InstallResult:
+def upgrade_package(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None) -> EnvChangeResult:
     """Upgrade a plugin to the latest channel version — an unpinned
     `pixi add <name>` that re-resolves to the newest compatible build. Thin
     wrapper over :func:`install_from_channel`."""
@@ -167,6 +180,23 @@ def diff_snapshots(before, after) -> EnvDiff:
                for n in before.keys() & after.keys()
                if before[n] != after[n]}
     return EnvDiff(added=added, changed=changed, removed=removed)
+
+
+def _try_snapshot(cwd):
+    """env_snapshot() or None. Snapshotting must never break an install: it
+    runs through _run, which raises InstallError on a non-zero exit."""
+    try:
+        return env_snapshot(cwd=cwd)
+    except Exception as e:
+        logger.warning(f"could not snapshot the pixi environment: {e}")
+        return None
+
+
+def _diff_or_none(before, after):
+    """EnvDiff, or None when either snapshot is missing."""
+    if before is None or after is None:
+        return None
+    return diff_snapshots(before, after)
 
 
 def search_channel(channel_url: str = PLUGIN_CHANNEL_URL, *, cwd=None) -> list[dict]:
@@ -235,11 +265,19 @@ def documentation_url(dist_name) -> str:
     return (metadata.get("Home-page") or "").strip()
 
 
-def uninstall_package(name, *, cwd=None) -> None:
-    """`pixi remove <name>`. Best-effort; logs on failure."""
+def uninstall_package(name, *, cwd=None) -> EnvChangeResult:
+    """`pixi remove <name>` + `pixi install`. Best-effort: a failure is logged,
+    not raised, and reports requires_relaunch=True so a failed removal never
+    claims the hot path."""
     cwd = Path(cwd or WORKSPACE_DIR)
+    before = _try_snapshot(cwd)
     try:
         _run(["remove", name], cwd=cwd)
         _run(["install"], cwd=cwd)
     except InstallError as e:
         logger.warning(f"`pixi remove {name}` failed: {e}")
+        return EnvChangeResult(name=name, diff=None, requires_relaunch=True)
+    diff = _diff_or_none(before, _try_snapshot(cwd))
+    return EnvChangeResult(
+        name=name, diff=diff,
+        requires_relaunch=diff is None or not diff.is_pure_removal)

--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -76,6 +76,7 @@ def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
     try:
         _ensure_channel_registered(channel_url, cwd)
         _run(["add", spec], cwd=cwd)
+        _run(["install"], cwd=cwd)
     except Exception:
         _restore(cwd, snapshot)
         raise
@@ -178,5 +179,6 @@ def uninstall_package(name, *, cwd=None) -> None:
     cwd = Path(cwd or WORKSPACE_DIR)
     try:
         _run(["remove", name], cwd=cwd)
+        _run(["install"], cwd=cwd)
     except InstallError as e:
         logger.warning(f"`pixi remove {name}` failed: {e}")

--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -85,13 +85,25 @@ def _restore(cwd, snapshot):
         (Path(cwd) / name).write_bytes(data)
 
 
+#: (channel_url, workspace dir) pairs this process has already registered —
+#: `pixi workspace channel add` is idempotent but costs a subprocess, and the
+#: channel URL is a fixed constant, so paying it once per run is enough.
+_registered_channels = set()
+
+
 def _ensure_channel_registered(channel_url, cwd):
-    """`pixi workspace channel add <url>`; tolerate an already-registered channel."""
+    """`pixi workspace channel add <url>`; tolerate an already-registered
+    channel, and skip the subprocess entirely once this process has
+    registered the pair."""
+    key = (channel_url, str(cwd or WORKSPACE_DIR))
+    if key in _registered_channels:
+        return
     try:
         _run(["workspace", "channel", "add", channel_url], cwd=cwd)
     except InstallError as e:
         if "already" not in str(e).lower():
             raise
+    _registered_channels.add(key)
 
 
 def install_from_channel(name, channel_url=PLUGIN_CHANNEL_URL, *, cwd=None,
@@ -266,17 +278,15 @@ def documentation_url(dist_name) -> str:
 
 
 def uninstall_package(name, *, cwd=None) -> EnvChangeResult:
-    """`pixi remove <name>` + `pixi install`. Best-effort: a failure is logged,
-    not raised, and reports requires_relaunch=True so a failed removal never
-    claims the hot path."""
+    """`pixi remove <name>` + `pixi install`. Raises InstallError on failure —
+    swallowing it made a failed removal indistinguishable from a successful
+    one that merely needs a relaunch, so the UI reported "Uninstalled X."
+    for a package still on disk. InstallError names the failing pixi command,
+    and the controllers' on_error path surfaces it in an error dialog."""
     cwd = Path(cwd or WORKSPACE_DIR)
     before = _try_snapshot(cwd)
-    try:
-        _run(["remove", name], cwd=cwd)
-        _run(["install"], cwd=cwd)
-    except InstallError as e:
-        logger.warning(f"`pixi remove {name}` failed: {e}")
-        return EnvChangeResult(name=name, diff=None, requires_relaunch=True)
+    _run(["remove", name], cwd=cwd)
+    _run(["install"], cwd=cwd)
     diff = _diff_or_none(before, _try_snapshot(cwd))
     return EnvChangeResult(
         name=name, diff=diff,

--- a/plugin_management/package_installer.py
+++ b/plugin_management/package_installer.py
@@ -30,6 +30,31 @@ class InstallResult:
     requires_relaunch: bool
 
 
+@dataclass(frozen=True)
+class EnvDiff:
+    """What a pixi command did to the environment, keyed by package name.
+
+    ``added``/``removed`` map name -> version; ``changed`` maps
+    name -> (old_version, new_version)."""
+
+    added: dict
+    changed: dict
+    removed: dict
+
+    @property
+    def is_pure_addition(self):
+        """True when packages were only ADDED — nothing upgraded, downgraded,
+        rebuilt or removed. The only shape safe to import into a live
+        interpreter."""
+        return not self.changed and not self.removed
+
+    @property
+    def is_pure_removal(self):
+        """True when packages were only REMOVED. Safe after pre_uninstall has
+        already disabled the affected groups."""
+        return not self.changed and not self.added
+
+
 def _run(args, *, cwd=None):
     proc = subprocess.run(["pixi", *args], cwd=str(cwd or WORKSPACE_DIR),
                           capture_output=True, text=True)
@@ -106,6 +131,42 @@ def _parse_search_json(stdout: str) -> list[dict]:
         if isinstance(subdir_packages, list):
             packages.extend(subdir_packages)
     return packages
+
+
+def _parse_list_json(stdout: str) -> list[dict]:
+    """Parse `pixi list --json` stdout (which may be preceded by warning
+    lines) into the package record list."""
+    start = stdout.find("[")
+    if start == -1:
+        raise InstallError("no JSON array in pixi list output")
+    try:
+        return json.loads(stdout[start:])
+    except ValueError as e:
+        raise InstallError(f"could not parse pixi list JSON: {e}") from e
+
+
+def env_snapshot(*, cwd=None) -> dict:
+    """{name: (version, build, kind)} for every package in the workspace env.
+
+    `pixi list` defaults to the platform best matching this machine — the
+    same platform, and the same prefix, the running interpreter uses."""
+    proc = _run(["list", "--json"], cwd=cwd)
+    return {r["name"]: (r["version"], r["build"], r["kind"])
+            for r in _parse_list_json(proc.stdout)}
+
+
+def diff_snapshots(before, after) -> EnvDiff:
+    """Classify per-package differences between two env_snapshot() results.
+
+    Compares the FULL (version, build, kind) record, so a same-version
+    rebuild counts as changed — it still replaces files on disk underneath
+    whatever is already imported."""
+    added = {n: rec[0] for n, rec in after.items() if n not in before}
+    removed = {n: rec[0] for n, rec in before.items() if n not in after}
+    changed = {n: (before[n][0], after[n][0])
+               for n in before.keys() & after.keys()
+               if before[n] != after[n]}
+    return EnvDiff(added=added, changed=changed, removed=removed)
 
 
 def search_channel(channel_url: str = PLUGIN_CHANNEL_URL, *, cwd=None) -> list[dict]:

--- a/plugin_management/relaunch.py
+++ b/plugin_management/relaunch.py
@@ -6,7 +6,6 @@ the same entry point under ``pixi run`` (the default environment).
 """
 
 import os
-import sys
 from pathlib import Path
 
 from microdrop_application.dialogs.pyface_wrapper import confirm, information, YES
@@ -16,19 +15,6 @@ from logger.logger_service import get_logger
 WORKSPACE_DIR = Path(__file__).resolve().parents[2]
 
 logger = get_logger(__name__)
-
-
-def _relaunch_argv(script: str):
-    """`pixi run python <script> <args...>` for the current process (default env).
-
-    ``script`` must already be an absolute path (resolved before any chdir).
-    ``sys.argv[1:]`` (the original arguments after the script name) are
-    forwarded verbatim so the restarted process receives the same flags.
-    """
-    return [
-        "pixi", "run",
-        "python", script, *sys.argv[1:],
-    ]
 
 
 def confirm_and_relaunch(task, msg_html):
@@ -49,26 +35,19 @@ def confirm_and_relaunch(task, msg_html):
 
 
 def relaunch_app(application=None):
-    """Quit the app (if given) and re-exec into the default pixi environment.
-    Best-effort: on failure, logs and returns so the caller can fall back to
-    a message.
+    """Quit the app (if given) and re-exec into the default pixi environment by
+    running the ``microdrop`` task. Best-effort: on failure, logs and returns so
+    the caller can fall back to a message.
 
-    The entry script is resolved to an ABSOLUTE path against the current
-    working directory BEFORE any ``os.chdir``.  If the resolved path does not
-    exist the function logs an error and returns WITHOUT touching the
-    application, leaving it running (graceful degradation).
+    ``--manifest-path`` points pixi at the workspace ``pyproject.toml`` so the
+    task resolves regardless of the current working directory.
     """
     try:
-        # Resolve the entry script while the original cwd is still intact.
-        script = os.path.abspath(sys.argv[0])
-        if not os.path.exists(script):
-            logger.error(
-                f"relaunch: entry script not found at '{script}'; "
-                "aborting relaunch to keep the app alive"
-            )
-            return
-
-        argv = _relaunch_argv(script)
+        argv = [
+            "pixi", "run",
+            "--manifest-path", str(WORKSPACE_DIR / "pyproject.toml"),
+            "microdrop",
+        ]
         logger.info(f"relaunching into default env: {' '.join(argv)}")
 
         # Ask the envisage app to exit cleanly first (saves window state).
@@ -78,8 +57,7 @@ def relaunch_app(application=None):
             except Exception:
                 logger.exception("relaunch: application.exit() failed; continuing")
 
-        # Replace this process. os.chdir so pixi finds the workspace manifest.
-        os.chdir(str(WORKSPACE_DIR))
+        # Replace this process with the pixi task.
         os.execvp(argv[0], argv)
     except Exception:
         logger.exception("relaunch into default env failed")

--- a/plugin_management/relaunch.py
+++ b/plugin_management/relaunch.py
@@ -8,7 +8,8 @@ the same entry point under ``pixi run`` (the default environment).
 import os
 from pathlib import Path
 
-from microdrop_application.dialogs.pyface_wrapper import confirm, information, YES
+from microdrop_application.dialogs.pyface_wrapper import (
+    confirm, escape_html_multiline, information, YES)
 from logger.logger_service import get_logger
 
 #: The pixi workspace root (microdrop-py/, parent of src/) — has pyproject.toml.
@@ -63,10 +64,15 @@ def relaunch_app(application=None):
         logger.exception("relaunch into default env failed")
 
 
-def finish_change(task, msg_html, ok):
+def finish_change(task, msg_html, ok, reason=""):
     """Report the outcome of an env change. ``ok`` means it is already live —
-    say so and stop. Otherwise fall back to the standard relaunch offer."""
+    say so and stop. Otherwise fall back to the standard relaunch offer,
+    naming the ``reason`` the change could not be applied live so the prompt
+    explains itself instead of reading as arbitrary nagging."""
     if ok:
         information(parent=None, title="Plugin ready", message=msg_html)
         return
+    if reason:
+        msg_html += (f"<br><br>Could not apply without a relaunch: "
+                     f"{escape_html_multiline(reason)}.")
     confirm_and_relaunch(task, msg_html)

--- a/plugin_management/relaunch.py
+++ b/plugin_management/relaunch.py
@@ -61,3 +61,12 @@ def relaunch_app(application=None):
         os.execvp(argv[0], argv)
     except Exception:
         logger.exception("relaunch into default env failed")
+
+
+def finish_change(task, msg_html, ok):
+    """Report the outcome of an env change. ``ok`` means it is already live —
+    say so and stop. Otherwise fall back to the standard relaunch offer."""
+    if ok:
+        information(parent=None, title="Plugin ready", message=msg_html)
+        return
+    confirm_and_relaunch(task, msg_html)

--- a/plugin_management/tests/test_browse_model.py
+++ b/plugin_management/tests/test_browse_model.py
@@ -31,3 +31,55 @@ def test_set_packages_dedupes_to_latest():
     assert len(model.packages) == 1
     assert model.packages[0].version == "0.2.0"
     assert model.stale is False
+
+
+def test_drop_installed_removes_the_row_without_refetching(monkeypatch):
+    """After an install the channel offers exactly what it did before — only
+    the installed set changed. Rebuilding the rows must not re-fetch."""
+    fetches = []
+    monkeypatch.setattr(package_installer, "search_channel",
+                        lambda url: fetches.append(url))
+    monkeypatch.setattr(package_installer, "installed_plugin_dists", lambda: {})
+    model = browse_model.BrowsePluginsModel()
+    model.set_packages([{"name": "a", "version": "1.0"},
+                        {"name": "b", "version": "2.0"}], False)
+    assert [p.name for p in model.packages] == ["a", "b"]
+
+    monkeypatch.setattr(package_installer, "installed_plugin_dists",
+                        lambda: {"a": "1.0"})
+    model.drop_installed()
+
+    assert [p.name for p in model.packages] == ["b"]
+    assert fetches == []               # no network round-trip
+
+
+def test_drop_installed_clears_a_selection_whose_row_is_gone(monkeypatch):
+    """The details pane must not keep describing a package that just left."""
+    monkeypatch.setattr(package_installer, "installed_plugin_dists", lambda: {})
+    model = browse_model.BrowsePluginsModel()
+    model.set_packages([{"name": "a", "version": "1.0"}], False)
+    model.selected = model.packages[0]
+    assert model.details_text
+
+    monkeypatch.setattr(package_installer, "installed_plugin_dists",
+                        lambda: {"a": "1.0"})
+    model.drop_installed()
+
+    assert model.selected is None
+    assert model.details_text == ""
+
+
+def test_drop_installed_keeps_an_unaffected_selection(monkeypatch):
+    """Installing one package must not clear a selection on a different row."""
+    monkeypatch.setattr(package_installer, "installed_plugin_dists", lambda: {})
+    model = browse_model.BrowsePluginsModel()
+    model.set_packages([{"name": "a", "version": "1.0"},
+                        {"name": "b", "version": "2.0"}], False)
+    model.selected = [p for p in model.packages if p.name == "b"][0]
+
+    monkeypatch.setattr(package_installer, "installed_plugin_dists",
+                        lambda: {"a": "1.0"})
+    model.drop_installed()
+
+    assert model.selected is not None
+    assert model.selected.name == "b"

--- a/plugin_management/tests/test_env_diff.py
+++ b/plugin_management/tests/test_env_diff.py
@@ -56,6 +56,13 @@ def test_is_pure_removal_only_when_nothing_else_moved():
     assert EnvDiff({}, {"a": ("1", "2")}, {"c": "1"}).is_pure_removal is False
 
 
+def test_empty_diff_is_both_pure_addition_and_pure_removal():
+    """A no-op pixi call changes nothing, so both directions are trivially safe."""
+    empty = EnvDiff({}, {}, {})
+    assert empty.is_pure_addition is True
+    assert empty.is_pure_removal is True
+
+
 def test_env_snapshot_parses_records(monkeypatch):
     payload = [{"name": "numpy", "version": "2.1.0", "build": "py313h0",
                 "kind": "conda"}]

--- a/plugin_management/tests/test_env_diff.py
+++ b/plugin_management/tests/test_env_diff.py
@@ -1,0 +1,80 @@
+"""Tests for the pixi environment snapshot + diff that gates hot-loading."""
+import json
+
+import pytest
+from types import SimpleNamespace
+
+from plugin_management import package_installer
+from plugin_management.package_installer import (
+    EnvDiff, diff_snapshots, env_snapshot)
+
+
+def _snap(**pkgs):
+    """{name: (version, build, kind)} from name="version" kwargs."""
+    return {n: (v, "b0", "conda") for n, v in pkgs.items()}
+
+
+def test_diff_detects_added():
+    d = diff_snapshots(_snap(a="1.0"), _snap(a="1.0", b="2.0"))
+    assert d.added == {"b": "2.0"}
+    assert d.changed == {} and d.removed == {}
+
+
+def test_diff_detects_removed():
+    d = diff_snapshots(_snap(a="1.0", b="2.0"), _snap(a="1.0"))
+    assert d.removed == {"b": "2.0"}
+    assert d.added == {} and d.changed == {}
+
+
+def test_diff_detects_changed_version():
+    d = diff_snapshots(_snap(a="1.0"), _snap(a="1.1"))
+    assert d.changed == {"a": ("1.0", "1.1")}
+
+
+def test_diff_build_only_change_counts_as_changed():
+    """A same-version rebuild replaces files on disk under live modules."""
+    before = {"a": ("1.0", "b0", "conda")}
+    after = {"a": ("1.0", "b1", "conda")}
+    assert diff_snapshots(before, after).changed == {"a": ("1.0", "1.0")}
+
+
+def test_diff_kind_change_counts_as_changed():
+    before = {"a": ("1.0", "b0", "conda")}
+    after = {"a": ("1.0", "b0", "pypi")}
+    assert diff_snapshots(before, after).changed == {"a": ("1.0", "1.0")}
+
+
+def test_is_pure_addition_only_when_nothing_else_moved():
+    assert EnvDiff({"b": "1"}, {}, {}).is_pure_addition is True
+    assert EnvDiff({"b": "1"}, {"a": ("1", "2")}, {}).is_pure_addition is False
+    assert EnvDiff({"b": "1"}, {}, {"c": "1"}).is_pure_addition is False
+
+
+def test_is_pure_removal_only_when_nothing_else_moved():
+    assert EnvDiff({}, {}, {"c": "1"}).is_pure_removal is True
+    assert EnvDiff({"b": "1"}, {}, {"c": "1"}).is_pure_removal is False
+    assert EnvDiff({}, {"a": ("1", "2")}, {"c": "1"}).is_pure_removal is False
+
+
+def test_env_snapshot_parses_records(monkeypatch):
+    payload = [{"name": "numpy", "version": "2.1.0", "build": "py313h0",
+                "kind": "conda"}]
+    monkeypatch.setattr(package_installer, "_run",
+                        lambda a, cwd=None: SimpleNamespace(
+                            stdout=json.dumps(payload)))
+    assert env_snapshot() == {"numpy": ("2.1.0", "py313h0", "conda")}
+
+
+def test_env_snapshot_tolerates_leading_warnings(monkeypatch):
+    """pixi prints warnings before the JSON, exactly as `search` does."""
+    payload = [{"name": "numpy", "version": "2.1.0", "build": "b0",
+                "kind": "conda"}]
+    stdout = f" WARN something deprecated\n{json.dumps(payload)}"
+    monkeypatch.setattr(package_installer, "_run",
+                        lambda a, cwd=None: SimpleNamespace(stdout=stdout))
+    assert env_snapshot()["numpy"][0] == "2.1.0"
+
+
+def test_parse_list_json_without_array_raises():
+    with pytest.raises(package_installer.InstallError):
+        package_installer._parse_list_json("no json here")

--- a/plugin_management/tests/test_hot_load.py
+++ b/plugin_management/tests/test_hot_load.py
@@ -159,6 +159,44 @@ def test_refuses_when_the_plugin_cannot_be_imported(monkeypatch):
     assert "failed to load" in reason
 
 
+def test_purge_then_reinstall_hot_loads(monkeypatch, dummy_module):
+    """install -> uninstall (disable + deregister + purge, what
+    manage_model.pre_change does) -> reinstall must hot-load: the purge drops
+    the stale module, so the guard passes and fresh code imports from disk."""
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    app, manager = FakeApp(), PluginGroupManager()
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is None
+
+    manager.disable(app, "my_group")
+    manager.deregister_plugin("my_plugin")
+    hot_load.purge_plugin_modules([f"{dummy_module}:HotDummyPlugin"])
+    assert dummy_module not in sys.modules
+
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is None
+    assert manager.is_loaded("my_group")
+
+
+def test_own_dist_version_change_is_allowed(monkeypatch, dummy_module):
+    """An in-place version change moves ONLY the target dist in the diff; its
+    modules were purged by pre_change, so hot-load instead of relaunching."""
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    app, manager = FakeApp(), PluginGroupManager()
+    own_change = EnvDiff(added={}, changed={DIST: ("1.0", "2.0")}, removed={})
+
+    assert hot_load.hot_load_installed(app, manager, DIST, own_change) is None
+    assert manager.is_loaded("my_group")
+
+
+def test_purge_plugin_modules_drops_module_and_submodules(dummy_module):
+    importlib.import_module(dummy_module)
+    assert dummy_module in sys.modules
+
+    purged = hot_load.purge_plugin_modules([f"{dummy_module}:HotDummyPlugin"])
+
+    assert dummy_module in purged
+    assert dummy_module not in sys.modules
+
+
 def test_live_modules_keys_on_the_top_level_package():
     """`plugin_management` is always imported here, so a spec nested under it
     must report the ROOT package, not the leaf module."""

--- a/plugin_management/tests/test_hot_load.py
+++ b/plugin_management/tests/test_hot_load.py
@@ -1,5 +1,6 @@
 """Tests for the hot-load gate: when may a just-installed plugin be applied
 to the LIVE app instead of relaunching?"""
+import importlib
 import sys
 
 import pytest
@@ -157,4 +158,37 @@ def test_live_modules_keys_on_the_top_level_package():
     """`plugin_management` is always imported here, so a spec nested under it
     must report the ROOT package, not the leaf module."""
     manifest = _manifest("plugin_management.tests.whatever")
-    assert list(hot_load._live_modules(manifest)) == ["plugin_management"]
+    assert list(hot_load._live_modules(manifest, set(sys.modules))) == [
+        "plugin_management"]
+
+
+def test_live_modules_reads_the_snapshot_not_sys_modules(dummy_module):
+    """The guard must key on what was imported BEFORE the install.
+
+    `discover_entry_point_manifests()` reads package data via
+    `importlib.resources.files(ep.module)`, which imports the entry point's
+    module. If the guard read `sys.modules` live it would see that import and
+    refuse every install — so it must consult a pre-discovery snapshot."""
+    manifest = _manifest(dummy_module)
+    before = set(sys.modules)                     # dummy_module not yet imported
+    importlib.import_module(dummy_module)         # what discovery does to us
+    assert dummy_module in sys.modules            # live read would refuse...
+    assert list(hot_load._live_modules(manifest, before)) == []   # ...snapshot does not
+
+
+def test_hot_loads_even_though_discovery_imported_the_module(monkeypatch,
+                                                             dummy_module):
+    """End-to-end regression: real discovery imports the plugin's module, so a
+    fresh install must still hot-load. Guarding on a live `sys.modules` read
+    made this refuse every time."""
+    manifest = _manifest(dummy_module)
+
+    def _discovery_that_imports():
+        importlib.import_module(dummy_module)     # exactly what the real one does
+        return [(manifest, DIST)]
+    monkeypatch.setattr(hot_load, "discover_entry_point_manifests",
+                        _discovery_that_imports)
+
+    app, manager = FakeApp(), PluginGroupManager()
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is True
+    assert manager.is_loaded("my_group")

--- a/plugin_management/tests/test_hot_load.py
+++ b/plugin_management/tests/test_hot_load.py
@@ -71,7 +71,7 @@ def test_hot_loads_and_enables_a_pure_addition(monkeypatch, dummy_module):
     _patch_discovery(monkeypatch, _manifest(dummy_module))
     app, manager = FakeApp(), PluginGroupManager()
 
-    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is True
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is None
     assert manager.is_loaded("my_group")
     assert [c for c in app.calls if c[0] == "add"] == [("add", "HotDummyPlugin")]
 
@@ -79,47 +79,51 @@ def test_hot_loads_and_enables_a_pure_addition(monkeypatch, dummy_module):
 def test_refuses_when_diff_is_none(monkeypatch, dummy_module):
     _patch_discovery(monkeypatch, _manifest(dummy_module))
     manager = PluginGroupManager()
-    assert hot_load.hot_load_installed(FakeApp(), manager, DIST, None) is False
+    reason = hot_load.hot_load_installed(FakeApp(), manager, DIST, None)
+    assert "could not be determined" in reason
     assert "my_group" not in manager.groups
 
 
 def test_refuses_when_a_dep_was_bumped(monkeypatch, dummy_module):
+    """The refusal reason names the moved packages, for the relaunch dialog."""
     _patch_discovery(monkeypatch, _manifest(dummy_module))
     manager = PluginGroupManager()
-    assert hot_load.hot_load_installed(
-        FakeApp(), manager, DIST, BUMPED_DEP) is False
+    reason = hot_load.hot_load_installed(FakeApp(), manager, DIST, BUMPED_DEP)
+    assert "numpy" in reason
     assert "my_group" not in manager.groups
 
 
 def test_refuses_when_nothing_was_discovered(monkeypatch):
     monkeypatch.setattr(hot_load, "discover_entry_point_manifests", lambda: [])
-    assert hot_load.hot_load_installed(
-        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+    reason = hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION)
+    assert "no plugin manifest" in reason
 
 
 def test_refuses_when_dist_name_does_not_match(monkeypatch, dummy_module):
     _patch_discovery(monkeypatch, _manifest(dummy_module), dist="someone-else")
-    assert hot_load.hot_load_installed(
-        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+    reason = hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION)
+    assert "no plugin manifest" in reason
 
 
 def test_dist_name_match_ignores_case_and_underscores(monkeypatch, dummy_module):
     _patch_discovery(monkeypatch, _manifest(dummy_module),
                      dist="My_Microdrop_Plugin")
     assert hot_load.hot_load_installed(
-        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is True
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is None
 
 
 def test_refuses_when_the_module_is_already_imported(monkeypatch, dummy_module):
     """Reinstall-after-uninstall: the lock diff says 'pure addition', but
     import_module would hand back the STALE module."""
-    import importlib
     importlib.import_module(dummy_module)          # simulate it being live
     _patch_discovery(monkeypatch, _manifest(dummy_module))
     manager = PluginGroupManager()
 
-    assert hot_load.hot_load_installed(
-        FakeApp(), manager, DIST, PURE_ADDITION) is False
+    reason = hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION)
+    assert "hotload_dummy_pkg" in reason and "already loaded" in reason
     assert "my_group" not in manager.groups
 
 
@@ -138,8 +142,8 @@ def test_refuses_when_a_colliding_group_is_loaded(monkeypatch, dummy_module):
     # module, so the guard passes and register_manifest is what refuses.
     _patch_discovery(monkeypatch, _manifest(dummy_module))
 
-    assert hot_load.hot_load_installed(
-        app, manager, DIST, PURE_ADDITION) is False
+    reason = hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION)
+    assert "currently enabled" in reason      # register_manifest's message
     # Prove it refused at register_manifest, not earlier: the live group's
     # spec is still the ORIGINAL one, not overwritten by the incoming one.
     assert manager.groups["my_group"].plugin_specs == [loaded_spec]
@@ -150,8 +154,9 @@ def test_refuses_when_the_plugin_cannot_be_imported(monkeypatch):
     resolve it, the group never loads, and relaunch is a real remedy."""
     _patch_discovery(monkeypatch, _manifest("hotload_missing_pkg"))
     manager = PluginGroupManager()
-    assert hot_load.hot_load_installed(
-        FakeApp(), manager, DIST, PURE_ADDITION) is False
+    reason = hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION)
+    assert "failed to load" in reason
 
 
 def test_live_modules_keys_on_the_top_level_package():
@@ -190,5 +195,5 @@ def test_hot_loads_even_though_discovery_imported_the_module(monkeypatch,
                         _discovery_that_imports)
 
     app, manager = FakeApp(), PluginGroupManager()
-    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is True
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is None
     assert manager.is_loaded("my_group")

--- a/plugin_management/tests/test_hot_load.py
+++ b/plugin_management/tests/test_hot_load.py
@@ -1,0 +1,145 @@
+"""Tests for the hot-load gate: when may a just-installed plugin be applied
+to the LIVE app instead of relaunching?"""
+import sys
+
+import pytest
+
+from plugin_management import group_manager, hot_load
+from plugin_management.group_manager import PluginGroupManager
+from plugin_management.manifest import manifest_from_dict
+from plugin_management.package_installer import EnvDiff
+from plugin_management.tests.test_group_manager_adoption import FakeApp
+
+PURE_ADDITION = EnvDiff(added={"my-plugin": "1.0"}, changed={}, removed={})
+BUMPED_DEP = EnvDiff(added={"my-plugin": "1.0"},
+                     changed={"numpy": ("2.1", "2.2")}, removed={})
+
+DIST = "my-microdrop-plugin"
+
+
+@pytest.fixture(autouse=True)
+def isolated_preferences(monkeypatch):
+    """Keep enable/disable from writing the REAL application preferences."""
+    from apptools.preferences.api import Preferences
+    store = Preferences()
+    monkeypatch.setattr(group_manager, "get_default_preferences",
+                        lambda: store)
+    return store
+
+
+@pytest.fixture
+def dummy_module(tmp_path, monkeypatch):
+    """A real, importable, TOP-LEVEL module that is not yet in sys.modules.
+
+    The guard keys on the top-level package name, so a dummy living inside
+    `plugin_management` would always trip it — this has to be its own root."""
+    (tmp_path / "hotload_dummy_pkg.py").write_text(
+        "from envisage.plugin import Plugin\n"
+        "\n"
+        "class HotDummyPlugin(Plugin):\n"
+        "    id = 'hotload_dummy_pkg.plugin'\n",
+        encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    yield "hotload_dummy_pkg"
+    sys.modules.pop("hotload_dummy_pkg", None)
+
+
+def _manifest(module):
+    return manifest_from_dict({
+        "schema_version": 1,
+        "name": "my_plugin",
+        "packages": [module],
+        "groups": [{
+            "name": "my_group",
+            "plugins": [f"{module}:HotDummyPlugin"],
+            "enabled_key": "plugin_group_enabled.my_group",
+        }],
+    })
+
+
+def _patch_discovery(monkeypatch, manifest, dist=DIST):
+    monkeypatch.setattr(hot_load, "discover_entry_point_manifests",
+                        lambda: [(manifest, dist)])
+
+
+def test_hot_loads_and_enables_a_pure_addition(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    app, manager = FakeApp(), PluginGroupManager()
+
+    assert hot_load.hot_load_installed(app, manager, DIST, PURE_ADDITION) is True
+    assert manager.is_loaded("my_group")
+    assert [c for c in app.calls if c[0] == "add"] == [("add", "HotDummyPlugin")]
+
+
+def test_refuses_when_diff_is_none(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(FakeApp(), manager, DIST, None) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_a_dep_was_bumped(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, BUMPED_DEP) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_nothing_was_discovered(monkeypatch):
+    monkeypatch.setattr(hot_load, "discover_entry_point_manifests", lambda: [])
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+
+
+def test_refuses_when_dist_name_does_not_match(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module), dist="someone-else")
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is False
+
+
+def test_dist_name_match_ignores_case_and_underscores(monkeypatch, dummy_module):
+    _patch_discovery(monkeypatch, _manifest(dummy_module),
+                     dist="My_Microdrop_Plugin")
+    assert hot_load.hot_load_installed(
+        FakeApp(), PluginGroupManager(), DIST, PURE_ADDITION) is True
+
+
+def test_refuses_when_the_module_is_already_imported(monkeypatch, dummy_module):
+    """Reinstall-after-uninstall: the lock diff says 'pure addition', but
+    import_module would hand back the STALE module."""
+    import importlib
+    importlib.import_module(dummy_module)          # simulate it being live
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
+    manager = PluginGroupManager()
+
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION) is False
+    assert "my_group" not in manager.groups
+
+
+def test_refuses_when_a_colliding_group_is_loaded(monkeypatch, dummy_module):
+    manifest = _manifest(dummy_module)
+    _patch_discovery(monkeypatch, manifest)
+    app, manager = FakeApp(), PluginGroupManager()
+    manager.register_manifest(manifest, dist_name=DIST)
+    manager.enable(app, "my_group")               # already live
+
+    assert hot_load.hot_load_installed(
+        app, manager, DIST, PURE_ADDITION) is False
+
+
+def test_refuses_when_the_plugin_cannot_be_imported(monkeypatch):
+    """A manifest pointing at a module that does not exist: enable() cannot
+    resolve it, the group never loads, and relaunch is a real remedy."""
+    _patch_discovery(monkeypatch, _manifest("hotload_missing_pkg"))
+    manager = PluginGroupManager()
+    assert hot_load.hot_load_installed(
+        FakeApp(), manager, DIST, PURE_ADDITION) is False
+
+
+def test_live_modules_keys_on_the_top_level_package():
+    """`plugin_management` is always imported here, so a spec nested under it
+    must report the ROOT package, not the leaf module."""
+    manifest = _manifest("plugin_management.tests.whatever")
+    assert list(hot_load._live_modules(manifest)) == ["plugin_management"]

--- a/plugin_management/tests/test_hot_load.py
+++ b/plugin_management/tests/test_hot_load.py
@@ -44,17 +44,21 @@ def dummy_module(tmp_path, monkeypatch):
     sys.modules.pop("hotload_dummy_pkg", None)
 
 
-def _manifest(module):
+def _manifest_for(plugin_spec):
     return manifest_from_dict({
         "schema_version": 1,
         "name": "my_plugin",
-        "packages": [module],
+        "packages": [plugin_spec.partition(":")[0]],
         "groups": [{
             "name": "my_group",
-            "plugins": [f"{module}:HotDummyPlugin"],
+            "plugins": [plugin_spec],
             "enabled_key": "plugin_group_enabled.my_group",
         }],
     })
+
+
+def _manifest(module):
+    return _manifest_for(f"{module}:HotDummyPlugin")
 
 
 def _patch_discovery(monkeypatch, manifest, dist=DIST):
@@ -119,14 +123,25 @@ def test_refuses_when_the_module_is_already_imported(monkeypatch, dummy_module):
 
 
 def test_refuses_when_a_colliding_group_is_loaded(monkeypatch, dummy_module):
-    manifest = _manifest(dummy_module)
-    _patch_discovery(monkeypatch, manifest)
+    """A group-NAME collision across two distributions shipping DIFFERENT
+    top-level packages: enable() imports test_group_manager_adoption's
+    module (already in sys.modules anyway, since this test suite imports it),
+    so the sys.modules guard passes and register_manifest is what refuses."""
     app, manager = FakeApp(), PluginGroupManager()
-    manager.register_manifest(manifest, dist_name=DIST)
+    loaded_spec = ("plugin_management.tests.test_group_manager_adoption"
+                   ":DummyUiPlugin")
+    manager.register_manifest(_manifest_for(loaded_spec), dist_name=DIST)
     manager.enable(app, "my_group")               # already live
+
+    # The incoming manifest reuses the NAME but points at a fresh, unimported
+    # module, so the guard passes and register_manifest is what refuses.
+    _patch_discovery(monkeypatch, _manifest(dummy_module))
 
     assert hot_load.hot_load_installed(
         app, manager, DIST, PURE_ADDITION) is False
+    # Prove it refused at register_manifest, not earlier: the live group's
+    # spec is still the ORIGINAL one, not overwritten by the incoming one.
+    assert manager.groups["my_group"].plugin_specs == [loaded_spec]
 
 
 def test_refuses_when_the_plugin_cannot_be_imported(monkeypatch):

--- a/plugin_management/tests/test_package_installer.py
+++ b/plugin_management/tests/test_package_installer.py
@@ -75,9 +75,22 @@ def test_ensure_channel_registered_passes_url(monkeypatch):
     calls = []
     monkeypatch.setattr(package_installer, "_run",
                         lambda args, cwd=None: calls.append((list(args), cwd)))
+    monkeypatch.setattr(package_installer, "_registered_channels", set())
     package_installer._ensure_channel_registered("https://prefix.dev/microdrop-plugins", cwd=None)
     assert calls[0][0] == ["workspace", "channel", "add",
                            "https://prefix.dev/microdrop-plugins"]
+
+
+def test_ensure_channel_registered_memoizes_per_process(monkeypatch):
+    """The channel URL is a fixed constant; re-registering it on every install
+    wastes a pixi subprocess. Once per (url, workspace) per run is enough."""
+    calls = []
+    monkeypatch.setattr(package_installer, "_run",
+                        lambda args, cwd=None: calls.append(list(args)))
+    monkeypatch.setattr(package_installer, "_registered_channels", set())
+    package_installer._ensure_channel_registered("https://c", cwd=None)
+    package_installer._ensure_channel_registered("https://c", cwd=None)
+    assert len(calls) == 1
 
 
 def test_install_from_channel_adds_and_returns(tmp_path, monkeypatch):
@@ -196,16 +209,16 @@ def test_uninstall_pure_removal_does_not_require_relaunch(tmp_path, monkeypatch)
     assert result.diff.removed == {"my-plugin": "1.0.0"}
 
 
-def test_uninstall_failure_requires_relaunch(tmp_path, monkeypatch):
-    """`pixi remove` failing is swallowed (existing contract) but must never
-    claim the hot path."""
+def test_uninstall_failure_raises(tmp_path, monkeypatch):
+    """A failed `pixi remove` must RAISE, not be swallowed — swallowing made
+    it indistinguishable from success-needing-relaunch, so the UI reported
+    'Uninstalled X.' for a package still on disk. The controllers' on_error
+    path turns the raise into an error dialog."""
     def fake_run(args, cwd=None):
         if args[:1] == ["remove"]:
             raise package_installer.InstallError("boom")
         return SimpleNamespace(stdout=json.dumps([_rec("numpy", "2.1.0")]))
     monkeypatch.setattr(package_installer, "_run", fake_run)
 
-    result = package_installer.uninstall_package("my-plugin", cwd=tmp_path)
-
-    assert result.diff is None
-    assert result.requires_relaunch is True
+    with pytest.raises(package_installer.InstallError):
+        package_installer.uninstall_package("my-plugin", cwd=tmp_path)

--- a/plugin_management/tests/test_package_installer.py
+++ b/plugin_management/tests/test_package_installer.py
@@ -1,5 +1,6 @@
 """Tests for the channel search/parse/cache data layer."""
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -89,6 +90,8 @@ def test_install_from_channel_adds_and_returns(tmp_path, monkeypatch):
         "scipy_analysis", "https://prefix.dev/microdrop-plugins", cwd=tmp_path)
     assert ["add", "scipy_analysis"] in calls
     assert result.name == "scipy_analysis"
+    # The fake _run returns None, so snapshotting fails -> unknown -> relaunch.
+    assert result.diff is None
     assert result.requires_relaunch is True
 
 
@@ -113,3 +116,96 @@ def test_installed_plugin_dists_shape():
     for name, version in dists.items():
         assert name and isinstance(name, str)
         assert version and isinstance(version, str)
+
+
+def _rec(name, version, build="b0", kind="conda"):
+    return {"name": name, "version": version, "build": build, "kind": kind}
+
+
+class _FakeRun:
+    """Stands in for package_installer._run.
+
+    Serves a different `pixi list --json` payload on each successive `list`
+    call, so an install can be made to look purely additive or not."""
+
+    def __init__(self, *list_payloads):
+        self.payloads = list(list_payloads)
+        self.calls = []
+
+    def __call__(self, args, cwd=None):
+        self.calls.append(list(args))
+        if args[:1] == ["list"]:
+            return SimpleNamespace(stdout=json.dumps(self.payloads.pop(0)))
+        return None
+
+
+def test_install_pure_addition_does_not_require_relaunch(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+    fake = _FakeRun([_rec("numpy", "2.1.0")],
+                    [_rec("numpy", "2.1.0"), _rec("my-plugin", "1.0.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.requires_relaunch is False
+    assert result.diff.added == {"my-plugin": "1.0.0"}
+
+
+def test_install_that_bumps_a_dep_requires_relaunch(tmp_path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+    fake = _FakeRun([_rec("numpy", "2.1.0")],
+                    [_rec("numpy", "2.2.0"), _rec("my-plugin", "1.0.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.requires_relaunch is True
+    assert result.diff.changed == {"numpy": ("2.1.0", "2.2.0")}
+
+
+def test_install_snapshot_failure_still_installs_and_asks_relaunch(
+        tmp_path, monkeypatch):
+    """A broken `pixi list` must never break the install — it degrades to the
+    relaunch prompt."""
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+
+    def fake_run(args, cwd=None):
+        if args[:1] == ["list"]:
+            raise package_installer.InstallError("list exploded")
+        return None
+    monkeypatch.setattr(package_installer, "_run", fake_run)
+
+    result = package_installer.install_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path)
+
+    assert result.name == "my-plugin"
+    assert result.diff is None
+    assert result.requires_relaunch is True
+
+
+def test_uninstall_pure_removal_does_not_require_relaunch(tmp_path, monkeypatch):
+    fake = _FakeRun([_rec("numpy", "2.1.0"), _rec("my-plugin", "1.0.0")],
+                    [_rec("numpy", "2.1.0")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+
+    result = package_installer.uninstall_package("my-plugin", cwd=tmp_path)
+
+    assert result.requires_relaunch is False
+    assert result.diff.removed == {"my-plugin": "1.0.0"}
+
+
+def test_uninstall_failure_requires_relaunch(tmp_path, monkeypatch):
+    """`pixi remove` failing is swallowed (existing contract) but must never
+    claim the hot path."""
+    def fake_run(args, cwd=None):
+        if args[:1] == ["remove"]:
+            raise package_installer.InstallError("boom")
+        return SimpleNamespace(stdout=json.dumps([_rec("numpy", "2.1.0")]))
+    monkeypatch.setattr(package_installer, "_run", fake_run)
+
+    result = package_installer.uninstall_package("my-plugin", cwd=tmp_path)
+
+    assert result.diff is None
+    assert result.requires_relaunch is True

--- a/plugin_management/tests/test_package_installer.py
+++ b/plugin_management/tests/test_package_installer.py
@@ -222,3 +222,45 @@ def test_uninstall_failure_raises(tmp_path, monkeypatch):
 
     with pytest.raises(package_installer.InstallError):
         package_installer.uninstall_package("my-plugin", cwd=tmp_path)
+
+
+def test_reinstall_diffs_across_the_whole_cycle(tmp_path, monkeypatch):
+    """The diff must span pre-remove -> post-add: a plugin-only dep that left
+    and came back at a DIFFERENT version is a change (its old build may still
+    be imported), never a harmless addition against the post-remove trough."""
+    fake = _FakeRun([_rec("my-plugin", "1.0"), _rec("scipy", "1.10")],
+                    [_rec("my-plugin", "2.0"), _rec("scipy", "1.11")])
+    monkeypatch.setattr(package_installer, "_run", fake)
+    monkeypatch.setattr(package_installer, "_registered_channels", set())
+
+    result = package_installer.reinstall_from_channel(
+        "my-plugin", "https://c", cwd=tmp_path, version="2.0")
+
+    assert ["remove", "my-plugin"] in fake.calls
+    assert ["add", "my-plugin==2.0"] in fake.calls
+    assert result.diff.changed == {"my-plugin": ("1.0", "2.0"),
+                                   "scipy": ("1.10", "1.11")}
+
+
+def test_reinstall_failure_rolls_back_and_rematerializes(tmp_path, monkeypatch):
+    """A failed add must restore pyproject/lock AND re-run `pixi install`, so
+    the env is not left at the post-remove trough."""
+    (tmp_path / "pyproject.toml").write_text("orig", encoding="utf-8")
+    calls = []
+
+    def fake_run(args, cwd=None):
+        calls.append(list(args))
+        if args[:1] == ["add"]:
+            raise package_installer.InstallError("boom")
+        if args[:1] == ["list"]:
+            return SimpleNamespace(stdout=json.dumps([_rec("my-plugin", "1.0")]))
+        return None
+    monkeypatch.setattr(package_installer, "_run", fake_run)
+    monkeypatch.setattr(package_installer, "_registered_channels", set())
+
+    with pytest.raises(package_installer.InstallError):
+        package_installer.reinstall_from_channel("my-plugin", "https://c",
+                                                 cwd=tmp_path)
+
+    assert (tmp_path / "pyproject.toml").read_text(encoding="utf-8") == "orig"
+    assert ["install"] in calls

--- a/plugin_management/tests/test_relaunch.py
+++ b/plugin_management/tests/test_relaunch.py
@@ -27,3 +27,17 @@ def test_finish_change_offers_relaunch_when_not_live(monkeypatch):
 
     assert seen["msg"] == "Installed <b>X</b>."
     assert "informed" not in seen
+
+
+def test_finish_change_names_the_refusal_reason(monkeypatch):
+    """The relaunch prompt must say WHY the change could not be applied live
+    — a bare prompt reads as arbitrary nagging."""
+    seen = {}
+    monkeypatch.setattr(relaunch, "confirm_and_relaunch",
+                        lambda task, msg: seen.update(msg=msg))
+
+    relaunch.finish_change(None, "Installed <b>X</b>.", False,
+                           reason="heater_controller is already loaded")
+
+    assert "Installed <b>X</b>." in seen["msg"]
+    assert "heater_controller is already loaded" in seen["msg"]

--- a/plugin_management/tests/test_relaunch.py
+++ b/plugin_management/tests/test_relaunch.py
@@ -1,0 +1,29 @@
+"""finish_change picks the right ending: a plain confirmation when the change
+is already live, the relaunch offer when it is not."""
+from plugin_management import relaunch
+
+
+def test_finish_change_informs_when_already_live(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(relaunch, "information",
+                        lambda **kw: seen.update(kw))
+    monkeypatch.setattr(relaunch, "confirm_and_relaunch",
+                        lambda *a: seen.update(relaunched=True))
+
+    relaunch.finish_change(None, "Installed and enabled <b>X</b>.", True)
+
+    assert seen["message"] == "Installed and enabled <b>X</b>."
+    assert "relaunched" not in seen
+
+
+def test_finish_change_offers_relaunch_when_not_live(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(relaunch, "information",
+                        lambda **kw: seen.update(informed=True))
+    monkeypatch.setattr(relaunch, "confirm_and_relaunch",
+                        lambda task, msg: seen.update(msg=msg))
+
+    relaunch.finish_change(None, "Installed <b>X</b>.", False)
+
+    assert seen["msg"] == "Installed <b>X</b>."
+    assert "informed" not in seen


### PR DESCRIPTION
## Summary

Plugin installs, uninstalls, reinstalls, and in-place version changes now apply to the **live app** whenever it is safe — dock panes mount/unmount immediately — falling back to the relaunch prompt (now with the reason named in the dialog) only when it is genuinely needed.

**Why it's safe:** `pixi install` writes into the same site-packages the running interpreter imports from, so brand-new code is importable without a restart. What is *not* safe is code already imported — so two independent gates protect the fast path:

1. **Env-diff gate** — snapshot `pixi list --json` either side of the pixi transaction; any package *other than the target dist itself* changing or vanishing forces a relaunch (its old build may be live in memory).
2. **`sys.modules` guard** — none of the modules `enable()` would import may predate the install. Snapshot taken *before* discovery (discovery itself imports entry-point modules to read package data).

**What makes cycling work:** unloading a plugin for a change (`pre_change`) disables + deregisters its groups, then **purges its modules from `sys.modules`** — the union of group-spec tops and everything the dist's file RECORD ships. Version changes are a full `pixi remove` + `pixi add` cycle so nothing of the old build survives on disk, diffed **across the whole cycle** (pre-remove → post-add) so a plugin-only dep returning at a different version still counts as changed. Purging is sound because plugins are fully isolated (no cross-plugin imports; separate-process capable).

**Failure handling:** a failed pixi step rolls back pyproject/lock, re-materializes the env, and re-enables the plugin from disk — cost is one error dialog. A failed `pixi remove` now raises into an error dialog instead of reporting "Uninstalled X." for a package still on disk.

**UX:** relaunch prompts name the refusal reason; upgrade glyph is success-green only when a newer version exists (grey + inert when current); Browse and Manage tables and the details pane all follow changes without reopening dialogs.

## Structure

- `package_installer.py` — env snapshot/diff (`EnvDiff`), honest `EnvChangeResult` (replaces the never-read `InstallResult.requires_relaunch=True`), `reinstall_from_channel`, per-process channel-registration memo
- `hot_load.py` (new) — the two gates, module purge, register+enable orchestration
- `relaunch.py` — `finish_change` (confirm vs relaunch-with-reason)
- controllers/models — worker-thread pixi, GUI-thread hot-load via `run_with_wait`, uniform table/details refresh
- Design doc: `docs/superpowers/specs/2026-07-16-plugin-hot-load-design.md`

## Test plan

Unit tests included (env-diff classification, gate refusal reasons, purge, collision refusal at `register_manifest`, cross-cycle reinstall diff, rollback re-materialization). Manually verified in the running app:

- [x] Fresh install from Browse hot-loads: pane appears live, no relaunch prompt
- [x] Uninstall applies live; reinstall in the same session hot-loads (purge)
- [x] In-place version change / upgrade hot-loads the new version's panes
- [x] Refusal reasons appear in the relaunch dialog
- [x] Upgrade glyph green only when a newer version exists
- [x] Details pane follows version changes; installed row leaves Browse list

## Notes for reviewers

- `update_controller` (launch update-check) deliberately keeps the unconditional relaunch — bulk updates always move installed packages.
- Known open item: `relaunch_app` re-execs the `microdrop` pixi task, which drops `--device opendrop` / frontend-backend-split launch modes (pre-existing from 5be1f242; left for a separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)