### PR TITLE
Shared editors and glyphs for the ROI analysis feature

### DIFF
--- a/dropbot_status_and_controls/consts.py
+++ b/dropbot_status_and_controls/consts.py
@@ -38,6 +38,7 @@ DIELECTRIC_MATERIALS = {
     "Parylene D": 2.84,
     "PDMS": 2.7,
     "Si3N4": 7.5,
+    "Kapton": 3.4
 }
 
 # Status colors

--- a/examples/run_device_viewer_pluggable.py
+++ b/examples/run_device_viewer_pluggable.py
@@ -80,6 +80,12 @@ def main(plugins, contexts, application, persist):
 
 
 if __name__ == "__main__":
+    # Required before anything spawns a process on Windows,
+    # and a no-op elsewhere.
+    import multiprocessing
+
+    multiprocessing.freeze_support()
+
     import argparse
 
     parser = argparse.ArgumentParser(description="Run the device viewer plugins.")

--- a/examples/run_device_viewer_pluggable_backend.py
+++ b/examples/run_device_viewer_pluggable_backend.py
@@ -26,6 +26,12 @@ def main(args):
 
 
 if __name__ == "__main__":
+    # Required before anything spawns a process on Windows,
+    # and a no-op elsewhere.
+    import multiprocessing
+
+    multiprocessing.freeze_support()
+
     import argparse
 
     parser = argparse.ArgumentParser(description="Run the frontend device viewer plugins.")

--- a/examples/run_device_viewer_pluggable_frontend.py
+++ b/examples/run_device_viewer_pluggable_frontend.py
@@ -28,6 +28,12 @@ def main(args):
 
 
 if __name__ == "__main__":
+    # Required before anything spawns a process on Windows,
+    # and a no-op elsewhere.
+    import multiprocessing
+
+    multiprocessing.freeze_support()
+
     import argparse
 
     parser = argparse.ArgumentParser(description="Run the frontend device viewer plugins.")

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -59,3 +59,5 @@ ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
 ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward
 ICON_CHEVRON_RIGHT   = "chevron_right" # reveal a collapsed sidebar
 ICON_FUNCTION        = "function"      # fit equations table
+ICON_COPY            = "content_copy"  # copy the selected ROI
+ICON_PASTE           = "content_paste" # paste a copied ROI

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -51,6 +51,7 @@ ICON_USB             = "usb"         # manual serial-port selection
 ICON_ARCHIVE         = "folder_zip"  # select a .zip firmware bundle
 ICON_CIRCLE          = "circle"       # draw circular ROI
 ICON_RECTANGLE       = "rectangle"    # draw rectangular ROI
+ICON_CAPSULE         = "pill"         # draw capsule (spherocylinder) ROI
 ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
 ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
 ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -53,6 +53,7 @@ ICON_CIRCLE          = "circle"       # draw circular ROI
 ICON_RECTANGLE       = "rectangle"    # draw rectangular ROI
 ICON_CAPSULE         = "pill"         # draw capsule (spherocylinder) ROI
 ICON_CONTOUR         = "pentagon"     # trace a contour (polygon) ROI
+ICON_RULER           = "straighten"   # calibrate the image scale
 ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
 ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
 ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -55,3 +55,4 @@ ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
 ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
 ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward
 ICON_CHEVRON_RIGHT   = "chevron_right" # reveal a collapsed sidebar
+ICON_FUNCTION        = "function"      # fit equations table

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -49,3 +49,7 @@ ICON_DELETE          = "delete"      # clear regions
 ICON_SAVE            = "save"        # export/save
 ICON_USB             = "usb"         # manual serial-port selection
 ICON_ARCHIVE         = "folder_zip"  # select a .zip firmware bundle
+ICON_CIRCLE          = "circle"       # draw circular ROI
+ICON_RECTANGLE       = "rectangle"    # draw rectangular ROI
+ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
+ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -52,6 +52,7 @@ ICON_ARCHIVE         = "folder_zip"  # select a .zip firmware bundle
 ICON_CIRCLE          = "circle"       # draw circular ROI
 ICON_RECTANGLE       = "rectangle"    # draw rectangular ROI
 ICON_CAPSULE         = "pill"         # draw capsule (spherocylinder) ROI
+ICON_CONTOUR         = "pentagon"     # trace a contour (polygon) ROI
 ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
 ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
 ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -53,3 +53,5 @@ ICON_CIRCLE          = "circle"       # draw circular ROI
 ICON_RECTANGLE       = "rectangle"    # draw rectangular ROI
 ICON_SHOW_CHART      = "show_chart"   # calculate & plot intensities
 ICON_DELETE_SWEEP    = "delete_sweep" # clear all ROIs
