### PR TITLE
chore: release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.4.2 (2026-07-23)
+
+### Refactor
+
+- **firmware-upload**: drop the dead default_firmware_dir trait
+
 ## v1.4.1 (2026-07-23)
 
 ### Fix


### PR DESCRIPTION
## v1.4.2 (2026-07-23)

### Refactor

- **firmware-upload**: drop the dead default_firmware_dir trait

[main b1fafe33] chore: release v1.4.2
 1 file changed, 6 insertions(+)

