### PR TITLE
feat(protocol logging): report-contribution topics for external plugins

### DIFF
--- a/MESSAGES.md
+++ b/MESSAGES.md
@@ -219,7 +219,7 @@ Everything a protocol run's HTML report contains flows through one dramatiq list
 
 **Contribution topics (any plugin → report)**
 - `PROTOCOL_LOGGING_METADATA_CONTRIBUTION = "microdrop/protocol_tree/logging/metadata"` and `PROTOCOL_LOGGING_DATA_CONTRIBUTION = "microdrop/protocol_tree/logging/data"` — defined in `pluggable_protocol_tree/consts.py`.
-- Payloads are flat JSON objects (no Pydantic model; malformed / non-object payloads are ignored, matching the other listener handlers).
+- Payloads are flat scalar-valued JSON objects. Publish through `protocol_logging_metadata_contribution_publisher` / `protocol_logging_data_contribution_publisher` in `pluggable_protocol_tree/consts.py` (RootModel contracts in `pluggable_protocol_tree/models/report_contributions.py` — validated publishers that serialize to the bare object). Subscribers stay lenient: malformed / non-object payloads are ignored, matching the other listener handlers.
 - Metadata → `controller.on_metadata_contribution` merges the object into the report's Metadata table (`LoggingIngestion.log_metadata`).
 - Data → `controller.on_data_contribution` appends the object as a data row (`LoggingIngestion.log_contributed_data`); `step_idx`/`step_id` are stamped from the currently running step unless the payload carries its own. Numeric columns automatically get a Data Summary row and a per-step Data Trends chart in the report, and every column lands in the persisted `data_<t>.json`/`.csv`.
 - Timing: contributions are accepted from `start_logging` until the post-`stop_logging` settling flush, so messages published shortly after the run ends still make the report.

--- a/MESSAGES.md
+++ b/MESSAGES.md
@@ -204,3 +204,24 @@ One topic carries both the spontaneous hardware shorts signal and the answer to 
 - `task._on_shorts_detected_triggered` validates the payload and hands off to the UI thread.
 - `task._on_shorts_detected_dialog`: with shorts → a `confirm` offering to keep the channels enabled; declining publishes them via `disabled_channels_changed_publisher`. Without shorts → the "No Shorts Detected" info dialog, unconditionally when `show_window` is set, otherwise only when the `suppress_no_shorts_information` preference is unset (that dialog carries the "do not show again" checkbox which writes the preference).
 
+### Protocol tree run logging: report data collection + external contributions
+
+Everything a protocol run's HTML report contains flows through one dramatiq listener into a per-run collector. A single active-logger registry gates all of it: `ProtocolLoggingController.start_logging` registers the controller (`listener.set_active_logger`), `stop_logging` clears it, and any message arriving outside a run is dropped silently.
+
+**Listener + routing**
+- Actor `protocol_tree_logging_listener` at `pluggable_protocol_tree/services/logging/listener.py` — `route_to_active_logger()` branches on topic and forwards to the active `ProtocolLoggingController` (`services/logging/controller.py`); subscriptions declared in `ACTOR_TOPIC_DICT[LOGGING_LISTENER_NAME]` in `pluggable_protocol_tree/consts.py`.
+
+**Core topics (owned by other plugins, consumed by the logger)**
+- `CAPACITANCE_UPDATED` (`dropbot_controller/consts.py`) → one data row per sample, stamped with the current step + actuation phase; capacitance/voltage parsed leniently, force derived from capacitance-per-unit-area.
+- `ELECTRODES_STATE_CHANGE` (`electrode_controller/consts.py`) → updates the current actuation context (channels + summed electrode area) stamped onto subsequent capacitance rows.
+- `DEVICE_VIEWER_MEDIA_CAPTURED` (`device_viewer/consts.py`) → media bucket for the report's Media Captures section. Note: the camera capture path also caches into `app_globals["media_captures"]` without publishing this topic, so `_flush` additionally drains that bucket.
+- `CALIBRATION_DATA` (`device_viewer/consts.py`) → live capacitance-per-unit-area update so the Force column populates mid-run.
+
+**Contribution topics (any plugin → report)**
+- `PROTOCOL_LOGGING_METADATA_CONTRIBUTION = "microdrop/protocol_tree/logging/metadata"` and `PROTOCOL_LOGGING_DATA_CONTRIBUTION = "microdrop/protocol_tree/logging/data"` — defined in `pluggable_protocol_tree/consts.py`.
+- Payloads are flat JSON objects (no Pydantic model; malformed / non-object payloads are ignored, matching the other listener handlers).
+- Metadata → `controller.on_metadata_contribution` merges the object into the report's Metadata table (`LoggingIngestion.log_metadata`).
+- Data → `controller.on_data_contribution` appends the object as a data row (`LoggingIngestion.log_contributed_data`); `step_idx`/`step_id` are stamped from the currently running step unless the payload carries its own. Numeric columns automatically get a Data Summary row and a per-step Data Trends chart in the report, and every column lands in the persisted `data_<t>.json`/`.csv`.
+- Timing: contributions are accepted from `start_logging` until the post-`stop_logging` settling flush, so messages published shortly after the run ends still make the report.
+- Demo: `examples/demos/protocol_report_contribution_demo.py` runs the whole pipeline headlessly over redis and prints the generated report path.
+

