### PR TITLE
fix(device_viewer): user-resizable route table spacing

### DIFF
--- a/device_viewer/views/route_selection_view/route_selection_view.py
+++ b/device_viewer/views/route_selection_view/route_selection_view.py
@@ -1,3 +1,4 @@
+from PySide6.QtWidgets import QApplication
 from traitsui.api import View, Item, TableEditor, UIInfo, UItem, HGroup, VGroup, Label, RangeEditor
 from traitsui.key_bindings import KeyBindings, KeyBinding
 
@@ -5,7 +6,7 @@ from device_viewer.views.route_selection_view.menu import RouteLayerMenu
 from device_viewer.models.route import RouteLayer
 
 from microdrop_utils.traitsui_qt_helpers import ColorColumn, VisibleColumn, ObjectColumn, CustomCheckboxColumn, \
-    SafeCancelTableHandler, DoubleSpinBoxEditor
+    SafeCancelTableHandler, DoubleSpinBoxEditor, make_table_row_header_resizable
 
 from logger.logger_service import get_logger
 
@@ -14,6 +15,15 @@ logger = get_logger(__name__)
 class RouteLayerTableHandler(SafeCancelTableHandler):
     # For these handlers, info is as usual, and rows is a list of rows that the action is acting on
     # In the case of the right click menu, always a list of size 1 with the affected row
+
+    def init(self, info: UIInfo):
+        """Runs once when the UI is generated."""
+        super().init(info)
+
+        # Columns are interactive; extend that to the row-number header too
+        make_table_row_header_resizable(info.layers.table_view)
+
+        return True
 
     def execute_path(self, info: UIInfo, rows: list[RouteLayer]):
         """Request execution of the selected path via the RouteLayerManager event."""
@@ -66,20 +76,20 @@ class RunColumn(CustomCheckboxColumn):
 
 layer_table_editor = TableEditor(
     columns=[
-        ObjectColumn(name="name", label="Path", resize_mode="stretch", editable=False),
+        ObjectColumn(name="name", label="Path", resize_mode="interactive", editable=False),
         VisibleColumn(
             name="visible",
             label="",
             editable=False,
             horizontal_alignment="center",
-            width=16,
+            resize_mode="interactive",
         ),
         RunColumn(
             name="selected_for_run",
             label="Run",
             editable=False,
             horizontal_alignment="center",
-            width=16,
+            resize_mode="interactive",
         ),
     ],
     menu=RouteLayerMenu,
@@ -230,3 +240,55 @@ RouteLayerView = View(
         ),
     )
 )
