### PR TITLE
refactor(firmware-upload): drop dead default_firmware_dir trait

### DIFF
--- a/microdrop_utils/firmware_upload_dialog/controller.py
+++ b/microdrop_utils/firmware_upload_dialog/controller.py
@@ -55,7 +55,6 @@ class FirmwareUploadDialogController(HasTraits):
     started_topic = Str()
     log_topic = Str()
     finished_topic = Str()
-    default_firmware_dir = Str()
     default_device_id = Str()
     dialog_title = Str("Upload Firmware")
 

--- a/microdrop_utils/firmware_upload_dialog/model.py
+++ b/microdrop_utils/firmware_upload_dialog/model.py
@@ -28,7 +28,6 @@ logger = get_logger(__name__)
 class FirmwareUploadModel(HasTraits):
     """Options for one firmware-upload request, plus the live log."""
 
-    default_firmware_dir = Directory()
     #: Safe id the upload targets when no whoami id is known (device-specific).
     default_device_id = Str()
 
@@ -85,9 +84,6 @@ class FirmwareUploadModel(HasTraits):
     def _save_firmware_source(self, event):
         logger.info(f"Saved firmware source: {event.new}")
         self.preferences.firmware_source = event.new
-
-    def _firmware_source_default(self):
-        return self.default_firmware_dir
 
     def _available_ports_default(self):
         return self._scan_port_entries()


### PR DESCRIPTION
## What

Follow-up cleanup to #561 (released in v1.4.1). Now that the firmware source comes from the plugin's `PreferencesHelper`, the old injection plumbing is dead code:

- `default_firmware_dir` removed from `FirmwareUploadDialogController` and `FirmwareUploadModel` — it was only ever fed the hardcoded dev path that #561 deleted, so it now always resolved to `""`.
- `_firmware_source_default` (which just returned that trait) removed. `firmware_source` defaults to `""` on its own, and `traits_init` seeds it from the saved preference.

No behavior change: an install with no saved preference starts with an empty Firmware field exactly as it did after #561.

🤖 Generated with [Claude Code](https://claude.com/claude-code)