### PR TITLE
Changelog UX: What's New startup dialog + full-changelog help viewer

### DIFF
--- a/examples/demos/mock_changelog_render_demo.py
+++ b/examples/demos/mock_changelog_render_demo.py
@@ -1,0 +1,88 @@
+"""Demo: changelog markdown rendering with a mock changelog.
+
+Exercises the two changelog UX paths without touching the real
+CHANGELOG.md or the application-home cache:
+
+1. ``changelog_sections_added_since`` — the What's New delta between a
+   "previous run" changelog and the current one (printed to stdout and
+   shown in the styled information dialog, like startup does).
+2. ``markdown_text_to_html`` + ``WebViewDialog`` — the full changelog
+   rendered as HTML (the Help -> Changelog... path).
+
+The mock changelog deliberately includes the hostile cases:
+- tag-like tokens (``PID_<HEATER>``, ``Dict<str, int>``) that used to be
+  parsed as unclosed inline HTML and swallow the rest of the document,
+- ``[text](url)`` links, ``<https://...>`` autolinks and ``<mailto:...>``,
+- a LAST LINE MARKER so a cut-off render is obvious at a glance.
+
+Run (no Redis needed):
+    pixi run python examples/demos/mock_changelog_render_demo.py
+"""
+
+import sys
+
+# QtWebEngine must be imported before the QApplication is created.
+from microdrop_application.dialogs.web_view_dialog import WebViewDialog
+from PySide6.QtWidgets import QApplication
+
+from microdrop_utils.markdown_helpers import changelog_sections_added_since
+from microdrop_utils.pyside_helpers import markdown_text_to_html
+
+MOCK_PREVIOUS_CHANGELOG = """\
+## v1.1.0 (2026-07-06)
+
+### Feat
+
+- **heater_ui**: per-heater status readouts driven by PID_<HEATER> frames
+- **protocol-tree**: typed step params as Dict<str, int> maps
+
+### Fix
+
+- **logger**: write log files as utf-8
+
+## v1.0.0 (2026-07-06)
+
+### Feat
+
+- initial release, see [Microdrop](https://github.com/Blue-Ocean-Technologies-Inc/Microdrop)
+
+LAST LINE MARKER — if you can't scroll down to this line, rendering is cut off.
+"""
+
+MOCK_CHANGELOG = """\
+## v1.2.0 (2026-07-21)
+
+### Feat
+
+- **heater_ui**: retune PID_<HEATER> frames, see <https://sci-bots.com>
+- **user_help**: Changelog viewer + What's New dialog
+- **support**: reach us at <mailto:support@sci-bots.com>
+
+### Fix
+
+- **dialogs**: render markdown with tag-like tokens such as List<Path>
+
+""" + MOCK_PREVIOUS_CHANGELOG
+
+
+def main():
+    app = QApplication(sys.argv)
+
+    whats_new_delta = changelog_sections_added_since(
+        MOCK_PREVIOUS_CHANGELOG, MOCK_CHANGELOG)
+    print("=== What's New delta (should be only the v1.2.0 section) ===")
+    print(whats_new_delta)
+
+    from microdrop_application.dialogs.pyface_wrapper import information
+    information(None, markdown_text_to_html(whats_new_delta),
+                title="What's New?", cancel=False)
+
+    dialog = WebViewDialog(html_content=markdown_text_to_html(MOCK_CHANGELOG),
+                           title="Mock Changelog — scroll to the LAST LINE MARKER",
+                           open_links_externally=True)
+    dialog.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/microdrop_application/application.py
+++ b/microdrop_application/application.py
@@ -93,7 +93,7 @@ def _show_whats_new():
     information(None, markdown_text_to_html(new_sections), title="What's New?",
                 cancel=False)
 
-    # cache.write_text(current_changelog, encoding="utf-8")
+    cache.write_text(current_changelog, encoding="utf-8")
 
 
 class MicrodropApplication(TasksApplication):