+
+if __name__ == "__main__":
+    # demo view
+    import sys
+
+    from traits.api import HasTraits, Bool, DelegatesTo, Instance, Str, observe
+
+    from device_viewer.models.route import Route, RouteLayerManager
+    from microdrop_style.helpers import style_app
+
+    class RouteSelectionDemoModel(HasTraits):
+        """Stand-in for DeviceViewMainModel exposing only the traits
+        RouteLayerView / ExecutionSettingsView bind to."""
+
+        routes = Instance(RouteLayerManager, ())
+
+        # Execution state (normally driven by RouteExecutionService)
+        route_execution_service_executing = Bool(False)
+        route_execution_service_paused = Bool(False)
+        execution_status = Str("")
+
+        protocol_running = Bool(False)
+
+        # Top-level mirrors for enabled_when bindings (nested paths like
+        # `object.routes.commit_enabled` don't re-evaluate reliably)
+        routes_commit_enabled = DelegatesTo("routes", prefix="commit_enabled")
+        routes_repeats_frozen = DelegatesTo("routes", prefix="repeats_frozen")
+
+        @observe("routes.execute_path_requested")
+        def _log_execute_path_requested(self, event):
+            logger.info(f"Execute path requested for layers: {event.new}")
+
+    demo_model = RouteSelectionDemoModel()
+
+    # A few sample layers: a linear path, a loop, and a short path
+    demo_model.routes.add_layer(Route(route=["a", "b", "c"]))
+    demo_model.routes.add_layer(Route(route=["d", "e", "f", "d"]))
+    demo_model.routes.add_layer(Route(route=["g", "h"]))
+
+    # channel_map: channel id -> list of electrode ids
+    demo_channel_map = {channel: [electrode_id] for channel, electrode_id in enumerate("abcdefgh")}
+    for demo_layer in demo_model.routes.layers:
+        demo_layer.name = demo_layer.route.get_name(demo_channel_map)
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    style_app(app)
+
+    # Same pattern as the device viewer dock pane: both views edit one model
+    layer_ui = demo_model.edit_traits(view=RouteLayerView)
+    execution_settings_ui = demo_model.edit_traits(view=ExecutionSettingsView)
+
+    sys.exit(app.exec())

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -3,12 +3,12 @@ import math
 
 from PySide6.QtWidgets import QToolButton
 from pyface.qt.QtCore import (
-    Qt, QSize, QPoint, QPointF, QRectF,
+    Qt, QSize, QPoint, QPointF, QRectF, QObject, QEvent,
     QEasingCurve, QPropertyAnimation, QSequentialAnimationGroup,
     Slot, Property as QtProperty,   # aliased: traits.api.Property (below) shadows it
 )
 from pyface.qt.QtGui import (
-    QColor, QFont, QShortcut, QKeySequence, QPixmap,
+    QColor, QCursor, QFont, QShortcut, QKeySequence, QPixmap,
     QBrush, QPaintEvent, QPen, QPainter,
 )
 from pyface.qt.QtWidgets import (
@@ -37,6 +37,12 @@ logger = get_logger(__name__)
 DOUBLE_SPINBOX_UNBOUNDED_MAX = 1e12
 
 DEFAULT_GLYPH_POINT_SIZE_PX = 16
+
+# Drag grip for resizing a table's row-number header (see
+# make_table_row_header_resizable): grip strip width along the header's
+# right edge, and the narrowest the user can drag the header down to.
+TABLE_ROW_HEADER_RESIZE_GRIP_PX = 4
+TABLE_ROW_HEADER_MINIMUM_WIDTH_PX = 12
 
 
 class TableColumn(TableColumn_):
@@ -544,6 +550,65 @@ class DictFloatTableEditor(BasicEditorFactory):
     allow_infinity = Bool(False)
     infinity_value = Float(-1.0)
     infinity_text = Str("∞")
+
+class _RowLabelHeaderResizer(QObject):
+    """Event filter that lets the user drag the right edge of a QTableView's
+    vertical (row-number) header to change its width.
+
+    Qt only supports dragging section *heights* on a vertical header — its
+    width comes from a style hint the user can't adjust. This turns the strip
+    along the header's right edge into a horizontal drag grip."""
+
+    def __init__(self, vertical_header):
+        super().__init__(vertical_header)
+        self._vertical_header = vertical_header
+        self._dragging = False
+
+    def _in_grip_zone(self, event):
+        distance_to_right_edge = self._vertical_header.width() - event.position().x()
+        return 0 <= distance_to_right_edge <= TABLE_ROW_HEADER_RESIZE_GRIP_PX
+
+    def eventFilter(self, watched, event):
+        event_type = event.type()
+
+        if (event_type == QEvent.Type.MouseButtonPress
+                and event.button() == Qt.LeftButton
+                and self._in_grip_zone(event)):
+            self._dragging = True
+            return True
+
+        if event_type == QEvent.Type.MouseMove:
+            if self._dragging:
+                self._vertical_header.setFixedWidth(
+                    max(TABLE_ROW_HEADER_MINIMUM_WIDTH_PX, round(event.position().x()))
+                )
+                return True
+            if self._in_grip_zone(event):
+                watched.setCursor(QCursor(Qt.SplitHCursor))
+            else:
+                watched.unsetCursor()
+            return False
+
+        if event_type == QEvent.Type.MouseButtonRelease and self._dragging:
+            self._dragging = False
+            return True
+
+        if event_type == QEvent.Type.Leave:
+            watched.unsetCursor()
+
+        return False
+
+
+def make_table_row_header_resizable(table_view):
+    """Let the user drag the right edge of ``table_view``'s row-number header
+    to set its width, like an interactive column."""
+    vertical_header = table_view.verticalHeader()
+    # Parented to the header, so the filter lives exactly as long as it does
+    resizer = _RowLabelHeaderResizer(vertical_header)
+    vertical_header.viewport().installEventFilter(resizer)
+    # Hover move events are needed for the grip-zone cursor feedback
+    vertical_header.viewport().setMouseTracking(True)
+
 
 class SafeCancelTableHandler(Handler):
     """


### PR DESCRIPTION
## Summary

Fixes the sidebar route table's clipped row indices (#442) by handing column spacing to the user instead of auto-fitting:

- All three columns (Path / visibility / Run) now use `resize_mode=interactive` with no fixed widths — users drag the column edges, and TraitsUI preserves dragged sizes across table refreshes (explicit widths get re-applied on every refresh, snapping back user adjustments, so they were removed).
- New `make_table_row_header_resizable()` helper in `microdrop_utils/traitsui_qt_helpers.py`: Qt has no built-in way to resize a vertical header's *width*, so an event filter turns the strip along the row-number header's right edge into a horizontal drag grip (split-cursor feedback, clamped minimum width). The route table handler applies it, making the row-number gutter resizable like the columns.
- Adds a standalone `__main__` demo to `route_selection_view.py` that opens `RouteLayerView` + `ExecutionSettingsView` against a stand-in model with sample layers (linear path, loop, short path) for quick GUI iteration.

## Verification

- Offscreen renders at 15 layers with long path names: all row indices visible, single-line rows, column drag sizes preserved through add/reorder/delete.
- Header grip verified with synthesized mouse events: hover shows split cursor, drag resizes (clamps at 12px), normal header clicks still select rows.
- Manual GUI check: run `pixi run python -m device_viewer.views.route_selection_view.route_selection_view`.

Fixes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)