### PR TITLE
feat(pluggable_protocol_tree): generic per-row column locks

### DIFF
--- a/pluggable_protocol_tree/builtins/repeat_duration_column.py
+++ b/pluggable_protocol_tree/builtins/repeat_duration_column.py
@@ -7,6 +7,13 @@ diverges from what the auto-estimate would compute given the current
 Route Reps + Duration + trail config. On confirm, the row's
 ``repeat_duration_controls`` flag flips to True; on cancel, the edit
 is rejected and the column reverts to its previous value.
+
+Flipping the flag to True locks the ``route_repetitions`` cell (via the
+BaseRow observer in models/row.py — issue #541), so once duration
+control is active Route Reps is genuinely read-only. Editing Route Reps
+Dur back to 0 is therefore the only way back to count mode: it prompts
+with the same handoff dialog and, on confirm, flips the flag back to
+False, which unlocks Route Reps again.
 """
 
 from traits.api import Float
@@ -45,6 +52,26 @@ class RepeatDurationHandler(BaseColumnHandler):
         new_value = float(value or 0.0)
         already_controls = bool(getattr(row, "repeat_duration_controls", False))
         if already_controls:
+            if new_value == 0.0:
+                # 0 disables duration control (matches the DV sidebar,
+                # which derives the flag from repeat_duration > 0) —
+                # and it is the only way back now that the lock makes
+                # Route Reps genuinely read-only in duration mode.
+                choice = confirm(
+                    None,
+                    title="Switch to Route Reps Control",
+                    message=(
+                        "Setting Route Reps Dur to 0 hands loop control "
+                        "back to Route Reps: routes loop until the largest "
+                        "loop has completed all repetitions.<br><br>"
+                        "Route Reps will become editable again."
+                    ),
+                    yes_label="Switch",
+                    no_label="Cancel",
+                )
+                if choice != YES:
+                    return False
+                row.repeat_duration_controls = False
             return model.set_value(row, new_value)
 
         routes = list(getattr(row, "routes", []) or [])

--- a/pluggable_protocol_tree/builtins/repeat_duration_column.py
+++ b/pluggable_protocol_tree/builtins/repeat_duration_column.py
@@ -39,9 +39,12 @@ class RepeatDurationColumnModel(BaseColumnModel):
 
 
 class RepeatDurationHandler(BaseColumnHandler):
-    """Intercepts edits to prompt for the Route Reps --> Route Reps Dur
-    mode handoff. Read-through writes (no prompt) when:
-      * the row is already in Route Reps Dur-controls mode, or
+    """Intercepts edits to prompt for the Route Reps <--> Route Reps Dur
+    mode handoffs: entering duration mode on a diverging non-zero edit,
+    and handing control back on a 0 edit while in duration mode.
+    Read-through writes (no prompt) when:
+      * the row is already in Route Reps Dur-controls mode and the new
+        value is non-zero, or
       * the new value matches the auto-estimate (rounding to the
         column's display precision), or
       * the row has no routes (Route Reps Dur has no semantic effect, so

--- a/pluggable_protocol_tree/builtins/route_repetitions_column.py
+++ b/pluggable_protocol_tree/builtins/route_repetitions_column.py
@@ -5,20 +5,18 @@ open-route passes when Lin Reps is on). Distinct from the "Reps" column,
 which repeats the whole step/group via row_manager._expand_frames. On a
 step, total route plays = Reps x Route Reps. Inert on groups.
 
-Edits prompt the user to hand control back from Route Reps Dur when the
-row is in duration-controlled mode (``repeat_duration_controls`` True).
-Confirming flips the flag back to False; cancelling rejects the edit.
-This is the count-side of the same mode handoff the legacy protocol_grid
-used between Repetitions and Repeat Duration.
+While a row is in duration-controlled mode (``repeat_duration_controls``
+True) this cell is LOCKED read-only via the per-row column-lock
+mechanism (issue #541) — the lock is applied by a BaseRow observer on
+the flag, so it also holds on protocol load and DV-sidebar sync. The
+way back to count mode is editing Route Reps Dur to 0, which prompts
+(see repeat_duration_column.py). No custom handler remains: edits can
+only happen in count mode, where they are plain writes.
 """
 
 from traits.api import Int
 
-from microdrop_application.dialogs.pyface_wrapper import YES, confirm
-
-from pluggable_protocol_tree.models.column import (
-    BaseColumnHandler, BaseColumnModel, Column,
-)
+from pluggable_protocol_tree.models.column import BaseColumnModel, Column
 from pluggable_protocol_tree.views.columns.spinbox import IntSpinBoxColumnView
 
 
@@ -26,30 +24,6 @@ class RouteRepetitionsColumnModel(BaseColumnModel):
     def trait_for_row(self):
         return Int(1, desc="Number of times this step's routes loop "
                            "(loop-route cycles / open-route passes).")
-
-
-class RouteRepsHandler(BaseColumnHandler):
-    """Count-side of the Route Reps <-> Route Reps Dur mode handoff."""
-
-    def on_interact(self, row, model, value):
-        if not bool(getattr(row, "repeat_duration_controls", False)):
-            return model.set_value(row, value)
-        choice = confirm(
-            None,
-            title="Switch to Route Reps Control",
-            message=(
-                "Switching back to Route Reps control will loop until the "
-                "largest loop has completed all repetitions.<br><br>"
-                "Route Reps Dur will be recalculated to match exactly "
-                "(no idle time)."
-            ),
-            yes_label="Switch",
-            no_label="Cancel",
-        )
-        if choice != YES:
-            return False
-        row.repeat_duration_controls = False
-        return model.set_value(row, value)
 
 
 def make_route_repetitions_column():
@@ -60,5 +34,4 @@ def make_route_repetitions_column():
         ),
         # Bounds mirror the DV sidebar's RouteLayerManager.repetitions.
         view=IntSpinBoxColumnView(low=1, high=10000),
