### PR TITLE
fix: prevent peripheral monitors claiming another board's port

### DIFF
--- a/microdrop_utils/hardware_device_monitoring_helpers.py
+++ b/microdrop_utils/hardware_device_monitoring_helpers.py
@@ -5,6 +5,8 @@ import time
 
 import serial
 from serial.tools.list_ports import grep
+from traits.api import Any, HasTraits, Str
+
 from logger.logger_service import get_logger
 
 logger = get_logger(__name__)
@@ -100,9 +102,36 @@ def device_id_from_whoami_output(text) -> str | None:
     return None
 
 
-def _probe_port(port, baudrate, timeout_s=WHOAMI_PROBE_WAIT_S):
-    """``device_id`` string, ``None`` (opened, no identity — older firmware),
-    or ``PORT_BUSY`` (could not open). Probes are serialized in-process.
+class ClaimedPort(HasTraits):
+    """A port claimed for a device, with the serial handle that has been
+    open since the whoami probe identified it. Handing this handle to the
+    device's proxy makes probe→connect atomic: the port is never released
+    between identification and ownership, so nothing can grab it in
+    between (and Windows' USB-CDC close→reopen latency never applies).
+    """
+
+    port = Str(desc="Serial port name, e.g. COM7")
+    serial = Any(
+        desc="serial.Serial handle open since the whoami probe identified "
+             "the board")
+
+    def __str__(self):
+        return self.port
+
+    def close(self):
+        try:
+            self.serial.close()
+        except Exception:
+            pass
+
+
+def _probe_port(port, baudrate, timeout_s=WHOAMI_PROBE_WAIT_S,
+                keep_open=False):
+    """``(result, handle)``: result is a ``device_id`` string, ``None``
+    (opened, no identity — older firmware), or ``PORT_BUSY`` (could not
+    open). ``handle`` is the still-open serial port when ``keep_open`` and
+    the board identified, else None (port closed). Probes are serialized
+    in-process.
 
     Reads line by line until a WHOAMI frame parses or ``timeout_s`` elapses,
     so a reply that arrives late (board busy streaming) or lands split
@@ -113,7 +142,8 @@ def _probe_port(port, baudrate, timeout_s=WHOAMI_PROBE_WAIT_S):
             probe = serial.Serial(port, baudrate, timeout=0.2, write_timeout=2)
         except Exception as e:
             logger.debug(f"whoami probe: cannot open {port}: {e}")
-            return PORT_BUSY
+            return PORT_BUSY, None
+        keep = False
         try:
             probe.reset_input_buffer()
             probe.write(b"whoami\n")
@@ -125,16 +155,18 @@ def _probe_port(port, baudrate, timeout_s=WHOAMI_PROBE_WAIT_S):
                 device_id = device_id_from_whoami_output(
                     buf.decode(errors="replace"))
                 if device_id is not None:
-                    return device_id
+                    keep = keep_open
+                    return device_id, (probe if keep_open else None)
         except Exception as e:
             logger.debug(f"whoami probe: read failed on {port}: {e}")
-            return None
+            return None, None
         finally:
-            try:
-                probe.close()
-            except Exception:
-                pass
-    return None
+            if not keep:
+                try:
+                    probe.close()
+                except Exception:
+                    pass
+    return None, None
 
 
 def probe_port_device_id(port, baudrate=115200) -> str | None:
@@ -145,7 +177,7 @@ def probe_port_device_id(port, baudrate=115200) -> str | None:
     monitors tell apart boards that share a VID:PID (the heater and
     fluorescence boards are both Pico 2E8A:0005) before claiming a port.
     """
-    result = _probe_port(port, baudrate)
+    result, _ = _probe_port(port, baudrate)
     return None if result is PORT_BUSY else result
 
 
@@ -184,10 +216,14 @@ def _prune_unidentified_state(device_id_fragment, seen_ports):
             del _unidentified_miss_counts[key]
 
 
-def find_port_by_device_id(hwids, device_id_fragment, *,
-                           min_unidentified_scans=1) -> str:
-    """The port of the board whose whoami ``device_id`` contains
-    ``device_id_fragment``, searching all ports matching ``hwids`` by VID:PID.
+def claim_port_by_device_id(hwids, device_id_fragment, *,
+                            min_unidentified_scans=1) -> ClaimedPort:
+    """Claim the port of the board whose whoami ``device_id`` contains
+    ``device_id_fragment``, searching all ports matching ``hwids`` by
+    VID:PID. Returns a ClaimedPort whose serial handle has been open since
+    the identifying probe — hand it to the device proxy so the port is
+    never released (and up for grabs) between identification and
+    connection.
 
     Ports that identify as some OTHER device are never claimed. Ports that
     cannot be OPENED are skipped entirely (busy: the other plugin's board or
@@ -199,10 +235,9 @@ def find_port_by_device_id(hwids, device_id_fragment, *,
 
     ``min_unidentified_scans`` gates that fallback: a port is only claimed
     once it has stayed unidentified across that many consecutive calls for
-    this ``device_id_fragment``. The default of 1 keeps one-shot semantics
-    (the firmware uploader's probe); the periodic peripheral monitors pass
-    a higher value so one missed probe window on a busy board doesn't hand
-    it to the wrong plugin.
+    this ``device_id_fragment``. The default of 1 keeps one-shot semantics;
+    the periodic peripheral monitors pass a higher value so one missed
+    probe window on a busy board doesn't hand it to the wrong plugin.
     """
     unidentified = []
     seen_ports = set()
@@ -210,7 +245,7 @@ def find_port_by_device_id(hwids, device_id_fragment, *,
         for port_info in grep(hwid):
             port = str(port_info.device)
             seen_ports.add(port)
-            result = _probe_port(port, 115200)
+            result, handle = _probe_port(port, 115200, keep_open=True)
             if result is PORT_BUSY:
                 logger.debug(f"Port {port} busy; skipping this scan")
             elif result is None:
@@ -218,25 +253,54 @@ def find_port_by_device_id(hwids, device_id_fragment, *,
             elif device_id_fragment in result:
                 _note_port_identified(device_id_fragment, port)
                 logger.info(f"Board '{result}' matched on port {port}")
-                return port
+                return ClaimedPort(port=port, serial=handle)
             else:
                 _note_port_identified(device_id_fragment, port)
                 logger.debug(
                     f"Port {port} identifies as '{result}' — not a "
                     f"'{device_id_fragment}' board; skipping")
+                try:
+                    handle.close()
+                except Exception:
+                    pass
     _prune_unidentified_state(device_id_fragment, seen_ports)
     for port in unidentified:
         misses = _note_port_unidentified(device_id_fragment, port)
-        if misses >= min_unidentified_scans:
-            logger.warning(
-                f"No port identified as a '{device_id_fragment}' board; "
-                f"falling back to port {port} after {misses} scans with no "
-                f"whoami reply (older firmware?)")
-            return port
-        logger.debug(
-            f"Port {port} unidentified for {misses}/{min_unidentified_scans} "
-            f"scans; not yet eligible for the '{device_id_fragment}' fallback")
+        if misses < min_unidentified_scans:
+            logger.debug(
+                f"Port {port} unidentified for "
+                f"{misses}/{min_unidentified_scans} scans; not yet eligible "
+                f"for the '{device_id_fragment}' fallback")
+            continue
+        # The probe closed this port (only identified ports stay open), so
+        # the fallback reopens it here. A failure just skips this scan: the
+        # miss count is kept and the next scan retries.
+        try:
+            handle = serial.Serial(port, 115200, timeout=2, write_timeout=2)
+        except Exception as e:
+            logger.debug(f"Fallback could not reopen {port}: {e}")
+            continue
+        logger.warning(
+            f"No port identified as a '{device_id_fragment}' board; falling "
+            f"back to port {port} after {misses} scans with no whoami reply "
+            f"(older firmware?)")
+        return ClaimedPort(port=port, serial=handle)
     raise Exception(f"No '{device_id_fragment}' board found for hwids {hwids}")
+
+
+def find_port_by_device_id(hwids, device_id_fragment, *,
+                           min_unidentified_scans=1) -> str:
+    """The port NAME of the board whose whoami ``device_id`` contains
+    ``device_id_fragment`` (see claim_port_by_device_id for the search and
+    fallback rules). The claimed handle is closed before returning — for
+    one-shot callers like the firmware uploader that need the port free;
+    the periodic monitors use claim_port_by_device_id instead to hand the
+    open port straight to the proxy."""
+    claimed = claim_port_by_device_id(
+        hwids, device_id_fragment,
+        min_unidentified_scans=min_unidentified_scans)
+    claimed.close()
+    return claimed.port
 
 
 if __name__ == "__main__":

--- a/microdrop_utils/hardware_device_monitoring_helpers.py
+++ b/microdrop_utils/hardware_device_monitoring_helpers.py
@@ -9,9 +9,11 @@ from logger.logger_service import get_logger
 
 logger = get_logger(__name__)
 
-#: How long the whoami probe waits for the firmware to answer (the legacy
-#: heater UI's Identify feature used the same delay).
-WHOAMI_PROBE_WAIT_S = 0.7
+#: Deadline for the whoami probe's read loop. The probe returns as soon as a
+#: WHOAMI frame parses, so fast boards never wait this long; the headroom is
+#: for boards busy streaming telemetry, whose reply can lag well past the
+#: legacy Identify feature's 0.7 s delay.
+WHOAMI_PROBE_WAIT_S = 1.5
 
 #: Serializes whoami probes within this process: the heater and fluorescence
 #: monitors run in the same backend, and concurrent probes of the same port
@@ -65,32 +67,50 @@ def check_devices_available(hwids_to_check):
             raise Exception(f'No device for hwids {hwids_to_check} found')
 
 
-def device_id_from_whoami_output(text) -> str | None:
-    """The ``device_id`` from a board's raw whoami output, or None.
+#: Prefix of a board's identity frame line: ``§WHOAMI{json}``.
+WHOAMI_MARKER = "§WHOAMI"
+
+
+def parse_whoami_line(line) -> dict | None:
+    """The identity payload ({"uid", "device_id", ...}) from one WHOAMI
+    frame line, or None.
 
     Boards in the heater firmware family reply to ``whoami`` with a
     ``§WHOAMI{json}`` line whose payload carries a per-board
     ``device_id`` (e.g. ``heater_board`` / ``fluo_board``).
     """
+    line = line.strip()
+    if not line.startswith(WHOAMI_MARKER):
+        return None
+    brace = line.find("{")
+    if brace < 0:
+        return None
+    try:
+        return json.loads(line[brace:])
+    except Exception:
+        return None
+
+
+def device_id_from_whoami_output(text) -> str | None:
+    """The ``device_id`` from a board's raw whoami output, or None."""
     for line in text.splitlines():
-        line = line.strip()
-        if line.startswith("§WHOAMI"):
-            brace = line.find("{")
-            if brace < 0:
-                continue
-            try:
-                return json.loads(line[brace:]).get("device_id")
-            except Exception:
-                continue
+        identity = parse_whoami_line(line)
+        if identity is not None:
+            return identity.get("device_id")
     return None
 
 
-def _probe_port(port, baudrate):
+def _probe_port(port, baudrate, timeout_s=WHOAMI_PROBE_WAIT_S):
     """``device_id`` string, ``None`` (opened, no identity — older firmware),
-    or ``PORT_BUSY`` (could not open). Probes are serialized in-process."""
+    or ``PORT_BUSY`` (could not open). Probes are serialized in-process.
+
+    Reads line by line until a WHOAMI frame parses or ``timeout_s`` elapses,
+    so a reply that arrives late (board busy streaming) or lands split
+    across reads is not lost the way a single fixed-delay read_all() loses
+    a line truncated mid-JSON."""
     with _probe_lock:
         try:
-            probe = serial.Serial(port, baudrate, timeout=2, write_timeout=2)
+            probe = serial.Serial(port, baudrate, timeout=0.2, write_timeout=2)
         except Exception as e:
             logger.debug(f"whoami probe: cannot open {port}: {e}")
             return PORT_BUSY
@@ -98,8 +118,14 @@ def _probe_port(port, baudrate):
             probe.reset_input_buffer()
             probe.write(b"whoami\n")
             probe.flush()
-            time.sleep(WHOAMI_PROBE_WAIT_S)   # give the firmware time to reply
-            text = probe.read_all().decode(errors="replace")
+            deadline = time.monotonic() + timeout_s
+            buf = b""
+            while time.monotonic() < deadline:
+                buf += probe.readline()
+                device_id = device_id_from_whoami_output(
+                    buf.decode(errors="replace"))
+                if device_id is not None:
+                    return device_id
         except Exception as e:
             logger.debug(f"whoami probe: read failed on {port}: {e}")
             return None
@@ -108,7 +134,7 @@ def _probe_port(port, baudrate):
                 probe.close()
             except Exception:
                 pass
-    return device_id_from_whoami_output(text)
+    return None
 
 
 def probe_port_device_id(port, baudrate=115200) -> str | None:
@@ -123,40 +149,93 @@ def probe_port_device_id(port, baudrate=115200) -> str | None:
     return None if result is PORT_BUSY else result
 
 
-def find_port_by_device_id(hwids, device_id_fragment) -> str:
+#: Per-caller count of consecutive scans a port has failed to identify,
+#: keyed (device_id_fragment, port). Lets the unidentified-port fallback in
+#: find_port_by_device_id demand several misses in a row before claiming a
+#: port: one missed probe window (board busy streaming) must not hand a
+#: board to the wrong plugin. Process-local like _probe_lock.
+_unidentified_miss_counts = {}
+_unidentified_state_lock = threading.Lock()
+
+
+def _note_port_identified(device_id_fragment, port):
+    """The port answered with an identity (any identity) — it is not an
+    older-firmware board, so its miss count is moot."""
+    with _unidentified_state_lock:
+        _unidentified_miss_counts.pop((device_id_fragment, port), None)
+
+
+def _note_port_unidentified(device_id_fragment, port) -> int:
+    """Bump and return the port's consecutive-miss count."""
+    key = (device_id_fragment, port)
+    with _unidentified_state_lock:
+        count = _unidentified_miss_counts.get(key, 0) + 1
+        _unidentified_miss_counts[key] = count
+        return count
+
+
+def _prune_unidentified_state(device_id_fragment, seen_ports):
+    """Drop counts for ports this fragment's scan no longer sees (board
+    unplugged, or the COM name reassigned) so stale misses can't carry over
+    to whatever appears there next."""
+    with _unidentified_state_lock:
+        for key in [k for k in _unidentified_miss_counts
+                    if k[0] == device_id_fragment and k[1] not in seen_ports]:
+            del _unidentified_miss_counts[key]
+
+
+def find_port_by_device_id(hwids, device_id_fragment, *,
+                           min_unidentified_scans=1) -> str:
     """The port of the board whose whoami ``device_id`` contains
     ``device_id_fragment``, searching all ports matching ``hwids`` by VID:PID.
 
     Ports that identify as some OTHER device are never claimed. Ports that
     cannot be OPENED are skipped entirely (busy: the other plugin's board or
     a probe in flight — the monitor's next scheduled scan retries them). If
-    no port identifies with a matching id, falls back to the first port that
-    opened but did not identify (older firmware without whoami) so
-    single-board setups keep working — with a warning, since the fallback
-    cannot distinguish devices.
+    no port identifies with a matching id, falls back to a port that opened
+    but did not identify (older firmware without whoami) so single-board
+    setups keep working — with a warning, since the fallback cannot
+    distinguish devices.
+
+    ``min_unidentified_scans`` gates that fallback: a port is only claimed
+    once it has stayed unidentified across that many consecutive calls for
+    this ``device_id_fragment``. The default of 1 keeps one-shot semantics
+    (the firmware uploader's probe); the periodic peripheral monitors pass
+    a higher value so one missed probe window on a busy board doesn't hand
+    it to the wrong plugin.
     """
     unidentified = []
+    seen_ports = set()
     for hwid in hwids:
         for port_info in grep(hwid):
             port = str(port_info.device)
+            seen_ports.add(port)
             result = _probe_port(port, 115200)
             if result is PORT_BUSY:
                 logger.debug(f"Port {port} busy; skipping this scan")
             elif result is None:
                 unidentified.append(port)
             elif device_id_fragment in result:
+                _note_port_identified(device_id_fragment, port)
                 logger.info(f"Board '{result}' matched on port {port}")
                 return port
             else:
+                _note_port_identified(device_id_fragment, port)
                 logger.debug(
                     f"Port {port} identifies as '{result}' — not a "
                     f"'{device_id_fragment}' board; skipping")
-    if unidentified:
-        logger.warning(
-            f"No port identified as a '{device_id_fragment}' board; falling "
-            f"back to unidentified port {unidentified[0]} (no whoami reply — "
-            f"older firmware?)")
-        return unidentified[0]
+    _prune_unidentified_state(device_id_fragment, seen_ports)
+    for port in unidentified:
+        misses = _note_port_unidentified(device_id_fragment, port)
+        if misses >= min_unidentified_scans:
+            logger.warning(
+                f"No port identified as a '{device_id_fragment}' board; "
+                f"falling back to port {port} after {misses} scans with no "
+                f"whoami reply (older firmware?)")
+            return port
+        logger.debug(
+            f"Port {port} unidentified for {misses}/{min_unidentified_scans} "
+            f"scans; not yet eligible for the '{device_id_fragment}' fallback")
     raise Exception(f"No '{device_id_fragment}' board found for hwids {hwids}")
 
 

--- a/microdrop_utils/tests/test_whoami_probe.py
+++ b/microdrop_utils/tests/test_whoami_probe.py
@@ -32,16 +32,34 @@ def test_no_frame_or_bad_json_gives_none():
 
 # --- port selection --------------------------------------------------------------
 
+class _FakeSerial:
+    """Stands in for the probe's kept-open handle and the fallback reopen."""
+
+    def __init__(self, *args, **kwargs):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
 @pytest.fixture
 def ports(monkeypatch):
-    """Fake the VID:PID port listing and per-port probe results."""
+    """Fake the VID:PID port listing, per-port probe results, and the
+    fallback's reopen."""
     state = {"ports": [], "ids": {}}
     monkeypatch.setattr(
         helpers, "grep",
         lambda hwid: [SimpleNamespace(device=p) for p in state["ports"]])
-    monkeypatch.setattr(
-        helpers, "_probe_port",
-        lambda port, baudrate: state["ids"].get(port))
+
+    def fake_probe(port, baudrate, timeout_s=None, keep_open=False):
+        result = state["ids"].get(port)
+        handle = _FakeSerial() if (keep_open and isinstance(result, str)) else None
+        return result, handle
+
+    monkeypatch.setattr(helpers, "_probe_port", fake_probe)
+    monkeypatch.setattr(helpers.serial, "Serial", _FakeSerial)
+    # Consecutive-miss fallback state is module-level; isolate each test.
+    helpers._unidentified_miss_counts.clear()
     return state
 
 
@@ -90,3 +108,27 @@ def test_busy_port_skipped_but_open_unidentified_still_falls_back(ports):
     ports["ports"] = ["COM3", "COM4"]
     ports["ids"] = {"COM3": PORT_BUSY, "COM4": None}
     assert find_port_by_device_id(HWIDS, "heater") == "COM4"
+
+
+# --- port claiming ----------------------------------------------------------------
+
+def test_claim_hands_over_the_open_probe_handle(ports):
+    # The handle opened by the identifying probe is passed on, still open —
+    # the port is never released between identification and connection.
+    ports["ports"] = ["COM4"]
+    ports["ids"] = {"COM4": "heater_board"}
+    claimed = helpers.claim_port_by_device_id(HWIDS, "heater")
+    assert str(claimed) == "COM4"
+    assert isinstance(claimed.serial, _FakeSerial)
+    assert not claimed.serial.closed
+
+
+def test_fallback_needs_consecutive_unidentified_scans(ports):
+    ports["ports"] = ["COM5"]
+    ports["ids"] = {"COM5": None}
+    with pytest.raises(Exception, match="No 'heater' board found"):
+        helpers.claim_port_by_device_id(HWIDS, "heater",
+                                        min_unidentified_scans=2)
+    claimed = helpers.claim_port_by_device_id(HWIDS, "heater",
+                                              min_unidentified_scans=2)
+    assert str(claimed) == "COM5"

--- a/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
+++ b/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
@@ -9,7 +9,7 @@ from apscheduler.schedulers.base import STATE_STOPPED, STATE_RUNNING, STATE_PAUS
 from microdrop_utils.datetime_helpers import TimestampedMessage
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
 from microdrop_utils.hardware_device_monitoring_helpers import (
-    check_devices_available, find_port_by_device_id,
+    ClaimedPort, check_devices_available, claim_port_by_device_id,
 )
 from logger.logger_service import get_logger
 
@@ -69,9 +69,12 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         """Return the serial port for a device matching one of ``hwids``.
         With ``_device_id_fragment`` set, candidates are disambiguated by
         their whoami identity (needed when several peripherals share one
-        VID:PID)."""
+        VID:PID) and returned as a ClaimedPort whose handle has stayed open
+        since the identifying probe — _make_proxy hands it to the proxy so
+        the port is never up for grabs between identification and
+        connection."""
         if self._device_id_fragment:
-            return find_port_by_device_id(
+            return claim_port_by_device_id(
                 hwids, self._device_id_fragment,
                 min_unidentified_scans=self._unidentified_fallback_scans)
         return check_devices_available(hwids)
@@ -219,8 +222,11 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         self.monitor_scheduler.pause()
         logger.debug(f"Paused {self._device_name} monitor")
         self.port_name = str(event.retval)
-        logger.info(f'Attempting to connect to {self._device_name} on port: %s', self.port_name)
-        self._connect_to_device(port_name=self.port_name)
+        logger.info(f'Attempting to connect to {self._device_name} on port: {self.port_name}')
+        # Pass the finder's retval itself: a ClaimedPort carries the serial
+        # handle held open since the identifying probe, which _make_proxy
+        # hands to the proxy.
+        self._connect_to_device(port_name=event.retval)
         self._error_shown = False  # Reset error state when device is found
 
     def _connect_to_device(self, port_name):
@@ -240,6 +246,10 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
 
             except Exception as e:
                 logger.error(f"An unexpected error occurred with {self._device_name}: {e}", exc_info=True)
+                # Don't leak the claimed handle: release the port so the
+                # next scan (or the rightful monitor) can reach it.
+                if isinstance(port_name, ClaimedPort):
+                    port_name.close()
 
             finally:
                 # If the connection is not active, the 'try' block failed: run disconnect routine.

--- a/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
+++ b/peripheral_device_controller_base/services/peripheral_device_monitor_mixin_service.py
@@ -1,6 +1,6 @@
 import json
 
-from traits.api import provides, HasTraits, Bool, Instance, Str, List, observe, Event
+from traits.api import provides, HasTraits, Bool, Instance, Int, Str, List, observe, Event
 from apscheduler.events import EVENT_JOB_EXECUTED, EVENT_SCHEDULER_SHUTDOWN
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.interval import IntervalTrigger
@@ -8,7 +8,9 @@ from apscheduler.schedulers.base import STATE_STOPPED, STATE_RUNNING, STATE_PAUS
 
 from microdrop_utils.datetime_helpers import TimestampedMessage
 from microdrop_utils.dramatiq_pub_sub_helpers import publish_message
-from microdrop_utils.hardware_device_monitoring_helpers import check_devices_available
+from microdrop_utils.hardware_device_monitoring_helpers import (
+    check_devices_available, find_port_by_device_id,
+)
 from logger.logger_service import get_logger
 
 from ..interfaces.i_peripheral_device_control_mixin_service import IPeripheralDeviceControlMixinService
@@ -27,8 +29,14 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
     Subclasses customize the device by overriding:
         ``_default_hwids`` — HWIDs to scan for when no payload is supplied.
         ``_make_proxy(port_name)`` — build and return the device's serial proxy.
-        ``_find_port(hwids)`` — locate the serial port (defaults to a USB-serial
-            HWID grep); override when the device's port description differs.
+        ``_device_id_fragment`` — set when the device shares its VID:PID with
+            other peripherals (e.g. the Pico-based boards): each candidate
+            port is then probed for a whoami ``device_id`` containing this
+            fragment before it is claimed.
+        ``_find_port(hwids)`` — locate the serial port (defaults to a
+            device-id probe when ``_device_id_fragment`` is set, else a
+            USB-serial HWID grep); override when the device's port discovery
+            differs entirely.
     """
     id = Str("peripheral_device_monitor_mixin_service")
     name = Str("Peripheral Device Monitor Mixin")
@@ -37,6 +45,12 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         desc="An AP scheduler job to periodically look for connected ports.")
 
     _default_hwids = List(Str)
+    _device_id_fragment = Str(
+        desc="whoami device_id substring identifying this device's boards; "
+             "empty disables identity probing")
+    _unidentified_fallback_scans = Int(
+        3, desc="consecutive scans a port must stay unidentified before the "
+                "older-firmware fallback may claim it")
     _error_shown = Bool(False)  # Track if we've shown the error for current disconnection
     _searching = Event(desc="Is the monitor thread actively scanning right now?")
 
@@ -52,7 +66,14 @@ class PeripheralDeviceMonitorMixinService(HasTraits):
         raise NotImplementedError
 
     def _find_port(self, hwids):
-        """Return the serial port for a device matching one of ``hwids``."""
+        """Return the serial port for a device matching one of ``hwids``.
+        With ``_device_id_fragment`` set, candidates are disambiguated by
+        their whoami identity (needed when several peripherals share one
+        VID:PID)."""
+        if self._device_id_fragment:
+            return find_port_by_device_id(
+                hwids, self._device_id_fragment,
+                min_unidentified_scans=self._unidentified_fallback_scans)
         return check_devices_available(hwids)
 
     ######################################## Methods to Expose #############################################


### PR DESCRIPTION
## Problem
The heater and fluorescence boards share the Pico VID:PID (`2E8A:0005`), so both backend monitors scan the same COM ports. Two field-observed failures:
1. **Wrong claim**: a whoami probe reply that arrived late (board busy streaming) or split mid-line was read as "no identity" by the single fixed-delay `read_all()`, and the older-firmware fallback then handed the board's port to the wrong plugin — which held it forever, showed the wrong board id in its dock pane, and starved the rightful monitor with `PORT_BUSY`.
2. **Connect flapping**: even with a correct match, the probe closed the port and the proxy reopened it 1–2 ms later — which fails with `PermissionError: Access is denied` (Windows/Pico USB-CDC close→reopen latency, plus the other monitor's probes competing). Logs showed 5 failed cycles (~9 s) before a connect stuck.

## Changes (`microdrop_utils` + `peripheral_device_controller_base`)

**Probe robustness**
- `_probe_port` readline-accumulates against a deadline (1.5 s, early exit the instant a WHOAMI frame parses) instead of `sleep(0.7)` + one `read_all()` — no truncation loss, tolerant of late replies.
- `WHOAMI_MARKER` / `parse_whoami_line` consolidated here for reuse by the plugin proxies.

**Fallback gating**
- `find_port_by_device_id` / `claim_port_by_device_id` gain `min_unidentified_scans`: the older-firmware fallback only claims a port after N consecutive scans without an identity, tracked per (fragment, port), reset when a port identifies, pruned when it disappears. Default 1 preserves the firmware uploader's one-shot semantics; monitors use 3.

**Atomic probe→connect handover**
- New `claim_port_by_device_id` returns a `ClaimedPort` (HasTraits: port name + the serial handle **kept open since the identifying probe**). The handle flows probe → monitor → proxy, so the port is never released between identification and ownership — nothing to race, no reopen latency. `find_port_by_device_id` is now a thin closing wrapper (uploader contract unchanged).

**Base monitor generalization**
- `PeripheralDeviceMonitorMixinService` gains `_device_id_fragment` / `_unidentified_fallback_scans` traits: with the fragment set, the default `_find_port` claims by whoami identity. Future VID:PID-sharing peripherals only set traits — no `_find_port` override. On proxy-construction failure the claimed handle is closed so the port isn't leaked.

## Companion PRs (merge this one first)
- heater: Blue-Ocean-Technologies-Inc/heater-microdrop-plugin-py#18 — proxy adopts the claimed handle + relinquishes on wrong-board whoami identity.
- fluorescence: Blue-Ocean-Technologies-Inc/fluorescence-microdrop-plugin-py#10 — same, plus shared-parser dedup.

## Testing
- `src/microdrop_utils/tests/test_whoami_probe.py`: existing cases pass; new cases for the claim handover and the consecutive-miss fallback gate.
- Hardware: identity matching confirmed working in field logs (`Board 'fluo_board' matched on port COM8`); cable-swap retest of the handover pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)