--- a/microdrop_application/application.py
+++ b/microdrop_application/application.py
@@ -11,7 +11,7 @@ from dropbot_tools_menu.menus import dropbot_tools_menu_factory
 from microdrop_style.helpers import is_dark_mode
 from microdrop_style.icons.icons import ICON_MENU
 from .consts import (scibots_icon_path, sidebar_menu_options,
-                     hamburger_btn_stylesheet, EXPERIMENT_DIR)
+                     hamburger_btn_stylesheet, EXPERIMENT_DIR, CHANGELOG_PATH)
 
 # Enthought library imports.
 from traits.etsconfig.api import ETSConfig
@@ -28,7 +28,7 @@ from PySide6.QtWidgets import (QToolBar, QLabel,
                                QPushButton, QVBoxLayout,
                                QHBoxLayout, QWidget, QFrame)
 from PySide6.QtCore import Qt, QEvent, QSize
-from PySide6.QtGui import QPixmap, QFont
+from PySide6.QtGui import QPixmap, QFont, QTextDocument
 
 
 from logger.logger_service import get_logger
@@ -59,6 +59,42 @@ def _show_beta_disclaimer():
 
     marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text("Beta disclaimer accepted.")
+
+
+def _show_whats_new():
+    """Show a What's New dialog with changelog sections added since the last run.
+
+    Mirrors the beta-disclaimer marker pattern: the changelog text as of the
+    previous run is cached in application_home/.previous_changelog, anything
+    newly prepended to CHANGELOG.md since then (commitizen prepends a section
+    per release) is rendered in an information dialog, and the cache is
+    refreshed. The first ever run only seeds the cache so users aren't
+    greeted with the entire history.
+    """
+    from microdrop_application.dialogs.pyface_wrapper import information
+    from microdrop_utils.markdown_helpers import changelog_sections_added_since
+
+    if not CHANGELOG_PATH.exists():
+        return
+    current_changelog = CHANGELOG_PATH.read_text(encoding="utf-8")
+
+    cache = Path(ETSConfig.application_home) / ".previous_changelog"
+    if not cache.exists():
+        cache.parent.mkdir(parents=True, exist_ok=True)
+        cache.write_text(current_changelog, encoding="utf-8")
+        return
+
+    new_sections = changelog_sections_added_since(
+        cache.read_text(encoding="utf-8"), current_changelog)
+    if not new_sections.strip():
+        return
+
+    document = QTextDocument()
+    document.setMarkdown(new_sections)
+    information(None, informative=document.toHtml(), title="What's New?",
+                cancel=False)
+
+    cache.write_text(current_changelog, encoding="utf-8")
 
 
 class MicrodropApplication(TasksApplication):
@@ -207,6 +243,7 @@ class MicrodropApplication(TasksApplication):
     def _on_application_initialized(self, event):
         logger.critical("Application Initialized")
         _show_beta_disclaimer()
+        _show_whats_new()
 
         logger.info("Requesting Dropbot Search")
         publish_message(message="", topic=START_DEVICE_MONITORING)

--- a/microdrop_application/application.py
+++ b/microdrop_application/application.py
@@ -28,7 +28,7 @@ from PySide6.QtWidgets import (QToolBar, QLabel,
                                QPushButton, QVBoxLayout,
                                QHBoxLayout, QWidget, QFrame)
 from PySide6.QtCore import Qt, QEvent, QSize
-from PySide6.QtGui import QPixmap, QFont, QTextDocument
+from PySide6.QtGui import QPixmap, QFont
 
 
 from logger.logger_service import get_logger
