### PR TITLE
ci: fix invalid YAML in release workflow (quote the if expression)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
   tag-and-release:
     name: tag merged release & publish
-    if: startsWith(github.event.head_commit.message, 'chore: release')
+    if: "startsWith(github.event.head_commit.message, 'chore: release')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `tag-and-release` job's `if:` was an unquoted scalar containing `chore: release` — the inner colon-space makes the whole workflow file invalid YAML, so every Release run since #552 failed at startup with zero jobs. Quoting the expression fixes it (validated with a YAML parse).

After merging, the merge push itself will trigger `release-pr` and the first `chore: release v1.3.0` PR should appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)