### PR TITLE
feat: remember legacy import selection, fix dialog sizing

### DIFF
--- a/microdrop_application/dialogs/base_message_dialog.py
+++ b/microdrop_application/dialogs/base_message_dialog.py
@@ -24,7 +24,6 @@ from PySide6.QtGui import (
     QPainter,
     QPainterPath,
     QPixmap,
-    QTextDocument,
     QDesktopServices,
 )
 from PySide6.QtWidgets import (
@@ -354,15 +353,12 @@ class BaseMessageDialog(QDialog):
             content_width = 500
         content_width = max(200, content_width)
 
-        doc = QTextDocument()
-        doc.setDefaultFont(self.message_label.font())
-        if self.message_label.textFormat() == Qt.TextFormat.RichText:
-            doc.setHtml(self.message_text)
-        else:
-            doc.setPlainText(self.message_text)
-        doc.setTextWidth(content_width)
-
-        message_height = int(doc.size().height()) + 2
+        # Ask the label that will actually render the text, rather than
+        # re-deriving its format here: a message left at the default
+        # AutoText renders as rich text when it looks like markup, but a
+        # `textFormat() == RichText` test misses that and measures the raw
+        # HTML source, sizing the dialog for markup it never displays.
+        message_height = self.message_label.heightForWidth(content_width) + 2
         self.message_label.setMinimumHeight(message_height)
         self.adjustSize()
         self.setMinimumSize(

--- a/microdrop_application/dialogs/pyface_wrapper.py
+++ b/microdrop_application/dialogs/pyface_wrapper.py
@@ -83,7 +83,11 @@ def _prepare_dialog(
 
     # When both informative and detail are provided, disable scrolling for
     # main message so informative stays in non-scrollable area
-    disable_main_scrolling = informative is not None and detail is not None
+    # except when its given in kwargs.
+    disable_main_scrolling = kwargs.pop(
+        "disable_main_scrolling",
+        informative is not None and detail is not None,
+    )
 
     # Create the dialog
     dialog = dialog_factory(parent=parent, title=title, message=main_message, disable_main_scrolling=disable_main_scrolling, **kwargs)

--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -102,6 +102,15 @@ class ProtocolPreferences(PreferencesHelper):
     # added since) keep their natural position at the end on restore.
     protocol_tree_column_order = List(Str)
 
+    # Programmatic preferences (no Settings-dialog item): the last values
+    # the user confirmed in the Import Legacy Protocol dialog, restored as
+    # its initial state on the next open. Written on dialog accept, so
+    # they persist even when the import itself is later cancelled or
+    # fails validation.
+    legacy_import_root_path = Str()
+    legacy_import_device_svg_path = Str()
+    legacy_import_protocol_path = Str()
+
     # {col_id: seconds} acknowledgement-wait time per wait-capable column
     # (issue #427), keyed by the stable col_id (base_id for compounds),
     # NOT the display col_name — the same key handlers resolve at run

--- a/pluggable_protocol_tree/views/legacy_import_dialog.py
+++ b/pluggable_protocol_tree/views/legacy_import_dialog.py
@@ -34,6 +34,11 @@ def default_legacy_root_path() -> str:
     return candidate if os.path.isdir(candidate) else ""
 
 
+def _normalized(path: str) -> str:
+    """Comparison form of a path (case- and separator-insensitive)."""
+    return os.path.normcase(os.path.normpath(path))
+
+
 class LegacyImportDialogModel(HasTraits):
     """Selection state for the legacy import dialog."""
 
@@ -81,6 +86,33 @@ class LegacyImportDialogModel(HasTraits):
             return
         self.protocol_path = device.protocol_paths[index]
 
+    def restore_selection(self, device_svg_path: str,
+                          protocol_path: str) -> None:
+        """Re-apply a previously used selection after the root scan.
+
+        A path that matches a scanned dropdown entry restores that
+        dropdown; one that doesn't (a manual override last time) lands
+        back in the editable path field. Files that no longer exist are
+        ignored, leaving the scan's own defaults in place."""
+        if device_svg_path and os.path.isfile(device_svg_path):
+            wanted = _normalized(device_svg_path)
+            for index, device in enumerate(self.device_folders):
+                if _normalized(device.device_svg_path) == wanted:
+                    self.selected_device_index = index
+                    break
+            else:
+                self.device_svg_path = device_svg_path
+        if protocol_path and os.path.isfile(protocol_path):
+            wanted = _normalized(protocol_path)
+            device = self.selected_device()
+            paths = device.protocol_paths if device else []
+            for index, path in enumerate(paths):
+                if _normalized(path) == wanted:
+                    self.selected_protocol_index = index
+                    break
+            else:
+                self.protocol_path = protocol_path
+
     def selected_device(self):
         if 0 <= self.selected_device_index < len(self.device_folders):
             return self.device_folders[self.selected_device_index]
@@ -96,18 +128,25 @@ class LegacyImportDialogModel(HasTraits):
 class LegacyImportDialog(QDialog):
     """Root directory -> device -> protocol, with editable path overrides."""
 
-    def __init__(self, parent=None, initial_root_path=""):
+    def __init__(self, parent=None, initial_root_path="",
+                 initial_device_svg_path="", initial_protocol_path=""):
         super().__init__(parent)
         self.setWindowTitle("Import Legacy Protocol")
         self.model = LegacyImportDialogModel()
         self._build_widgets()
         self._connect_widgets()
         self.model.observe(self._refresh_devices, "device_folders")
-        self.model.observe(self._refresh_protocols, "selected_device_index")
+        self.model.observe(self._refresh_selected_device,
+                           "selected_device_index")
+        self.model.observe(self._refresh_selected_protocol,
+                           "selected_protocol_index")
         self.model.observe(self._refresh_paths,
                            "device_svg_path,protocol_path")
         self.model.root_path = initial_root_path or default_legacy_root_path()
         self._root_edit.setText(self.model.root_path)
+        if initial_device_svg_path or initial_protocol_path:
+            self.model.restore_selection(
+                initial_device_svg_path, initial_protocol_path)
 
     def _build_widgets(self):
         layout = QVBoxLayout(self)
@@ -171,6 +210,21 @@ class LegacyImportDialog(QDialog):
         self._device_combo.setCurrentIndex(self.model.selected_device_index)
         self._device_combo.blockSignals(False)
         self._refresh_protocols()
+
+    def _refresh_selected_device(self, event=None):
+        # Keeps the device combo in step with programmatic index changes
+        # (e.g. restoring the last-used selection) -- user-driven changes
+        # come *from* the combo, which then shows the value already.
+        self._device_combo.blockSignals(True)
+        self._device_combo.setCurrentIndex(self.model.selected_device_index)
+        self._device_combo.blockSignals(False)
+        self._refresh_protocols()
+
+    def _refresh_selected_protocol(self, event=None):
+        self._protocol_combo.blockSignals(True)
+        self._protocol_combo.setCurrentIndex(
+            self.model.selected_protocol_index)
+        self._protocol_combo.blockSignals(False)
 
     def _refresh_protocols(self, event=None):
         self._protocol_combo.blockSignals(True)

--- a/pluggable_protocol_tree/views/protocol_tree_pane.py
+++ b/pluggable_protocol_tree/views/protocol_tree_pane.py
@@ -677,11 +677,23 @@ class ProtocolTreePane(QWidget):
         Load menus afterwards."""
         if not self._confirm_proceed_or_abort():
             return
-        dialog = LegacyImportDialog(parent=self)
+        dialog = LegacyImportDialog(
+            parent=self,
+            initial_root_path=self.preferences.legacy_import_root_path,
+            initial_device_svg_path=(
+                self.preferences.legacy_import_device_svg_path),
+            initial_protocol_path=self.preferences.legacy_import_protocol_path,
+        )
         if dialog.exec() != QDialog.Accepted:
             dialog.deleteLater()
             return
         device_svg_path, protocol_path = dialog.selected_paths()
+        # Remember the confirmed selection for the next open -- on accept,
+        # not on a successful import, so a conversion that fails still
+        # reopens where the user left off.
+        self.preferences.legacy_import_root_path = dialog.model.root_path
+        self.preferences.legacy_import_device_svg_path = device_svg_path
+        self.preferences.legacy_import_protocol_path = protocol_path
         dialog.deleteLater()
         if not device_svg_path or not protocol_path:
             error_dialog(parent=self, title="Import error",


### PR DESCRIPTION
Follow-up to #438 / #572, now that the legacy protocol import has landed.

## Remember the import dialog's selection

Re-browsing to the same MicroDrop folder, device and protocol on every import was the main friction left in the flow. The dialog's confirmed selection now persists on the existing `microdrop.protocol` preferences node and seeds the next open.

Three programmatic preferences, no Settings-dialog entries — matching how `PROTOCOL_REPO_DIR` and the column visibility/order maps already work, since this is remembered state rather than something you would hand-edit.

Saved on dialog **accept** rather than on a successful import, so a conversion cancelled at the validation prompt still reopens where you left off. A restored path that matches a scanned dropdown entry re-selects that dropdown; one that doesn't (a manual override) returns to the editable field; paths whose files no longer exist are ignored in favour of the scan's defaults.

This required the dialog's combo boxes to follow programmatic index changes, not just user clicks — every change previously originated from the widget itself.

## Two dialog fixes

These are in `microdrop_application/dialogs/`, so they affect every dialog in the app, not just the import ones.

**`disable_main_scrolling` could not be overridden.** `_prepare_dialog` read the kwarg but left it in `kwargs`, then passed it to the dialog factory both explicitly and via the splat — raising `TypeError` in exactly the case the code existed to support.

**Dialogs were sized from raw markup rather than rendered text.** `_adjust_min_size_to_message` rebuilt the message in a `QTextDocument` and picked `setHtml`/`setPlainText` from the label's `textFormat`. A message left at the default `AutoText` renders as rich text when it looks like markup but fails a `textFormat == RichText` test, so its HTML source was measured as plain text. A device-mismatch prompt came out 472px tall for 350px of content; passing an empty `informative` was the only way to correct it, which worked only as a side effect of how `is_html` was derived.

Asking the label via `heightForWidth` removes the second guess at the format — whatever the label renders is what gets measured. Checked against HTML messages, plain multi-line messages, long messages that still scroll, and plain text containing `<`, `>` and `&`, which a looks-like-HTML heuristic would size wrongly.

## Testing

The 10 existing legacy-import and menu tests pass. The persistence round trip was verified across a process restart (values written to the preferences `.ini` and read back in a fresh interpreter), along with the manual-override and stale-path branches. There are no existing dialog tests, so the sizing change is worth a click through a few dialogs — a long error with details, a success toast — before merge.

## Follow-up

Converting this code from `os.path` to `pathlib.Path` is filed separately as #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)