@@ -73,6 +73,7 @@ def _show_whats_new():
     """
     from microdrop_application.dialogs.pyface_wrapper import information
     from microdrop_utils.markdown_helpers import changelog_sections_added_since
+    from microdrop_utils.pyside_helpers import markdown_text_to_html
 
     if not CHANGELOG_PATH.exists():
         return
@@ -89,12 +90,10 @@ def _show_whats_new():
     if not new_sections.strip():
         return
 
-    document = QTextDocument()
-    document.setMarkdown(new_sections)
-    information(None, informative=document.toHtml(), title="What's New?",
+    information(None, markdown_text_to_html(new_sections), title="What's New?",
                 cancel=False)
 
-    cache.write_text(current_changelog, encoding="utf-8")
+    # cache.write_text(current_changelog, encoding="utf-8")
 
 
 class MicrodropApplication(TasksApplication):

--- a/microdrop_application/consts.py
+++ b/microdrop_application/consts.py
@@ -21,6 +21,7 @@ ADVANCED_MODE_CHANGE = "microdrop/advanced_mode_change"
 
 
 scibots_icon_path = Path(__file__).parent / "resources" / "scibots-icon.png"
+CHANGELOG_PATH = Path(__file__).parent.parent / "CHANGELOG.md"
 application_home_directory = Path.home() / "Documents"/ "MicroDropNextGen"
 APP_GLOBALS_REDIS_HASH = "microdrop_application_globals"
 

--- a/microdrop_utils/markdown_helpers.py
+++ b/microdrop_utils/markdown_helpers.py
@@ -7,7 +7,53 @@ import requests
 GITHUB_BLOB_URL_PATTERN = re.compile(
     r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/blob/(?P<ref>[^/]+)/(?P<path>.+)"
 )
+GITHUB_MARKDOWN_RENDER_API_URL = "https://api.github.com/markdown"
 GITHUB_REQUEST_TIMEOUT_S = 10
+
+# Literal "<" in markdown, except when opening an autolink (<https://...>,
+# <mailto:...>). Markdown renderers otherwise treat any other <token> as
+# inline HTML: QTextDocument swallows the rest of the document and GitHub's
+# markdown API strips the token (e.g. "PID_<HEATER>" in a changelog entry).
+MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN = re.compile(
+    r"<(?!(?:https?|mailto):[^\s>]+>)")
+
+
+def escape_tag_like_tokens(markdown_text: str) -> str:
+    """Escape literal ``<`` (sparing autolinks) so tag-like tokens survive
+    markdown rendering as text; intentional inline HTML is consequently not
+    supported."""
+    return MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN.sub("&lt;", markdown_text)
+
+
+MARKDOWN_PAGE_TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+{base_tag}
+<style>
+body {{
+    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: #1f2328; line-height: 1.5; max-width: 850px;
+    margin: 0 auto; padding: 2rem;
+}}
+a {{ color: #0969da; text-decoration: none; }}
+a:hover {{ text-decoration: underline; }}
+h1, h2 {{ border-bottom: 1px solid #d1d9e0; padding-bottom: .3em; }}
+code, pre {{ font-family: ui-monospace, Consolas, monospace; background: #f6f8fa; border-radius: 6px; }}
+code {{ padding: .2em .4em; font-size: 85%; }}
+pre {{ padding: 1em; overflow-x: auto; }}
+pre code {{ padding: 0; }}
+img {{ max-width: 100%; }}
+blockquote {{ color: #59636e; border-left: .25em solid #d1d9e0; margin: 0; padding: 0 1em; }}
+table {{ border-collapse: collapse; }}
+th, td {{ border: 1px solid #d1d9e0; padding: 6px 13px; }}
+</style>
+</head>
+<body>
+{rendered_markdown}
+</body>
+</html>
+"""
 
 
 def changelog_sections_added_since(previous_text: str, current_text: str) -> str:
@@ -56,3 +102,24 @@ def fetch_github_markdown(github_blob_url: str) -> str:
     )
     raw_response.raise_for_status()
     return raw_response.text
