### PR TITLE
feat(protocol-tree): run selected steps from the tree

### DIFF
--- a/docs/superpowers/specs/2026-07-24-run-selected-steps-design.md
+++ b/docs/superpowers/specs/2026-07-24-run-selected-steps-design.md
@@ -1,0 +1,138 @@
+# Run Selected Steps — design (issue #558)
+
+Status: approved 2026-07-24
+Branch: `feat/558-run-single-step-option-in-protocol-tree`
+Scope: `src/pluggable_protocol_tree/`
+
+## Problem
+
+The protocol tree can only run the whole protocol, or (via the current
+selection) run *from* a step to the end — `ProtocolExecutor.start()` already
+takes `start_step_path`. Operators developing a protocol want to exercise a
+subset: one step, several steps, a group, or a mixed selection, without
+running everything around it.
+
+## User-facing behaviour
+
+Select one or more rows in the protocol tree, right-click, choose **Run
+Selected Steps** (or press **Ctrl+R**). Only the selected rows execute.
+
+The run is an ordinary run in every other respect: Preview Mode and the
+"Repeat Protocol" spinbox both apply, logging and the run summary happen, the
+active-row highlight and device-viewer sync behave as usual.
+
+## Selection semantics
+
+Each selected row becomes an **independent execution root**:
+
+- Paths that are descendants of another selected path are dropped — a selected
+  group already covers its children.
+- Roots execute in tree order.
+- A row's **own** `repetitions` apply. Repetitions of ancestors *outside* the
+  selection do not.
+
+```
+Wash (reps=3)
+├─ Step A
+└─ Step B          select B     -> B                     (1 frame)
+                   select Wash  -> A,B,A,B,A,B           (6 frames)
+
+Step C (reps=4)    select C     -> C,C,C,C               (4 frames)
+```
+
+This falls out of *re-rooting* the frame expansion at each selection root,
+rather than filtering the full frame list. Filtering would have preserved
+ancestor repeats, which is the behaviour we explicitly rejected.
+
+A selection that yields no frames (nothing selected, or only empty groups) is
+not runnable: the menu entry is disabled and the shortcut is a no-op.
+
+## Architecture
+
+### Scope lives in two places only
+
+`RowManager.iter_execution_frames(scope_paths=None)` — absent means today's
+whole-protocol walk; present means re-root at each normalized selection root.
+`iter_execution_steps(scope_paths=None)` mirrors it. One public entry point,
+backwards-compatible with every existing caller.
+
+`ProtocolExecutor.run_paths` — a public trait, set by `start(run_paths=...)`
+and cleared when the run terminates. `_run_steps` sources its `frames` list
+from it. Everything downstream in the executor (step index/total, the pause
+cursor, mid-run seek resolution, the active-row highlight) already works off
+that list, so no other executor logic changes.
+
+The executor is the single source of truth for the active scope. No component
+stores a second copy.
+
+### Status counter
+
+`ProtocolStatusController` already holds an `executor` reference, so it reads
+the scope from there rather than keeping a copy. Two of its four
+`manager.iter_execution_*` call sites pass `executor.run_paths` through:
+`_distinct_steps` (which `_count_steps` and `_step_index_of` both build on) and
+`_next_name`. During a subset run the status bar reads "Step 2/3"; a full run
+is unchanged.
+
+`_row_at` and `_frame_index_for_rep` stay **unscoped**. `_row_at` is a pure
+path lookup — scoping it would only make previewing an out-of-scope step
+return None. `_frame_index_for_rep` maps timeline cells to executor frame
+indices, and the timeline renders the full protocol (see Out of scope), so
+scoping one half of that mapping would make it inconsistent with itself.
+
+The dock pane's logging `n_steps_provider` gets the same treatment so the run
+log records the subset size, not the protocol size.
+
+### UI wiring
+
+`views/tree_widget.py` owns the menu entry and the shortcut. It does not know
+the executor exists — it emits `run_selected_requested(list)` carrying the
+path tuples. `ProtocolTreePane` relays the signal alongside its existing
+`selection_changed`. `dock_pane._on_run_selected` re-checks
+`_is_protocol_active()` and calls `_start_protocol_run(preview_mode=...,
+run_paths=scope)`.
+
+Ctrl+R is gated on `_structural_editable`, exactly like the existing Ctrl+G /
+Ctrl+Shift+G fold shortcuts, so it is dead during a run. The context menu is
+already suppressed entirely while running. With the dock pane's guard that is
+three independent barriers against starting a subset run over a live one.
+
+No shortcut clash: the tree's only other bindings are Ctrl+G, Ctrl+Shift+G,
+and the copy/cut/paste standards; quick actions use bare letter keys.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `models/row_manager.py` | `scope_paths` argument; selection-root normalizer |
+| `execution/executor.py` | `run_paths` trait; `start(run_paths=)`; frame source |
+| `services/protocol_status_controller.py` | scope-aware step counts and lookups |
+| `views/tree_widget.py` | menu entry, Ctrl+R, `run_selected_requested` |
+| `views/protocol_tree_pane.py` | signal relay |
+| `views/dock_pane.py` | `_on_run_selected`; scoped `n_steps_provider` |
+
+## Out of scope
+
+The timeline bar keeps rendering the **full** protocol during a subset run. The
+playhead lands on the correct rows but visibly skips the unselected ones —
+arguably the right affordance, since you can see what is being skipped.
+Scoping the timeline is separate work.
+
+## Tests
+
+Targeted, not exhaustive:
+
+- `test_row_manager.py` — selection-root normalization; the own-reps rule;
+  descendant-of-selected dropping; tree ordering across mixed depths; empty
+  scope vs `None`.
+- `test_executor.py` — `run_paths` honoured; step totals reported against the
+  subset; `repeats` loops the scoped sequence; scope cleared on terminate.
+- `test_run_selected.py` (new) — the widget's runnability guard, emitted
+  roots, and the run-lock on the keyboard path.
+- `test_protocol_status_controller.py` — step counts follow the active scope.
+
+Note for whoever runs these: the suite needs Redis up, or directory-level
+collection skips wholesale. `test_protocol_tree_pane.py` carries ~100
+pre-existing failures (it still expects `pane.executor`, which moved to the
+dock pane in #471) and `test_executor.py` three more; those are unrelated to
+this work and were verified failing on the untouched branch first.

--- a/pluggable_protocol_tree/execution/executor.py
+++ b/pluggable_protocol_tree/execution/executor.py
@@ -79,6 +79,12 @@ class ProtocolExecutor(HasTraits):
     # encounters this path, then proceeds normally. Cleared on every
     # start() so a previous "play from selected" doesn't carry over.
     _start_step_path = Union(None, Tuple)
+    # Selection scope for the current run (issue #558). None runs the whole
+    # protocol; a list of row paths runs only those subtrees. Public so the
+    # status controller can scope its step counts off a single source of
+    # truth rather than keeping its own copy. Set by start(), cleared once
+    # the run terminates.
+    run_paths = Union(None, List)
     # Live ProtocolContext for the current run; seek() drives its cursor.
     # None between runs.
     _active_proto_ctx = Any
@@ -142,6 +148,7 @@ class ProtocolExecutor(HasTraits):
         preview_mode: bool = False,
         advanced_mode: bool = False,
         repeats: int = 1,
+        run_paths: Optional[list] = None,
     ) -> None:
         """Spawn a worker thread and call run() on it. Idempotent —
         a second call while already running is ignored.
@@ -167,6 +174,11 @@ class ProtocolExecutor(HasTraits):
         loops the step sequence that many times inside a single run(),
         firing on_pre_protocol_start / on_post_protocol_end once around
         the whole thing.
+
+        ``run_paths`` narrows the run to a selection of rows (issue #558):
+        only those subtrees execute, each as an independent execution root
+        (see ``RowManager.iter_execution_frames``). ``repeats`` still loops
+        the whole scoped sequence. None runs the entire protocol.
         """
         if self._thread is not None and self._thread.is_alive():
             return
