### PR TITLE
fix(firmware-upload): persist firmware source in prefs

### DIFF
--- a/microdrop_utils/firmware_upload_dialog/controller.py
+++ b/microdrop_utils/firmware_upload_dialog/controller.py
@@ -19,6 +19,7 @@ from PySide6.QtCore import QSize, QTimer
 from PySide6.QtWidgets import QFileDialog, QSizePolicy
 
 from traits.api import Any, HasTraits, Instance, Str, observe
+from apptools.preferences.api import PreferencesHelper
 
 from microdrop_application.dialogs.base_message_dialog import BaseMessageDialog
 from microdrop_application.dialogs.pyface_wrapper import YES, confirm, error
@@ -59,14 +60,16 @@ class FirmwareUploadDialogController(HasTraits):
     dialog_title = Str("Upload Firmware")
 
     model = Instance(FirmwareUploadModel)
+    preferences = Instance(PreferencesHelper)
 
     dialog = Any()
     traits_ui = Any()
 
     def _model_default(self):
         return FirmwareUploadModel(
-            default_firmware_dir=self.default_firmware_dir,
-            default_device_id=self.default_device_id)
+            default_device_id=self.default_device_id,
+            preferences=self.preferences,
+        )
 
     # ---- dialog assembly -------------------------------------------------
 

--- a/microdrop_utils/firmware_upload_dialog/model.py
+++ b/microdrop_utils/firmware_upload_dialog/model.py
@@ -12,19 +12,23 @@ import serial.tools.list_ports
 
 from traits.api import (
     Bool, Button, Directory, File, HasTraits, Range, Str, observe,
-    List,
+    List, Instance
 )
+
+from apptools.preferences.api import PreferencesHelper
 
 from .consts import (
     DEVICE_ID_PLACEHOLDER, PICO_USB_VENDOR_ID, PORT_ENTRY_SEPARATOR,
 )
 
+from logger.logger_service import get_logger
+logger = get_logger(__name__)
+
 
 class FirmwareUploadModel(HasTraits):
     """Options for one firmware-upload request, plus the live log."""
 
-    #: Injected by the controller (device-specific).
-    default_firmware_dir = Str()
+    default_firmware_dir = Directory()
     #: Safe id the upload targets when no whoami id is known (device-specific).
     default_device_id = Str()
 
@@ -69,6 +73,18 @@ class FirmwareUploadModel(HasTraits):
     show_source = Bool(True)
     show_port = Bool(True)
     show_options = Bool(True)
+
+    preferences = Instance(PreferencesHelper)
+
+    def traits_init(self):
+        _firmware_source_saved = self.preferences.trait_get("firmware_source")
+        if _firmware_source_saved:
+            self.firmware_source = _firmware_source_saved["firmware_source"]
+
+    @observe("firmware_source")
+    def _save_firmware_source(self, event):
+        logger.info(f"Saved firmware source: {event.new}")
+        self.preferences.firmware_source = event.new
 
     def _firmware_source_default(self):
         return self.default_firmware_dir


### PR DESCRIPTION
## Problem

The shared firmware-upload dialog took an injected `default_firmware_dir`. Each plugin supplied it from a `consts.py` holding an absolute path on one developer's machine, so on any other install the **Firmware** field opened pointing at a folder that does not exist.

## Change

`FirmwareUploadModel` takes a `PreferencesHelper` instead:

- `traits_init` seeds `firmware_source` from the saved `firmware_source` preference.
- An `@observe("firmware_source")` handler writes every change back.

The dialog now reopens on whatever folder or zip the user last browsed to, and it survives restarts.

## Companion PRs

- heater-microdrop-plugin-py `feat/firmware-upload`
- fluorescence-microdrop-plugin-py `feat/6-capture-chain`

Both delete their `firmware_upload/consts.py` and pass their own `PreferencesHelper` in. Merge this first — the plugins depend on the new `preferences` trait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)