-        handler=RouteRepsHandler(),
     )

--- a/pluggable_protocol_tree/models/row.py
+++ b/pluggable_protocol_tree/models/row.py
@@ -11,7 +11,9 @@ and add one trait per column in the active column set.
 
 import uuid as _uuid
 
-from traits.api import HasTraits, Str, List, Instance, Tuple, Property, Bool, provides
+from traits.api import (
+    HasTraits, Str, List, Instance, Tuple, Property, Bool, Dict, provides,
+)
 
 from pluggable_protocol_tree.interfaces.i_row import IRow, IGroupRow
 
@@ -29,6 +31,12 @@ class BaseRow(HasTraits):
         desc="Internal mode flag: True when Route Reps Dur is the "
              "authoritative loop knob; False when Route Reps controls. "
              "Not a column — persisted via the row_flags map.")
+    column_locks = Dict(
+        Str, Dict,
+        desc="Owner-keyed per-row column locks: {col_id: {owner: reason}}. "
+             "Runtime-derived state, rebuilt from its source on load — "
+             "never persisted (a lock with no live owner could never be "
+             "released).")
 
     def _uuid_default(self):
         return _uuid.uuid4().hex
@@ -49,6 +57,40 @@ class BaseRow(HasTraits):
         """1-indexed dotted display id ('1.2.3') for this row — matches
         the Id column's rendering. Empty string for detached rows."""
         return ".".join(str(i + 1) for i in self.path) if self.path else ""
+
+    # --- per-row column locks (issue #541) ---
+
+    def lock_column(self, col_id: str, owner: str, reason: str = "") -> None:
+        """Lock ``col_id``'s cell on this row on behalf of ``owner``.
+
+        ``reason`` surfaces as the cell tooltip. The whole dict is
+        rebuilt and reassigned so trait observers (the tree model's
+        repaint wiring) fire — Traits does not notify on nested
+        mutation.
+        """
+        locks = {cid: dict(owners) for cid, owners in self.column_locks.items()}
+        locks.setdefault(col_id, {})[owner] = reason
+        self.column_locks = locks
+
+    def unlock_column(self, col_id: str, owner: str) -> None:
+        """Release ``owner``'s lock on ``col_id``. The cell stays locked
+        while any other owner still holds one. Unknown column ids or
+        owners are a no-op."""
+        if owner not in self.column_locks.get(col_id, {}):
+            return
+        locks = {cid: dict(owners) for cid, owners in self.column_locks.items()}
+        del locks[col_id][owner]
+        if not locks[col_id]:
+            del locks[col_id]
+        self.column_locks = locks
+
+    def is_column_locked(self, col_id: str) -> bool:
+        return bool(self.column_locks.get(col_id))
+
+    def column_lock_reasons(self, col_id: str) -> list:
+        """Non-empty lock reasons for ``col_id`` — the cell tooltip."""
+        return [reason for reason in self.column_locks.get(col_id, {}).values()
+                if reason]
 
 
 @provides(IGroupRow)