@@ -175,6 +187,9 @@ class ProtocolExecutor(HasTraits):
         self._error = None
         self._start_step_path = (
             tuple(start_step_path) if start_step_path is not None else None
+        )
+        self.run_paths = (
+            [tuple(p) for p in run_paths] if run_paths is not None else None
         )
         self._preview_mode = bool(preview_mode)
         self._advanced_mode = bool(advanced_mode)
@@ -330,6 +345,12 @@ class ProtocolExecutor(HasTraits):
                 f"{time.monotonic() - proto_started_at:.2f}s"
             )
             self._active_proto_ctx = None
+            # Back to whole-protocol scope so idle-state consumers (status
+            # counts, step navigation) don't keep answering against the
+            # selection a finished run used. Cleared AFTER the terminal
+            # signal: the status controller observes it with the default
+            # dispatch, so its handler has already run on this thread.
+            self.run_paths = None
             # threading.Thread terminates naturally when run() returns;
             # nothing to quit() here. start() checks is_alive() to make
             # sure a previous run has completed before starting a new one.
@@ -340,7 +361,7 @@ class ProtocolExecutor(HasTraits):
         """Run one repetition. Honors stop_event, pause_event (step + phase
         checkpoints), skip_until (start-of-run), and the cursor's resume target
         (#471 mid-run seek)."""
-        frames = list(self.row_manager.iter_execution_frames())
+        frames = list(self.row_manager.iter_execution_frames(self.run_paths))
         frame_paths = [tuple(row.path) for row, _ in frames]
         cursor = proto_ctx.cursor
 

--- a/pluggable_protocol_tree/models/row_manager.py
+++ b/pluggable_protocol_tree/models/row_manager.py
@@ -486,16 +486,48 @@ class RowManager(HasTraits):
 
     # --- execution iteration ---
 
