### PR TITLE
feat: shared firmware-upload backend + dialog for Pico peripherals

### DIFF
--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -48,3 +48,4 @@ ICON_CROP            = "crop"        # region-of-interest edit mode
 ICON_DELETE          = "delete"      # clear regions
 ICON_SAVE            = "save"        # export/save
 ICON_USB             = "usb"         # manual serial-port selection
+ICON_ARCHIVE         = "folder_zip"  # select a .zip firmware bundle

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -47,3 +47,4 @@ ICON_TRANSFORM       = "transform"   # device-aligned (warped) view
 ICON_CROP            = "crop"        # region-of-interest edit mode
 ICON_DELETE          = "delete"      # clear regions
 ICON_SAVE            = "save"        # export/save
+ICON_USB             = "usb"         # manual serial-port selection

--- a/microdrop_utils/firmware_upload_dialog/consts.py
+++ b/microdrop_utils/firmware_upload_dialog/consts.py
@@ -1,0 +1,15 @@
+"""Device-agnostic constants for the shared firmware-upload dialog."""
+
+#: Separates "COM7" from its human-readable description in the port dropdown.
+PORT_ENTRY_SEPARATOR = " — "
+
+LOG_CONSOLE_FONT_FAMILY = "Consolas"
+
+#: Shown in the read-only Device ID field until the board's whoami arrives
+#: (matches the status panes' board_id_text "-" placeholder). Treated as
+#: "no id known" when building the upload payload.
+DEVICE_ID_PLACEHOLDER = "-"
+
+#: Raspberry Pi Foundation's USB vendor id (the whole Pico family) — the port
+#: dropdown lists Pico-vendor ports first.
+PICO_USB_VENDOR_ID = 0x2E8A