--- a/pluggable_protocol_tree/models/row.py
+++ b/pluggable_protocol_tree/models/row.py
@@ -13,6 +13,7 @@ import uuid as _uuid
 
 from traits.api import (
     HasTraits, Str, List, Instance, Tuple, Property, Bool, Dict, provides,
+    observe,
 )
 
 from pluggable_protocol_tree.interfaces.i_row import IRow, IGroupRow
@@ -91,6 +92,19 @@ class BaseRow(HasTraits):
         """Non-empty lock reasons for ``col_id`` — the cell tooltip."""
         return [reason for reason in self.column_locks.get(col_id, {}).values()
                 if reason]
+
+    @observe("repeat_duration_controls")
+    def _sync_repeat_duration_lock(self, event):
+        # "Route Reps will become read-only while Route Reps Dur is in
+        # control" — the mode-handoff dialog's promise (issue #541
+        # debt). Observed on the trait, not done in the column handler,
+        # because DV-sidebar sync and protocol load write this flag
+        # directly and the lock must follow on every path.
+        if event.new:
+            self.lock_column("route_repetitions", owner="repeat_duration",
+                             reason="Route Reps Dur is in control")
+        else:
+            self.unlock_column("route_repetitions", owner="repeat_duration")
 
 
 @provides(IGroupRow)

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -600,8 +600,14 @@ class RowManager(HasTraits):
         self._set_value(path, col, value)
 
     def set_values(self, paths: List[Path], col_id: str, value) -> None:
+        """Bulk write — the Bulk Set dialog's apply path. Rows where the
+        column is locked (issue #541) are skipped: a lock means some
+        owner arbitrates that cell, and a bulk write must not bypass
+        what the per-cell editor would refuse."""
         col = self._column_by_id(col_id)
         for path in paths:
+            if self.get_row(path).is_column_locked(col.model.col_id):
+                continue
             self._set_value(path, col, value)
 
     def apply(self, paths: List[Path], fn) -> None:

--- a/pluggable_protocol_tree/tests/test_builtins.py
+++ b/pluggable_protocol_tree/tests/test_builtins.py
@@ -190,7 +190,7 @@ def test_route_repetitions_editable_on_step_not_group():
     assert not (col.view.get_flags(GroupRow()) & Qt.ItemIsEditable)
 
 