-    def iter_execution_steps(self) -> Iterator[BaseRow]:
+    def run_scope_roots(self, scope_paths: List[Path]) -> List[Path]:
+        """Normalize a selection into the roots a scoped run executes.
+
+        Paths that no longer resolve to a row are skipped, paths that are
+        descendants of another selected path are dropped (the ancestor's
+        subtree already covers them), and the result is sorted into tree
+        order. Drives ``iter_execution_frames(scope_paths=...)``; also usable
+        on its own to ask whether a selection is runnable at all.
+        """
+        candidates = []
+        for path in {tuple(p) for p in scope_paths}:
+            try:
+                self.get_row(path)
+            except (IndexError, KeyError):
+                continue
+            candidates.append(path)
+        return sorted(
+            p for p in candidates
+            if not any(self._is_ancestor(a, p) for a in candidates if a != p)
+        )
+
+    def iter_execution_steps(self, scope_paths: Optional[List[Path]] = None
+                             ) -> Iterator[BaseRow]:
         """Yield rows in execution order, flattening groups and expanding
         repetitions. Backward-compat shim — delegates to the richer
         ``iter_execution_frames``.
         """
-        for row, _rep_chain in self.iter_execution_frames():
+        for row, _rep_chain in self.iter_execution_frames(scope_paths):
             yield row
 
-    def iter_execution_frames(self) -> Iterator[tuple]:
+    def iter_execution_frames(self, scope_paths: Optional[List[Path]] = None
+                              ) -> Iterator[tuple]:
         """Yield ``(row, rep_chain)`` tuples in execution order.
+
+        ``scope_paths`` narrows the run to a selection (issue #558). ``None``
+        walks the whole protocol. Otherwise each normalized selection root
+        (see ``run_scope_roots``) is expanded as an INDEPENDENT execution
+        root: the selected row's own ``repetitions`` — and any inside its
+        subtree — expand normally, while repetitions of ancestors outside
+        the selection contribute nothing. Selecting a step inside a 3x group
+        therefore runs it once; selecting the group runs its children 3x. An
+        empty list is a legitimate empty scope and yields no frames.
 
         ``rep_chain`` is a tuple of ``(name, rep_idx_1based, rep_total)``
         triples, ordered outermost-first, covering ancestors with
@@ -511,7 +543,11 @@ class RowManager(HasTraits):
         Repetitions contract: any row may have an integer attribute
         named ``repetitions``. Missing attribute defaults to 1.
         """
-        yield from self._expand_frames(self.root, prefix=(), is_root=True)
+        if scope_paths is None:
+            yield from self._expand_frames(self.root, prefix=(), is_root=True)
+            return
+        for path in self.run_scope_roots(scope_paths):
+            yield from self._expand_frames(self.get_row(path), prefix=())
 
     @classmethod
     def _expand_frames(cls, node, prefix, is_root=False) -> Iterator[tuple]:

--- a/pluggable_protocol_tree/services/protocol_status_controller.py
+++ b/pluggable_protocol_tree/services/protocol_status_controller.py
@@ -164,12 +164,22 @@ class ProtocolStatusController(HasTraits):
 
     # --- helpers (need manager) ---
 
