### PR TITLE
chore: release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.4.1 (2026-07-23)
+
+### Fix
+
+- **firmware-upload**: persist firmware source in prefs
+
 ## v1.4.0 (2026-07-22)
 
 ### Feat


### PR DESCRIPTION
## v1.4.1 (2026-07-23)

### Fix

- **firmware-upload**: persist firmware source in prefs

[main 6e07b3c8] chore: release v1.4.1
 1 file changed, 6 insertions(+)