+ICON_CHEVRON_LEFT    = "chevron_left"  # collapse a sidebar leftward
+ICON_CHEVRON_RIGHT   = "chevron_right" # reveal a collapsed sidebar

--- a/microdrop_style/icons/icons.py
+++ b/microdrop_style/icons/icons.py
@@ -61,3 +61,5 @@ ICON_CHEVRON_RIGHT   = "chevron_right" # reveal a collapsed sidebar
 ICON_FUNCTION        = "function"      # fit equations table
 ICON_COPY            = "content_copy"  # copy the selected ROI
 ICON_PASTE           = "content_paste" # paste a copied ROI
+ICON_TONALITY        = "tonality"      # rolling-ball flattening
+ICON_ADJUST          = "adjust"        # show the ball at its size

--- a/microdrop_utils/app_setup_helpers.py
+++ b/microdrop_utils/app_setup_helpers.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 import shutil
 import subprocess
@@ -51,8 +52,15 @@ def self_update_source_repo(repo_root=PROJECT_ROOT,
     - every failure is a logged warning, never a blocked launch.
 
     Skipped when ``MICRODROP_SKIP_GIT_UPDATE`` is set, when git or the
-    ``.git`` link is absent (frozen/tarball installs), or on any error.
+    ``.git`` link is absent (frozen/tarball installs), in a spawned
+    worker process, or on any error.
     """
+    if multiprocessing.parent_process() is not None:
+        # A spawned child re-imports the launcher, so without this every
+        # worker in a pool would run its own git pull — the app's own
+        # ROI batch once produced one per CPU.
+        logger.debug("source self-update skipped: worker process")
+        return
     if os.environ.get(SKIP_GIT_UPDATE_ENV_VAR):
         logger.info(f"source self-update skipped ({SKIP_GIT_UPDATE_ENV_VAR} is set)")
         return

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -973,8 +973,8 @@ class SlidingToggleEditor(BasicEditorFactory):
     klass = _SlidingToggleEditor
 
     #: Trait values the checked / unchecked states map to.
-    on_value = Any()
-    off_value = Any()
+    on_value = Any(default_value=True)
+    off_value = Any(default_value=False)
     #: Toggle widget colours (hex string or Qt colour).
     bar_color = Any(Qt.gray)         # unchecked bar
     checked_color = Any(PRIMARY_COLOR)  # checked bar + handle accent

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -1034,6 +1034,10 @@ class _InPlaceToggleEditor(QtEditor):
                 font-weight: bold;
                 max-width: 100px;
             }}
+            QPushButton:disabled {{
+                background-color: {GREY["light"]};
+                color: {GREY["dark"]};
+            }}
         """)
 
     def _on_click(self):

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -17,7 +17,7 @@ from pyface.qt.QtWidgets import (
 )
 from pyface.qt import QtWidgets
 
-from traits.api import Instance, Any, Bool, Range, List, Str, Int, Property, Float
+from traits.api import Instance, Any, Bool, Range, List, Str, Int, Property, Float, Callable
 from traitsui.api import (ObjectColumn as ObjectTableColumn_, TableColumn as TableColumn_, Controller,
                           UIInfo, Handler, RangeEditor, EnumEditor, BasicEditorFactory)
 from traitsui.qt.editor import Editor as QtEditor
@@ -43,6 +43,29 @@ DEFAULT_GLYPH_POINT_SIZE_PX = 16
 # right edge, and the narrowest the user can drag the header down to.
 TABLE_ROW_HEADER_RESIZE_GRIP_PX = 4
 TABLE_ROW_HEADER_MINIMUM_WIDTH_PX = 12
+
+
+def toggle_editor_default_style_sheet_factory(checked, border="none",
+                                              border_radius="4px", padding="8px 16px",
+                                              font_weight="bold", max_width="100px", other="" ):
+    background = SUCCESS_COLOR if checked else GREY["lighter"]
+    foreground = "white" if checked else "#333333"
+    return f"""
+            QPushButton {{
+                background-color: {background};
+                color: {foreground};
+                border: {border};
+                border-radius: {border_radius};
+                padding: {padding};
+                font-weight: {font_weight};
+                max-width: {max_width};
+                {other}
+            }}
+            QPushButton:disabled {{
+                background-color: {GREY["light"]};
+                color: {GREY["dark"]};
+            }}
+        """
 
 
 class TableColumn(TableColumn_):
@@ -1015,6 +1038,9 @@ class _InPlaceToggleEditor(QtEditor):
         # Item("flag", editor=InPlaceToggleEditor(...), tooltip="...").
         self.set_tooltip()
 
+        if not self.factory.custom_style_sheet_factory:
+            self.factory.custom_style_sheet_factory = toggle_editor_default_style_sheet_factory
+
         # Apply initial label + styling, and keep them in sync on every toggle
         # (click included; the trait-driven update_editor() does not fire on a
         # user click).