+    def _run_scope(self):
+        """The active run's selection scope, or None for a whole-protocol run
+        (issue #558). Read off the executor rather than cached here so there
+        is one source of truth; the executor clears it when the run ends."""
+        return getattr(self.executor, "run_paths", None)
+
     def _distinct_steps(self):
         """Step rows in execution order with repetitions collapsed (one entry
-        per row), so the status bar counts steps -- not per-rep frames."""
+        per row), so the status bar counts steps -- not per-rep frames.
+
+        Scoped to the active run's selection, so a "Run Selected" run reads
+        "Step 2/3" against the subset rather than against the whole protocol.
+        """
         seen = set()
         out = []
-        for row in self.manager.iter_execution_steps():
+        for row in self.manager.iter_execution_steps(self._run_scope()):
             key = tuple(row.path)
             if key in seen:
                 continue
@@ -184,7 +194,9 @@ class ProtocolStatusController(HasTraits):
             return 0
 
     def _next_name(self, current):
-        steps = self.manager.iter_execution_steps()
+        # Scoped like _distinct_steps: during a selected-subset run the "Next
+        # Step" label should name the next step that will actually run.
+        steps = self.manager.iter_execution_steps(self._run_scope())
         cur_path = tuple(current.path)
         for row in steps:
             if tuple(row.path) == cur_path:

--- a/pluggable_protocol_tree/tests/test_executor.py
+++ b/pluggable_protocol_tree/tests/test_executor.py
@@ -758,3 +758,77 @@ def test_wait_pre_protocol_freezes_while_paused():
     assert time.monotonic() - t0 >= 0.1  # paused time did not count down
 
 
+
+
+# --- scoped runs ("Run Selected Steps", issue #558) ---
+
+
+def _scoped_executor():
+    """Executor over Root: [A, Wash(reps=3){B, C}, D]."""
+    ex = _make_executor()
+    rm = ex.row_manager
+    rm.add_step(values={"name": "A"})
+    g = rm.add_group(name="Wash")
+    setattr(rm.get_row(g), "repetitions", 3)
+    rm.add_step(parent_path=g, values={"name": "B"})
+    rm.add_step(parent_path=g, values={"name": "C"})
+    rm.add_step(values={"name": "D"})
+    return ex
+
+
+def _names_of_run(ex, **start_kwargs):
+    started = []
+    ex.signals.observe(lambda event: started.append(event.new[0].name),
+                       "step_started")
+    ex.start(**start_kwargs)
+    assert ex.wait(timeout=10) is True
+    return started
+
+
+def test_run_paths_defaults_to_none_for_a_whole_protocol_run():
+    ex = _scoped_executor()
+    assert _names_of_run(ex) == ["A", "B", "C", "B", "C", "B", "C", "D"]
+    assert ex.run_paths is None
+
+
+def test_run_paths_restricts_the_run_to_the_selection():
+    ex = _scoped_executor()
+    assert _names_of_run(ex, run_paths=[(0,), (2,)]) == ["A", "D"]
+
+
+def test_run_paths_ignores_ancestor_repetitions():
+    """A step selected inside the 3x group runs once."""
+    ex = _scoped_executor()
+    assert _names_of_run(ex, run_paths=[(1, 0)]) == ["B"]
+
+
+def test_run_paths_reports_step_totals_against_the_subset():
+    """The (row, index, total) tuple the status bar reads must count the
+    scoped frames, not the protocol's."""
+    ex = _scoped_executor()
+    seen = []
+    ex.signals.observe(lambda event: seen.append(event.new[1:]), "step_started")
+    ex.start(run_paths=[(0,), (2,)])
+    assert ex.wait(timeout=10) is True
+    assert seen == [(1, 2), (2, 2)]
+
+
+def test_repeats_loops_the_scoped_sequence():
+    ex = _scoped_executor()
+    assert _names_of_run(ex, run_paths=[(0,)], repeats=3) == ["A", "A", "A"]
+
+
+def test_run_paths_is_cleared_once_the_run_terminates():
+    """Idle-state consumers (status counts, navigation) must go back to
+    answering against the whole protocol."""
+    ex = _scoped_executor()
+    _names_of_run(ex, run_paths=[(0,)])
+    assert ex.run_paths is None
+
+
+def test_empty_run_paths_runs_nothing_but_still_terminates():
+    ex = _scoped_executor()
+    finished = []
+    ex.signals.observe(lambda event: finished.append(True), "protocol_finished")
+    assert _names_of_run(ex, run_paths=[]) == []
+    assert finished == [True]