--- a/examples/demos/protocol_report_contribution_demo.py
+++ b/examples/demos/protocol_report_contribution_demo.py
@@ -9,7 +9,9 @@ without the GUI:
 2. starts a logging run and simulates two protocol steps with a few
    CAPACITANCE_UPDATED samples (the logger's core data),
 3. plays the part of an external "heater plugin" publishing report
-   metadata (firmware version, sample id) and per-step temperature rows,
+   metadata (firmware version, sample id) and per-step temperature rows
+   through the validated contribution publishers in
+   pluggable_protocol_tree.consts,
 4. stops the run and prints the generated HTML report path.
 
 In the report: the contributed metadata appears in the Metadata table, and
@@ -45,7 +47,8 @@ from microdrop_utils.dramatiq_pub_sub_helpers import (
 )
 from pluggable_protocol_tree.consts import (
     ACTOR_TOPIC_DICT, LOGGING_LISTENER_NAME,
-    PROTOCOL_LOGGING_DATA_CONTRIBUTION, PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+    protocol_logging_data_contribution_publisher,
+    protocol_logging_metadata_contribution_publisher,
 )
 import pluggable_protocol_tree.services.logging.listener  # noqa: F401 — registers the logging_listener actor
 from pluggable_protocol_tree.services.logging.controller import (
@@ -109,10 +112,8 @@ def main():
     controller.start_logging(context, n_steps=N_STEPS, preview_mode=False)
 
     # --- external "heater plugin" contributes report metadata -------------
-    publish_message(
-        message=json.dumps({"Heater Firmware": "v2.1.0",
-                            "Sample ID": "S-042"}),
-        topic=PROTOCOL_LOGGING_METADATA_CONTRIBUTION)
+    protocol_logging_metadata_contribution_publisher.publish(
+        {"Heater Firmware": "v2.1.0", "Sample ID": "S-042"})
 
     # --- simulated run: core capacitance + contributed temperature rows ---
     instrument_time_us = 0
@@ -134,10 +135,8 @@ def main():
                     "reception_time": int(time.time()),
                 }),
                 topic=CAPACITANCE_UPDATED)
-            publish_message(
-                message=json.dumps(
-                    {"Temperature (C)": 60.0 + step_number + 0.2 * sample}),
-                topic=PROTOCOL_LOGGING_DATA_CONTRIBUTION)
+            protocol_logging_data_contribution_publisher.publish(
+                {"Temperature (C)": 60.0 + step_number + 0.2 * sample})
         time.sleep(ROUTING_DRAIN_SECONDS)
 
     controller.stop_logging()

