### PR TITLE
ci: auto-release (tag + changelog) on every feat/fix push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+# Every push to main is auto-released: commitizen computes the next semver
+# from Conventional Commits (fix -> patch, feat -> minor, BREAKING CHANGE ->
+# major), commits the CHANGELOG.md update, tags vX.Y.Z (see .cz.toml), and
+# publishes a GitHub Release with the changelog increment as its notes.
+# Pushes with no releasable commits (docs/chore/refactor/ci only) skip the
+# whole thing.
+#
+# The bump commit itself ("chore: release vX.Y.Z") is pushed with
+# GITHUB_TOKEN, which never retriggers workflows; the head_commit guard is
+# belt-and-suspenders on top of that.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write   # push bump commit + tag, create the release
+
+# Queue runs so two quick pushes to main can't race the same bump.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: bump version, changelog & release
+    if: "!startsWith(github.event.head_commit.message, 'chore: release')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # cz bump walks the full history and tags
+
+      - name: Install commitizen
+        run: pipx install "commitizen>=4,<5"
+
+      - name: Bump version, update changelog, push tag
+        id: bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set +e
+          cz bump --yes --changelog --changelog-to-stdout > release_notes.md
+          rc=$?
+          set -e
+          # 3 = no commits since last tag, 21 = commits but none releasable
+          if [ "$rc" -eq 3 ] || [ "$rc" -eq 21 ]; then
+            echo "No feat/fix/BREAKING commits since the last tag — nothing to release."
+            echo "tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$rc" -ne 0 ]; then
+            exit "$rc"
+          fi
+          tag="$(git describe --tags --abbrev=0)"
+          git push origin main "refs/tags/$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub release
+        if: steps.bump.outputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          gh release create "$TAG" --repo "${{ github.repository }}" \
+            --title "$TAG" --notes-file release_notes.md


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release.yml`, completing the Conventional-Commits setup already in the repo (`conventional-commits.yml` PR check + `.cz.toml` with `update_changelog_on_bump`): every push to `main` containing `feat:`/`fix:`/`BREAKING CHANGE` commits now automatically

1. runs `cz bump` to derive the next semver (fix → patch, feat → minor, breaking → major),
2. commits the `CHANGELOG.md` update as `chore: release vX.Y.Z`,
3. pushes the annotated `vX.Y.Z` tag, and
4. publishes a GitHub Release with the changelog increment as notes.

Pushes with only non-releasable commits (docs/chore/refactor/ci) skip cleanly via commitizen exit codes 3/21. Mirrors [microdrop-launcher's release.yml](https://github.com/Blue-Ocean-Technologies-Inc/microdrop-launcher/blob/main/.github/workflows/release.yml) minus the binary-build matrix. Runs are queued via a concurrency group so rapid merges can't race the same bump.

## Note
The workflow pushes the bump commit directly to `main` with `GITHUB_TOKEN`. If branch protection later blocks pushes from Actions, allow the `github-actions` app to bypass it (or switch to a PAT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)