-def test_route_reps_handler_plain_write_when_not_in_duration_mode():
+def test_route_reps_plain_write_when_not_in_duration_mode():
     from pluggable_protocol_tree.models.row import build_row_type, BaseRow
     from pluggable_protocol_tree.builtins.route_repetitions_column import (
         make_route_repetitions_column,
@@ -203,31 +203,72 @@ def test_route_reps_handler_plain_write_when_not_in_duration_mode():
     assert row.route_repetitions == 5
 
 
-def test_route_reps_handler_switch_back_from_duration_on_confirm(monkeypatch):
-    import pluggable_protocol_tree.builtins.route_repetitions_column as mod
+def test_repeat_duration_flag_locks_route_reps_cell():
+    """The mode-handoff dialog promises 'Route Reps will become
+    read-only while Route Reps Dur is in control' — the flag now
+    drives a column lock (issue #541 debt), on every path that flips
+    it (edit dialog, DV-sidebar sync, protocol load)."""
+    from pluggable_protocol_tree.models.row import BaseRow
+    row = BaseRow()
+    row.repeat_duration_controls = True
+    assert row.is_column_locked("route_repetitions") is True
+    assert row.column_lock_reasons("route_repetitions") == [
+        "Route Reps Dur is in control"]
+    row.repeat_duration_controls = False
+    assert row.is_column_locked("route_repetitions") is False
+
+
+def test_repeat_duration_zero_edit_switches_back_on_confirm(monkeypatch):
+    """Route Reps Dur = 0 is the way back to count mode now that the
+    Route Reps cell is genuinely read-only in duration mode."""
+    import pluggable_protocol_tree.builtins.repeat_duration_column as mod
     from pluggable_protocol_tree.models.row import build_row_type, BaseRow
+    from pluggable_protocol_tree.builtins.repeat_duration_column import (
+        make_repeat_duration_column,
+    )
     monkeypatch.setattr(mod, "confirm", lambda *a, **k: mod.YES)
-    col = mod.make_route_repetitions_column()
+    col = make_repeat_duration_column()
     Row = build_row_type([col], base=BaseRow)
     row = Row()
     row.repeat_duration_controls = True
-    assert col.handler.on_interact(row, col.model, 3) is True
-    assert row.repeat_duration_controls is False     # handed back to count mode
-    assert row.route_repetitions == 3
+    assert col.handler.on_interact(row, col.model, 0.0) is True
+    assert row.repeat_duration_controls is False
+    assert row.is_column_locked("route_repetitions") is False
+    assert row.repeat_duration == 0.0
 
 
-def test_route_reps_handler_cancel_rejects_edit(monkeypatch):
-    import pluggable_protocol_tree.builtins.route_repetitions_column as mod
+def test_repeat_duration_zero_edit_cancel_stays_in_duration_mode(monkeypatch):
+    import pluggable_protocol_tree.builtins.repeat_duration_column as mod
     from pluggable_protocol_tree.models.row import build_row_type, BaseRow
+    from pluggable_protocol_tree.builtins.repeat_duration_column import (
+        make_repeat_duration_column,
+    )
     monkeypatch.setattr(mod, "confirm", lambda *a, **k: 0)   # not YES
-    col = mod.make_route_repetitions_column()
+    col = make_repeat_duration_column()
     Row = build_row_type([col], base=BaseRow)
     row = Row()
     row.repeat_duration_controls = True
-    row.route_repetitions = 1
-    assert col.handler.on_interact(row, col.model, 9) is False
-    assert row.repeat_duration_controls is True          # unchanged
-    assert row.route_repetitions == 1                    # edit rejected
+    row.repeat_duration = 30.0
+    assert col.handler.on_interact(row, col.model, 0.0) is False
+    assert row.repeat_duration_controls is True
+    assert row.repeat_duration == 30.0
+
+
+def test_repeat_duration_nonzero_edit_in_duration_mode_is_plain_write(monkeypatch):
+    import pluggable_protocol_tree.builtins.repeat_duration_column as mod
+    from pluggable_protocol_tree.models.row import build_row_type, BaseRow
+    from pluggable_protocol_tree.builtins.repeat_duration_column import (
+        make_repeat_duration_column,
+    )
+    monkeypatch.setattr(mod, "confirm", lambda *a, **k: (_ for _ in ()).throw(
+        AssertionError("no dialog for a non-zero edit in duration mode")))
+    col = make_repeat_duration_column()
+    Row = build_row_type([col], base=BaseRow)
+    row = Row()
+    row.repeat_duration_controls = True
+    assert col.handler.on_interact(row, col.model, 45.0) is True
+    assert row.repeat_duration == 45.0
+    assert row.repeat_duration_controls is True
 
 
 def test_reps_handler_is_plain_write_through_even_in_duration_mode():

--- a/pluggable_protocol_tree/tests/test_column_locks.py
+++ b/pluggable_protocol_tree/tests/test_column_locks.py
@@ -1,0 +1,126 @@
+"""MvcTreeModel enforcement of per-row column locks (issue #541).
+
+Locks live on the row (see test_row.py for storage semantics); this
+module covers the central enforcement: flags() clearing, tooltip,
+grey read-only fill, and the auto-wired repaint."""
+
+from pyface.qt.QtCore import Qt
+from traits.api import Bool
+
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.models.column import BaseColumnModel, Column
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.columns.checkbox import CheckboxColumnView
+from pluggable_protocol_tree.views.qt_tree_model import MvcTreeModel
+
+
+class _BoolColumnModel(BaseColumnModel):
+    def trait_for_row(self):
+        return Bool(False)
+
+
+def _make_checkbox_column():
+    return Column(
+        model=_BoolColumnModel(col_id="capture", col_name="Capture",
+                               default_value=False),
+        view=CheckboxColumnView(),
+    )
+
+
+def _build():
+    manager = RowManager(columns=[
+        make_type_column(), make_name_column(), _make_checkbox_column(),
+    ])
+    manager.add_step()
+    qm = MvcTreeModel(manager)
+    ids = [c.model.col_id for c in manager.columns]
+    return manager, qm, ids
+
+
+def _cell(qm, row_idx, col_idx):
+    from pyface.qt.QtCore import QModelIndex
+    return qm.index(row_idx, col_idx, QModelIndex())
+
+
+def test_locked_editable_cell_loses_editable_flag():
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    idx = _cell(qm, 0, ids.index("name"))
+    assert qm.flags(idx) & Qt.ItemIsEditable
+    row.lock_column("name", owner="test", reason="because")
+    assert not (qm.flags(idx) & Qt.ItemIsEditable)
+
+
+def test_locked_checkbox_cell_loses_user_checkable_flag():
+    """Checkboxes are never ItemIsEditable — clearing only that flag
+    would do nothing at all. Both flags must go."""
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    idx = _cell(qm, 0, ids.index("capture"))
+    assert qm.flags(idx) & Qt.ItemIsUserCheckable
+    row.lock_column("capture", owner="fluorescence", reason="chain owns step")
+    flags = qm.flags(idx)
+    assert not (flags & Qt.ItemIsUserCheckable)
+    assert not (flags & Qt.ItemIsEditable)
+    assert flags & Qt.ItemIsEnabled    # still selectable/enabled, just inert
+
+
+def test_unlocking_last_owner_restores_flags():
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    idx = _cell(qm, 0, ids.index("capture"))
+    row.lock_column("capture", owner="a")
+    row.lock_column("capture", owner="b")
+    row.unlock_column("capture", owner="a")
+    assert not (qm.flags(idx) & Qt.ItemIsUserCheckable)   # b still holds
+    row.unlock_column("capture", owner="b")
+    assert qm.flags(idx) & Qt.ItemIsUserCheckable
+
+
+def test_lock_reason_is_cell_tooltip():
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    idx = _cell(qm, 0, ids.index("capture"))
+    assert qm.data(idx, Qt.ToolTipRole) is None
+    row.lock_column("capture", owner="fluorescence",
+                    reason="Captured by fluorescence chain")
+    assert qm.data(idx, Qt.ToolTipRole) == "Captured by fluorescence chain"
+
+
+def test_locked_cell_gets_read_only_background():
+    """The grey fill tests for the absence of BOTH flags — it must read
+    lock-aware flags, not the view's raw get_flags."""
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    idx = _cell(qm, 0, ids.index("name"))
+    assert qm.data(idx, Qt.BackgroundRole) is None
+    row.lock_column("name", owner="test")
+    assert qm.data(idx, Qt.BackgroundRole) is not None
+
+
+def test_lock_change_emits_datachanged_for_the_row():
+    """Repaint is auto-wired: no gated column declares anything."""
+    manager, qm, ids = _build()
+    row = manager.root.children[0]
+    received = []
+    qm.dataChanged.connect(
+        lambda top, bottom, *_: received.append(
+            (top.row(), top.column(), bottom.column())),
+    )
+    row.lock_column("capture", owner="fluorescence")
+    assert (0, 0, len(ids) - 1) in received
+    received.clear()
+    row.unlock_column("capture", owner="fluorescence")
+    assert (0, 0, len(ids) - 1) in received
+
+
+def test_lock_repaint_wired_for_rows_added_after_model_creation():
+    manager, qm, ids = _build()
+    manager.add_step()
+    received = []
+    qm.dataChanged.connect(
+        lambda top, bottom, *_: received.append((top.row(), top.column())),
+    )
+    manager.root.children[1].lock_column("capture", owner="fluorescence")
+    assert (1, 0) in received

--- a/pluggable_protocol_tree/tests/test_persistence.py
+++ b/pluggable_protocol_tree/tests/test_persistence.py
@@ -189,6 +189,30 @@ def test_load_old_payload_without_row_flags_defaults_false(manager):
     assert new_mgr.root.children[0].repeat_duration_controls is False
 
 
+def test_column_locks_are_never_serialized(manager):
+    """Locks are runtime-derived; persisting one would strand a
+    protocol opened without the owning plugin (issue #541)."""
+    import json
+    p = manager.add_step(values={"name": "A"})
+    row = manager.get_row(p)
+    row.lock_column("route_repetitions", owner="repeat_duration",
+                     reason="Route Reps Dur is in control")
+    data = manager.to_json()
+    assert "column_locks" not in json.dumps(data)
+
+
+def test_loading_row_flags_rebuilds_route_reps_lock(manager):
+    """persistence writes repeat_duration_controls directly onto the
+    row; the BaseRow observer must rebuild the lock from it."""
+    p = manager.add_step(values={"name": "A"})
+    manager.get_row(p).repeat_duration_controls = True
+    data = manager.to_json()
+    new_mgr = RowManager.from_json(data, columns=list(manager.columns))
+    loaded_step = new_mgr.root.children[0]
+    assert loaded_step.repeat_duration_controls is True
+    assert loaded_step.is_column_locked("route_repetitions") is True
+
+
 # --- Issue-1 dedup fix ---
 
 def test_serialize_no_duplicate_type_or_name_in_fields():

--- a/pluggable_protocol_tree/tests/test_row.py
+++ b/pluggable_protocol_tree/tests/test_row.py
@@ -187,3 +187,65 @@ def test_build_row_type_preserves_traits_semantics():
     r.observe(lambda e: seen.append((e.old, e.new)), "voltage")
     r.voltage = 5.0
     assert seen == [(0.0, 5.0)]
+
+
+# --- per-row column locks (issue #541) ---
+
+def test_lock_column_makes_column_locked():
+    r = BaseRow()
+    assert r.is_column_locked("capture") is False
+    r.lock_column("capture", owner="fluorescence", reason="Chain 'GFP' owns this step")
+    assert r.is_column_locked("capture") is True
+
+
+def test_unlock_requires_all_owners_released():
+    """Owner-keying is the point: one releasing owner must not re-enable
+    a cell another owner still wants locked."""
+    r = BaseRow()
+    r.lock_column("capture", owner="fluorescence", reason="chain")
+    r.lock_column("capture", owner="other_plugin", reason="busy")
+    r.unlock_column("capture", owner="fluorescence")
+    assert r.is_column_locked("capture") is True
+    r.unlock_column("capture", owner="other_plugin")
+    assert r.is_column_locked("capture") is False
+
+
+def test_unlock_unknown_owner_or_column_is_noop():
+    r = BaseRow()
+    r.unlock_column("capture", owner="nobody")          # never locked
+    r.lock_column("capture", owner="fluorescence")
+    r.unlock_column("capture", owner="somebody_else")   # wrong owner
+    assert r.is_column_locked("capture") is True
+
+
+def test_column_lock_reasons_collects_nonempty_reasons():
+    r = BaseRow()
+    r.lock_column("capture", owner="fluorescence", reason="Chain 'GFP' owns this step")
+    r.lock_column("capture", owner="other_plugin")      # no reason given
+    assert r.column_lock_reasons("capture") == ["Chain 'GFP' owns this step"]
+    assert r.column_lock_reasons("voltage") == []
+
+
+def test_relock_same_owner_updates_reason():
+    r = BaseRow()
+    r.lock_column("capture", owner="fluorescence", reason="old")
+    r.lock_column("capture", owner="fluorescence", reason="new")
+    assert r.column_lock_reasons("capture") == ["new"]
+
+
+def test_lock_and_unlock_fire_trait_notifications():
+    """The tree model repaints by observing column_locks — mutations
+    must reassign the dict so the notification actually fires."""
+    r = BaseRow()
+    events = []
+    r.observe(lambda e: events.append(e), "column_locks")
+    r.lock_column("capture", owner="fluorescence")
+    assert len(events) == 1
+    r.unlock_column("capture", owner="fluorescence")
+    assert len(events) == 2
+
+
+def test_locks_do_not_leak_between_rows():
+    a, b = BaseRow(), BaseRow()
+    a.lock_column("capture", owner="fluorescence")
+    assert b.is_column_locked("capture") is False

--- a/pluggable_protocol_tree/tests/test_row_manager.py
+++ b/pluggable_protocol_tree/tests/test_row_manager.py
@@ -388,6 +388,17 @@ def test_set_values_bulk(manager):
     assert manager.get_row(b).duration_s == 4.2
 
 
+def test_set_values_skips_locked_rows(manager):
+    """Bulk Set must not write what the per-cell editor would refuse:
+    rows where the column is locked (issue #541) are skipped."""
+    a = manager.add_step()
+    b = manager.add_step()
+    manager.get_row(b).lock_column("duration_s", owner="test", reason="held")
+    manager.set_values([a, b], "duration_s", 4.2)
+    assert manager.get_row(a).duration_s == 4.2
+    assert manager.get_row(b).duration_s != 4.2
+
+
 def test_apply_runs_callable_per_row(manager):
     a = manager.add_step(values={"duration_s": 1.0})
     b = manager.add_step(values={"duration_s": 2.0})

--- a/pluggable_protocol_tree/views/qt_tree_model.py
+++ b/pluggable_protocol_tree/views/qt_tree_model.py
@@ -128,10 +128,19 @@ class MvcTreeModel(QAbstractItemModel):
         # Read-only cells get the light-grey fill (mirror of protocol_grid
         # #359): read-only == neither editable nor user-checkable. The
         # active-row highlight above already returned for that row.
+        # Reads self.flags(), not the view's raw get_flags, so per-row
+        # column locks (issue #541) pick up the fill for free.
         if role == Qt.BackgroundRole:
-            flags = col.view.get_flags(node)
+            flags = self.flags(index)
             if not (flags & Qt.ItemIsEditable) and not (flags & Qt.ItemIsUserCheckable):
                 return self._read_only_brush()
+
+        # A locked cell explains itself: lock reasons are the tooltip.
+        if role == Qt.ToolTipRole:
+            reasons = node.column_lock_reasons(col.model.col_id)
+            if reasons:
+                return "\n".join(reasons)
+            return None
 
         value = col.model.get_value(node)
 
@@ -169,7 +178,14 @@ class MvcTreeModel(QAbstractItemModel):
         if not index.isValid():
             return Qt.NoItemFlags
         col = self._manager.columns[index.column()]
-        return col.view.get_flags(index.internalPointer())
+        row = index.internalPointer()
+        flags = col.view.get_flags(row)
+        # Per-row column locks (issue #541): while any owner holds a
+        # lock on this col_id, the cell is inert. Both flags must go —
+        # checkbox cells are ItemIsUserCheckable, never ItemIsEditable.
+        if row.is_column_locked(col.model.col_id):
+            flags &= ~(Qt.ItemIsEditable | Qt.ItemIsUserCheckable)
+        return flags
 
     def headerData(self, section, orientation, role=Qt.DisplayRole):
         if role == Qt.DisplayRole and orientation == Qt.Horizontal:
@@ -290,9 +306,6 @@ class MvcTreeModel(QAbstractItemModel):
             traits = list(getattr(col.view, "depends_on_row_traits", []) or [])
             for trait_name in traits:
                 col_trait_pairs.append((col_idx, trait_name))
-        if not col_trait_pairs:
-            self._row_observer_handles.clear()
-            return
 
         live_rows = list(self._iter_all_rows())
         live_ids = {id(r) for r in live_rows}
@@ -316,19 +329,33 @@ class MvcTreeModel(QAbstractItemModel):
             if id(row) in self._row_observer_handles:
                 continue
             handles: list = []
+            # Column locks repaint centrally for every row (issue #541)
+            # — a gated column never has to declare the dependency, so
+            # the stale-grey-out class of bug can't recur.
+            lock_handler = partial(self._on_row_locks_changed, row)
+            row.observe(lock_handler, "column_locks")
+            handles.append(("column_locks", lock_handler))
             for col_idx, trait_name in col_trait_pairs:
                 if trait_name not in row.trait_names():
                     continue
                 handler = partial(self._on_row_trait_changed, row, col_idx)
                 row.observe(handler, trait_name)
                 handles.append((trait_name, handler))
-            if handles:
-                self._row_observer_handles[id(row)] = (row, handles)
+            self._row_observer_handles[id(row)] = (row, handles)
 
     def _on_row_trait_changed(self, row, col_idx, event):
         idx = self._index_for_cell(row, col_idx)
         if idx.isValid():
             self.dataChanged.emit(idx, idx)
+
+    def _on_row_locks_changed(self, row, event):
+        # A lock can gate any column on the row; one whole-row
+        # dataChanged is cheaper than diffing which col_ids moved.
+        top_left = self._index_for_cell(row, 0)
+        if not top_left.isValid():
+            return
+        bottom_right = self._index_for_cell(row, len(self._manager.columns) - 1)
+        self.dataChanged.emit(top_left, bottom_right)
 
     def _index_for_cell(self, row, col_idx) -> QModelIndex:
         parent = row.parent

--- a/video_protocol_controls/protocol_columns/capture_column.py
+++ b/video_protocol_controls/protocol_columns/capture_column.py
@@ -26,7 +26,7 @@ needed.
 import json
 
 from pyface.qt.QtCore import Qt
-from traits.api import Bool, Enum, List
+from traits.api import Bool, Enum, List, Str
 
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 
@@ -79,6 +79,12 @@ class CaptureAtComboBoxView(ComboBoxColumnView):
     when the step doesn't capture (cross-cell editability via the
     canonical PPT-11 get_flags(row) pattern, mirroring the magnet
     height cell)."""
+
+    #: get_flags/format_display above are pure functions of row.capture;
+    #: declare it so the tree model repaints this cell the moment the
+    #: checkbox toggles (issue #541 latent bug — previously the grey-out
+    #: waited for an incidental repaint).
+    depends_on_row_traits = List(Str, value=["capture"])
 
     def _options_default(self):
         return list(CHOICES)

--- a/video_protocol_controls/tests/test_capture_column.py
+++ b/video_protocol_controls/tests/test_capture_column.py
@@ -231,3 +231,13 @@ def test_payload_missing_capture_at_fills_from_pref_default(qapp):
     assert captures.capture is True and plain.capture is False
     assert captures.capture_at == StepTime.END    # filled from the pref
     assert plain.capture_at == StepTime.END
+
+
+def test_capture_at_view_declares_capture_dependency():
+    """CaptureAtComboBoxView gates flags + display on row.capture; without
+    this declaration its grey-out only refreshed on an incidental
+    repaint (issue #541 latent bug)."""
+    from video_protocol_controls.protocol_columns.capture_column import (
+        CaptureAtComboBoxView,
+    )
+    assert list(CaptureAtComboBoxView().depends_on_row_traits) == ["capture"]


### PR DESCRIPTION
## Summary

Owner-keyed per-row column locks, honoured centrally by `MvcTreeModel` — the mechanism issue #541 specifies, plus the two debts it names.

- **Storage** (`BaseRow`): `column_locks = {col_id: {owner: reason}}` with `lock_column` / `unlock_column` / `is_column_locked` / `column_lock_reasons`. Owner-keyed so one releasing owner can't re-enable a cell another owner still holds; mutations reassign the dict wholesale so trait observers fire.
- **Enforcement**: `flags()` clears `ItemIsEditable | ItemIsUserCheckable` on locked cells (checkboxes are checkable, never editable — both must go). Lock reasons render as the cell tooltip. The grey read-only fill now reads lock-aware `self.flags(index)` so the visual comes for free. Repaint is **auto-wired**: the model observes every row's `column_locks` itself — gated columns declare nothing, so the stale-grey-out class of bug can't recur.
- **Bulk Set respects locks**: the dialog filters columns on a template row's flags, which can't see per-row locks on the targets — `RowManager.set_values` (its only apply path) now skips locked rows.
- **Debt paid**: the Route Reps Dur handoff dialog's promise — *"Route Reps will become read-only while Route Reps Dur is in control"* — is now true. A `BaseRow` observer on `repeat_duration_controls` drives the lock on **every** flip path (edit dialog, DV-sidebar sync, protocol load). `RouteRepsHandler` retires; the way back to count mode is editing Route Reps Dur to 0, which prompts.
- **Latent bug retired**: `CaptureAtComboBoxView` now declares `depends_on_row_traits = ["capture"]` so its grey-out repaints the moment the checkbox toggles. *Deviation from the issue's wording*: the fix uses the existing declared-dependency mechanism rather than the lock auto-wiring — the gate is a pure function of a plain trait, and locks (owner-driven runtime state) would have nothing to rebuild them on load.
- **Locks are never persisted** — pinned by a test; runtime-derived state rebuilds from its source on load.

## Verification

- ~120 unit tests across storage/enforcement/bulk/builtins/persistence, all RED→GREEN TDD.
- Live-driven offscreen against real widgets: Route Reps Dur edit → real Switch dialog → cell genuinely grey-locks with tooltip; bulk set skipped the locked row; Dur=0 prompts and unlocks; fluorescence-style lock on the `capture` checkbox works end-to-end (screenshots verified).
- `test_electrodes_routes_columns.py` has 10 pre-existing failures confirmed identical at the base commit (unrelated loop-budget math).

Closes #541. Unblocks Blue-Ocean-Technologies-Inc/fluorescence-microdrop-plugin-py#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)