--- a/pluggable_protocol_tree/tests/test_protocol_status_controller.py
+++ b/pluggable_protocol_tree/tests/test_protocol_status_controller.py
@@ -9,9 +9,11 @@ from pluggable_protocol_tree.services.protocol_status_controller import (
 
 
 class _Executor:
-    """Minimal executor stand-in: the controller reads .signals off it."""
-    def __init__(self, signals):
+    """Minimal executor stand-in: the controller reads .signals off it, and
+    ``run_paths`` for the active run's selection scope (issue #558)."""
+    def __init__(self, signals, run_paths=None):
         self.signals = signals
+        self.run_paths = run_paths
 
 
 class _Row:
@@ -21,10 +23,15 @@ class _Row:
 
 
 class _Manager:
-    def __init__(self, rows):
+    def __init__(self, rows, scoped_rows=None):
         self._rows = rows
+        # Rows the manager would yield for a scoped run; keyed by nothing —
+        # the fake just checks that a scope was asked for at all.
+        self._scoped_rows = scoped_rows
 
-    def iter_execution_steps(self):
+    def iter_execution_steps(self, scope_paths=None):
+        if scope_paths is not None and self._scoped_rows is not None:
+            return iter(list(self._scoped_rows))
         return iter(list(self._rows))
 
 
@@ -43,6 +50,21 @@ def test_protocol_started_counts_steps():
     ctrl, sigs, clock, rows = _make()
     sigs.protocol_started = True
     assert ctrl.model.step_total == 2
+
+
+def test_step_counts_follow_the_active_run_scope():
+    """A "Run Selected" run reads "Step n/N" against the subset, not the
+    whole protocol (issue #558). The scope is read off the executor, so the
+    controller keeps no copy of its own."""
+    rows = [_Row("A", (0,)), _Row("B", (1,)), _Row("C", (2,))]
+    sigs = ExecutorSignals()
+    ctrl = ProtocolStatusController(
+        executor=_Executor(sigs, run_paths=[(1,)]),
+        manager=_Manager(rows, scoped_rows=[rows[1]]),
+        clock=lambda: 0.0,
+    )
+    sigs.protocol_started = True
+    assert ctrl.model.step_total == 1
     assert ctrl.model.running is True
 
 
@@ -161,6 +183,7 @@ class _StubExecutor:
     def __init__(self):
         self.seek_calls = []
         self.signals = None    # this test drives seek_to directly, no events
+        self.run_paths = None  # whole-protocol scope (issue #558)
 
     def seek(self, step_path, phase_index):
         self.seek_calls.append((tuple(step_path), phase_index))
@@ -188,7 +211,7 @@ def test_seek_to_calls_executor_and_updates_model():
                repeat_duration=0.0, repeat_duration_controls=False,
                linear_repeats=False, route_repetitions=1, duration_s=1.0)
     manager = SimpleNamespace(
-        iter_execution_steps=lambda: iter([row]),
+        iter_execution_steps=lambda scope_paths=None: iter([row]),
     )
     ex = _StubExecutor()
     c = ProtocolStatusController(signals=None, manager=manager, executor=ex,

--- a/pluggable_protocol_tree/tests/test_row_manager.py
+++ b/pluggable_protocol_tree/tests/test_row_manager.py
@@ -317,6 +317,85 @@ def test_iter_execution_group_repetitions_expand(manager):
     assert names == ["A", "B", "A", "B"]
 
 
+# --- scoped execution ("Run Selected Steps", issue #558) ---
+
+
+@pytest.fixture
+def nested_manager(manager):
+    """Root: [A, Wash(reps=3){B, C}, D]."""
+    manager.add_step(values={"name": "A"})
+    g = manager.add_group(name="Wash")
+    setattr(manager.get_row(g), "repetitions", 3)
+    manager.add_step(parent_path=g, values={"name": "B"})
+    manager.add_step(parent_path=g, values={"name": "C"})
+    manager.add_step(values={"name": "D"})
+    return manager
+
+
+def test_run_scope_roots_drops_descendants_of_selected_rows(nested_manager):
+    # Selecting the group AND a child inside it: the child is already covered.
+    roots = nested_manager.run_scope_roots([(1,), (1, 0)])
+    assert roots == [(1,)]
+
+
+def test_run_scope_roots_sorts_into_tree_order(nested_manager):
+    assert nested_manager.run_scope_roots([(2,), (0,), (1, 1)]) \
+        == [(0,), (1, 1), (2,)]
+
+
+def test_run_scope_roots_skips_stale_paths(nested_manager):
+    # (9,) never existed; it must not raise, just drop out.
+    assert nested_manager.run_scope_roots([(0,), (9,)]) == [(0,)]
+
+
+def test_scoped_run_ignores_ancestor_repetitions(nested_manager):
+    """A step selected inside a 3x group runs ONCE — ancestors outside the
+    selection contribute no repetitions (issue #558)."""
+    names = [r.name for r in nested_manager.iter_execution_steps([(1, 0)])]
+    assert names == ["B"]
+
+
+def test_scoped_run_honors_the_selected_rows_own_repetitions(nested_manager):
+    setattr(nested_manager.get_row((0,)), "repetitions", 4)
+    names = [r.name for r in nested_manager.iter_execution_steps([(0,)])]
+    assert names == ["A"] * 4
+
+
+def test_scoped_run_on_a_group_honors_that_groups_repetitions(nested_manager):
+    """Selecting the group itself re-introduces its own repeat loop."""
+    names = [r.name for r in nested_manager.iter_execution_steps([(1,)])]
+    assert names == ["B", "C"] * 3
+
+
+def test_scoped_run_covers_non_contiguous_selection_in_tree_order(nested_manager):
+    names = [r.name for r in nested_manager.iter_execution_steps([(2,), (0,)])]
+    assert names == ["A", "D"]
+
+
+def test_scoped_run_reports_rep_chain_relative_to_the_selection(nested_manager):
+    """The selected group is the outermost repeating scope, so it appears in
+    the chain; nothing above it does."""
+    chains = [chain for _row, chain in
+              nested_manager.iter_execution_frames([(1,)])]
+    assert chains[0] == (("Wash", 1, 3),)
+    assert chains[-1] == (("Wash", 3, 3),)
+
+
+def test_empty_scope_yields_no_frames(nested_manager):
+    """An empty list is a real empty scope — distinct from None, which means
+    'run the whole protocol'."""
+    assert list(nested_manager.iter_execution_frames([])) == []
+    assert len(list(nested_manager.iter_execution_frames(None))) == 8
+
+
+def test_scope_of_an_empty_group_yields_no_frames(manager):
+    """Normalizes to a root, but expands to nothing — this is the case the
+    tree's menu-entry guard has to catch."""
+    g = manager.add_group(name="Empty")
+    assert manager.run_scope_roots([g]) == [g]
+    assert list(manager.iter_execution_frames([g])) == []
+
+
 # --- slicing ---
 
 import pandas as pd

--- a/pluggable_protocol_tree/tests/test_run_selected.py
+++ b/pluggable_protocol_tree/tests/test_run_selected.py
@@ -1,0 +1,108 @@
+"""Tests for "Run Selected Steps" (issue #558) at the widget boundary.
+
+The tree widget deliberately knows nothing about the executor: it decides
+whether the selection is runnable, normalizes it to execution roots, and
+emits ``run_selected_requested``. Whoever owns run control connects to that.
+The scoping semantics themselves live in test_row_manager.py, and the
+executor's honouring of ``run_paths`` in test_executor.py.
+"""
+
+import pytest
+
+from pluggable_protocol_tree.builtins.duration_column import make_duration_column
+from pluggable_protocol_tree.builtins.id_column import make_id_column
+from pluggable_protocol_tree.builtins.name_column import make_name_column
+from pluggable_protocol_tree.builtins.type_column import make_type_column
+from pluggable_protocol_tree.models.row_manager import RowManager
+from pluggable_protocol_tree.views.tree_widget import ProtocolTreeWidget
+
+
+@pytest.fixture
+def manager():
+    """Root: [A, Wash(reps=3){B, C}, Empty]."""
+    rm = RowManager(columns=[make_type_column(), make_id_column(),
+                             make_name_column(), make_duration_column()])
+    rm.add_step(values={"name": "A"})
+    g = rm.add_group(name="Wash")
+    setattr(rm.get_row(g), "repetitions", 3)
+    rm.add_step(parent_path=g, values={"name": "B"})
+    rm.add_step(parent_path=g, values={"name": "C"})
+    rm.add_group(name="Empty")
+    return rm
+
+
+@pytest.fixture
+def widget(qapp, manager):
+    return ProtocolTreeWidget(manager)
+
+
+def _emitted(widget):
+    received = []
+    widget.run_selected_requested.connect(received.append)
+    return received
+
+
+# --- runnability guard ---------------------------------------------------
+
+def test_empty_selection_is_not_runnable(widget):
+    assert widget._can_run_selection() is False
+
+
+def test_selecting_a_step_is_runnable(widget, manager):
+    manager.select([(0,)])
+    assert widget._can_run_selection() is True
+
+
+def test_selecting_only_an_empty_group_is_not_runnable(widget, manager):
+    """It normalizes to a root but expands to no frames — the case that
+    would otherwise start a run that does nothing."""
+    manager.select([(2,)])
+    assert widget._can_run_selection() is False
+
+
+def test_empty_group_alongside_a_real_step_is_runnable(widget, manager):
+    manager.select([(0,), (2,)])
+    assert widget._can_run_selection() is True
+
+
+# --- request emission ----------------------------------------------------
+
+def test_run_selected_emits_normalized_roots(widget, manager):
+    received = _emitted(widget)
+    # Group plus one of its own children: the child is already covered.
+    manager.select([(1, 0), (1,), (0,)])
+    widget._run_selected()
+    assert received == [[(0,), (1,)]]
+
+
+def test_run_selected_stays_silent_when_nothing_would_run(widget, manager):
+    received = _emitted(widget)
+    manager.select([(2,)])
+    widget._run_selected()
+    assert received == []
+
+
+# --- run lock ------------------------------------------------------------
+
+def test_shortcut_is_inert_while_a_run_is_in_progress(widget, manager):
+    """set_editable(False) is what the dock pane calls for the duration of a
+    run; the context menu is suppressed wholesale in that state, so the
+    keyboard path has to be gated too."""
+    received = _emitted(widget)
+    manager.select([(0,)])
+    widget.set_editable(False)
+    widget._run_selected_shortcut()
+    assert received == []
+    widget.set_editable(True)
+    widget._run_selected_shortcut()
+    assert received == [[(0,)]]
+
+
+def test_shortcut_is_inert_in_advanced_mode_during_a_run(widget, manager):
+    """Advanced Mode reopens cell-value editing mid-run (#434) but not
+    structural actions — and not this one."""
+    received = _emitted(widget)
+    manager.select([(0,)])
+    widget.set_editable(True, structural=False)
+    widget._run_selected_shortcut()
+    assert received == []

--- a/pluggable_protocol_tree/views/dock_pane.py
+++ b/pluggable_protocol_tree/views/dock_pane.py
@@ -227,8 +227,13 @@ class PluggableProtocolDockPane(TraitsDockPane):
                 experiment_dir_provider=(
                     lambda: self.experiment_manager.get_experiment_directory()
                 ),
+                # Scoped to the active run (issue #558) so a "Run Selected"
+                # run logs the subset's step count, not the protocol's. The
+                # provider is called during on_pre_protocol_start, while
+                # executor.run_paths is still set.
                 n_steps_provider=(
-                    lambda: sum(1 for _ in self.manager.iter_execution_frames())
+                    lambda: sum(1 for _ in self.manager.iter_execution_frames(
+                        self.executor.run_paths))
                 ),
             ),
         ]
