### PR TITLE
chore: release v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.9.0 (2026-08-05)
+
+### Feat
+
+- **dropbot consts**: Add kapton to dielectric constants
+
 ## v1.8.0 (2026-07-30)
 
 ### Feat


### PR DESCRIPTION
## v1.9.0 (2026-08-05)

### Feat

- **dropbot consts**: Add kapton to dielectric constants

[main 8150e17d] chore: release v1.9.0
 1 file changed, 6 insertions(+)