--- a/examples/demos/protocol_report_contribution_demo.py
+++ b/examples/demos/protocol_report_contribution_demo.py
@@ -1,0 +1,162 @@
+"""Standalone demo: external plugins contributing protocol-report content.
+
+Exercises the PROTOCOL_LOGGING_METADATA_CONTRIBUTION /
+PROTOCOL_LOGGING_DATA_CONTRIBUTION topics end-to-end over redis/dramatiq,
+without the GUI:
+
+1. subscribes the protocol-tree logging listener to its topics on a
+   MessageRouterActor (the same wiring the app uses),
+2. starts a logging run and simulates two protocol steps with a few
+   CAPACITANCE_UPDATED samples (the logger's core data),
+3. plays the part of an external "heater plugin" publishing report
+   metadata (firmware version, sample id) and per-step temperature rows,
+4. stops the run and prints the generated HTML report path.
+
+In the report: the contributed metadata appears in the Metadata table, and
+the contributed "Temperature (C)" column gets its own Data Summary row and
+per-step Data Trends chart — no logger changes required.
+
+Run: pixi run python -m examples.demos.protocol_report_contribution_demo
+(redis-server must be on PATH or already running)
+"""
+
+import json
+import logging
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from microdrop_utils.broker_server_helpers import (
+    configure_dramatiq_broker, dramatiq_workers_context, redis_server_context,
+)
+
+# The logging listener actor registers itself on the broker at import time,
+# so the RedisBroker must be configured first (same pattern as the test
+# conftests).
+configure_dramatiq_broker()
+
+from traits.api import Event, HasTraits
+
+from dropbot_controller.consts import CAPACITANCE_UPDATED
+from electrode_controller.consts import ELECTRODES_STATE_CHANGE
+from microdrop_utils.dramatiq_pub_sub_helpers import (
+    MessageRouterActor, publish_message,
+)
+from pluggable_protocol_tree.consts import (
+    ACTOR_TOPIC_DICT, LOGGING_LISTENER_NAME,
+    PROTOCOL_LOGGING_DATA_CONTRIBUTION, PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+)
+import pluggable_protocol_tree.services.logging.listener  # noqa: F401 — registers the logging_listener actor
+from pluggable_protocol_tree.services.logging.controller import (
+    ProtocolLoggingController,
+)
+from pluggable_protocol_tree.services.logging.models import LoggingDeviceContext
+
+N_STEPS = 2
+SAMPLES_PER_STEP = 5
+# Short settling delay so the post-stop flush (which builds the report)
+# runs quickly; the real app reads this from ProtocolPreferences.
+DEMO_SETTLING_SECONDS = 1.0
+# Grace period for the dramatiq workers to route in-flight messages before
+# the run is stopped / between steps.
+ROUTING_DRAIN_SECONDS = 1.0
+
+
+class _DemoExecutorSignals(HasTraits):
+    """Stand-in for the executor's signals object: firing step_started with
+    a (row, step_index, step_total) tuple is exactly what
+    ProtocolLoggingController.attach observes."""
+    step_started = Event
+
+
+class _DemoRow:
+    """Minimal protocol row — the logger only reads row.uuid."""
+    def __init__(self, uuid: str):
+        self.uuid = uuid
+
+
+def main():
+    experiment_dir = Path(tempfile.mkdtemp(prefix="protocol_report_demo_"))
+    print(f"Experiment directory: {experiment_dir}")
+
+    # Wire the logging listener exactly like the app: subscribe it to its
+    # ACTOR_TOPIC_DICT topics (core + contribution) on the message router.
+    router = MessageRouterActor()
+    for topic in ACTOR_TOPIC_DICT[LOGGING_LISTENER_NAME]:
+        router.message_router_data.add_subscriber_to_topic(
+            topic=topic, subscribing_actor_name=LOGGING_LISTENER_NAME)
+
+    report_done = threading.Event()
+    report_paths = []
+
+    def _on_report(path):
+        report_paths.append(path)
+        report_done.set()
+
+    controller = ProtocolLoggingController(
+        settling_provider=lambda: DEMO_SETTLING_SECONDS,
+        completion_callback=_on_report)
+    signals = _DemoExecutorSignals()
+    controller.attach(signals)
+
+    context = LoggingDeviceContext(
+        experiment_directory=experiment_dir,
+        device_svg_path=None,                      # no SVG -> no heatmap
+        channel_areas={ch: 1.5 for ch in range(8)},
+        capacitance_per_unit_area=2.0)
+
+    controller.start_logging(context, n_steps=N_STEPS, preview_mode=False)
+
+    # --- external "heater plugin" contributes report metadata -------------
+    publish_message(
+        message=json.dumps({"Heater Firmware": "v2.1.0",
+                            "Sample ID": "S-042"}),
+        topic=PROTOCOL_LOGGING_METADATA_CONTRIBUTION)
+
+    # --- simulated run: core capacitance + contributed temperature rows ---
+    instrument_time_us = 0
+    for step_number in range(1, N_STEPS + 1):
+        print(f"Step {step_number}/{N_STEPS}")
+        signals.step_started = (
+            _DemoRow(f"demo-step-{step_number}"), step_number - 1, N_STEPS)
+        publish_message(
+            message=json.dumps({"channels": [step_number, step_number + 1]}),
+            topic=ELECTRODES_STATE_CHANGE)
+        time.sleep(ROUTING_DRAIN_SECONDS)   # actuation context before samples
+        for sample in range(SAMPLES_PER_STEP):
+            instrument_time_us += 50_000
+            publish_message(
+                message=json.dumps({
+                    "capacitance": f"{12.0 + step_number + 0.1 * sample}pF",
+                    "voltage": "100V",
+                    "instrument_time_us": instrument_time_us,
+                    "reception_time": int(time.time()),
+                }),
+                topic=CAPACITANCE_UPDATED)
+            publish_message(
+                message=json.dumps(
+                    {"Temperature (C)": 60.0 + step_number + 0.2 * sample}),
+                topic=PROTOCOL_LOGGING_DATA_CONTRIBUTION)
+        time.sleep(ROUTING_DRAIN_SECONDS)
+
+    controller.stop_logging()
+
+    if report_done.wait(timeout=30) and report_paths and report_paths[0]:
+        print(f"\nReport written: {report_paths[0]}")
+        print("Open it and look for:")
+        print("  - Metadata table rows 'Heater Firmware' / 'Sample ID'")
+        print("  - 'Temperature (C)' in Data Summary and Data Trends")
+    else:
+        print("\nReport generation failed — see log output above.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    with redis_server_context():
+        with dramatiq_workers_context():
+            main()

--- a/pluggable_protocol_tree/consts.py
+++ b/pluggable_protocol_tree/consts.py
@@ -19,6 +19,10 @@ from pluggable_protocol_tree.models.cell_sync import (
     ProtocolTreeRowSelectedPublisher, ProtocolTreeSetCellPublisher,
     ProtocolTreeAddStepPublisher,
 )
+from pluggable_protocol_tree.models.report_contributions import (
+    ProtocolLoggingDataContributionPublisher,
+    ProtocolLoggingMetadataContributionPublisher,
+)
 
 PKG = ".".join(__name__.split(".")[:-1])
 PKG_name = PKG.title().replace("_", " ")
@@ -110,6 +114,15 @@ PROTOCOL_TREE_ADD_STEP = "ui/protocol_tree/add_step"
 # payload omits them.
 PROTOCOL_LOGGING_METADATA_CONTRIBUTION = f"{PROTOCOL_TOPIC_PREFIX}/logging/metadata"
 PROTOCOL_LOGGING_DATA_CONTRIBUTION = f"{PROTOCOL_TOPIC_PREFIX}/logging/data"
+
+# Public endpoints for contributing plugins (validated flat-mapping
+# payloads; contracts in models/report_contributions.py).
+protocol_logging_metadata_contribution_publisher = \
+    ProtocolLoggingMetadataContributionPublisher(
+        topic=PROTOCOL_LOGGING_METADATA_CONTRIBUTION)
+protocol_logging_data_contribution_publisher = \
+    ProtocolLoggingDataContributionPublisher(
+        topic=PROTOCOL_LOGGING_DATA_CONTRIBUTION)
 
 protocol_tree_row_selected_publisher = ProtocolTreeRowSelectedPublisher(
     topic=PROTOCOL_TREE_ROW_SELECTED)

--- a/pluggable_protocol_tree/consts.py
+++ b/pluggable_protocol_tree/consts.py
@@ -100,6 +100,17 @@ PROTOCOL_TREE_ROW_SELECTED = "ui/protocol_tree/row_selected"
 PROTOCOL_TREE_SET_CELL = "ui/protocol_tree/set_cell"
 PROTOCOL_TREE_ADD_STEP = "ui/protocol_tree/add_step"
 
+# Report-contribution topics: any plugin may publish extra report content
+# while a protocol run is logging (dropped silently outside a run).
+# Metadata payload: flat JSON object merged into the report's Metadata
+# table. Data payload: flat JSON object appended as a data row — numeric
+# columns automatically get a Data Summary row + a per-step Data Trends
+# chart, and every column lands in the persisted data_<t>.json/.csv;
+# step_idx/step_id are stamped from the currently running step when the
+# payload omits them.
+PROTOCOL_LOGGING_METADATA_CONTRIBUTION = f"{PROTOCOL_TOPIC_PREFIX}/logging/metadata"
+PROTOCOL_LOGGING_DATA_CONTRIBUTION = f"{PROTOCOL_TOPIC_PREFIX}/logging/data"
+
 protocol_tree_row_selected_publisher = ProtocolTreeRowSelectedPublisher(
     topic=PROTOCOL_TREE_ROW_SELECTED)
 protocol_tree_set_cell_publisher = ProtocolTreeSetCellPublisher(
@@ -131,6 +142,8 @@ ACTOR_TOPIC_DICT = {
         ELECTRODES_STATE_CHANGE,
         DEVICE_VIEWER_MEDIA_CAPTURED,
         CALIBRATION_DATA,
+        PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+        PROTOCOL_LOGGING_DATA_CONTRIBUTION,
     ]
 }
 

--- a/pluggable_protocol_tree/models/report_contributions.py
+++ b/pluggable_protocol_tree/models/report_contributions.py
@@ -1,0 +1,58 @@
+"""Pydantic contracts for the report-contribution logging topics.
+
+``PROTOCOL_LOGGING_METADATA_CONTRIBUTION`` — flat mapping merged into the
+run report's Metadata table.
+
+``PROTOCOL_LOGGING_DATA_CONTRIBUTION`` — flat mapping appended as one data
+row; numeric columns automatically flow into the report's Data Summary /
+Data Trends sections and the persisted data files. ``step_idx`` /
+``step_id`` keys override the logger's own step stamping when present.
+
+Both messages are RootModels so they serialize to the flat JSON object
+itself (no wrapper key) — the wire format the logging listener's lenient
+handlers expect. Values are restricted to scalars: the Metadata table
+renders them with str(), and data-row scalars are what the summary/trends
+charting can aggregate. Publisher singletons live in
+``pluggable_protocol_tree/consts.py`` next to the topic constants.
+"""
+
+from typing import Annotated
+
+from pydantic import Field, RootModel
+
+from microdrop_utils.dramatiq_pub_sub_helpers import ValidatedTopicPublisher
+
+ContributionScalar = str | int | float | bool | None
+# Non-empty, flat (scalar-valued) mapping — an empty contribution is a
+# caller bug, and nested values would defeat the report's aggregation.
+FlatContributionMapping = Annotated[
+    dict[str, ContributionScalar], Field(min_length=1)]
+
+
+class ProtocolLoggingMetadataContributionMessage(
+        RootModel[FlatContributionMapping]):
+    """Key/value rows merged into the report's Metadata table."""
+
+
+class ProtocolLoggingDataContributionMessage(
+        RootModel[FlatContributionMapping]):
+    """One contributed data row (column name -> value)."""
+
+
+class ProtocolLoggingMetadataContributionPublisher(ValidatedTopicPublisher):
+    """Validated publisher for ``PROTOCOL_LOGGING_METADATA_CONTRIBUTION``.
+
+    ``publish({"Heater Firmware": "v2.1.0"})`` — the payload is the flat
+    mapping itself.
+    """
+    validator_class = ProtocolLoggingMetadataContributionMessage
+
+
+class ProtocolLoggingDataContributionPublisher(ValidatedTopicPublisher):
+    """Validated publisher for ``PROTOCOL_LOGGING_DATA_CONTRIBUTION``.
+
+    ``publish({"Temperature (C)": 64.5})`` — the payload is the flat
+    mapping itself; include ``step_idx``/``step_id`` keys to override the
+    logger's step stamping.
+    """
+    validator_class = ProtocolLoggingDataContributionMessage

--- a/pluggable_protocol_tree/services/logging/controller.py
+++ b/pluggable_protocol_tree/services/logging/controller.py
@@ -59,6 +59,16 @@ def _format_elapsed(delta: timedelta) -> str:
     return f"{h}:{m:02d}:{s:02d}"
 
 
+def _parse_dict_payload(message):
+    """JSON-decode a listener payload, returning the dict or None when the
+    payload is malformed or not an object (lenient, legacy parity)."""
+    try:
+        data = json.loads(message)
+    except (ValueError, TypeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _capacitance_per_unit_area(liquid, filler):
     """liquid - filler (pF/mm^2), or None when invalid. Mirrors the legacy
     ForceCalculationService.calculate_capacitance_per_unit_area: both
@@ -261,11 +271,8 @@ class ProtocolLoggingController(HasTraits):
         ing = self._ingestion
         if ing is None:
             return
-        try:
-            data = json.loads(message)
-        except (ValueError, TypeError):
-            return
-        if not isinstance(data, dict):
+        data = _parse_dict_payload(message)
+        if data is None:
             return
         channels = data.get("channels", []) or []
         areas = getattr(self._device_context, "channel_areas", {}) or {}
@@ -289,17 +296,37 @@ class ProtocolLoggingController(HasTraits):
         ing = self._ingestion
         if ing is None:
             return
-        try:
-            data = json.loads(message)
-        except (ValueError, TypeError):
-            return
-        if not isinstance(data, dict):
+        data = _parse_dict_payload(message)
+        if data is None:
             return
         cpa = _capacitance_per_unit_area(
             data.get(LIQUID_CAPACITANCE_KEY),
             data.get(FILLER_CAPACITANCE_KEY))
         if cpa is not None:
             ing.update_capacitance_per_unit_area(cpa)
+
+    def on_metadata_contribution(self, message) -> None:
+        """PROTOCOL_LOGGING_METADATA_CONTRIBUTION payload --> report
+        Metadata table. Lets any plugin merge extra key/value rows into
+        the report without coupling to the logger."""
+        ing = self._ingestion
+        if ing is None:
+            return
+        data = _parse_dict_payload(message)
+        if data is not None:
+            ing.log_metadata(data)
+
+    def on_data_contribution(self, message) -> None:
+        """PROTOCOL_LOGGING_DATA_CONTRIBUTION payload --> one data row.
+        Numeric columns automatically flow into the report's Data Summary
+        / Data Trends sections and the persisted data files; the current
+        step context is stamped when the payload omits it."""
+        ing = self._ingestion
+        if ing is None:
+            return
+        data = _parse_dict_payload(message)
+        if data is not None:
+            ing.log_contributed_data(data)
 
     def update_capacitance_per_unit_area(self, value) -> None:
         ing = self._ingestion

--- a/pluggable_protocol_tree/services/logging/ingestion.py
+++ b/pluggable_protocol_tree/services/logging/ingestion.py
@@ -59,6 +59,16 @@ class LoggingIngestion(HasTraits):
         with self._lock:
             self.metadata.update(entry)
 
+    def log_contributed_data(self, entry: dict) -> None:
+        """Append a data row contributed by an external plugin (via the
+        PROTOCOL_LOGGING_DATA_CONTRIBUTION topic). The current step context
+        is stamped when the payload omits it, so contributed rows group
+        under the step that was running when they arrived (step_idx 0 =
+        before any step started)."""
+        stamped = {"step_idx": self._step_idx, "step_id": self._step_id}
+        stamped.update(entry)
+        self.log_data(stamped)
+
     def log_media(self, model) -> None:
         type_obj = getattr(model, "type", None)
         bucket = getattr(type_obj, "value", None) or type_obj or "other"

--- a/pluggable_protocol_tree/services/logging/listener.py
+++ b/pluggable_protocol_tree/services/logging/listener.py
@@ -11,6 +11,7 @@ from dropbot_controller.consts import CAPACITANCE_UPDATED
 from device_viewer.consts import DEVICE_VIEWER_MEDIA_CAPTURED, CALIBRATION_DATA
 from pluggable_protocol_tree.consts import (
     ELECTRODES_STATE_CHANGE, LOGGING_LISTENER_NAME,
+    PROTOCOL_LOGGING_DATA_CONTRIBUTION, PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
 )
 from logger.logger_service import get_logger
 
@@ -53,6 +54,10 @@ def route_to_active_logger(topic: str, payload) -> None:
             sink.on_media(payload)
         elif topic == CALIBRATION_DATA:
             sink.on_calibration(payload)
+        elif topic == PROTOCOL_LOGGING_METADATA_CONTRIBUTION:
+            sink.on_metadata_contribution(payload)
+        elif topic == PROTOCOL_LOGGING_DATA_CONTRIBUTION:
+            sink.on_data_contribution(payload)
     except Exception as e:                     # pragma: no cover - defensive
         logger.error(f"logging route failed for {topic}: {e}")
 

--- a/pluggable_protocol_tree/tests/test_logging_controller.py
+++ b/pluggable_protocol_tree/tests/test_logging_controller.py
@@ -385,6 +385,43 @@ def test_report_failure_callback_fires_when_requested_report_fails(tmp_path):
     assert "render boom" in failures[0]
 
 
+# --- externally contributed metadata / data rows (contribution topics) -----
+
+def test_on_metadata_contribution_merges_into_report_metadata(tmp_path):
+    c = ProtocolLoggingController(settling_provider=lambda: 0.0,
+                                  flush_scheduler=_immediate)
+    c.start_logging(_ctx(tmp_path), n_steps=1, preview_mode=False)
+    c.on_metadata_contribution(json.dumps({"Heater Firmware": "v2.1.0"}))
+    assert c._ingestion.metadata["Heater Firmware"] == "v2.1.0"
+    c.on_metadata_contribution("not json")     # malformed -> must not raise
+    c.on_metadata_contribution("[1, 2]")       # valid JSON, non-dict -> ignored
+    assert "Heater Firmware" in c._ingestion.metadata
+    c.stop_logging(generate_report=False)
+
+
+def test_on_data_contribution_appends_row_with_step_context(tmp_path):
+    from types import SimpleNamespace
+    c = ProtocolLoggingController(settling_provider=lambda: 0.0,
+                                  flush_scheduler=_immediate)
+    c.start_logging(_ctx(tmp_path), n_steps=1, preview_mode=False)
+    c._on_step_started(SimpleNamespace(new=(_FakeRow(), 0, 1)))
+    c.on_data_contribution(json.dumps({"Temperature (C)": 64.5}))
+    e = c._ingestion.entries[-1]
+    assert e["Temperature (C)"] == 64.5
+    assert e["step_idx"] == 1
+    assert e["step_id"] == "row-uuid"
+    c.on_data_contribution("not json")         # malformed -> must not raise
+    assert len(c._ingestion.entries) == 1
+    c.stop_logging(generate_report=False)
+
+
+def test_contribution_handlers_noop_without_active_run():
+    c = ProtocolLoggingController(settling_provider=lambda: 0.0,
+                                  flush_scheduler=_immediate)
+    c.on_metadata_contribution(json.dumps({"k": "v"}))   # must not raise
+    c.on_data_contribution(json.dumps({"k": 1}))         # must not raise
+
+
 def test_report_failure_callback_silent_when_report_not_requested(tmp_path):
     failures = []
     c = ProtocolLoggingController(

--- a/pluggable_protocol_tree/tests/test_logging_ingestion.py
+++ b/pluggable_protocol_tree/tests/test_logging_ingestion.py
@@ -18,6 +18,28 @@ def test_log_metadata_merges():
     assert ing.metadata == {"x": 9, "y": 2}
 
 
+def test_log_contributed_data_stamps_current_step_context():
+    ing = LoggingIngestion()
+    ing.set_step(step_id="uuid-1", step_idx=2)
+    ing.log_contributed_data({"Temperature (C)": 64.5})
+    e = ing.entries[-1]
+    assert e["step_idx"] == 2
+    assert e["step_id"] == "uuid-1"
+    assert e["Temperature (C)"] == 64.5
+    assert "Temperature (C)" in ing.columns
+
+
+def test_log_contributed_data_payload_step_fields_win():
+    """A contributor that knows its own step attribution keeps it — the
+    stamp only fills in what the payload omits."""
+    ing = LoggingIngestion()
+    ing.set_step(step_id="uuid-1", step_idx=2)
+    ing.log_contributed_data({"step_idx": 7, "step_id": "explicit", "v": 1})
+    e = ing.entries[-1]
+    assert e["step_idx"] == 7
+    assert e["step_id"] == "explicit"
+
+
 def test_calculate_force_formula():
     ing = LoggingIngestion()
     ing.update_capacitance_per_unit_area(2.0)

--- a/pluggable_protocol_tree/tests/test_logging_listener.py
+++ b/pluggable_protocol_tree/tests/test_logging_listener.py
@@ -57,3 +57,36 @@ def test_calibration_topic_registered_in_consts():
     from pluggable_protocol_tree.consts import ACTOR_TOPIC_DICT, LOGGING_LISTENER_NAME
     from device_viewer.consts import CALIBRATION_DATA
     assert CALIBRATION_DATA in ACTOR_TOPIC_DICT[LOGGING_LISTENER_NAME]
+
+
+def test_route_contribution_topics_dispatch():
+    from pluggable_protocol_tree.consts import (
+        PROTOCOL_LOGGING_DATA_CONTRIBUTION,
+        PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+    )
+
+    class _ContribSink:
+        def __init__(self):
+            self.calls = []
+        def on_metadata_contribution(self, m): self.calls.append(("meta", m))
+        def on_data_contribution(self, m): self.calls.append(("data", m))
+
+    sink = _ContribSink()
+    L.set_active_logger(sink)
+    try:
+        L.route_to_active_logger(PROTOCOL_LOGGING_METADATA_CONTRIBUTION, "metamsg")
+        L.route_to_active_logger(PROTOCOL_LOGGING_DATA_CONTRIBUTION, "datamsg")
+    finally:
+        L.clear_active_logger()
+    assert sink.calls == [("meta", "metamsg"), ("data", "datamsg")]
+
+
+def test_contribution_topics_registered_in_consts():
+    from pluggable_protocol_tree.consts import (
+        ACTOR_TOPIC_DICT, LOGGING_LISTENER_NAME,
+        PROTOCOL_LOGGING_DATA_CONTRIBUTION,
+        PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+    )
+    topics = ACTOR_TOPIC_DICT[LOGGING_LISTENER_NAME]
+    assert PROTOCOL_LOGGING_METADATA_CONTRIBUTION in topics
+    assert PROTOCOL_LOGGING_DATA_CONTRIBUTION in topics

--- a/pluggable_protocol_tree/tests/test_report_contribution_publishers.py
+++ b/pluggable_protocol_tree/tests/test_report_contribution_publishers.py
@@ -1,0 +1,84 @@
+"""Unit tests for models/report_contributions.py — flat-mapping contracts
+and the validated contribution publishers bound in consts.py."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from pluggable_protocol_tree.models.report_contributions import (
+    ProtocolLoggingDataContributionMessage,
+    ProtocolLoggingDataContributionPublisher,
+    ProtocolLoggingMetadataContributionMessage,
+    ProtocolLoggingMetadataContributionPublisher,
+)
+
+
+class TestContributionMessages:
+
+    def test_flat_scalar_mapping_validates(self):
+        model = ProtocolLoggingMetadataContributionMessage.model_validate(
+            {"Heater Firmware": "v2.1.0", "Target Temperature (C)": 65})
+        assert model.root["Heater Firmware"] == "v2.1.0"
+
+    def test_serializes_to_bare_json_object(self):
+        """The wire format must be the flat object itself (what the
+        listener handlers json.loads into the metadata/data buckets),
+        not a wrapper like {"root": {...}}."""
+        model = ProtocolLoggingDataContributionMessage.model_validate(
+            {"Temperature (C)": 64.5, "step_idx": 3})
+        assert json.loads(model.model_dump_json()) == {
+            "Temperature (C)": 64.5, "step_idx": 3}
+
+    def test_empty_mapping_rejected(self):
+        with pytest.raises(ValidationError):
+            ProtocolLoggingMetadataContributionMessage.model_validate({})
+
+    def test_nested_value_rejected(self):
+        with pytest.raises(ValidationError):
+            ProtocolLoggingDataContributionMessage.model_validate(
+                {"readings": [1, 2, 3]})
+
+
+class TestContributionPublishers:
+
+    def test_publishers_bind_their_validators(self):
+        assert (ProtocolLoggingMetadataContributionPublisher.validator_class
+                is ProtocolLoggingMetadataContributionMessage)
+        assert (ProtocolLoggingDataContributionPublisher.validator_class
+                is ProtocolLoggingDataContributionMessage)
+
+    def test_publish_sends_flat_validated_json(self, monkeypatch):
+        captured = {}
+
+        def fake_publish_message(message, topic, **kwargs):
+            captured["message"] = message
+            captured["topic"] = topic
+
+        import microdrop_utils.dramatiq_pub_sub_helpers as pub_sub
+        monkeypatch.setattr(pub_sub, "publish_message", fake_publish_message)
+
+        publisher = ProtocolLoggingDataContributionPublisher(
+            topic="microdrop/protocol_tree/logging/data")
+        publisher.publish({"Temperature (C)": 64.5})
+
+        assert captured["topic"] == "microdrop/protocol_tree/logging/data"
+        assert json.loads(captured["message"]) == {"Temperature (C)": 64.5}
+
+    def test_publish_raises_on_invalid_payload(self):
+        publisher = ProtocolLoggingMetadataContributionPublisher(
+            topic="microdrop/protocol_tree/logging/metadata")
+        with pytest.raises(ValidationError):
+            publisher.publish({"nested": {"not": "allowed"}})
+
+    def test_consts_singletons_bound_to_their_topics(self):
+        from pluggable_protocol_tree.consts import (
+            PROTOCOL_LOGGING_DATA_CONTRIBUTION,
+            PROTOCOL_LOGGING_METADATA_CONTRIBUTION,
+            protocol_logging_data_contribution_publisher,
+            protocol_logging_metadata_contribution_publisher,
+        )
+        assert (protocol_logging_metadata_contribution_publisher.topic
+                == PROTOCOL_LOGGING_METADATA_CONTRIBUTION)
+        assert (protocol_logging_data_contribution_publisher.topic
+                == PROTOCOL_LOGGING_DATA_CONTRIBUTION)


### PR DESCRIPTION
## Summary

Lets any plugin add content to the protocol run report without coupling to the logger, via two new pub/sub topics routed through the existing `protocol_tree_logging_listener`:

- `PROTOCOL_LOGGING_METADATA_CONTRIBUTION` (`microdrop/protocol_tree/logging/metadata`) — flat JSON object merged into the report Metadata table.
- `PROTOCOL_LOGGING_DATA_CONTRIBUTION` (`microdrop/protocol_tree/logging/data`) — flat JSON object appended as a data row. Numeric columns automatically get a Data Summary row + per-step Data Trends chart and land in the persisted `data_<t>.json`/`.csv`. `step_idx`/`step_id` are stamped from the currently running step when the payload omits them.

Contributions ride the existing active-logger gate: accepted from `start_logging` until the post-`stop_logging` settling flush, dropped silently outside a run. Malformed / non-object payloads are ignored (lenient, matching the other listener handlers).

## Changes

- `pluggable_protocol_tree/consts.py` — topic constants + `ACTOR_TOPIC_DICT[LOGGING_LISTENER_NAME]` registration
- `services/logging/controller.py` — `on_metadata_contribution` / `on_data_contribution`; shared `_parse_dict_payload` helper (reused by actuation/calibration handlers)
- `services/logging/ingestion.py` — `log_contributed_data` with step-context stamping (payload-provided fields win)
- `services/logging/listener.py` — routing for the two topics
- tests — listener dispatch, consts registration, controller handlers, ingestion stamping
- `MESSAGES.md` — new Detailed Flows subsection documenting the whole run-logging flow + the contribution contract
- `examples/demos/protocol_report_contribution_demo.py` — headless end-to-end demo over redis/dramatiq (simulated run + external "heater plugin" contributing metadata and temperature rows)

## Test plan

- `pytest pluggable_protocol_tree/tests/test_logging_listener.py pluggable_protocol_tree/tests/test_logging_controller.py pluggable_protocol_tree/tests/test_logging_ingestion.py`
- `pixi run python -m examples.demos.protocol_report_contribution_demo` — open the printed report; check Metadata rows "Heater Firmware" / "Sample ID" and the "Temperature (C)" summary row + trends chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)
