### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.3.1 (2026-07-21)
+
+### Refactor
+
+- **microdrop_utils**: use QToolButton for glyph editors
+- **device_viewer**: drop the raw-frame capture path
+
+### CI
+
+- state-based release detection — merge-method-proof, recursion-free
+
 ## v1.3.0 (2026-07-21)
 
 ### Feat


### PR DESCRIPTION
## v1.3.1 (2026-07-21)

### Refactor

- **microdrop_utils**: use QToolButton for glyph editors
- **device_viewer**: drop the raw-frame capture path

### CI

- state-based release detection — merge-method-proof, recursion-free

[main bc124467] chore: release v1.3.1
 1 file changed, 11 insertions(+)