+
+
+def render_markdown_as_html_page(markdown_text: str, base_href: str = None) -> str:
+    """Render markdown to a styled standalone HTML page via GitHub's markdown API.
+
+    GFM rendering wrapped in a minimal GitHub-ish stylesheet — noticeably
+    nicer than QTextDocument's output. ``base_href`` (optional) becomes a
+    ``<base>`` tag so relative links resolve. Raises ``requests`` errors on
+    any network/HTTP failure — callers decide the fallback (typically the
+    offline ``pyside_helpers.markdown_text_to_html``).
+    """
+    render_response = requests.post(
+        GITHUB_MARKDOWN_RENDER_API_URL,
+        json={"text": escape_tag_like_tokens(markdown_text), "mode": "gfm"},
+        headers={"Accept": "application/vnd.github+json"},
+        timeout=GITHUB_REQUEST_TIMEOUT_S,
+    )
+    render_response.raise_for_status()
+    base_tag = f'<base href="{base_href}">' if base_href else ""
+    return MARKDOWN_PAGE_TEMPLATE.format(base_tag=base_tag,
+                                         rendered_markdown=render_response.text)

--- a/microdrop_utils/markdown_helpers.py
+++ b/microdrop_utils/markdown_helpers.py
@@ -1,4 +1,4 @@
-"""Helpers for rendering markdown documents into standalone HTML pages."""
+"""Helpers for working with markdown documents."""
 
 import re
 
@@ -7,38 +7,7 @@ import requests
 GITHUB_BLOB_URL_PATTERN = re.compile(
     r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/blob/(?P<ref>[^/]+)/(?P<path>.+)"
 )
-GITHUB_MARKDOWN_RENDER_API_URL = "https://api.github.com/markdown"
 GITHUB_REQUEST_TIMEOUT_S = 10
-
-MARKDOWN_PAGE_TEMPLATE = """<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<base href="{base_href}">
-<style>
-body {{
-    font-family: -apple-system, "Segoe UI", Helvetica, Arial, sans-serif;
-    color: #1f2328; line-height: 1.5; max-width: 850px;
-    margin: 0 auto; padding: 2rem;
-}}
-a {{ color: #0969da; text-decoration: none; }}
-a:hover {{ text-decoration: underline; }}
-h1, h2 {{ border-bottom: 1px solid #d1d9e0; padding-bottom: .3em; }}
-code, pre {{ font-family: ui-monospace, Consolas, monospace; background: #f6f8fa; border-radius: 6px; }}
-code {{ padding: .2em .4em; font-size: 85%; }}
-pre {{ padding: 1em; overflow-x: auto; }}
-pre code {{ padding: 0; }}
-img {{ max-width: 100%; }}
-blockquote {{ color: #59636e; border-left: .25em solid #d1d9e0; margin: 0; padding: 0 1em; }}
-table {{ border-collapse: collapse; }}
-th, td {{ border: 1px solid #d1d9e0; padding: 6px 13px; }}
-</style>
-</head>
-<body>
-{rendered_markdown}
-</body>
-</html>
-"""
 
 
 def changelog_sections_added_since(previous_text: str, current_text: str) -> str:
@@ -68,17 +37,13 @@ def changelog_sections_added_since(previous_text: str, current_text: str) -> str
     return "".join(newly_added_lines)
 
 
-def fetch_github_markdown_as_html(github_blob_url: str) -> str:
-    """Fetch a markdown file from GitHub and return it rendered as a full HTML page.
+def fetch_github_markdown(github_blob_url: str) -> str:
+    """Fetch the raw markdown text behind a GitHub blob URL.
 
     ``github_blob_url`` is a ``https://github.com/<owner>/<repo>/blob/<ref>/<path>``