@@ -298,6 +303,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
 
         nb.btn_play.clicked.connect(self._on_play_clicked)
         nb.btn_resume.clicked.connect(self._toggle_pause)
+        pane.run_selected_requested.connect(self._on_run_selected)
 
         def _conditional_stop():
             self.executor.pause()
@@ -780,15 +786,34 @@ class PluggableProtocolDockPane(TraitsDockPane):
             preview_mode=self._pane.navigation_bar.is_preview_mode(),
         )
 
-    def _start_protocol_run(self, preview_mode):
+    def _on_run_selected(self, paths):
+        """Run only the rows the user selected in the tree (issue #558).
+
+        The tree gates its own menu entry and shortcut on the structural-edit
+        lock, but that is a view-layer flag; the executor state is the
+        authority, so re-check it here before starting."""
+        if self._start_pending or self._is_protocol_active():
+            logger.info("Run Selected ignored — a run is already in progress")
+            return
+        if not paths:
+            return
+        self._start_protocol_run(
+            preview_mode=self._pane.navigation_bar.is_preview_mode(),
+            run_paths=[tuple(p) for p in paths],
+        )
+
+    def _start_protocol_run(self, preview_mode, run_paths=None):
         repeats = self._pane.status_bar.edit_repeat_protocol.value()
         self._current_run_preview_mode = preview_mode
         advanced_mode = is_advanced_mode()