@@ -1026,23 +1052,8 @@ class _InPlaceToggleEditor(QtEditor):
         checked = self.control.isChecked()
         self.control.setText(
             self.factory.on_label if checked else self.factory.off_label)
-        background = SUCCESS_COLOR if checked else GREY["lighter"]
-        foreground = "white" if checked else "#333333"
-        self.control.setStyleSheet(f"""
-            QPushButton {{
-                background-color: {background};
-                color: {foreground};
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-weight: bold;
-                max-width: 100px;
-            }}
-            QPushButton:disabled {{
-                background-color: {GREY["light"]};
-                color: {GREY["dark"]};
-            }}
-        """)
+
+        self.control.setStyleSheet(self.factory.custom_style_sheet_factory(checked))
 
     def _on_click(self):
         # Read the button state rather than inverting self.value, so the
@@ -1073,6 +1084,7 @@ class InPlaceToggleEditor(BasicEditorFactory):
     off_label = Str("Off")
 
     max_width = Int(100)
+    custom_style_sheet_factory = Callable(desc='Override default style sheet for the inplace toggle editor')
 
 
 class _IconToggleEditor(QtEditor):

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -1174,6 +1174,56 @@ class IconButtonEditor(BasicEditorFactory):
     max_width = Int(DEFAULT_GLYPH_POINT_SIZE_PX + 12)
 
 
+class _IconModeButtonEditor(_IconButtonEditor):
+    """An icon button that also shows, checked, whether the mode it arms
+    is the one currently active. The click still just fires the trait —
+    which mode results is the controller's business, so a tool that
+    refuses to arm (or disarms on a second click) stays honest."""
+
+    def init(self, parent):
+        super().init(parent)
+        self.control.setCheckable(True)
+        self.control.setChecked(self._armed())
+        self.object.observe(self._on_mode_changed, self.factory.mode_trait)
+
+    def _armed(self):
+        return (getattr(self.object, self.factory.mode_trait)
+                == self.factory.mode)
+
+    def _on_click(self):
+        # Qt has already flipped the check state on its own; the mode
+        # trait is the authority, so put it back and let whatever the
+        # click triggers set it.
+        self.control.setChecked(self._armed())
+        super()._on_click()
+
+    def _on_mode_changed(self, event):
+        self.control.setChecked(self._armed())
+
+    def dispose(self):
+        self.object.observe(self._on_mode_changed, self.factory.mode_trait,
+                            remove=True)
+        super().dispose()
+
+
+class IconModeButtonEditor(IconButtonEditor):
+    """Factory for a Button trait that arms a mode, rendered as a glyph
+    button that lights up while that mode is active::
+
+        UItem("draw_ellipse_button", editor=IconModeButtonEditor(
+            glyph=ICON_CIRCLE, mode="draw_ellipse",
+            mode_trait="interaction_mode", tooltip="Draw an ellipse"))
+
+    ``mode_trait`` names a trait on the same object as the button.
+    """
+
+    klass = _IconModeButtonEditor
+
+    #: The value of ``mode_trait`` this button represents.
+    mode = Str()
+    mode_trait = Str("interaction_mode")
+
+
 def _has_group_box_ancestor(layout):
     """True if ``layout`` lives inside a QGroupBox (i.e. it lays out a section's
     contents rather than arranging the section boxes themselves)."""

--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -1010,6 +1010,10 @@ class _InPlaceToggleEditor(QtEditor):
         self.control.setChecked(self.value)
         self.control.clicked.connect(self._on_click)
         self.control.setMaximumWidth(self.factory.max_width)
+        # TraitsUI hands the Item's tooltip= to the editor as its
+        # description, but only applies it when the editor asks:
+        # Item("flag", editor=InPlaceToggleEditor(...), tooltip="...").
+        self.set_tooltip()
 
         # Apply initial label + styling, and keep them in sync on every toggle
         # (click included; the trait-driven update_editor() does not fire on a


### PR DESCRIPTION
The Microdrop-side pieces the fluorescence ROI-analysis feature builds on:

- `IconModeButtonEditor`: an icon button that shows itself checked while a companion mode trait equals the mode it arms — the armed draw tool lights up, and the click stays the controller's decision
- `InPlaceToggleEditor`: stylesheet extracted into an overridable `toggle_editor_default_style_sheet_factory` (`custom_style_sheet_factory` per editor), used by the ROI plot pane for compact toggles
- `SlidingToggleEditor`: on/off values default to True/False
- Material glyphs: copy, paste, rolling-ball (tonality), ball-size guide (adjust)

Companion to fluorescence-microdrop-plugin-py#14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)