-    URL to a markdown file. The raw markdown is fetched and rendered to HTML via
-    GitHub's markdown API (GFM dialect), then wrapped in a minimally styled page
-    whose ``<base>`` tag points back at the blob directory so relative links
-    resolve to github.com.
-
-    Raises ``ValueError`` for a non-blob URL and ``requests`` errors on any
-    network/HTTP failure — callers decide the fallback.
+    URL to a markdown file. Raises ``ValueError`` for a non-blob URL and
+    ``requests`` errors on any network/HTTP failure — callers decide the
+    fallback.
     """
     match = GITHUB_BLOB_URL_PATTERN.match(github_blob_url)
     if match is None:
@@ -90,15 +55,4 @@ def fetch_github_markdown_as_html(github_blob_url: str) -> str:
         timeout=GITHUB_REQUEST_TIMEOUT_S,
     )
     raw_response.raise_for_status()
-
-    render_response = requests.post(
-        GITHUB_MARKDOWN_RENDER_API_URL,
-        json={"text": raw_response.text, "mode": "gfm", "context": f"{owner}/{repo}"},
-        headers={"Accept": "application/vnd.github+json"},
-        timeout=GITHUB_REQUEST_TIMEOUT_S,
-    )
-    render_response.raise_for_status()
-
-    base_href = github_blob_url.rsplit("/", 1)[0] + "/"
-    return MARKDOWN_PAGE_TEMPLATE.format(base_href=base_href,
-                                         rendered_markdown=render_response.text)
+    return raw_response.text

--- a/microdrop_utils/markdown_helpers.py
+++ b/microdrop_utils/markdown_helpers.py
@@ -41,6 +41,33 @@ th, td {{ border: 1px solid #d1d9e0; padding: 6px 13px; }}
 """
 
 
+def changelog_sections_added_since(previous_text: str, current_text: str) -> str:
+    """Return the content newly prepended to a prepend-style changelog.
+
+    Commitizen prepends each release's section to the top of CHANGELOG.md,
+    leaving the earlier content byte-identical below it, so the delta is the
+    prefix of ``current_text`` sitting above ``previous_text``. If the old
+    text is no longer a literal suffix (changelog rewritten or reformatted),
+    falls back to collecting top-level ``## `` sections from the top until
+    one whose header line already appears in ``previous_text``. Returns
+    ``""`` when nothing is new.
+    """
+    if current_text == previous_text:
+        return ""
+    if current_text.endswith(previous_text):
+        return current_text[:len(current_text) - len(previous_text)]
+
+    previous_section_headers = {
+        line for line in previous_text.splitlines() if line.startswith("## ")
+    }
+    newly_added_lines = []
+    for line in current_text.splitlines(keepends=True):
+        if line.startswith("## ") and line.rstrip() in previous_section_headers:
+            break
+        newly_added_lines.append(line)
+    return "".join(newly_added_lines)
+
+
 def fetch_github_markdown_as_html(github_blob_url: str) -> str:
     """Fetch a markdown file from GitHub and return it rendered as a full HTML page.
 

--- a/microdrop_utils/pyside_helpers.py
+++ b/microdrop_utils/pyside_helpers.py
@@ -5,7 +5,6 @@ This module provides reusable UI components that enhance the user interface
 with consistent styling and behavior across the application.
 """
 import functools
-import re
 from typing import Union, List, Optional
 
 from PySide6 import QtWidgets, QtGui, QtCore
@@ -36,12 +35,7 @@ from microdrop_style.helpers import is_dark_mode
 from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
-# Literal "<" in markdown, except when opening an autolink (<https://...>,
-# <mailto:...>). QTextDocument's markdown parser treats any other <token>
-# as an unclosed inline-HTML tag and silently swallows the rest of the
-# document (e.g. "PID_<HEATER>" in a changelog entry).
-MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN = re.compile(
-    r"<(?!(?:https?|mailto):[^\s>]+>)")
+from microdrop_utils.markdown_helpers import escape_tag_like_tokens
 
 
 def horizontal_spacer_widget(width=10) -> QWidget:
@@ -863,7 +857,7 @@ def markdown_text_to_html(markdown_text: str) -> str:
     and regular ``[text](url)`` links still render; intentional inline HTML
     is consequently not supported.
     """
-    escaped = MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN.sub("&lt;", markdown_text)
+    escaped = escape_tag_like_tokens(markdown_text)
     document = QtGui.QTextDocument()
     document.setMarkdown(escaped)
     return document.toHtml()

--- a/microdrop_utils/pyside_helpers.py
+++ b/microdrop_utils/pyside_helpers.py
@@ -5,6 +5,7 @@ This module provides reusable UI components that enhance the user interface
 with consistent styling and behavior across the application.
 """
 import functools