-        start_path = self._pane.selected_step_path()
+        # "Play from the selected step" and "run only the selected rows" are
+        # mutually exclusive readings of the same selection: a scoped run
+        # already starts at its first frame, so no skip-until target applies.
+        start_path = None if run_paths else self._pane.selected_step_path()
         logger.info(
             f"Protocol run starting: {repeats} rep(s), "
             f"preview={preview_mode}, advanced={advanced_mode}, "
-            f"start_step={start_path}"
+            f"start_step={start_path}, run_paths={run_paths}"
         )
         # Realtime-mode prep + settle and logging start are once-per-run
         # executor lifecycle hooks (RealtimeModeHandler / LoggingHandler, wired
@@ -802,6 +827,7 @@ class PluggableProtocolDockPane(TraitsDockPane):
             preview_mode=preview_mode,
             advanced_mode=advanced_mode,
             repeats=repeats,
+            run_paths=run_paths,
         )
 
     def _toggle_pause(self):

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -107,6 +107,10 @@ class ProtocolTreePane(QWidget):
     # QuickActionsController listens to both to drive button enabled state.
     protocol_running_changed = Signal(bool)
     selection_changed = Signal()
+    # Relayed from the tree widget: the user asked to run only the selected
+    # rows (issue #558). Carries the normalized selection roots. The dock
+    # pane owns run control and connects to this.
+    run_selected_requested = Signal(list)
 
     def __init__(
         self,
@@ -158,6 +162,11 @@ class ProtocolTreePane(QWidget):
         self.widget.tree.selectionModel().selectionChanged.connect(
             lambda *_: self.selection_changed.emit()
         )
+
+        # Relay the tree's run-selected request up to whoever owns the
+        # executor (the dock pane in the full app; nothing in the demos,
+        # where the signal simply goes unconnected).
+        self.widget.run_selected_requested.connect(self.run_selected_requested)
 
         self._build_status_bar()
         self._build_navigation_bar()

--- a/pluggable_protocol_tree/views/tree_widget.py
+++ b/pluggable_protocol_tree/views/tree_widget.py
@@ -72,6 +72,12 @@ class _ProtocolTreeView(QTreeView):
 
 
 class ProtocolTreeWidget(QWidget):
+    # Emitted with the normalized selection roots when the user asks to run
+    # just the selected rows (issue #558). The widget deliberately knows
+    # nothing about the executor — the dock pane owns run control and
+    # connects to this via the pane's relay.
+    run_selected_requested = Signal(list)
+
     def __init__(self, row_manager: RowManager, preferences=None, parent=None):
         super().__init__(parent)
         self._manager = row_manager
@@ -132,6 +138,8 @@ class ProtocolTreeWidget(QWidget):
             # (#471) the same way the context-menu entries do.
             (QKeySequence("Ctrl+G"),       self._fold_shortcut),
             (QKeySequence("Ctrl+Shift+G"), self._unfold_shortcut),
+            # Run just the selected rows (#529-style guard, issue #558).
+            (QKeySequence("Ctrl+R"),       self._run_selected_shortcut),
         ):
             sc = QShortcut(seq, self.tree)
             sc.setContext(Qt.WidgetWithChildrenShortcut)
@@ -288,6 +296,12 @@ class ProtocolTreeWidget(QWidget):
             return
         idx = self.tree.indexAt(pos)
         menu = QMenu()
+        # Run-selected sits first, and deliberately far from Delete — a
+        # misclick between "run this subset" and "delete this subset" is the
+        # one adjacency worth designing out.
+        run_selected = menu.addAction("Run Selected Steps", self._run_selected)
+        run_selected.setEnabled(self._can_run_selection())
+        menu.addSeparator()
         menu.addAction("Add Step", lambda: self._add_step_at(idx))
         menu.addAction("Add Group", lambda: self._add_group_at(idx))
         fold = menu.addAction("Fold into Group", self._fold_into_group)
