### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.7.0 (2026-07-29)
+
+### Feat
+
+- remember the legacy import dialog's last selection
+
+### Fix
+
+- size dialogs by rendered text, not raw markup
+- let callers override disable_main_scrolling
+
 ## v1.6.0 (2026-07-29)
 
 ### Feat


### PR DESCRIPTION
## v1.7.0 (2026-07-29)

### Feat

- remember the legacy import dialog's last selection

### Fix

- size dialogs by rendered text, not raw markup
- let callers override disable_main_scrolling

[main 7fe1dd41] chore: release v1.7.0
 1 file changed, 11 insertions(+)