+import re
 from typing import Union, List, Optional
 
 from PySide6 import QtWidgets, QtGui, QtCore
@@ -35,7 +36,12 @@ from microdrop_style.helpers import is_dark_mode
 from logger.logger_service import get_logger
 logger = get_logger(__name__)
 
-
+# Literal "<" in markdown, except when opening an autolink (<https://...>,
+# <mailto:...>). QTextDocument's markdown parser treats any other <token>
+# as an unclosed inline-HTML tag and silently swallows the rest of the
+# document (e.g. "PID_<HEATER>" in a changelog entry).
+MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN = re.compile(
+    r"<(?!(?:https?|mailto):[^\s>]+>)")
 
 
 def horizontal_spacer_widget(width=10) -> QWidget:
@@ -850,7 +856,14 @@ def markdown_text_to_html(markdown_text: str) -> str:
 
     Dependency-free markdown conversion (GitHub dialect by default) for
     showing markdown content in rich-text widgets or web views.
+
+    Literal ``<`` characters are escaped first so tag-like tokens (e.g.
+    ``PID_<HEATER>``) can't be parsed as unclosed inline HTML that swallows
+    the rest of the document. Autolinks (``<https://...>``, ``<mailto:...>``)
+    and regular ``[text](url)`` links still render; intentional inline HTML
+    is consequently not supported.
     """
+    escaped = MARKDOWN_NON_AUTOLINK_ANGLE_BRACKET_PATTERN.sub("&lt;", markdown_text)
     document = QtGui.QTextDocument()
-    document.setMarkdown(markdown_text)
+    document.setMarkdown(escaped)
     return document.toHtml()

--- a/microdrop_utils/pyside_helpers.py
+++ b/microdrop_utils/pyside_helpers.py
@@ -843,3 +843,14 @@ class _ScalingPixmapLabel(QLabel):
                 Qt.TransformationMode.SmoothTransformation,
             )
             self.setPixmap(scaled)
+
+
+def markdown_text_to_html(markdown_text: str) -> str:
+    """Render markdown to a standalone HTML document via QTextDocument.
+
+    Dependency-free markdown conversion (GitHub dialect by default) for
+    showing markdown content in rich-text widgets or web views.
+    """
+    document = QtGui.QTextDocument()
+    document.setMarkdown(markdown_text)
+    return document.toHtml()

--- a/user_help_plugin/menus.py
+++ b/user_help_plugin/menus.py
@@ -49,27 +49,41 @@ class OpenWebViewDialogAction(Action):
 class OpenMarkdownDialogAction(OpenWebViewDialogAction):
     """Renders a markdown document (just the document, not a full web page)
     in a WebViewDialog. ``source`` is a local ``Path`` or a GitHub blob URL;
-    a failed remote fetch falls back to loading the page itself."""
+    a failed remote fetch falls back to loading the page itself.
+
+    Rendering prefers GitHub's markdown API for the GitHub-look styling and
+    degrades to the offline QTextDocument renderer when that call fails
+    (no network for a local file, rate-limited, ...)."""
 
     open_links_externally = Bool(True)
 
     def perform(self, event):
         # Imported lazily so QtWebEngine only initializes on first use.
         from microdrop_application.dialogs.web_view_dialog import WebViewDialog
-        from microdrop_utils.markdown_helpers import fetch_github_markdown
+        from microdrop_utils.markdown_helpers import (
+            fetch_github_markdown, render_markdown_as_html_page)
         from microdrop_utils.pyside_helpers import markdown_text_to_html
 
+        base_href = None
         try:
             if isinstance(self.source, Path):
                 markdown_text = self.source.read_text(encoding="utf-8")
             else:
                 markdown_text = fetch_github_markdown(self.source)
+                base_href = self.source.rsplit("/", 1)[0] + "/"
         except Exception as e:
             logger.warning(f"Failed to load markdown from {self.source}: {e}. "
                            f"Falling back to loading it directly.")
             return super().perform(event)
 
-        self.dialog = WebViewDialog(html_content=markdown_text_to_html(markdown_text),
+        try:
+            html_content = render_markdown_as_html_page(markdown_text, base_href)
+        except Exception as e:
+            logger.warning(f"GitHub markdown render failed: {e}. "
+                           f"Using the offline renderer.")
+            html_content = markdown_text_to_html(markdown_text)
+
+        self.dialog = WebViewDialog(html_content=html_content,
                                     title=self.window_title,
                                     width=self.width, height=self.height,
                                     open_links_externally=self.open_links_externally)

--- a/user_help_plugin/menus.py
+++ b/user_help_plugin/menus.py
@@ -46,44 +46,31 @@ class OpenWebViewDialogAction(Action):
         self.dialog.show()
 
 
-class OpenGithubMarkdownDialogAction(OpenWebViewDialogAction):
-    """Renders a GitHub markdown file (just the document, not the full GitHub
-    page) in a WebViewDialog; falls back to loading the GitHub page itself if
-    fetching or rendering fails."""
+class OpenMarkdownDialogAction(OpenWebViewDialogAction):
+    """Renders a markdown document (just the document, not a full web page)
+    in a WebViewDialog. ``source`` is a local ``Path`` or a GitHub blob URL;
+    a failed remote fetch falls back to loading the page itself."""
 
     open_links_externally = Bool(True)
 
     def perform(self, event):
         # Imported lazily so QtWebEngine only initializes on first use.
         from microdrop_application.dialogs.web_view_dialog import WebViewDialog
-        from microdrop_utils.markdown_helpers import fetch_github_markdown_as_html
-
-        try:
-            html_content = fetch_github_markdown_as_html(self.source)
-        except Exception as e:
-            logger.warning(f"Failed to render markdown from {self.source}: {e}. "
-                           f"Falling back to loading the page directly.")
-            return super().perform(event)
-
-        self.dialog = WebViewDialog(html_content=html_content, title=self.window_title,
-                                    width=self.width, height=self.height,
-                                    open_links_externally=self.open_links_externally)
-        self.dialog.show()
-
-
-class OpenLocalMarkdownDialogAction(OpenWebViewDialogAction):
-    """Renders a local markdown file as HTML in a WebViewDialog."""
-
-    open_links_externally = Bool(True)
-
-    def perform(self, event):
-        # Imported lazily so QtWebEngine only initializes on first use.
-        from microdrop_application.dialogs.web_view_dialog import WebViewDialog
+        from microdrop_utils.markdown_helpers import fetch_github_markdown
         from microdrop_utils.pyside_helpers import markdown_text_to_html
 
-        html_content = markdown_text_to_html(
-            Path(self.source).read_text(encoding="utf-8"))
-        self.dialog = WebViewDialog(html_content=html_content, title=self.window_title,
+        try:
+            if isinstance(self.source, Path):
+                markdown_text = self.source.read_text(encoding="utf-8")
+            else:
+                markdown_text = fetch_github_markdown(self.source)
+        except Exception as e:
+            logger.warning(f"Failed to load markdown from {self.source}: {e}. "
+                           f"Falling back to loading it directly.")
+            return super().perform(event)
+
+        self.dialog = WebViewDialog(html_content=markdown_text_to_html(markdown_text),
+                                    title=self.window_title,
                                     width=self.width, height=self.height,
                                     open_links_externally=self.open_links_externally)
         self.dialog.show()
@@ -141,7 +128,7 @@ def menu_factory():
         OpenGitHubIssuesAction(),
         OpenSciBotsAction(),
         contact_submenu,
-        OpenLocalMarkdownDialogAction(
+        OpenMarkdownDialogAction(
             name="&Changelog...",
             tooltip="View the full MicroDrop changelog",
             source=CHANGELOG_PATH,
@@ -160,7 +147,7 @@ def menu_factory():
 def launcher_menu_factory():
     """Separate bottom group so the launcher item sits below a separator line."""
     return SGroup(
-        OpenGithubMarkdownDialogAction(
+        OpenMarkdownDialogAction(
             name="&Download MicroDrop Launcher...",
             tooltip="View the MicroDrop Launcher README with download instructions",
             source=MICRODROP_LAUNCHER_README_URL,

--- a/user_help_plugin/menus.py
+++ b/user_help_plugin/menus.py
@@ -1,4 +1,5 @@
 import webbrowser
+from pathlib import Path
 
 from pyface.action.api import Action
 from pyface.tasks.action.api import SGroup, SMenu
@@ -18,6 +19,7 @@ from .consts import (
     INFO_EMAIL,
 )
 
+from microdrop_application.consts import CHANGELOG_PATH
 from microdrop_application.dialogs.consts import (
     DEFAULT_WEB_VIEW_DIALOG_WIDTH,
     DEFAULT_WEB_VIEW_DIALOG_HEIGHT,
@@ -63,6 +65,24 @@ class OpenGithubMarkdownDialogAction(OpenWebViewDialogAction):
                            f"Falling back to loading the page directly.")
             return super().perform(event)
 
+        self.dialog = WebViewDialog(html_content=html_content, title=self.window_title,
+                                    width=self.width, height=self.height,
+                                    open_links_externally=self.open_links_externally)
+        self.dialog.show()
+
+
+class OpenLocalMarkdownDialogAction(OpenWebViewDialogAction):
+    """Renders a local markdown file as HTML in a WebViewDialog."""
+
+    open_links_externally = Bool(True)
+
+    def perform(self, event):
+        # Imported lazily so QtWebEngine only initializes on first use.
+        from microdrop_application.dialogs.web_view_dialog import WebViewDialog
+        from microdrop_utils.pyside_helpers import markdown_text_to_html
+
+        html_content = markdown_text_to_html(
+            Path(self.source).read_text(encoding="utf-8"))
         self.dialog = WebViewDialog(html_content=html_content, title=self.window_title,
                                     width=self.width, height=self.height,
                                     open_links_externally=self.open_links_externally)
@@ -121,6 +141,12 @@ def menu_factory():
         OpenGitHubIssuesAction(),
         OpenSciBotsAction(),
         contact_submenu,
+        OpenLocalMarkdownDialogAction(
+            name="&Changelog...",
+            tooltip="View the full MicroDrop changelog",
+            source=CHANGELOG_PATH,
+            window_title="MicroDrop Changelog",
+        ),
         OpenWebViewDialogAction(
             name="&About MicroDrop...",
             tooltip="Learn about MicroDrop's architecture and capabilities",


### PR DESCRIPTION
## Summary
Stacked on #549 (uses its `microdrop_utils/markdown_helpers.py` and `WebViewDialog`); retarget/merge after it lands. Pairs with #550, which makes the release workflow prepend changelog sections automatically.

### What's New startup dialog
- `changelog_sections_added_since()` in `microdrop_utils/markdown_helpers.py`: returns what was newly prepended to a prepend-style changelog — a literal suffix/prefix diff (commitizen leaves earlier content byte-identical), with a `## `-header fallback if the changelog was ever rewritten.
- `CHANGELOG_PATH` constant in `microdrop_application/consts.py`.
- `_show_whats_new()` in `application.py`, called on `application_initialized` right after the beta disclaimer (same marker-file pattern): caches the changelog as of the previous run in `application_home/.previous_changelog`, renders the delta and shows it in the styled `information` dialog titled **What's New?**. The very first run seeds the cache silently so users aren't greeted with the entire history.

### Full changelog viewer in the Help menu
- `markdown_text_to_html()` in `microdrop_utils/pyside_helpers.py`: dependency-free markdown→HTML via `QTextDocument.setMarkdown` (shared by both features).
- `OpenLocalMarkdownDialogAction` in `user_help_plugin/menus.py` renders a local markdown file in a `WebViewDialog` (links open in the system browser); new **Changelog…** item above **About MicroDrop…**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)