@@ -417,6 +431,38 @@ class ProtocolTreeWidget(QWidget):
         # Keyboard path for "Unfold Group"; run-locked like the menu entry.
         if self._structural_editable:
             self._unfold_group()
+
+    def _run_selected_shortcut(self):
+        # Keyboard path for "Run Selected Steps". Gated on
+        # _structural_editable like the fold shortcuts — not because running
+        # is a structural edit, but because that flag is False for the whole
+        # duration of a run, which is exactly when a second run must not
+        # start. The dock pane re-checks against the executor regardless.
+        if self._structural_editable:
+            self._run_selected()
+
+    def _selection_roots(self):
+        """Normalized selection roots for a scoped run — descendants of an
+        already-selected row dropped, tree-ordered."""
+        return self._manager.run_scope_roots(
+            [tuple(p) for p in self._manager.selection])
+
+    def _can_run_selection(self):
+        """True when the selection would actually execute something. Guards
+        against an empty selection and against selecting only empty groups,
+        which normalize to a root but expand to no frames. Short-circuits on
+        the first frame rather than materializing the whole expansion."""
+        frames = self._manager.iter_execution_frames(self._selection_roots())
+        return next(frames, None) is not None
+
+    def _run_selected(self):
+        """Ask the dock pane to run only the selected rows (issue #558)."""
+        if not self._can_run_selection():
+            return
+        roots = self._selection_roots()
+        logger.info(f"Run Selected Steps requested for {len(roots)} root(s): "
+                    f"{roots}")
+        self.run_selected_requested.emit(roots)
 
     def _fold_into_group(self):
         """Wrap the selected rows in a new group at the first row's


### PR DESCRIPTION
Closes #558.

Select any mix of steps and groups in the protocol tree, right-click → **Run Selected Steps** (or press **Ctrl+R**), and only those rows run. Preview Mode and the Repeat Protocol spinbox apply as they do for a normal Play — a scoped run is an ordinary run with a narrower step list, so it logs, reports, and drives hardware the same way.

## Selection semantics

Each selected row becomes an **independent execution root**. A row's own `repetitions` apply; repetitions of ancestors *outside* the selection do not.

```
Wash (reps=3)
├─ Step A
└─ Step B          select B     -> B                     (1 frame)
                   select Wash  -> A,B,A,B,A,B           (6 frames)

Step C (reps=4)    select C     -> C,C,C,C               (4 frames)
```

Descendants of an already-selected row are dropped (a selected group covers its children), and roots run in tree order. A selection that would run nothing — empty, or only empty groups — disables the menu entry.

## How it fits

`RowManager.iter_execution_frames()` gains an optional `scope_paths`. A scope **re-roots** the expansion at each selection root rather than filtering the full frame list — that re-rooting is precisely what makes a step inside a 3× group run once. `None` is the whole protocol; an empty list is a real empty scope.

`ProtocolExecutor` gains a public `run_paths`, set by `start()` and cleared on terminate. `_run_steps` sources its frame list from it, so step index/total, the pause cursor, and mid-run seek all follow the subset with no further changes — they already worked off that list. It is public so `ProtocolStatusController` can scope its counts off one source of truth rather than keeping a copy; the status bar then reads "Step 2/3" against the subset instead of "Step 7/20" against a total the run never reaches.

The tree widget stays decoupled from run control: it emits `run_selected_requested` with the normalized roots, the pane relays, and the dock pane starts the run.

## Two judgment calls worth a look

- The menu entry sits at the **top** of the context menu, not next to Delete. A misclick between "run this subset" and "delete this subset" is the one adjacency worth designing out.
- `_row_at` and `_frame_index_for_rep` are deliberately left **unscoped**. `_row_at` is a pure path lookup — scoping it would only make previewing an out-of-scope step return `None`. `_frame_index_for_rep` maps timeline cells to executor frame indices, and the timeline still renders the full protocol, so scoping one half of that mapping would leave it inconsistent with itself.

## Known limitation

The timeline bar renders the **full** protocol during a subset run: the playhead lands on the correct rows but visibly skips the unselected ones. That is arguably the right affordance — you can see what is being skipped — and scoping the timeline is separate work.

## Testing

22 new tests across `test_row_manager.py`, `test_executor.py`, `test_run_selected.py` (new), and `test_protocol_status_controller.py`. Full `pluggable_protocol_tree` suite run before and after with Redis up: **zero regressions**.

Two things reviewers should know rather than take on faith:

- The suite **silently skips everything** at directory level when Redis is down. Start it first or a green-looking run means nothing.
- **101 tests fail on this branch before any of these changes** — ~100 in `test_protocol_tree_pane.py` (it still expects `pane.executor`, which moved to the dock pane in #471) plus 3 in `test_executor.py`. Each was verified failing on the untouched branch. They are stale tests, not breakage from this PR, but someone should decide what to do about them.

The real GUI has not been driven — the right-click menu and Ctrl+R are unexercised against live hardware and need a manual pass.

Design notes: `docs/superpowers/specs/2026-07-24-run-selected-steps-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