--- a/microdrop_utils/firmware_upload_dialog/controller.py
+++ b/microdrop_utils/firmware_upload_dialog/controller.py
@@ -1,0 +1,214 @@
+"""Device-agnostic controller for the shared firmware-upload dialog.
+
+Pure frontend: Upload publishes a validated upload request via the injected
+publisher; the backend's started / log / finished signals arrive through the
+owning plugin's message handler, which ferries them into the injected
+``live_state.firmware_upload_message`` — the dispatch="ui" observer below
+applies them to the model on the GUI thread (the model is only ever mutated
+there).
+
+A concrete plugin wires one of these up with its device-specific bits: the
+live_state singleton (carrying ``firmware_upload_message`` /
+``board_device_id`` / ``board_port``), the upload publisher, the cancel and
+signal topics, and the firmware-dir / default-device-id values.
+"""
+
+import json
+
+from PySide6.QtCore import QSize, QTimer
+from PySide6.QtWidgets import QFileDialog, QSizePolicy
+
+from traits.api import Any, HasTraits, Instance, Str, observe
+
+from microdrop_application.dialogs.base_message_dialog import BaseMessageDialog
+from microdrop_application.dialogs.pyface_wrapper import YES, confirm, error
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+from microdrop_utils.traitsui_qt_helpers import stretch_group_layouts_horizontally
+
+from .consts import DEVICE_ID_PLACEHOLDER
+from .model import FirmwareUploadModel
+from .view import build_panel_stylesheet, firmware_upload_view
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+
+class FirmwareUploadDialogController(HasTraits):
+    """Builds the styled dialog, publishes upload/cancel requests to the
+    backend, and applies the backend's firmware-upload signals to the model
+    on the GUI thread via a dispatch="ui" observer on live_state.
+
+    Reopen-safe: keep one instance alive (the menu action does) and call
+    ``open()`` again — a visible dialog is raised instead of duplicated, a
+    closed one is rebuilt around the same model, so the log history and
+    options survive reopens.
+    """
+
+    # ---- device-specific wiring (set by the plugin) ----------------------
+    #: HasTraits carrying firmware_upload_message / board_device_id /
+    #: board_port (the plugin's live_state singleton).
+    live_state = Instance(HasTraits)
+    #: A peripheral_device_controller_base UploadFirmwarePublisher instance.
+    upload_publisher = Any()
+    cancel_topic = Str()
+    started_topic = Str()
+    log_topic = Str()
+    finished_topic = Str()
+    default_firmware_dir = Str()
+    default_device_id = Str()
+    dialog_title = Str("Upload Firmware")
+
+    model = Instance(FirmwareUploadModel)
+
+    dialog = Any()
+    traits_ui = Any()
+
+    def _model_default(self):
+        return FirmwareUploadModel(
+            default_firmware_dir=self.default_firmware_dir,
+            default_device_id=self.default_device_id)
+
+    # ---- dialog assembly -------------------------------------------------
+
+    def open(self):
+        if self.dialog is not None and self.dialog.isVisible():
+            self.dialog.raise_()
+            self.dialog.activateWindow()
+            return
+        self.dialog = BaseMessageDialog(
+            title=self.dialog_title,
+            message="Flash the MicroPython firmware to a connected Pico "
+                    "board. Configure the source, port, and options below, "
+                    "then press Upload.",
+            dialog_type=BaseMessageDialog.TYPE_QUESTION,
+            buttons={
+                "Close": {"action": self._request_close, "role": "exit"},
+                "Upload": {"action": self._start_upload},
+            },
+            resizable=True,
+        )
+        # Wide two-pane layout: give the config column and the log console
+        # room side by side (the base dialog would otherwise cap at 1000x800
+        # and open much narrower).
+        self.dialog.setMinimumSize(QSize(980, 620))
+        self.dialog.setMaximumSize(QSize(1700, 1200))
+        # Keep the intro message compact so the config panel gets the space.
+        self.dialog.message_label.setSizePolicy(
+            QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+        self.traits_ui = self.model.edit_traits(
+            view=firmware_upload_view, kind="subpanel", parent=self.dialog)
+        # The built control is the HSplit's QSplitter; the left column's own
+        # QScrollArea is made transparent by the panel stylesheet.
+        panel = self.traits_ui.control
+        panel.setObjectName("firmwareUploadPanel")
+        panel.setStyleSheet(build_panel_stylesheet(self.dialog))
+        stretch_group_layouts_horizontally(panel)
+        self.dialog.add_content_widget(panel)
+
+        # Reflect the connected board's identity into the read-only device id,
+        # and point the port combo at its auto-detected port (a board may have
+        # connected before the dialog was opened). Shows the placeholder until
+        # a whoami has actually been received.
+        self.model.device_id = (
+            self.live_state.board_device_id or DEVICE_ID_PLACEHOLDER)
+        self.model.sync_selected_port(self.live_state.board_port)
+
+        self.dialog.finished.connect(self._on_dialog_closed)
+        self.dialog.show()
+        # The base dialog queues a fit-to-message adjustSize() at singleShot(0)
+        # which would shrink the dialog back to its size hint — queue the
+        # opening size after it so it wins.
+        QTimer.singleShot(0, lambda: self.dialog.resize(1120, 700))
+
+    def _request_close(self):
+        if self.model.uploading:
+            if confirm(self.dialog,
+                       "An upload is still running — abort it and close?",
+                       title="Upload in progress") != YES:
+                return
+            publish_message(message="", topic=self.cancel_topic)
+        self.dialog.close_with_result(BaseMessageDialog.RESULT_CANCEL)
+
+    def _on_dialog_closed(self, *args):
+        if self.traits_ui is not None:
+            self.traits_ui.dispose()
+            self.traits_ui = None
+
+    @observe("model:browse_firmware_zip")
+    def _on_browse_firmware_zip(self, event):
+        """Zip-browse button: pick a .zip and set it as the firmware source
+        (the Directory field's own Browse handles folders)."""
+        path, _ = QFileDialog.getOpenFileName(
+            self.dialog, "Select firmware zip bundle", "",
+            "Zip archives (*.zip);;All files (*)")
+        if path:
+            self.model.firmware_source = path
+
+    # ---- upload run ------------------------------------------------------
+
+    def _start_upload(self):
+        if self.model.uploading:
+            return
+        problems = self.model.validation_problems()
+        if problems:
+            error(self.dialog,
+                  "Fix the following before uploading:",
+                  title="Cannot upload",
+                  detail="\n".join(problems), detail_collapsible=False)
+            return
+        # Optimistically lock the controls; the backend's STARTED/FINISHED
+        # signals confirm and release.
+        self.model.uploading = True
+        try:
+            self.upload_publisher.publish(**self.model.upload_request_kwargs())
+        except Exception as e:
+            logger.warning(f"Failed to publish upload request: {e}")
+            self.model.upload_log += f"Failed to publish upload request: {e}\n"
+            self.model.uploading = False
+
+    @observe("live_state:firmware_upload_message", dispatch="ui")
+    def _apply_backend_message(self, event):
+        """Apply one backend publish to the model (GUI thread)."""
+        topic, message = event.new
+        if topic == self.log_topic:
+            self.model.upload_log += f"{message}\n"
+        elif topic == self.started_topic:
+            self.model.uploading = True
+            self.model.upload_log += f"{message}\n"
+        elif topic == self.finished_topic:
+            self.model.uploading = False
+            self.model.upload_log += f"{self._finished_verdict(message)}\n"
+
+    @staticmethod
+    def _finished_verdict(message):
+        """Human-readable verdict from a firmware_upload_finished payload."""
+        try:
+            payload = json.loads(message)
+        except Exception:
+            logger.error(f"Unparseable upload-finished payload: {message!r}")
+            return f"\nUpload finished (unparseable result: {message!r})."
+        if "error" in payload:
+            return f"\nUpload CRASHED: {payload['error']}"
+        return ("\nUpload finished successfully." if payload.get("success")
+                else "\nUpload FAILED (see the log above).")
+
+    @observe("live_state:board_device_id", dispatch="ui")
+    def _on_board_device_id_changed(self, event):
+        """The board's whoami id arrived (or cleared on disconnect) — mirror
+        it into the read-only Device ID field, falling back to the
+        placeholder so the field only shows a real id while a whoami is
+        currently backing it (GUI thread)."""
+        self.model.device_id = event.new or DEVICE_ID_PLACEHOLDER
+
+    @observe("live_state:board_port", dispatch="ui")
+    def _on_board_port_changed(self, event):
+        """The auto-detected port changed — keep the port combo in sync
+        (GUI thread)."""
+        self.model.sync_selected_port(event.new)
+
+    @observe("model:uploading")
+    def _on_uploading_changed(self, event):
+        upload_button = self.dialog.get_button("Upload") if self.dialog else None
+        if upload_button is not None:
+            upload_button.setEnabled(not event.new)

--- a/microdrop_utils/firmware_upload_dialog/model.py
+++ b/microdrop_utils/firmware_upload_dialog/model.py
@@ -1,0 +1,169 @@
+"""Qt-free model for the shared firmware-upload dialog: the request options,
+the live log text, and the payload builder for the validated publisher.
+
+Device-specific values (the firmware-dir default and the safe fallback device
+id) are injected as traits by the controller, so the model itself carries no
+per-device knowledge.
+"""
+
+from pathlib import Path
+
+import serial.tools.list_ports
+
+from traits.api import (
+    Bool, Button, Directory, File, HasTraits, Range, Str, observe,
+    List,
+)
+
+from .consts import (
+    DEVICE_ID_PLACEHOLDER, PICO_USB_VENDOR_ID, PORT_ENTRY_SEPARATOR,
+)
+
+
+class FirmwareUploadModel(HasTraits):
+    """Options for one firmware-upload request, plus the live log."""
+
+    #: Injected by the controller (device-specific).
+    default_firmware_dir = Str()
+    #: Safe id the upload targets when no whoami id is known (device-specific).
+    default_device_id = Str()
+
+    #: Firmware source: a folder tree OR a .zip bundle (the backend unzips a
+    #: zip to a temp dir, uploads it, then deletes it). Kept a Directory trait
+    #: for the native folder-browse; the zip-browse button writes a .zip path
+    #: into the same field.
+    firmware_source = Directory()
+    browse_firmware_zip = Button()
+    single_file = File()
+
+    #: True: the backend resolves the port (a connected proxy's stored port,
+    #: else whoami / VID probing). False: send the selection below.
+    auto_port = Bool(True)
+    available_ports = List(Str)
+    selected_port_entry = Str()
+    refresh_ports = Button()
+
+    #: The connected board's whoami device_id, mirrored from live_state by the
+    #: controller and shown read-only. Shows DEVICE_ID_PLACEHOLDER until a
+    #: whoami arrives, so a real id here proves the signal was received. When
+    #: no id is known the upload still targets default_device_id (see
+    #: upload_request_kwargs) so an empty match can't grab a sibling board on
+    #: the shared VID:PID.
+    device_id = Str(DEVICE_ID_PLACEHOLDER)
+
+    update_config = Bool(False)
+    skip_filesystem_format = Bool(False)
+    reset_after_upload = Bool(True)
+    dry_run = Bool(False)
+
+    #: Kill the upload if it runs longer than this many seconds (0 = never);
+    #: enforced by the backend service, sent along in the request.
+    upload_timeout_s = Range(0, 10000, 0)
+
+    uploading = Bool(False)
+    upload_log = Str()
+    clear_log = Button()
+
+    # Section collapse states (fluo controls pane pattern: an arrow-glyph
+    # header toggles each `show_*`, the bordered group is visible_when it).
+    show_source = Bool(True)
+    show_port = Bool(True)
+    show_options = Bool(True)
+
+    def _firmware_source_default(self):
+        return self.default_firmware_dir
+
+    def _available_ports_default(self):
+        return self._scan_port_entries()
+
+    def _selected_port_entry_default(self):
+        return self.available_ports[0] if self.available_ports else ""
+
+    @staticmethod
+    def _scan_port_entries():
+        """Dropdown entries for every serial port, Pico-vendor ports first."""
+        ports = sorted(
+            serial.tools.list_ports.comports(),
+            key=lambda p: (p.vid != PICO_USB_VENDOR_ID, str(p.device)),
+        )
+        return [f"{p.device}{PORT_ENTRY_SEPARATOR}{p.description}"
+                for p in ports]
+
+    @observe("refresh_ports")
+    def _on_refresh_ports(self, event):
+        entries = self._scan_port_entries()
+        self.available_ports = entries
+        if self.selected_port_entry not in entries:
+            self.selected_port_entry = entries[0] if entries else ""
+        listing = "\n".join(f"    {entry}" for entry in entries) or "    (none)"
+        self.upload_log += f"Found {len(entries)} serial port(s):\n{listing}\n"
+
+    @observe("clear_log")
+    def _on_clear_log(self, event):
+        self.upload_log = ""
+
+    def selected_port_device(self):
+        return self.selected_port_entry.split(PORT_ENTRY_SEPARATOR)[0]
+
+    def _entry_for_device(self, port_device):
+        """The dropdown entry whose port device matches, or None."""
+        for entry in self.available_ports:
+            if entry.split(PORT_ENTRY_SEPARATOR)[0] == port_device:
+                return entry
+        return None
+
+    def sync_selected_port(self, port_device):
+        """Point the combo at the connected / auto-detected port, rescanning
+        the port list if it isn't currently listed. No-op if the port can't
+        be matched (e.g. empty, or disconnected)."""
+        if not port_device:
+            return
+        entry = self._entry_for_device(port_device)
+        if entry is None:
+            self.available_ports = self._scan_port_entries()
+            entry = self._entry_for_device(port_device)
+        if entry is not None:
+            self.selected_port_entry = entry
+
+    def _effective_device_id(self):
+        """The id to flash: the board's real whoami id when known, else the
+        device's default — never the placeholder, since an empty / "-" match
+        could grab a sibling board on the shared VID:PID."""
+        if self.device_id and self.device_id != DEVICE_ID_PLACEHOLDER:
+            return self.device_id
+        return self.default_device_id
+
+    def _firmware_source_is_zip(self):
+        return self.firmware_source.lower().endswith(".zip")
+
+    def validation_problems(self):
+        """Human-readable reasons the upload can't start (empty when OK)."""
+        problems = []
+        if self.single_file:
+            if not Path(self.single_file).is_file():
+                problems.append(f"Single file not found: {self.single_file}")
+        elif self._firmware_source_is_zip():
+            if not Path(self.firmware_source).is_file():
+                problems.append(
+                    f"Firmware zip not found: {self.firmware_source}")
+        elif not Path(self.firmware_source).is_dir():
+            problems.append(
+                f"Firmware folder not found: {self.firmware_source}")
+        if not self.auto_port and not self.selected_port_entry:
+            problems.append("Manual port mode is on but no port is selected.")
+        return problems
+
+    def upload_request_kwargs(self):
+        """Keyword payload for the upload publisher reflecting the current
+        options (empty port = backend auto-resolution)."""
+        return dict(
+            firmware_source=self.firmware_source,
+            single_file=self.single_file,
+            port="" if self.auto_port else self.selected_port_device(),
+            device_id=self._effective_device_id(),
+            update_config=self.update_config,
+            skip_filesystem_format=self.skip_filesystem_format,
+            reset_after_upload=self.reset_after_upload,
+            dry_run=self.dry_run,
+            upload_timeout_s=self.upload_timeout_s,
+        )

--- a/microdrop_utils/firmware_upload_dialog/view.py
+++ b/microdrop_utils/firmware_upload_dialog/view.py
@@ -1,0 +1,423 @@
+"""View layer for the firmware-upload dialog: the append-only log console
+editor, the TraitsUI config-panel view, and the panel stylesheet that makes
+the embedded TraitsUI widgets match BaseMessageDialog's theme."""
+
+from PySide6.QtGui import QFont
+from PySide6.QtWidgets import QPlainTextEdit
+
+from traits.api import Int
+from traitsui.api import (
+    BasicEditorFactory, HGroup, HSplit, Item, Label, RangeEditor, UItem,
+    VGroup, View, spring,
+)
+from traitsui.qt.editor import Editor as QtEditor
+
+from microdrop_style.colors import PRIMARY_COLOR, WHITE
+from microdrop_style.icons.icons import (
+    ICON_ARCHIVE, ICON_AUTOMATION, ICON_DELETE, ICON_REFRESH, ICON_USB,
+)
+from microdrop_utils.traitsui_qt_helpers import (
+    HoverScrollEnumEditor, IconButtonEditor, IconToggleEditor,
+)
+
+from .consts import LOG_CONSOLE_FONT_FAMILY
+
+
+# --------------------------------------------------------------------------
+# Log console editor (append-only, auto-scrolling)
+# --------------------------------------------------------------------------
+
+class _LogViewEditor(QtEditor):
+    """Read-only console over a Str trait: appends only the new tail on each
+    change (the upload log grows by appending), auto-scrolls to the bottom,
+    and resets wholesale when the trait shrinks (e.g. Clear log)."""
+
+    def init(self, parent):
+        self.control = QPlainTextEdit()
+        self.control.setReadOnly(True)
+        self.control.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
+        font = QFont(LOG_CONSOLE_FONT_FAMILY)
+        font.setPointSize(self.factory.point_size)
+        self.control.setFont(font)
+        self.control.setMinimumHeight(self.factory.min_height)
+        self.control.setMinimumWidth(self.factory.min_width)
+        self.control.setStyleSheet(f"""
+            QPlainTextEdit {{
+                background-color: #1E1E1E;
+                color: #D4D4D4;
+                border: 1px solid #3C3C3C;
+                border-radius: 6px;
+                padding: 6px;
+                selection-background-color: {PRIMARY_COLOR};
+            }}
+            /* This widget-level QSS forces non-native scrollbars, so restyle
+               them to match the console (dark twin of the panel's light
+               scrollbar rules). */
+            QScrollBar:vertical {{
+                background: transparent;
+                width: 12px;
+                border-radius: 6px;
+                margin: 0px;
+            }}
+            QScrollBar::handle:vertical {{
+                background-color: #4A4A4A;
+                border-radius: 6px;
+                min-height: 20px;
+            }}
+            QScrollBar::handle:vertical:hover {{
+                background-color: #5C5C5C;
+            }}
+            QScrollBar:horizontal {{
+                background: transparent;
+                height: 12px;
+                border-radius: 6px;
+                margin: 0px;
+            }}
+            QScrollBar::handle:horizontal {{
+                background-color: #4A4A4A;
+                border-radius: 6px;
+                min-width: 20px;
+            }}
+            QScrollBar::handle:horizontal:hover {{
+                background-color: #5C5C5C;
+            }}
+            QScrollBar::add-line, QScrollBar::sub-line {{
+                width: 0px;
+                height: 0px;
+            }}
+            QScrollBar::add-page, QScrollBar::sub-page {{
+                background: none;
+            }}
+        """)
+        self._shown_text = ""
+        self.update_editor()
+
+    def update_editor(self):
+        text = self.value or ""
+        if text == self._shown_text:
+            return
+        if text.startswith(self._shown_text):
+            cursor = self.control.textCursor()
+            cursor.movePosition(cursor.MoveOperation.End)
+            cursor.insertText(text[len(self._shown_text):])
+        else:
+            self.control.setPlainText(text)
+        self._shown_text = text
+        scrollbar = self.control.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
+
+
+class LogViewEditor(BasicEditorFactory):
+    """Factory for the dark console log view over a Str trait."""
+
+    klass = _LogViewEditor
+
+    min_height = Int(220)
+    min_width = Int(300)
+    point_size = Int(9)
+
+
+# --------------------------------------------------------------------------
+# View
+# --------------------------------------------------------------------------
+
+def _collapse_header(trait, label):
+    """A section header row: a Material arrow glyph that expands / collapses
+    the section by toggling ``trait``, followed by the section's label (same
+    structure as the fluorescence controls pane)."""
+    return HGroup(
+        UItem(trait, editor=IconToggleEditor()),
+        Label(label),
+    )
+
+
+# Left: collapsible config sections. Right: the log console, permanently
+# visible on the other side of a draggable splitter.
+firmware_upload_view = View(
+    HSplit(
+        VGroup(
+            _collapse_header("show_source", "Firmware source"),
+            VGroup(
+                HGroup(
+                    Item("firmware_source", label="Firmware", springy=True,
+                         tooltip="Folder tree, or a .zip bundle, pushed to "
+                                 "the board (a zip is unzipped, uploaded, "
+                                 "then deleted)"),
+                    UItem("browse_firmware_zip", editor=IconButtonEditor(
+                        glyph=ICON_ARCHIVE,
+                        tooltip="Select a firmware .zip bundle")),
+                ),
+                Item("single_file", label="Single file",
+                     tooltip="Optional: upload only this file instead of "
+                             "the whole firmware source"),
+                visible_when="show_source",
+                show_border=True,
+                enabled_when="not uploading",
+            ),
+            _collapse_header("show_port", "Device & port"),
+            VGroup(
+                HGroup(
+                    Item("auto_port", label="Auto-detect port",
+                         editor=IconToggleEditor(
+                             on_glyph=ICON_AUTOMATION, off_glyph=ICON_USB,
+                             tooltip="On: the backend finds the board itself "
+                                     "(a connected proxy's port, else "
+                                     "whoami / Pico VID probing). "
+                                     "Off: use the port selected here.")),
+                    Item("selected_port_entry", label="Port",
+                         editor=HoverScrollEnumEditor(
+                             values_name="available_ports"),
+                         enabled_when="not auto_port", springy=True),
+                    UItem("refresh_ports", editor=IconButtonEditor(
+                        glyph=ICON_REFRESH, tooltip="Re-scan serial ports")),
+                ),
+                Item("device_id", label="Device ID", style="readonly",
+                     tooltip="The connected board's whoami id — the upload "
+                             "flashes exactly this board (read from the "
+                             "board, not editable)."),
+                visible_when="show_port",
+                show_border=True,
+                enabled_when="not uploading",
+            ),
+            _collapse_header("show_options", "Options"),
+            VGroup(
+                Item("update_config", label="Upload config.json",
+                     tooltip="Overwrite the board's config.json with the repo "
+                             "copy. Off: the board keeps its own, backed up "
+                             "and restored around the reflash."),
+                Item("skip_filesystem_format", label="Skip format",
+                     tooltip="Don't wipe the board's filesystem first"),
+                Item("reset_after_upload", label="Reset after upload",
+                     tooltip="Reset the board when the upload finishes"),
+                Item("dry_run", label="Dry run",
+                     tooltip="Only log what would happen"),
+                Item("upload_timeout_s", label="Timeout (s)",
+                     editor=RangeEditor(low=0, high=10000, mode="spinner"),
+                     tooltip="Kill the upload if it runs longer than this many "
+                             "seconds (0 = no timeout)"),
+                visible_when="show_options",
+                show_border=True,
+                enabled_when="not uploading",
+            ),
+            # Only this column scrolls (vertically) when the dialog is short —
+            # the log console on the right has its own scrollbars.
+            scrollable=True,
+        ),
+        VGroup(
+            HGroup(
+                Label("Upload log"),
+                spring,
+                UItem("clear_log", editor=IconButtonEditor(
+                    glyph=ICON_DELETE, tooltip="Clear the log")),
+            ),
+            UItem("upload_log", editor=LogViewEditor()),
+            show_border=True,
+            springy=True,
+        ),
+    ),
+    # Resizable so sections take their natural height instead of being
+    # crushed to their minimums; scrolling is per-side — the left column has
+    # scrollable=True, the log console scrolls by itself.
+    resizable=True,
+)
+
+
+# --------------------------------------------------------------------------
+# Panel stylesheet
+# --------------------------------------------------------------------------
+
+def build_panel_stylesheet(dialog):
+    """Scoped stylesheet for the embedded TraitsUI panel.
+
+    BaseMessageDialog styles only its own widgets: its bare ``QPushButton``
+    rule cascades primary-color/white onto the panel's Browse buttons, while
+    the panel's labels/checkboxes/line edits get no rule at all and fall back
+    to the system palette (white text in Windows dark mode on the dialog's
+    always-light background). Pin every widget class here, in the dialog's own
+    theme colors, so the panel matches the dialog in both system modes.
+    QToolButton glyph buttons keep their Material Symbols font (no font-family
+    rule on them); the log console carries its own stylesheet and wins anyway.
+    """
+    dialog_color = dialog.TYPE_COLORS.get(dialog.dialog_type, PRIMARY_COLOR)
+    accent_bg = dialog._lighten_color(dialog_color, dialog.LIGHT_ACCENT_FACTOR)
+    text_font = dialog.text_font_family
+    return f"""
+        #firmwareUploadPanel {{
+            background: transparent;
+        }}
+        #firmwareUploadPanel QScrollArea {{
+            background: transparent;
+            border: none;
+        }}
+        #firmwareUploadPanel QScrollArea > QWidget > QWidget {{
+            background: transparent;
+        }}
+        /* Any QSS on a scroll area drops its scrollbars to the ancient
+           non-native look — restyle them like the dialog's own scroll areas
+           (slim, rounded, no arrow buttons). */
+        #firmwareUploadPanel QScrollBar:vertical {{
+            background: transparent;
+            width: 12px;
+            border-radius: 6px;
+            margin: 0px;
+        }}
+        #firmwareUploadPanel QScrollBar::handle:vertical {{
+            background-color: #C0C0C0;
+            border-radius: 6px;
+            min-height: 20px;
+        }}
+        #firmwareUploadPanel QScrollBar::handle:vertical:hover {{
+            background-color: #A0A0A0;
+        }}
+        #firmwareUploadPanel QScrollBar:horizontal {{
+            background: transparent;
+            height: 12px;
+            border-radius: 6px;
+            margin: 0px;
+        }}
+        #firmwareUploadPanel QScrollBar::handle:horizontal {{
+            background-color: #C0C0C0;
+            border-radius: 6px;
+            min-width: 20px;
+        }}
+        #firmwareUploadPanel QScrollBar::handle:horizontal:hover {{
+            background-color: #A0A0A0;
+        }}
+        #firmwareUploadPanel QScrollBar::add-line, #firmwareUploadPanel QScrollBar::sub-line {{
+            width: 0px;
+            height: 0px;
+        }}
+        #firmwareUploadPanel QScrollBar::add-page, #firmwareUploadPanel QScrollBar::sub-page {{
+            background: none;
+        }}
+        #firmwareUploadPanel::handle:horizontal {{
+            width: 5px;
+            background-color: {dialog.BORDER_COLOR};
+            border-radius: 2px;
+            margin: 8px 0px;
+        }}
+        #firmwareUploadPanel QLabel {{
+            color: {dialog.TEXT_COLOR};
+            background: transparent;
+            font-family: "{text_font}";
+            font-size: 12px;
+        }}
+        #firmwareUploadPanel QGroupBox {{
+            color: {dialog.TEXT_COLOR};
+            background: transparent;
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 8px;
+            margin-top: 12px;
+            font-family: "{text_font}";
+            font-size: 12px;
+            font-weight: 600;
+        }}
+        #firmwareUploadPanel QGroupBox::title {{
+            subcontrol-origin: margin;
+            subcontrol-position: top left;
+            left: 12px;
+            padding: 0px 4px;
+            color: {dialog_color};
+            background-color: {accent_bg};
+        }}
+        #firmwareUploadPanel QCheckBox {{
+            color: {dialog.TEXT_COLOR};
+            background: transparent;
+            font-family: "{text_font}";
+            font-size: 12px;
+        }}
+        #firmwareUploadPanel QCheckBox::indicator {{
+            width: 15px;
+            height: 15px;
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 4px;
+            background-color: {dialog.DIALOG_BG_COLOR};
+        }}
+        #firmwareUploadPanel QCheckBox::indicator:checked {{
+            background-color: {dialog_color};
+            border-color: {dialog_color};
+        }}
+        #firmwareUploadPanel QLineEdit {{
+            color: {dialog.TEXT_COLOR};
+            background-color: {dialog.DIALOG_BG_COLOR};
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 4px;
+            padding: 3px 6px;
+            font-family: "{text_font}";
+            font-size: 12px;
+            selection-background-color: {dialog_color};
+            selection-color: {WHITE};
+        }}
+        #firmwareUploadPanel QComboBox {{
+            color: {dialog.TEXT_COLOR};
+            background-color: {dialog.DIALOG_BG_COLOR};
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 4px;
+            padding: 3px 6px;
+            font-family: "{text_font}";
+            font-size: 12px;
+        }}
+        #firmwareUploadPanel QComboBox QAbstractItemView {{
+            color: {dialog.TEXT_COLOR};
+            background-color: {dialog.DIALOG_BG_COLOR};
+            selection-background-color: {dialog_color};
+            selection-color: {WHITE};
+        }}
+        #firmwareUploadPanel QSpinBox {{
+            color: {dialog.TEXT_COLOR};
+            background-color: {dialog.DIALOG_BG_COLOR};
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 4px;
+            padding: 2px 4px;
+            font-family: "{text_font}";
+            font-size: 12px;
+            selection-background-color: {dialog_color};
+            selection-color: {WHITE};
+        }}
+        /* Slim up/down buttons in the dialog's border color; the arrows keep
+           the native glyphs (no image needed). */
+        #firmwareUploadPanel QSpinBox::up-button,
+        #firmwareUploadPanel QSpinBox::down-button {{
+            width: 16px;
+            background-color: {accent_bg};
+            border-left: 1px solid {dialog.BORDER_COLOR};
+        }}
+        #firmwareUploadPanel QSpinBox::up-button {{
+            subcontrol-position: top right;
+            border-top-right-radius: 4px;
+        }}
+        #firmwareUploadPanel QSpinBox::down-button {{
+            subcontrol-position: bottom right;
+            border-bottom-right-radius: 4px;
+        }}
+        #firmwareUploadPanel QSpinBox::up-button:hover,
+        #firmwareUploadPanel QSpinBox::down-button:hover {{
+            background-color: {dialog._lighten_color(dialog_color, 0.7)};
+        }}
+        #firmwareUploadPanel QPushButton {{
+            color: {dialog.EXIT_BUTTON_TEXT_COLOR};
+            background-color: {dialog.EXIT_BUTTON_COLOR};
+            border: 1px solid {dialog.BORDER_COLOR};
+            border-radius: 6px;
+            padding: 4px 12px;
+            font-family: "{text_font}";
+            font-size: 12px;
+        }}
+        #firmwareUploadPanel QPushButton:hover {{
+            background-color: {dialog._darken_color(dialog.EXIT_BUTTON_COLOR, 0.05)};
+        }}
+        #firmwareUploadPanel QToolButton {{
+            color: {dialog.TEXT_COLOR};
+            background: transparent;
+            border: none;
+            border-radius: 4px;
+            padding: 2px;
+        }}
+        #firmwareUploadPanel QToolButton:hover {{
+            background-color: rgba(0, 0, 0, 0.08);
+        }}
+        #firmwareUploadPanel QToolButton:checked {{
+            color: {WHITE};
+            background-color: {dialog_color};
+        }}
+    """

--- a/peripheral_device_controller_base/consts.py
+++ b/peripheral_device_controller_base/consts.py
@@ -10,6 +10,42 @@ the base classes and the per-device ``consts.py`` modules stay in sync.
 # Everything else under ``<device>/requests/`` is gated on an active connection.
 DEFAULT_ALWAYS_ALLOWED_SUBTOPICS = ["start_device_monitoring", "retry_connection"]
 
+# Firmware upload/cancel are always-allowed too, on the devices that offer
+# them: flashing IS the recovery path for a board whose firmware can't
+# connect, and the upload service releases the proxy (disconnecting) before it
+# flashes. An upload-capable controller extends its _always_allowed_subtopics
+# with these (see PeripheralFirmwareUploadService).
+FIRMWARE_UPLOAD_ALWAYS_ALLOWED_SUBTOPICS = [
+    "upload_firmware", "cancel_firmware_upload",
+]
+
+
+def upload_firmware_topic(device_name: str) -> str:
+    """Request: flash the board's firmware (UploadFirmwareData payload)."""
+    return f"{device_name}/requests/upload_firmware"
+
+
+def cancel_firmware_upload_topic(device_name: str) -> str:
+    """Request: abort the running firmware upload."""
+    return f"{device_name}/requests/cancel_firmware_upload"
+
+
+def firmware_upload_started_topic(device_name: str) -> str:
+    """Signal: an upload was accepted and started (drives the dialog's
+    uploading state); the message is a human-readable run description."""
+    return f"{device_name}/signals/firmware_upload_started"
+
+
+def firmware_upload_log_topic(device_name: str) -> str:
+    """Signal: one uploader progress line per message."""
+    return f"{device_name}/signals/firmware_upload_log"
+
+
+def firmware_upload_finished_topic(device_name: str) -> str:
+    """Signal: upload outcome — JSON {"success": bool}, or {"error": str} on
+    an uploader crash."""
+    return f"{device_name}/signals/firmware_upload_finished"
+
 
 def connected_topic(device_name: str) -> str:
     return f"{device_name}/signals/connected"

--- a/peripheral_device_controller_base/firmware_upload_datamodels.py
+++ b/peripheral_device_controller_base/firmware_upload_datamodels.py
@@ -1,0 +1,62 @@
+"""Shared firmware-upload message contract for Pico-family peripherals.
+
+Every board this covers takes the same upload options; only the topic (and
+the safe default device id, applied frontend-side) differs per device, so the
+payload model and its validated publisher live here once. Each device creates
+one publisher bound to its own upload topic:
+
+    upload_firmware_publisher = UploadFirmwarePublisher(
+        topic=upload_firmware_topic(DEVICE_NAME))
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from microdrop_utils.dramatiq_pub_sub_helpers import ValidatedTopicPublisher
+
+
+class UploadFirmwareData(BaseModel):
+    """One firmware-upload run: mirrors firmware_uploader.upload_firmware.
+
+    ``firmware_source`` is a folder tree OR a .zip bundle (the backend unzips
+    a zip to a temp dir, uploads it, then deletes it). ``port`` empty means
+    auto: the backend reuses a connected proxy's stored port, else probes for
+    the board (whoami / Pico VID). ``device_id`` empty matches the first
+    board that identifies at all (the frontend substitutes the device's own
+    safe default before it gets here). ``upload_timeout_s`` 0 means never kill
+    the upload.
+    """
+    model_config = ConfigDict(extra='forbid')
+
+    firmware_source: str
+    single_file: str = ""  # upload only this file (absolute or dir-relative)
+    port: str = ""
+    device_id: str = ""
+    update_config: bool = False
+    skip_filesystem_format: bool = False
+    reset_after_upload: bool = True
+    dry_run: bool = False
+    upload_timeout_s: int = Field(default=0, ge=0)
+
+
+class UploadFirmwarePublisher(ValidatedTopicPublisher):
+    """Validated publisher for a device's upload_firmware topic.
+
+    Exposes a keyword-only .publish(...) that mirrors the UploadFirmwareData
+    fields for call-site readability.
+    """
+    validator_class = UploadFirmwareData
+
+    def publish(self, *, firmware_source, single_file, port, device_id,
+                update_config, skip_filesystem_format, reset_after_upload,
+                dry_run, upload_timeout_s, **kw):
+        super().publish({
+            "firmware_source": firmware_source,
+            "single_file": single_file,
+            "port": port,
+            "device_id": device_id,
+            "update_config": update_config,
+            "skip_filesystem_format": skip_filesystem_format,
+            "reset_after_upload": reset_after_upload,
+            "dry_run": dry_run,
+            "upload_timeout_s": upload_timeout_s,
+        }, **kw)

--- a/peripheral_device_controller_base/firmware_uploader.py
+++ b/peripheral_device_controller_base/firmware_uploader.py
@@ -301,11 +301,17 @@ def _diff_configs(device_config_path, repo_config_path, log):
 # File selection                                                      #
 # ------------------------------------------------------------------ #
 
+#: Packaging junk that a zip may carry but must never reach the board: macOS
+#: Finder adds a top-level __MACOSX/ tree of ._* AppleDouble sidecar files
+#: when zipping a folder.
+_ARCHIVE_JUNK_DIRS = frozenset({"__pycache__", "__MACOSX"})
+
+
 def _keep(f: Path) -> bool:
     """True if f is a candidate for upload at all (before the config.json
-    filter): no bytecode caches, markdown, hidden files/dirs, or
-    suffix-less non-directories."""
-    if "__pycache__" in f.parts:
+    filter): no bytecode caches, packaging junk, markdown, hidden files/dirs,
+    or suffix-less non-directories."""
+    if _ARCHIVE_JUNK_DIRS.intersection(f.parts):
         return False
     if f.suffix == ".pyc":
         return False
@@ -334,10 +340,17 @@ def _cancelled(cancel_event, log):
 # ------------------------------------------------------------------ #
 
 def _firmware_root(extracted_dir: Path) -> Path:
-    """The firmware root inside an extracted bundle. If the archive wrapped
-    everything in a single top-level directory (a zip of the firmware
-    folder), that directory is the root; otherwise the extraction dir is."""
-    entries = list(extracted_dir.iterdir())
+    """The firmware root inside an extracted bundle. Packaging junk (macOS
+    __MACOSX/, hidden dot-entries) is ignored; if exactly one real directory
+    remains at the top level (a zip of the firmware folder), that directory
+    is the root, otherwise the extraction dir is.
+
+    Ignoring the junk matters: a Finder-made zip carries both ``firmware/``
+    and ``__MACOSX/`` at the top level, and without this the wrapper wouldn't
+    be unwrapped — every file would land under ``:firmware/`` on the board."""
+    entries = [e for e in extracted_dir.iterdir()
+               if e.name not in _ARCHIVE_JUNK_DIRS
+               and not e.name.startswith(".")]
     if len(entries) == 1 and entries[0].is_dir():
         return entries[0]
     return extracted_dir

--- a/peripheral_device_controller_base/firmware_uploader.py
+++ b/peripheral_device_controller_base/firmware_uploader.py
@@ -1,0 +1,620 @@
+"""Qt-free firmware uploader for a MicroPython (Pico-family) peripheral board.
+
+Shared by every Pico-based peripheral (heater, fluorescence, ...): the raw
+per-board upload scripts were identical bar the default device id, so the
+logic lives here once. Only the firmware SOURCE (a folder or a .zip bundle)
+stays external (the request points at it). Files are pushed with mpremote,
+one command per ``python -m mpremote`` subprocess: that keeps mpremote's
+sys.argv/SystemExit machinery out of the backend process and lets each
+command's output be captured for the caller's log.
+
+Every function takes a ``log`` callable for progress lines (the firmware
+upload service publishes them to the device's FIRMWARE_UPLOAD_LOG topic) and
+``upload_firmware`` honours a ``cancel_event`` between steps — mid-command
+cancellation is bounded by MPREMOTE_COMMAND_TIMEOUT_S.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from pathlib import Path
+
+import serial
+import serial.tools.list_ports
+
+from microdrop_utils.hardware_device_monitoring_helpers import find_port_by_device_id
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+#: Pico-family USB identity, shared by every board this uploader targets
+#: (heater and fluorescence both enumerate as RP2040 VID:PID 2E8A:0005 at
+#: 115200 baud). A board with a different HWID can override via the
+#: ``hwids`` argument of ``upload_firmware``.
+PICO_USB_VENDOR_ID = 0x2E8A
+PICO_RP2040_HWID = "VID:PID=2E8A:0005"
+BOARD_BAUDRATE = 115200
+
+#: Hard ceiling per mpremote command so one wedged copy can't hang an upload
+#: forever (the full-filesystem wipe is the slowest single command).
+MPREMOTE_COMMAND_TIMEOUT_S = 120
+
+#: The boot window is only open for ~3s after the board re-enumerates; the
+#: Ctrl-C burst is bounded so a MISSED window doesn't keep firing Ctrl-C into
+#: the now-running asyncio loop (which would wedge the board).
+REPL_CATCH_BURST_S = 3.5
+#: Startup-banner fragments proving the firmware is already running — the
+#: boot window has passed, stop bursting immediately.
+FIRMWARE_RUNNING_MARKERS = (
+    b"System ready", b"USB listener started", b"Starting MicroPython",
+    b"Command processor",
+)
+
+
+# ------------------------------------------------------------------ #
+# mpremote plumbing                                                   #
+# ------------------------------------------------------------------ #
+
+def _run_mpremote_subprocess(cmd):
+    """One ``python -m mpremote <cmd...>`` run with captured, merged output."""
+    return subprocess.run(
+        [sys.executable, "-m", "mpremote"] + cmd,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, encoding="utf-8", errors="replace",
+        timeout=MPREMOTE_COMMAND_TIMEOUT_S,
+        creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+    )
+
+
+def run_mpremote(cmd, log, retries=3):
+    """Run a single mpremote command with retry, streaming its output through
+    ``log``. Assumes the board is already at the REPL (see
+    ensure_repl_via_window), so no per-command Ctrl-C is sent."""
+    for attempt in range(1, retries + 1):
+        try:
+            completed = _run_mpremote_subprocess(cmd)
+        except Exception as e:
+            log(f"WARNING: mpremote attempt {attempt}/{retries} raised: {e}")
+            time.sleep(0.5 * attempt)
+            continue
+        for line in completed.stdout.splitlines():
+            if line.strip():
+                log(f"  {line}")
+        if completed.returncode == 0:
+            return True
+        log(f"WARNING: mpremote attempt {attempt}/{retries} failed "
+            f"(exit {completed.returncode}): {' '.join(cmd)}")
+        time.sleep(0.5 * attempt)
+    log(f"ERROR: mpremote command failed after {retries} attempts: "
+        f"{' '.join(cmd)}")
+    return False
+
+
+def _wipe_filesystem(port, log):
+    """Wipe the board's filesystem contents WITHOUT touching the root itself.
+
+    ``rm -rv :/`` removes every child but then tries to rmdir the root,
+    which the board refuses (EPERM) — mpremote reports ``rm -r: cannot
+    remove :/ Operation not permitted`` and exits non-zero on every retry
+    even though the wipe actually happened (the standalone upload script
+    had the same noise, its format step's result was just never checked).
+    Removing each top-level entry instead ends clean.
+    """
+    try:
+        listing = _run_mpremote_subprocess(["connect", port, "fs", "ls", ":/"])
+    except Exception as e:
+        listing = None
+        logger.debug(f"Filesystem listing raised: {e}")
+    if listing is None or listing.returncode != 0:
+        log("WARNING: could not list the filesystem before the wipe; "
+            "falling back to rm -r :/")
+        run_mpremote(["connect", port, "rm", "-rv", ":/"], log)
+        return
+    # `fs ls :/` lines are "<size> <name>" (directories keep a trailing /),
+    # preceded by an "ls :/" header — keep only the size-prefixed entries.
+    entries = []
+    for line in listing.stdout.splitlines():
+        parts = line.split(None, 1)
+        if len(parts) == 2 and parts[0].isdigit():
+            entries.append(parts[1].strip().rstrip("/"))
+    if not entries:
+        log("Filesystem already empty.")
+        return
+    for entry in entries:
+        run_mpremote(["connect", port, "rm", "-rv", f":/{entry}"], log)
+
+
+def _pull_device_config(port):
+    """Best-effort single-attempt pull of the device's current config.json to
+    a local temp file. Returns the temp Path on success, or None if the
+    device has no config.json right now (a fresh board, or one already
+    wiped) — that's an expected outcome, not an error, so no retries and no
+    logging here; the caller decides what to report."""
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix="fluorescence_config_backup_", suffix=".json")
+    os.close(tmp_fd)
+    tmp_path = Path(tmp_name)
+    try:
+        completed = _run_mpremote_subprocess(
+            ["connect", port, "cp", ":config.json", str(tmp_path)])
+        pulled = completed.returncode == 0
+    except Exception as e:
+        logger.debug(f"config.json pull failed: {e}")
+        pulled = False
+    if not pulled or not tmp_path.exists() or tmp_path.stat().st_size == 0:
+        tmp_path.unlink(missing_ok=True)
+        return None
+    return tmp_path
+
+
+# ------------------------------------------------------------------ #
+# Getting the board to a quiescent REPL                               #
+# ------------------------------------------------------------------ #
+
+def _current_pico_port(preferred):
+    """The current Pico port, tolerating re-enumeration name changes."""
+    devices = [p.device for p in serial.tools.list_ports.comports()]
+    if preferred in devices:
+        return preferred
+    for p in serial.tools.list_ports.comports():
+        if p.vid == PICO_USB_VENDOR_ID:
+            return p.device
+    return preferred
+
+
+def _reset_and_catch_once(port, log, timeout_s):
+    """One attempt: reboot a running firmware via '|||reset', then burst
+    Ctrl-C to catch main.py's boot window. Returns (reached_repl, port)."""
+    # Reboot a healthy running firmware into its boot window. Ctrl-C is NEVER
+    # sent to the running loop (that can wedge it) — only during the window.
+    try:
+        with serial.Serial(port, BOARD_BAUDRATE, timeout=0) as ser:
+            ser.write(b"\r|||reset\r\n")
+            ser.flush()
+    except Exception as e:
+        log(f"WARNING: could not send |||reset (board may already be at "
+            f"REPL): {e}")
+    time.sleep(0.4)  # let the reset begin (USB drops) before the burst
+
+    buf = b""
+    ser = None
+    t0 = time.time()
+    reopened_at = None
+    cur = port
+    while time.time() - t0 < timeout_s:
+        if ser is None:
+            cur = _current_pico_port(port)
+            try:
+                ser = serial.Serial(cur, BOARD_BAUDRATE, timeout=0)
+            except Exception:
+                time.sleep(0.02)
+                continue
+            if reopened_at is None:
+                reopened_at = time.time()
+        # Stop bursting once we've hammered the live port past the window, or
+        # if the firmware is clearly already running — never overrun into the
+        # loop.
+        if reopened_at is not None and time.time() - reopened_at > REPL_CATCH_BURST_S:
+            break
+        if any(marker in buf for marker in FIRMWARE_RUNNING_MARKERS):
+            break
+        try:
+            ser.write(b"\x03")
+            buf += ser.read(256)
+        except Exception:
+            try:
+                ser.close()
+            except Exception:
+                pass
+            ser = None
+            reopened_at = None
+            continue
+        if b">>>" in buf or b"staying at REPL" in buf:
+            try:
+                ser.close()
+            except Exception:
+                pass
+            return True, cur
+        time.sleep(0.02)
+    if ser is not None:
+        try:
+            ser.close()
+        except Exception:
+            pass
+    return False, cur
+
+
+def ensure_repl_via_window(port, log, attempts=4, timeout_s=7):
+    """Get the board to a quiescent REPL WITHOUT a UF2 reflash or physical
+    replug. Reboots a running firmware via its own '|||reset' command and
+    catches main.py's boot-time safe-mode window with a Ctrl-C burst.
+    Catching a short window across USB re-enumeration is timing-sensitive, so
+    each miss simply reboots and tries again. Returns (port, reached_repl)
+    with the possibly re-enumerated port name."""
+    cur = port
+    for attempt in range(1, attempts + 1):
+        ok, cur = _reset_and_catch_once(cur, log, timeout_s)
+        if ok:
+            log(f"Reached REPL via boot window on {cur} (attempt {attempt})")
+            return cur, True
+        log(f"WARNING: boot-window catch attempt {attempt}/{attempts} "
+            f"missed; retrying")
+    return cur, False
+
+
+# ------------------------------------------------------------------ #
+# config.json diffing                                                 #
+# ------------------------------------------------------------------ #
+
+def _flatten_json(d, prefix=""):
+    """Flatten a nested dict into {"a.b.c": leaf_value} pairs. Lists and
+    other non-dict values are treated as leaves (compared by equality),
+    which is sufficient for config.json's shape (nested objects with the
+    occasional flat sensor-name list)."""
+    out = {}
+    if isinstance(d, dict):
+        for k, v in d.items():
+            out.update(_flatten_json(v, f"{prefix}.{k}" if prefix else str(k)))
+    else:
+        out[prefix] = d
+    return out
+
+
+def _diff_configs(device_config_path, repo_config_path, log):
+    """Log a read-only, key-by-key diff between the device's current
+    config.json and the repo's copy. Purely informational — this never
+    merges or resolves anything; telling a stale placeholder apart from an
+    intentional per-board tuning value isn't something code can safely
+    judge, so that call is always left to the human running this."""
+    try:
+        device_cfg = json.loads(Path(device_config_path).read_text())
+    except Exception as e:
+        log(f"WARNING: could not parse device's config.json for diff: {e}")
+        return
+    try:
+        repo_cfg = json.loads(Path(repo_config_path).read_text())
+    except Exception as e:
+        log(f"WARNING: could not parse repo config.json for diff: {e}")
+        return
+
+    device_flat = _flatten_json(device_cfg)
+    repo_flat = _flatten_json(repo_cfg)
+    keys = sorted(set(device_flat) | set(repo_flat))
+    diffs = [(k, device_flat.get(k, "<missing>"), repo_flat.get(k, "<missing>"))
+             for k in keys]
+    diffs = [d for d in diffs if d[1] != d[2]]
+
+    if not diffs:
+        log("config.json: device matches repo (no differences)")
+        return
+    log(f"config.json: device and repo differ in {len(diffs)} key(s):")
+    for k, device_value, repo_value in diffs:
+        log(f"    {k}: device={device_value!r}  repo={repo_value!r}")
+
+
+# ------------------------------------------------------------------ #
+# File selection                                                      #
+# ------------------------------------------------------------------ #
+
+def _keep(f: Path) -> bool:
+    """True if f is a candidate for upload at all (before the config.json
+    filter): no bytecode caches, markdown, hidden files/dirs, or
+    suffix-less non-directories."""
+    if "__pycache__" in f.parts:
+        return False
+    if f.suffix == ".pyc":
+        return False
+    if f.suffix == ".md":
+        return False
+    if any(part.startswith(".") for part in f.parts):
+        return False
+    if not f.is_dir() and f.suffix == "":
+        return False
+    return True
+
+
+def _is_top_level_config(f: Path, fw_path: Path) -> bool:
+    return f.name == "config.json" and f.parent == fw_path
+
+
+def _cancelled(cancel_event, log):
+    if cancel_event is not None and cancel_event.is_set():
+        log("Upload cancelled.")
+        return True
+    return False
+
+
+# ------------------------------------------------------------------ #
+# Zip bundle handling                                                 #
+# ------------------------------------------------------------------ #
+
+def _firmware_root(extracted_dir: Path) -> Path:
+    """The firmware root inside an extracted bundle. If the archive wrapped
+    everything in a single top-level directory (a zip of the firmware
+    folder), that directory is the root; otherwise the extraction dir is."""
+    entries = list(extracted_dir.iterdir())
+    if len(entries) == 1 and entries[0].is_dir():
+        return entries[0]
+    return extracted_dir
+
+
+def _extract_firmware_zip(zip_path: Path, log):
+    """Unzip a firmware bundle into a fresh temp dir and return
+    ``(firmware_root, temp_dir)``. ``temp_dir`` is always the mkdtemp root so
+    the caller deletes exactly what was created, even when the firmware root
+    is a subdirectory of it."""
+    temp_dir = Path(tempfile.mkdtemp(prefix="microdrop_fw_"))
+    log(f"Unzipping firmware bundle {zip_path.name} -> {temp_dir}")
+    with zipfile.ZipFile(zip_path) as archive:
+        names = archive.namelist()
+        archive.extractall(temp_dir)
+    for name in names:
+        logger.debug(f"  extracted: {name}")
+    log(f"Unzipped {len(names)} entr{'y' if len(names) == 1 else 'ies'}.")
+    root = _firmware_root(temp_dir)
+    if root != temp_dir:
+        log(f"Firmware root inside the bundle: {root.name}/")
+    return root, temp_dir
+
+
+def _cleanup_extracted_dir(temp_dir: Path, log):
+    """Delete the temp dir an upload's zip bundle was extracted into."""
+    log(f"Deleting unzipped firmware copy {temp_dir}")
+    try:
+        shutil.rmtree(temp_dir)
+    except Exception as e:
+        logger.warning(f"Could not delete temp firmware dir {temp_dir}: {e}")
+        log(f"WARNING: could not delete unzipped copy {temp_dir}: {e}")
+
+
+# ------------------------------------------------------------------ #
+# Main entry point                                                    #
+# ------------------------------------------------------------------ #
+
+def upload_firmware(
+    firmware_path,
+    port=None,
+    reset_device=True,
+    single_file=None,
+    no_format=False,
+    update_config=False,
+    device_id=None,
+    dry_run=False,
+    hwids=None,
+    log=logger.info,
+    cancel_event=None,
+):
+    """Upload the firmware tree (or one file) to the board. Returns success.
+
+    Args:
+        firmware_path: Directory containing the firmware files, OR a .zip
+            bundle of them — a zip is extracted to a temp dir, uploaded, and
+            the temp dir deleted before returning.
+        port: Serial port to use; None probes for the board by HWID and
+            whoami ``device_id`` (find_port_by_device_id — an empty/None
+            device_id claims the first board that identifies at all).
+        hwids: USB HWIDs to probe when ``port`` is None; defaults to the
+            Pico RP2040 id shared by every board this uploader targets.
+        reset_device: Reset the device after a fully successful upload.
+        single_file: Upload only this file (absolute, or relative to
+            firmware_path).
+        no_format: Skip formatting the filesystem first.
+        update_config: If True, wipe everything including config.json and
+            push the repo's copy (no backup kept). If False (default), the
+            device's current config.json is backed up before the wipe and
+            restored afterward, so per-board tuned values survive a routine
+            full reflash. Either way a key-by-key diff between the device's
+            and repo's config.json is logged before anything is touched.
+            Ignored when single_file is set.
+        dry_run: Log what would happen and return without touching the
+            device.
+        log: Callable receiving one progress line per call.
+        cancel_event: threading.Event checked between steps; setting it
+            aborts the upload (bounded by MPREMOTE_COMMAND_TIMEOUT_S while a
+            command is in flight).
+    """
+    fw_path = Path(firmware_path)
+    temp_extract_dir = None
+    try:
+        # Zip bundle: unzip to a temp dir, upload that, delete it in finally.
+        if fw_path.is_file() and fw_path.suffix.lower() == ".zip":
+            fw_path, temp_extract_dir = _extract_firmware_zip(fw_path, log)
+
+        if single_file:
+            single_file_path = Path(single_file)
+            if single_file_path.is_absolute():
+                files = [single_file_path]
+                fw_path = single_file_path.parent
+            else:
+                files = [fw_path / single_file_path]
+            if not files[0].exists():
+                log(f"ERROR: single file {single_file} does not exist")
+                return False
+            skipped_config = False
+        else:
+            if not fw_path.is_dir():
+                log(f"ERROR: firmware path {firmware_path} is not a directory")
+                return False
+            files = [f for f in fw_path.glob("**/*") if _keep(f)]
+            skipped_config = False
+            if not update_config:
+                before = len(files)
+                files = [f for f in files
+                         if not _is_top_level_config(f, fw_path)]
+                skipped_config = len(files) < before
+            # boot.py first, then main.py, then everything else.
+            files.sort(key=lambda f: (0 if f.name == "boot.py" else
+                                      (1 if f.name == "main.py" else 2)))
+
+        if not files:
+            log("WARNING: no files found to upload")
+            return False
+
+        will_format = not single_file and not no_format
+        need_restore = will_format and not update_config and not single_file
+
+        if dry_run:
+            log(f"[dry-run] Firmware source: {fw_path}")
+            log(f"[dry-run] Format filesystem: {will_format}")
+            if update_config:
+                log("[dry-run] config.json: OVERWRITE with repo version "
+                    "(update_config)")
+            elif need_restore:
+                log("[dry-run] config.json: back up device's current copy "
+                    "before the wipe, then restore it afterward (default — "
+                    "device keeps its own config). If the device has no "
+                    "config.json to back up, the repo's copy is pushed "
+                    "instead of leaving the device with none.")
+            else:
+                log("[dry-run] config.json: left untouched (no format, no "
+                    "wipe happening)")
+            if not single_file:
+                log("[dry-run] config.json diff vs repo: only shown on a "
+                    "real run (requires reading the device)")
+            for f in files:
+                tag = "mkdir" if f.is_dir() else "upload"
+                log(f"[dry-run]   [{tag}] {f.relative_to(fw_path).as_posix()}")
+            if skipped_config:
+                log("[dry-run]   [skip: config] config.json (enable "
+                    "update_config to overwrite it)")
+            return True
+
+        if not port:
+            try:
+                port = find_port_by_device_id(hwids or [PICO_RP2040_HWID],
+                                              device_id or "")
+            except Exception as e:
+                log(f"ERROR: {e}")
+                return False
+        log(f"Using port: {port}")
+
+        if _cancelled(cancel_event, log):
+            return False
+
+        # Get the board to a quiescent REPL first. Do this ONCE; all the
+        # mpremote ops below then run against an idle REPL. The port name can
+        # change after the reset's USB re-enumeration, so adopt whatever
+        # ensure_repl_via_window reports back. If the REPL can't be
+        # confirmed, ABORT rather than let mpremote hammer Ctrl-C at a
+        # running loop (which would wedge the board).
+        port, at_repl = ensure_repl_via_window(port, log)
+        if not at_repl:
+            log("ERROR: could not drop the board to its REPL. It may be "
+                "fully wedged. Power-cycle it and run recover_pico.py, then "
+                "retry.")
+            return False
+
+        if _cancelled(cancel_event, log):
+            return False
+
+        # Read the device's current config.json (best-effort) before doing
+        # anything destructive: drives both the diff-vs-repo report and, when
+        # not update_config, gives us something to restore after a full wipe.
+        device_config_backup = None
+        if not single_file:
+            pulled = _pull_device_config(port)
+            repo_config_path = fw_path / "config.json"
+            if pulled is not None:
+                if repo_config_path.exists():
+                    _diff_configs(pulled, repo_config_path, log)
+                if need_restore:
+                    log("config.json: will be backed up and restored after "
+                        "the reflash (device keeps its own copy)")
+                    device_config_backup = pulled
+                else:
+                    if update_config:
+                        log("config.json: overwriting with repo version "
+                            "(update_config); see diff above for what "
+                            "changes")
+                    pulled.unlink(missing_ok=True)
+            else:
+                log("config.json: device currently has none (fresh board, or "
+                    "previously wiped) — nothing to diff or back up")
+                if need_restore:
+                    if repo_config_path.exists():
+                        log("WARNING: config.json: nothing on the device to "
+                            "back up, so pushing the repo's copy instead of "
+                            "leaving the device with none after the wipe. "
+                            "Enable update_config to do this intentionally "
+                            "and skip this warning.")
+                        files.append(repo_config_path)
+                    else:
+                        log("WARNING: filesystem will be formatted and there "
+                            "is no existing config.json to restore, and the "
+                            "repo has no config.json either — the device "
+                            "will have NO config.json until you add one "
+                            "manually.")
+
+        if will_format:
+            if _cancelled(cancel_event, log):
+                if device_config_backup is not None:
+                    device_config_backup.unlink(missing_ok=True)
+                return False
+            log("Formatting device filesystem...")
+            _wipe_filesystem(port, log)
+        elif no_format:
+            log("Skipping filesystem format")
+
+        all_successful = True
+        for i, filename in enumerate(files):
+            if _cancelled(cancel_event, log):
+                all_successful = False
+                break
+            log(f"Uploading file {i + 1}/{len(files)}: {filename}")
+
+            local_path = str(filename.absolute())
+            # The device's filesystem always uses forward slashes, regardless
+            # of the host OS. str(Path) would use "\" on Windows, which the
+            # Pico treats as a literal filename character rather than a
+            # directory separator — nested files would land flat on the
+            # device instead of inside their subdirectory.
+            remote_path = filename.relative_to(fw_path).as_posix()
+
+            if filename.is_dir():
+                # Best-effort: mkdir fails when the dir already exists (e.g.
+                # on no-format re-uploads), which is fine — don't abort on it.
+                run_mpremote(["connect", port, "mkdir", remote_path],
+                             log, retries=1)
+                continue
+
+            if run_mpremote(["connect", port, "cp", local_path,
+                             f":{remote_path}"], log):
+                log(f"Successfully uploaded {filename}")
+            else:
+                log(f"ERROR: failed to upload {filename} after retries")
+                all_successful = False
+                break
+
+        # Restore the device's original config.json if we backed one up. This
+        # runs regardless of all_successful — the wipe already happened, so
+        # leaving the device without its config would be strictly worse than
+        # a partial upload.
+        if device_config_backup is not None:
+            log("Restoring device's original config.json...")
+            if run_mpremote(["connect", port, "cp",
+                             str(device_config_backup), ":config.json"], log):
+                log("config.json restored.")
+            else:
+                log("ERROR: failed to restore config.json backup after "
+                    "wipe! Device has NO config.json now.")
+                all_successful = False
+            device_config_backup.unlink(missing_ok=True)
+
+        if reset_device and all_successful:
+            log("Resetting device...")
+            run_mpremote(["connect", port, "reset"], log, retries=1)
+
+        return all_successful
+
+    except Exception as e:
+        logger.exception("Error during firmware upload")
+        log(f"ERROR: error during firmware upload: {e}")
+        return False
+    finally:
+        if temp_extract_dir is not None:
+            _cleanup_extracted_dir(temp_extract_dir, log)

--- a/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
+++ b/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
@@ -119,8 +119,16 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         if self.connection_active:
             logger.info(f"Retry connection request rejected: {self._device_name} already connected")
             return
+        # A shutdown (or never-started) monitor stays down: cleanup() stops it
+        # deliberately — e.g. a firmware upload releasing the port — and the
+        # disconnect-triggered retry must not resurrect the search; only a new
+        # start_device_monitoring request restarts it.
+        scheduler = self.monitor_scheduler
+        if not isinstance(scheduler, BackgroundScheduler) or scheduler.state == STATE_STOPPED:
+            logger.info(f"{self._device_name} monitoring is stopped; not resuming the search.")
+            return
         logger.info(f"Attempting to retry connecting with a {self._device_name}")
-        self.monitor_scheduler.resume()
+        scheduler.resume()
         self._searching = True
 
     ############################################################

--- a/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
+++ b/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
@@ -73,25 +73,32 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
             self._searching = True
             return None
 
-        ## handle cases where monitor scheduler object already exists
-        if isinstance(self.monitor_scheduler, BackgroundScheduler):
-            if self.monitor_scheduler.state == STATE_RUNNING:
+        ## A live (running or paused) monitor is reused as-is. A shut-down one
+        ## CANNOT be restarted: APScheduler's start() returns and flips the
+        ## state to RUNNING, but the scan job never fires again (its executor
+        ## and jobstore were torn down by shutdown()). That happens after
+        ## cleanup() releases the port for a firmware upload — so a stopped
+        ## scheduler is rebuilt from scratch below instead of restarted, else
+        ## the device would never be rediscovered and stay disconnected.
+        scheduler = self.monitor_scheduler
+        if isinstance(scheduler, BackgroundScheduler) and scheduler.state != STATE_STOPPED:
+            if scheduler.state == STATE_RUNNING:
                 logger.warning(f"{self._device_name} connections are already being monitored.")
-            elif self.monitor_scheduler.state == STATE_STOPPED:
-                self.monitor_scheduler.start()
-                logger.info(f"{self._device_name} connection monitoring started now.")
-            elif self.monitor_scheduler.state == STATE_PAUSED:
-                self.monitor_scheduler.resume()
+            elif scheduler.state == STATE_PAUSED:
+                scheduler.resume()
                 logger.info(f"{self._device_name} connection monitoring was paused, now it is resumed.")
             else:
                 logger.error(
-                    f"Invalid {self._device_name} monitor scheduler state: it is {self.monitor_scheduler.state}")
-
+                    f"Invalid {self._device_name} monitor scheduler state: it is {scheduler.state}")
             self._searching = True
-
             return None
 
-        ## monitor was never created, so we can make one now:
+        ## No monitor yet, or the previous one was shut down: build a fresh one.
+        self._create_and_start_monitor(hwids_to_check)
+        self._searching = True
+
+    def _create_and_start_monitor(self, hwids_to_check):
+        """Build and start a fresh port-scanning scheduler."""
         def check_devices_with_error_handling():
             """Wrapper to handle errors from the port finder."""
             try:
@@ -112,8 +119,7 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         self.monitor_scheduler = scheduler
 
         logger.info(f"{self._device_name} monitor created and started")
-        self.monitor_scheduler.start()
-        self._searching = True
+        scheduler.start()
 
     def on_retry_connection_request(self, message):
         if self.connection_active:

--- a/peripheral_device_controller_base/services/peripheral_firmware_upload_service.py
+++ b/peripheral_device_controller_base/services/peripheral_firmware_upload_service.py
@@ -1,0 +1,198 @@
+"""Shared firmware-upload backend service for Pico-family peripherals.
+
+Runs firmware_uploader.upload_firmware on a worker thread, streaming each
+progress line onto ``<device>/signals/firmware_upload_log`` so any frontend
+can render a live console. The accepted run is announced on
+``firmware_upload_started`` and the outcome ({"success": bool}, or
+{"error": str} on a crash) on ``firmware_upload_finished``.
+
+Device-agnostic: every topic is derived from ``self._device_name`` (set by
+the composed controller base), so a concrete device only needs a thin
+subclass that ``@provides`` its own control-mixin interface and narrows the
+``proxy`` type. Compose it exactly like the monitor / command-setter mixins.
+"""
+
+import json
+import threading
+
+from traits.api import Any, HasTraits, Instance
+
+from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
+
+from ..consts import (
+    firmware_upload_finished_topic,
+    firmware_upload_log_topic,
+    firmware_upload_started_topic,
+)
+from ..firmware_uploader import upload_firmware
+from ..firmware_upload_datamodels import UploadFirmwareData
+
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
+
+class PeripheralFirmwareUploadService(HasTraits):
+    """Flashes a peripheral board's MicroPython firmware.
+
+    Port resolution: an explicit requested port wins; otherwise a connected
+    proxy's stored port is reused directly — the board is already
+    identified, no whoami probing needed. Whenever the target port is the
+    proxy's own, the proxy is released first via the composed controller's
+    ``cleanup()`` (the uploader needs exclusive port access, and cleanup also
+    stops the monitor so it can't reclaim the port mid-flash), and device
+    monitoring is re-requested once the upload ends so the freshly flashed
+    board reconnects.
+
+    The upload thread and the timeout timer publish from non-worker threads —
+    same precedent as the proxy's telemetry reader thread. Cancel and timeout
+    both set the run's cancel event, which the uploader honours between steps.
+    """
+
+    #: Narrowed to the device's serial proxy by the concrete subclass.
+    proxy = Any()
+
+    #: The running upload thread (None / dead while idle).
+    upload_thread = Instance(threading.Thread)
+    #: Set to abort the running upload (cancel request or timeout).
+    upload_cancel_event = Instance(threading.Event)
+    #: Cancels the upload at the request's timeout (None when no timeout).
+    upload_timeout_timer = Instance(threading.Timer)
+    #: Serializes upload start/cancel against the upload thread's completion.
+    upload_state_lock = Any()
+
+    def _upload_state_lock_default(self):
+        return threading.Lock()
+
+    # ---- device-derived topics -------------------------------------------
+
+    @property
+    def _upload_started_topic(self):
+        return firmware_upload_started_topic(self._device_name)
+
+    @property
+    def _upload_log_topic(self):
+        return firmware_upload_log_topic(self._device_name)
+
+    @property
+    def _upload_finished_topic(self):
+        return firmware_upload_finished_topic(self._device_name)
+
+    @property
+    def _start_device_monitoring_topic(self):
+        return f"{self._device_name}/requests/start_device_monitoring"
+
+    # ---- request handlers ------------------------------------------------
+
+    def on_upload_firmware_request(self, body):
+        """Validate an UploadFirmwareData payload and launch one upload;
+        a request arriving while an upload runs is logged and ignored."""
+        data = UploadFirmwareData(**json.loads(body))
+        with self.upload_state_lock:
+            if self.upload_thread is not None and self.upload_thread.is_alive():
+                publish_message(
+                    message="A firmware upload is already running — "
+                            "request ignored.",
+                    topic=self._upload_log_topic)
+                return
+            port, proxy_released = self._resolve_upload_port(data)
+            self.upload_cancel_event = threading.Event()
+
+            started_message = (
+                f"Starting firmware upload from "
+                f"{data.single_file or data.firmware_source} "
+                f"(port: {port or 'auto-detect'}"
+                f"{', dry run' if data.dry_run else ''})")
+            publish_message(message=started_message,
+                            topic=self._upload_started_topic)
+            logger.info(started_message)
+
+            if data.upload_timeout_s > 0:
+                self.upload_timeout_timer = threading.Timer(
+                    data.upload_timeout_s, self._cancel_timed_out_upload,
+                    args=(self.upload_cancel_event, data.upload_timeout_s,
+                          self._upload_log_topic))
+                self.upload_timeout_timer.daemon = True
+                self.upload_timeout_timer.start()
+            self.upload_thread = threading.Thread(
+                target=self._run_upload,
+                args=(data, port, proxy_released, self.upload_cancel_event),
+                daemon=True)
+            self.upload_thread.start()
+
+    def on_cancel_firmware_upload_request(self, body):
+        """Abort the running upload; the uploader stops at the next step
+        boundary and reports through the normal finish path."""
+        with self.upload_state_lock:
+            if self.upload_thread is None or not self.upload_thread.is_alive():
+                return
+            self._publish_upload_log_line(
+                "Cancel requested — stopping the upload at the next step.")
+            self.upload_cancel_event.set()
+
+    # ---- upload run ------------------------------------------------------
+
+    def _resolve_upload_port(self, data):
+        """The port to flash and whether the proxy was released for it.
+
+        Whenever the target port is the connected proxy's own (explicitly, or
+        because the empty auto port resolves to it), the proxy must go: the
+        uploader needs exclusive access to the port.
+        """
+        port = data.port
+        if self.proxy is not None:
+            if not port:
+                port = self.proxy.port
+            if port == self.proxy.port:
+                self._publish_upload_log_line(
+                    f"Disconnecting the board on {port} to free the port for "
+                    f"the upload.")
+                self.cleanup()
+                return port, True
+        return port, False
+
+    def _run_upload(self, data, port, proxy_released, cancel_event):
+        """Upload thread: run the uploader with a topic-publishing log, then
+        report the outcome; if the proxy was released for this upload,
+        re-request monitoring so the freshly flashed board reconnects."""
+        try:
+            success = upload_firmware(
+                firmware_path=data.firmware_source,
+                port=port or None,
+                reset_device=data.reset_after_upload,
+                single_file=data.single_file or None,
+                no_format=data.skip_filesystem_format,
+                update_config=data.update_config,
+                device_id=data.device_id,
+                dry_run=data.dry_run,
+                hwids=getattr(self, "_default_hwids", None) or None,
+                log=self._publish_upload_log_line,
+                cancel_event=cancel_event,
+            )
+            finished_payload = {"success": success}
+        except Exception as e:
+            logger.exception("Firmware upload crashed")
+            finished_payload = {"error": str(e)}
+        with self.upload_state_lock:
+            if self.upload_timeout_timer is not None:
+                self.upload_timeout_timer.cancel()
+                self.upload_timeout_timer = None
+        publish_message(message=json.dumps(finished_payload),
+                        topic=self._upload_finished_topic)
+        if proxy_released:
+            publish_message(message="",
+                            topic=self._start_device_monitoring_topic)
+
+    def _publish_upload_log_line(self, line):
+        """Every uploader progress line goes to both the dialog's log console
+        (topic) and the regular logger, so a headless run is traceable too."""
+        publish_message(message=line, topic=self._upload_log_topic)
+        logger.info(line)
+
+    @staticmethod
+    def _cancel_timed_out_upload(cancel_event, upload_timeout_s, log_topic):
+        if cancel_event.is_set():
+            return
+        message = f"Upload timed out after {upload_timeout_s} s — aborting."
+        publish_message(message=message, topic=log_topic)
+        logger.info(message)
+        cancel_event.set()


### PR DESCRIPTION
Extracts a reusable firmware-upload capability into the peripheral base and `microdrop_utils`, so any Pico-family peripheral (heater, fluorescence, …) gets a styled "Upload Firmware" dialog and a GUI-free backend service without duplicating the per-board upload scripts (which were identical bar the default device id).

## What's here

**`peripheral_device_controller_base`**
- `firmware_uploader.py` — Qt-free mpremote uploader: one `python -m mpremote` subprocess per command (keeps mpremote's `sys.argv`/`SystemExit` out of the backend process), a `log` callback, a `cancel_event` honoured between steps, `.zip` bundle support (unzip → upload → delete), and a per-entry filesystem wipe.
- `firmware_upload_datamodels.py` — shared `UploadFirmwareData` payload + validated publisher.
- `services/peripheral_firmware_upload_service.py` — device-agnostic `PeripheralFirmwareUploadService`: derives every topic from the composed controller's `_device_name`, finds the port via its `_default_hwids`, releases the proxy for the flash and re-requests monitoring after.
- `consts.py` — upload/cancel/started/log/finished topic factories + the always-allowed upload subtopics.

**`microdrop_utils/firmware_upload_dialog/`** — the device-agnostic dialog: Qt-free model (device-specific firmware-dir / default-device-id injected as traits), the log-console view + panel stylesheet, and a `FirmwareUploadDialogController` parameterized by a live_state object, the publisher, and the signal/cancel topics.

**Fixes / supporting changes**
- `fix(peripheral-base): rebuild the monitor after it was shut down` — a shut-down APScheduler can't be restarted (its jobs never fire again); the connection monitor is now rebuilt fresh, so a board reconnects after a firmware flash instead of staying disconnected.
- `fix(peripheral-base): don't resume a stopped monitor on retry` — the disconnect-triggered retry no longer resurrects a monitor that was deliberately stopped to free the port.
- `fix(uploader): unwrap the firmware folder past macOS zip junk` — a Finder-made zip carries `firmware/` and `__MACOSX/`; the wrapper is now unwrapped and the AppleDouble sidecars dropped, so files land at the board root.
- `feat(style)`: `ICON_USB` and `ICON_ARCHIVE` glyphs for the dialog.

The heater and fluorescence plugins wire onto this in their own repos (companion PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)