### PR TITLE
feat(touch-assist): virtual mouse, numpad and keyboard for touchscreens

### DIFF
--- a/device_viewer/preferences.py
+++ b/device_viewer/preferences.py
@@ -137,7 +137,7 @@ class DeviceViewerPreferences(PreferencesHelper):
 
         default_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Default repo directory is: {default_dir}")
+        logger.debug(f"Default repo directory is: {default_dir}")
 
         # Seed the repo with the bundled device files on first run. Only copy a
         # file that is missing so user-modified copies are never clobbered.
@@ -154,15 +154,15 @@ class DeviceViewerPreferences(PreferencesHelper):
 
     def _DEFAULT_SVG_FILE_default(self):
         # --- Define Master File Path (local to the script) ---
-        logger.debug(f"Master svg file is located at: {MASTER_SVG_FILE}")
+        logger.debug(f"Master default device svg is located at: {MASTER_SVG_FILE}")
 
         if not MASTER_SVG_FILE.exists():
-            logger.error("Master file not found!.")
-            raise FileNotFoundError("Master file not found!.")
+            logger.error("Master default device svg not found!.")
+            raise FileNotFoundError("Master default device svg not found!.")
 
         # --- Ensure User's File is a Copy of Master on First Run ---
         default_user_file = Path(self.DEVICE_REPO_DIR) / MASTER_SVG_FILE.name
-        logger.debug(f"Checking for user's default file: {default_user_file}")
+        logger.debug(f"Checking for user's default device svg file: {default_user_file}")
 
         should_overwrite = True
 
@@ -170,16 +170,16 @@ class DeviceViewerPreferences(PreferencesHelper):
             # If the user's file exists, check if it's different from master
 
             if filecmp.cmp(MASTER_SVG_FILE, default_user_file, shallow=False):
-                logger.info("User's file already exists and matches master.")
+                logger.info("User's default device svg file already exists and matches master.")
                 should_overwrite = False
 
             else:
                 logger.info(
-                    "User's default svg file exists but is different from master. Overwriting..."
+                    "User's default device svg file exists but is different from master. Overwriting..."
                 )
 
         else:
-            logger.info("User's default svg file not found, creating it from master...")
+            logger.info("User's default device svg file not found, creating it from master...")
 
         if should_overwrite:
             default_user_file = safe_copy_file(

--- a/device_viewer/views/camera_control_view/preferences.py
+++ b/device_viewer/views/camera_control_view/preferences.py
@@ -116,7 +116,7 @@ class CameraPreferences(PreferencesHelper):
     def _refresh_qt_supported_video_codecs(self, event=None):
         codec_names = supported_qt_video_codec_names(self.qt_video_format)
         self.qt_supported_video_codecs_ = codec_names
-        logger.info(f"Video codecs supported for {self.qt_video_format}: "
+        logger.debug(f"Video codecs supported for {self.qt_video_format}: "
                     f"{codec_names}")
         if codec_names and self.qt_video_codec not in codec_names:
             if "H264" in codec_names:

--- a/docs/superpowers/specs/2026-08-12-touch-assist-design.md
+++ b/docs/superpowers/specs/2026-08-12-touch-assist-design.md
@@ -1,0 +1,100 @@
+# Touch Assist: virtual mouse, numpad, keyboard (design)
+
+Date: 2026-08-12
+Branch: `feat/touchscreen-input-assist`
+
+## Problem
+
+On a touchscreen bench setup there is no mouse or keyboard: nothing
+to scroll with, right-click with, or type numbers and names into.
+Microdrop's panes assume all three.
+
+## Decision
+
+Three independent floating tools, each summoned from a **Tools →
+Touch Assist** submenu of checkbox actions — Virtual Numpad, Virtual
+Keyboard, Virtual Mouse. No mode switch, no focus detection, no
+per-widget wiring: the user decides what is on screen. Checked
+states persist in `MicrodropPreferences`, so the tools come back as
+they were left.
+
+All three live in a new `microdrop_application/touch_assist/`
+subpackage (application chrome, like the canvas background — not a
+hardware plugin): `virtual_mouse.py`, `input_pads.py`,
+`manager.py`. Widgets are styled with `microdrop_style` helpers.
+
+## Components
+
+### Menu and manager
+
+- Three pyface toggle `Action`s (the `AdvancedModeAction` pattern)
+  in a "Touch Assist" menu group under Tools, each flipping one Bool
+  on `MicrodropPreferences`: `touch_virtual_numpad`,
+  `touch_virtual_keyboard`, `touch_virtual_mouse` (all False by
+  default).
+- `TouchAssistManager` (singleton owned by the application task):
+  observes the three preferences, creates each widget lazily on
+  first show, shows/hides on toggle, and tears all three down on
+  application exit. No dramatiq/Redis involvement — purely
+  frontend-local.
+
+### Key delivery (numpad + keyboard)
+
+Both pads deliver input as synthesized `QKeyEvent`s
+(press + release) posted to `QApplication.focusWidget()` — the
+widget the user last tapped. This works unmodified with TraitsUI
+editors, plugin panes, and dialogs. Guards: no focus widget → the
+tap does nothing; the pads themselves are
+`Qt.WindowDoesNotAcceptFocus` tool windows, so tapping keys never
+steals the caret from the target field.
+
+Both are frameless, always-on-top, movable by a drag-handle strip,
+and closable from their corner (which unchecks the menu item).
+
+### Virtual Numpad (`input_pads.py`)
+
+Digits 0-9, minus sign, decimal point, Backspace, Up/Down arrows
+(spinbox stepping), Enter, and a close button. Large touch-target
+buttons.
+
+### Virtual Keyboard (`input_pads.py`)
+
+Compact QWERTY: letter rows, digit row, Shift (latching, one shot),
+Space, Backspace, Enter, close button. Shift shifts letters and
+sends the shifted key text; no symbols layer in v1 beyond what
+Shift+digit provides.
+
+### Virtual Mouse (`virtual_mouse.py`)
+
+A frameless, always-on-top widget painted as a mouse — left and
+right button zones with a wheel strip between them — plus a visible
+**pointer tip (crosshair) fixed above the body**. Dragging the body
+moves the whole widget, so the pointer aims precisely while the
+finger stays below the target (the classic assistive offset).
+
+- Left/right button tap → synthesized `QMouseEvent` press+release
+  at the pointer tip: target found with `QApplication.widgetAt()`,
+  coordinates mapped to it, events sent with the matching button.
+  Two quick left taps read as a double-click through Qt's normal
+  timing. Right-click opens context menus.
+- Wheel strip vertical drag → `QWheelEvent`s at the pointer tip,
+  angle delta proportional to finger travel, so whatever is under
+  the pointer scrolls as with a real wheel.
+- Scope is the Microdrop application only (Qt event synthesis, not
+  an OS-level mouse). Press-and-hold / drag latching is explicitly
+  out of v1.
+- Guards: no widget under the tip → the tap does nothing; targets
+  re-resolved per event so a widget destroyed mid-gesture cannot be
+  dereferenced.
+
+## Error handling
+
+Every synthesized event re-checks its target for `None` first. The
+manager tolerates a missing main window (headless tests) by simply
+not showing widgets.
+
+## Testing
+
+User verifies through the GUI (per their call — this is UI work).
+The widgets are self-contained and take injected targets, so unit
+tests can come later if wanted.

--- a/docs/superpowers/specs/2026-08-12-touch-assist-design.md
+++ b/docs/superpowers/specs/2026-08-12-touch-assist-design.md
@@ -59,10 +59,12 @@ buttons.
 
 ### Virtual Keyboard (`input_pads.py`)
 
-Compact QWERTY: letter rows, digit row, Shift (latching, one shot),
-Space, Backspace, Enter, close button. Shift shifts letters and
-sends the shifted key text; no symbols layer in v1 beyond what
-Shift+digit provides.
+Compact QWERTY: letter rows, digit row, Space, Backspace, Enter,
+close button, and three one-shot latching modifiers — Shift, Ctrl,
+Alt. Each arms the NEXT key and then releases: Shift uppercases
+letters and turns the digit row into its symbols; Ctrl/Alt send a
+shortcut chord (Ctrl+A, Ctrl+C…) with no typed text. No further
+symbols layer in v1.
 
 ### Virtual Mouse (`virtual_mouse.py`)
 
@@ -81,8 +83,13 @@ finger stays below the target (the classic assistive offset).
   angle delta proportional to finger travel, so whatever is under
   the pointer scrolls as with a real wheel.
 - Scope is the Microdrop application only (Qt event synthesis, not
-  an OS-level mouse). Press-and-hold / drag latching is explicitly
-  out of v1.
+  an OS-level mouse).
+- A **Hold pill** on the body latches a left press at the tip:
+  while lit, dragging the body streams MouseMove events (left
+  button down) to the held widget — sliders, ROI drags and text
+  selection in slow motion. Tapping Hold again, or the L zone,
+  releases at the current tip position; closing the widget releases
+  first.
 - Guards: no widget under the tip → the tap does nothing; targets
   re-resolved per event so a widget destroyed mid-gesture cannot be
   dereferenced.

--- a/microdrop_application/task.py
+++ b/microdrop_application/task.py
@@ -26,6 +26,7 @@ from logger.logger_service import get_logger
 from .dialogs.pyface_wrapper import information, confirm, YES
 from .menus import AdvancedModeAction
 from .preferences import MicrodropPreferences
+from .touch_assist.actions import touch_assist_menu
 
 logger = get_logger(__name__)
 
@@ -80,7 +81,7 @@ class MicrodropTask(Task):
 
         SMenu(AdvancedModeAction(), id="Edit", name="&Edit"),
 
-        SMenu(id="Tools", name="&Tools"),
+        SMenu(touch_assist_menu(), id="Tools", name="&Tools"),
 
         SMenu(TaskToggleGroup(), id="View", name="&View"),
 

--- a/microdrop_application/touch_assist/actions.py
+++ b/microdrop_application/touch_assist/actions.py
@@ -1,0 +1,38 @@
+"""The Tools -> Touch Assist menu: three independent checkbox
+actions, one per floating tool. No mode switch and no detection —
+the user decides what is on screen."""
+from pyface.action.api import Action
+from pyface.tasks.action.api import SMenu
+from traits.api import Str
+
+from .consts import PKG, TOOL_KEYBOARD, TOOL_MOUSE, TOOL_NUMPAD
+from .manager import touch_assist_manager
+
+
+class TouchAssistAction(Action):
+    """One checkbox: show/hide one Touch Assist tool."""
+
+    style = "toggle"
+
+    #: Which tool this checkbox drives (consts.TOOL_*).
+    tool = Str()
+
+    def perform(self, event):
+        # Registered here rather than at construction so the manager
+        # only ever holds actions that reached a live menu.
+        touch_assist_manager.register_action(self.tool, self)
+        touch_assist_manager.set_visible(self.tool, self.checked)
+
+
+def touch_assist_menu():
+    """The Touch Assist submenu, built fresh per menu bar (pyface
+    actions bind to the window that renders them)."""
+    return SMenu(
+        TouchAssistAction(id=f"{PKG}.virtual_numpad",
+                          name="Virtual &Numpad", tool=TOOL_NUMPAD),
+        TouchAssistAction(id=f"{PKG}.virtual_keyboard",
+                          name="Virtual &Keyboard", tool=TOOL_KEYBOARD),
+        TouchAssistAction(id=f"{PKG}.virtual_mouse",
+                          name="Virtual &Mouse", tool=TOOL_MOUSE),
+        id="TouchAssist", name="Touch &Assist",
+    )

--- a/microdrop_application/touch_assist/consts.py
+++ b/microdrop_application/touch_assist/consts.py
@@ -1,0 +1,31 @@
+"""Constants for the Touch Assist tools (virtual numpad, keyboard,
+mouse — floating helpers for touchscreen benches with no physical
+mouse or keyboard)."""
+
+PKG = '.'.join(__name__.split('.')[:-1])
+
+#: The three tools, as the manager and the menu actions name them.
+TOOL_NUMPAD = "numpad"
+TOOL_KEYBOARD = "keyboard"
+TOOL_MOUSE = "mouse"
+
+#: Pad buttons are finger targets, not mouse targets.
+PAD_KEY_SIZE_PX = 44
+PAD_KEY_SPACING_PX = 4
+
+#: The virtual mouse's proportions: the body, the wheel strip inside
+#: it, and the gap between the body and the crosshair pointer tip
+#: floating above (the offset that keeps the finger off the target).
+MOUSE_BODY_WIDTH_PX = 110
+MOUSE_BODY_HEIGHT_PX = 150
+MOUSE_WHEEL_WIDTH_PX = 26
+MOUSE_TIP_GAP_PX = 14
+MOUSE_TIP_SIZE_PX = 25
+
+#: A press that travels less than this (px) is a tap (a click); more
+#: is a drag that moves the mouse widget.
+MOUSE_TAP_SLOP_PX = 8
+
+#: Wheel-strip travel to wheel-notch conversion: one notch (120
+#: angle-delta units) per this many pixels of finger travel.
+MOUSE_WHEEL_PX_PER_NOTCH = 12

--- a/microdrop_application/touch_assist/consts.py
+++ b/microdrop_application/touch_assist/consts.py
@@ -13,6 +13,12 @@ TOOL_MOUSE = "mouse"
 PAD_KEY_SIZE_PX = 44
 PAD_KEY_SPACING_PX = 4
 
+#: Held-key auto-repeat (the numpad's ▲/▼): how long a hold waits
+#: before repeating, then the repeat cadence — a spinbox climbs
+#: steadily without racing away.
+PAD_KEY_REPEAT_DELAY_MS = 400
+PAD_KEY_REPEAT_INTERVAL_MS = 80
+
 #: The virtual mouse's proportions: the body, the wheel strip inside
 #: it, and the gap between the body and the crosshair pointer tip
 #: floating above (the offset that keeps the finger off the target).

--- a/microdrop_application/touch_assist/input_pads.py
+++ b/microdrop_application/touch_assist/input_pads.py
@@ -11,9 +11,12 @@ from PySide6.QtWidgets import (
     QVBoxLayout, QWidget,
 )
 
-from microdrop_style.colors import GREY, PRIMARY_COLOR, WHITE
+from microdrop_style.colors import BLACK, GREY, PRIMARY_COLOR, WHITE
 
-from .consts import PAD_KEY_SIZE_PX, PAD_KEY_SPACING_PX
+from .consts import (
+    PAD_KEY_REPEAT_DELAY_MS, PAD_KEY_REPEAT_INTERVAL_MS,
+    PAD_KEY_SIZE_PX, PAD_KEY_SPACING_PX,
+)
 
 #: (label, Qt key, text) rows of the numpad. Text is what lands in
 #: the field; the key code is what spinboxes and shortcuts read.
@@ -31,6 +34,9 @@ _NUMPAD_ROWS = (
 #: Keyboard letter rows; digits get their own row above.
 _KEYBOARD_LETTER_ROWS = ("qwertyuiop", "asdfghjkl", "zxcvbnm")
 
+#: What the digit row types while Shift is latched.
+_SHIFTED_DIGITS = str.maketrans("1234567890", "!@#$%^&*()")
+
 _PAD_STYLE = f"""
     QWidget#touch_pad {{
         background: {GREY["dark"]};
@@ -40,6 +46,7 @@ _PAD_STYLE = f"""
     QLabel {{ color: {WHITE}; font-weight: bold; }}
     QPushButton {{
         background: {WHITE};
+        color: {BLACK};
         border: 1px solid #999;
         border-radius: 4px;
         font-size: 15px;
@@ -113,11 +120,16 @@ class FloatingPad(QWidget):
 
     # -- key delivery ------------------------------------------------
     def add_key(self, label, key, text, row, column, *, width=1,
-                modifiers=Qt.KeyboardModifier.NoModifier, span_px=None):
+                modifiers=Qt.KeyboardModifier.NoModifier, span_px=None,
+                repeat=False):
         button = QPushButton(label)
         button.setFocusPolicy(Qt.NoFocus)
         button.setFixedHeight(PAD_KEY_SIZE_PX)
         button.setMinimumWidth(span_px or PAD_KEY_SIZE_PX)
+        if repeat:                  # a held key keeps firing
+            button.setAutoRepeat(True)
+            button.setAutoRepeatDelay(PAD_KEY_REPEAT_DELAY_MS)
+            button.setAutoRepeatInterval(PAD_KEY_REPEAT_INTERVAL_MS)
         button.clicked.connect(
             lambda *_: self.send_key(key, text, modifiers))
         self.body.addWidget(button, row, column, 1, width)
@@ -144,51 +156,75 @@ class VirtualNumpad(FloatingPad):
         super().__init__("Numpad")
         for row, keys in enumerate(_NUMPAD_ROWS):
             for column, (label, key, text) in enumerate(keys):
-                self.add_key(label, key, text, row, column)
+                self.add_key(label, key, text, row, column,
+                             repeat=key in (Qt.Key_Up, Qt.Key_Down))
 
 
 class VirtualKeyboard(FloatingPad):
-    """Compact QWERTY with a digit row and a one-shot Shift. Shift
-    uppercases the NEXT letter (and ships the Shift modifier), then
-    releases — the usual touch-keyboard behaviour."""
+    """Compact QWERTY with a digit row and one-shot latching
+    modifiers: Shift, Ctrl and Alt each arm the NEXT key (uppercase
+    or symbol for Shift, a shortcut chord like Ctrl+A for the
+    others), then release — the usual touch-keyboard behaviour."""
 
     def __init__(self):
         super().__init__("Keyboard")
         self._letter_buttons = []
-        self._shift = None
+        self._modifier_buttons = {}
         for column, digit in enumerate("1234567890"):
             self.add_key(digit, getattr(Qt, f"Key_{digit}"), digit,
                          0, column)
         for row, letters in enumerate(_KEYBOARD_LETTER_ROWS, start=1):
             offset = row - 1        # stagger like a real keyboard
             for column, letter in enumerate(letters):
-                button = self.add_key(
+                self._letter_buttons.append(self.add_key(
                     letter, getattr(Qt, f"Key_{letter.upper()}"),
-                    letter, row, column + offset)
-                button.clicked.disconnect()
-                button.clicked.connect(
-                    lambda *_, l=letter: self._send_letter(l))
-                self._letter_buttons.append(button)
-        self._shift = self.add_key("⇧", Qt.Key_Shift, "", 3, 9)
-        self._shift.setCheckable(True)
-        self._shift.clicked.disconnect()
-        self._shift.clicked.connect(self._update_letter_case)
+                    letter, row, column + offset))
+        self._shift = self._add_modifier(
+            "⇧", Qt.KeyboardModifier.ShiftModifier, 3, 9)
         self.add_key("⌫", Qt.Key_Backspace, "", 1, 10)
         self.add_key("⏎", Qt.Key_Return, "\r", 2, 10)
+        self._add_modifier("ctrl", Qt.KeyboardModifier.ControlModifier,
+                           4, 0)
+        self._add_modifier("alt", Qt.KeyboardModifier.AltModifier,
+                           4, 1)
         self.add_key("space", Qt.Key_Space, " ", 4, 2, width=5)
         self.add_key(".", Qt.Key_Period, ".", 4, 7)
         self.add_key("_", Qt.Key_Underscore, "_", 4, 8,
                      modifiers=Qt.KeyboardModifier.ShiftModifier)
 
-    def _send_letter(self, letter):
-        shifted = self._shift.isChecked()
-        self.send_key(
-            getattr(Qt, f"Key_{letter.upper()}"),
-            letter.upper() if shifted else letter,
-            Qt.KeyboardModifier.ShiftModifier if shifted
-            else Qt.KeyboardModifier.NoModifier)
-        if shifted:                 # one-shot, like a touch keyboard
-            self._shift.setChecked(False)
+    def _add_modifier(self, label, flag, row, column):
+        """A latching key: checked arms the flag for the next real
+        key, which consumes it (see send_key)."""
+        button = self.add_key(label, Qt.Key_unknown, "", row, column)
+        button.clicked.disconnect()
+        button.setCheckable(True)
+        button.clicked.connect(self._update_letter_case)
+        self._modifier_buttons[flag] = button
+        return button
+
+    def _latched_modifiers(self):
+        latched = Qt.KeyboardModifier.NoModifier
+        for flag, button in self._modifier_buttons.items():
+            if button.isChecked():
+                latched |= flag
+        return latched
+
+    def send_key(self, key, text, modifiers=None):
+        """Every key passes through here: latched modifiers join the
+        chord, shape the text (uppercase/symbols for Shift, none for
+        a Ctrl/Alt shortcut), and release afterwards."""
+        latched = self._latched_modifiers()
+        combined = ((modifiers if modifiers is not None
+                     else Qt.KeyboardModifier.NoModifier) | latched)
+        if combined & (Qt.KeyboardModifier.ControlModifier
+                       | Qt.KeyboardModifier.AltModifier):
+            text = ""               # a chord types nothing
+        elif latched & Qt.KeyboardModifier.ShiftModifier and text:
+            text = text.upper().translate(_SHIFTED_DIGITS)
+        super().send_key(key, text, combined)
+        if latched:                 # one-shot, like a touch keyboard
+            for button in self._modifier_buttons.values():
+                button.setChecked(False)
             self._update_letter_case()
 
     def _update_letter_case(self, *_):

--- a/microdrop_application/touch_assist/input_pads.py
+++ b/microdrop_application/touch_assist/input_pads.py
@@ -1,0 +1,198 @@
+"""The virtual numpad and keyboard: frameless, always-on-top pads
+whose keys are posted to whatever widget currently has focus — the
+field the user last tapped. The pads never take focus themselves
+(``WindowDoesNotAcceptFocus``), so tapping a key cannot steal the
+caret from its target. No per-widget wiring: synthesized QKeyEvents
+work with TraitsUI editors, plugin panes and dialogs alike."""
+from PySide6.QtCore import QCoreApplication, QEvent, Qt
+from PySide6.QtGui import QKeyEvent
+from PySide6.QtWidgets import (
+    QApplication, QGridLayout, QHBoxLayout, QLabel, QPushButton,
+    QVBoxLayout, QWidget,
+)
+
+from microdrop_style.colors import GREY, PRIMARY_COLOR, WHITE
+
+from .consts import PAD_KEY_SIZE_PX, PAD_KEY_SPACING_PX
+
+#: (label, Qt key, text) rows of the numpad. Text is what lands in
+#: the field; the key code is what spinboxes and shortcuts read.
+_NUMPAD_ROWS = (
+    (("7", Qt.Key_7, "7"), ("8", Qt.Key_8, "8"), ("9", Qt.Key_9, "9"),
+     ("⌫", Qt.Key_Backspace, "")),
+    (("4", Qt.Key_4, "4"), ("5", Qt.Key_5, "5"), ("6", Qt.Key_6, "6"),
+     ("▲", Qt.Key_Up, "")),
+    (("1", Qt.Key_1, "1"), ("2", Qt.Key_2, "2"), ("3", Qt.Key_3, "3"),
+     ("▼", Qt.Key_Down, "")),
+    (("-", Qt.Key_Minus, "-"), ("0", Qt.Key_0, "0"),
+     (".", Qt.Key_Period, "."), ("⏎", Qt.Key_Return, "\r")),
+)
+
+#: Keyboard letter rows; digits get their own row above.
+_KEYBOARD_LETTER_ROWS = ("qwertyuiop", "asdfghjkl", "zxcvbnm")
+
+_PAD_STYLE = f"""
+    QWidget#touch_pad {{
+        background: {GREY["dark"]};
+        border: 1px solid {PRIMARY_COLOR};
+        border-radius: 6px;
+    }}
+    QLabel {{ color: {WHITE}; font-weight: bold; }}
+    QPushButton {{
+        background: {WHITE};
+        border: 1px solid #999;
+        border-radius: 4px;
+        font-size: 15px;
+    }}
+    QPushButton:pressed, QPushButton:checked {{
+        background: {PRIMARY_COLOR};
+        color: {WHITE};
+    }}
+"""
+
+
+class FloatingPad(QWidget):
+    """A frameless, always-on-top, finger-draggable pad with a title
+    strip and close button. Subclasses fill ``self.body``."""
+
+    #: Set by the manager: called when the user closes the pad from
+    #: its own ✕, so the menu checkbox can follow.
+    closed_by_user = None
+
+    def __init__(self, title):
+        super().__init__(None, Qt.Tool | Qt.FramelessWindowHint
+                         | Qt.WindowStaysOnTopHint
+                         | Qt.WindowDoesNotAcceptFocus)
+        self.setAttribute(Qt.WA_ShowWithoutActivating)
+        self.setObjectName("touch_pad")
+        self.setStyleSheet(_PAD_STYLE)
+        self._drag_offset = None
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(6, 4, 6, 6)
+        handle = QHBoxLayout()
+        handle.addWidget(QLabel(title))
+        handle.addStretch(1)
+        close = QPushButton("✕")
+        close.setFixedSize(28, 28)
+        close.setFocusPolicy(Qt.NoFocus)
+        close.clicked.connect(self._close_from_button)
+        handle.addWidget(close)
+        outer.addLayout(handle)
+        self.body = QGridLayout()
+        self.body.setSpacing(PAD_KEY_SPACING_PX)
+        outer.addLayout(self.body)
+
+    def _close_from_button(self):
+        self.hide()
+        if self.closed_by_user is not None:
+            self.closed_by_user()
+
+    # -- finger drag anywhere on the pad's chrome moves it ----------
+    def mousePressEvent(self, event):
+        self._drag_offset = (event.globalPosition().toPoint()
+                             - self.frameGeometry().topLeft())
+
+    def mouseMoveEvent(self, event):
+        if self._drag_offset is not None:
+            self.move(event.globalPosition().toPoint()
+                      - self._drag_offset)
+
+    def mouseReleaseEvent(self, event):
+        self._drag_offset = None
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if not event.spontaneous() and self._drag_offset is None \
+                and not self.property("placed"):
+            # First show: bottom-right of the screen, out of the way.
+            self.setProperty("placed", True)
+            area = self.screen().availableGeometry()
+            self.adjustSize()
+            self.move(area.right() - self.width() - 40,
+                      area.bottom() - self.height() - 60)
+
+    # -- key delivery ------------------------------------------------
+    def add_key(self, label, key, text, row, column, *, width=1,
+                modifiers=Qt.KeyboardModifier.NoModifier, span_px=None):
+        button = QPushButton(label)
+        button.setFocusPolicy(Qt.NoFocus)
+        button.setFixedHeight(PAD_KEY_SIZE_PX)
+        button.setMinimumWidth(span_px or PAD_KEY_SIZE_PX)
+        button.clicked.connect(
+            lambda *_: self.send_key(key, text, modifiers))
+        self.body.addWidget(button, row, column, 1, width)
+        return button
+
+    def send_key(self, key, text, modifiers=None):
+        """Post press+release to the focused widget; no focus, no-op."""
+        target = QApplication.focusWidget()
+        if target is None:
+            return
+        if modifiers is None:
+            modifiers = Qt.KeyboardModifier.NoModifier
+        QCoreApplication.postEvent(target, QKeyEvent(
+            QEvent.Type.KeyPress, key, modifiers, text))
+        QCoreApplication.postEvent(target, QKeyEvent(
+            QEvent.Type.KeyRelease, key, modifiers, text))
+
+
+class VirtualNumpad(FloatingPad):
+    """Digits, sign, decimal point, Backspace, spinbox stepping
+    (▲/▼) and Enter."""
+
+    def __init__(self):
+        super().__init__("Numpad")
+        for row, keys in enumerate(_NUMPAD_ROWS):
+            for column, (label, key, text) in enumerate(keys):
+                self.add_key(label, key, text, row, column)
+
+
+class VirtualKeyboard(FloatingPad):
+    """Compact QWERTY with a digit row and a one-shot Shift. Shift
+    uppercases the NEXT letter (and ships the Shift modifier), then
+    releases — the usual touch-keyboard behaviour."""
+
+    def __init__(self):
+        super().__init__("Keyboard")
+        self._letter_buttons = []
+        self._shift = None
+        for column, digit in enumerate("1234567890"):
+            self.add_key(digit, getattr(Qt, f"Key_{digit}"), digit,
+                         0, column)
+        for row, letters in enumerate(_KEYBOARD_LETTER_ROWS, start=1):
+            offset = row - 1        # stagger like a real keyboard
+            for column, letter in enumerate(letters):
+                button = self.add_key(
+                    letter, getattr(Qt, f"Key_{letter.upper()}"),
+                    letter, row, column + offset)
+                button.clicked.disconnect()
+                button.clicked.connect(
+                    lambda *_, l=letter: self._send_letter(l))
+                self._letter_buttons.append(button)
+        self._shift = self.add_key("⇧", Qt.Key_Shift, "", 3, 9)
+        self._shift.setCheckable(True)
+        self._shift.clicked.disconnect()
+        self._shift.clicked.connect(self._update_letter_case)
+        self.add_key("⌫", Qt.Key_Backspace, "", 1, 10)
+        self.add_key("⏎", Qt.Key_Return, "\r", 2, 10)
+        self.add_key("space", Qt.Key_Space, " ", 4, 2, width=5)
+        self.add_key(".", Qt.Key_Period, ".", 4, 7)
+        self.add_key("_", Qt.Key_Underscore, "_", 4, 8,
+                     modifiers=Qt.KeyboardModifier.ShiftModifier)
+
+    def _send_letter(self, letter):
+        shifted = self._shift.isChecked()
+        self.send_key(
+            getattr(Qt, f"Key_{letter.upper()}"),
+            letter.upper() if shifted else letter,
+            Qt.KeyboardModifier.ShiftModifier if shifted
+            else Qt.KeyboardModifier.NoModifier)
+        if shifted:                 # one-shot, like a touch keyboard
+            self._shift.setChecked(False)
+            self._update_letter_case()
+
+    def _update_letter_case(self, *_):
+        shifted = self._shift.isChecked()
+        for button in self._letter_buttons:
+            text = button.text()
+            button.setText(text.upper() if shifted else text.lower())

--- a/microdrop_application/touch_assist/manager.py
+++ b/microdrop_application/touch_assist/manager.py
@@ -1,0 +1,66 @@
+"""Owner of the Touch Assist floating widgets: creates each lazily on
+first show, shows/hides on menu toggles, and pushes a widget's own
+close button back into the menu checkbox so the two never disagree.
+GUI-thread only; no Redis or dramatiq involvement."""
+from traits.api import Dict, HasTraits, Str
+
+from logger.logger_service import get_logger
+
+from .consts import TOOL_KEYBOARD, TOOL_MOUSE, TOOL_NUMPAD
+
+logger = get_logger(__name__)
+
+
+class TouchAssistManager(HasTraits):
+
+    #: tool name -> the created widget (absent until first shown).
+    _widgets = Dict(Str)
+
+    #: tool name -> the menu action, registered by the action itself
+    #: on its first toggle, so a widget closed from its own ✕ can
+    #: uncheck the menu.
+    _actions = Dict(Str)
+
+    def register_action(self, tool, action):
+        self._actions[tool] = action
+
+    def set_visible(self, tool, visible):
+        widget = self._widgets.get(tool)
+        if widget is None:
+            if not visible:
+                return
+            widget = self._create(tool)
+            if widget is None:
+                return
+            self._widgets[tool] = widget
+        widget.setVisible(visible)
+        if visible:
+            widget.raise_()
+        logger.info(f"Touch Assist {tool}: "
+                    f"{'shown' if visible else 'hidden'}")
+
+    def widget_closed(self, tool):
+        """The widget's own close button: mirror it into the menu."""
+        action = self._actions.get(tool)
+        if action is not None:
+            action.checked = False
+
+    def _create(self, tool):
+        # Imported here so headless code paths (backend, tests) never
+        # pay for Qt widget imports they will not show.
+        from .input_pads import VirtualKeyboard, VirtualNumpad
+        from .virtual_mouse import VirtualMouse
+        factories = {TOOL_NUMPAD: VirtualNumpad,
+                     TOOL_KEYBOARD: VirtualKeyboard,
+                     TOOL_MOUSE: VirtualMouse}
+        factory = factories.get(tool)
+        if factory is None:
+            logger.warning(f"Unknown Touch Assist tool: {tool}")
+            return None
+        widget = factory()
+        widget.closed_by_user = lambda: self.widget_closed(tool)
+        return widget
+
+
+#: The one manager the menu actions talk to.
+touch_assist_manager = TouchAssistManager()

--- a/microdrop_application/touch_assist/virtual_mouse.py
+++ b/microdrop_application/touch_assist/virtual_mouse.py
@@ -80,6 +80,10 @@ class VirtualMouse(QWidget):
         self._wheel_sent = 0        # notches already sent this drag
         self._wheel_target = None   # resolved once per wheel gesture
         self._last_click = (0.0, None)  # (time, zone) for dbl-click
+        #: Widget holding a latched left press (the Hold pill), or
+        #: None. While set, dragging the body streams MouseMove
+        #: events to it — a click-drag in slow motion.
+        self._held_target = None
 
     # -- lifecycle ----------------------------------------------------
     def setVisible(self, visible):
@@ -105,6 +109,7 @@ class VirtualMouse(QWidget):
     def moveEvent(self, event):
         super().moveEvent(event)
         self._place_tip()
+        self._stream_held_move()
 
     def _place_tip(self):
         self._tip.move(
@@ -113,10 +118,12 @@ class VirtualMouse(QWidget):
 
     # -- zones ---------------------------------------------------------
     def _zone_at(self, pos):
-        """'left' / 'right' / 'wheel' / 'close' / 'body' for a point
-        in widget coordinates."""
+        """'left' / 'right' / 'wheel' / 'hold' / 'close' / 'body' for
+        a point in widget coordinates."""
         if self._close_rect().contains(pos):
             return "close"
+        if self._hold_rect().contains(pos):
+            return "hold"
         button_zone = self.height() * _BUTTON_ZONE_FRACTION
         wheel_left = (self.width() - MOUSE_WHEEL_WIDTH_PX) // 2
         if pos.y() <= button_zone:
@@ -127,6 +134,9 @@ class VirtualMouse(QWidget):
 
     def _close_rect(self):
         return QRect(self.width() - 22, self.height() - 22, 18, 18)
+
+    def _hold_rect(self):
+        return QRect(4, self.height() - 24, 44, 20)
 
     # -- interaction ----------------------------------------------------
     def mousePressEvent(self, event):
@@ -160,10 +170,18 @@ class VirtualMouse(QWidget):
         if travelled > MOUSE_TAP_SLOP_PX:
             return                  # it was a drag, not a tap
         if zone == "close":
+            self._release_hold()
             self.hide()
             self._tip.hide()
             if self.closed_by_user is not None:
                 self.closed_by_user()
+            return
+        if zone == "hold":
+            self._toggle_hold()
+            return
+        if zone == "left" and self._held_target is not None:
+            # A left tap while holding IS the release click.
+            self._release_hold()
             return
         self._send_click(Qt.MouseButton.LeftButton if zone == "left"
                          else Qt.MouseButton.RightButton, zone)
@@ -245,6 +263,52 @@ class VirtualMouse(QWidget):
                                 local_pos.toPoint(),
                                 self._tip.hotspot()))
 
+    # -- the Hold latch -----------------------------------------------
+    def _toggle_hold(self):
+        if self._held_target is not None:
+            self._release_hold()
+            return
+        resolved = self._target()
+        if resolved is None:
+            return
+        target, local, global_pos = resolved
+        QApplication.sendEvent(target, QMouseEvent(
+            QEvent.Type.MouseButtonPress, local, local, global_pos,
+            Qt.MouseButton.LeftButton, Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier))
+        self._held_target = target
+        self.update()
+
+    def _release_hold(self):
+        target, self._held_target = self._held_target, None
+        self.update()
+        if target is None or not shiboken6.isValid(target):
+            return
+        global_pos = QPointF(self._tip.hotspot())
+        local = QPointF(target.mapFromGlobal(self._tip.hotspot()))
+        QApplication.sendEvent(target, QMouseEvent(
+            QEvent.Type.MouseButtonRelease, local, local, global_pos,
+            Qt.MouseButton.LeftButton, Qt.MouseButton.NoButton,
+            Qt.KeyboardModifier.NoModifier))
+
+    def _stream_held_move(self):
+        """While holding, aiming IS dragging: every body move sends a
+        MouseMove (left button down) to the held widget, mapped to
+        the tip — outside its bounds too, exactly as a real grab
+        delivers them."""
+        target = self._held_target
+        if target is None:
+            return
+        if not shiboken6.isValid(target):
+            self._held_target = None
+            return
+        global_pos = QPointF(self._tip.hotspot())
+        local = QPointF(target.mapFromGlobal(self._tip.hotspot()))
+        QApplication.sendEvent(target, QMouseEvent(
+            QEvent.Type.MouseMove, local, local, global_pos,
+            Qt.MouseButton.NoButton, Qt.MouseButton.LeftButton,
+            Qt.KeyboardModifier.NoModifier))
+
     def _send_wheel(self, notches):
         # Resolved once per gesture (the tip is not moving while the
         # strip is dragged) so the hide-probe fallback cannot flicker
@@ -295,6 +359,14 @@ class VirtualMouse(QWidget):
         painter.drawText(left_zone, Qt.AlignCenter, "L")
         painter.drawText(right_zone, Qt.AlignCenter, "R")
         painter.drawText(self._close_rect(), Qt.AlignCenter, "✕")
+        # The Hold pill: lit while a left press is latched.
+        held = self._held_target is not None
+        painter.setBrush(QColor(PRIMARY_COLOR) if held
+                         else QColor(GREY["lighter"]))
+        painter.setPen(QPen(QColor(GREY["dark"]), 1))
+        painter.drawRoundedRect(self._hold_rect(), 8, 8)
+        painter.setPen(QPen(QColor(WHITE if held else GREY["dark"])))
+        painter.drawText(self._hold_rect(), Qt.AlignCenter, "hold")
         painter.setPen(QPen(QColor(WHITE)))
         painter.drawText(
             QRect(body.left(), split_y, body.width(),

--- a/microdrop_application/touch_assist/virtual_mouse.py
+++ b/microdrop_application/touch_assist/virtual_mouse.py
@@ -1,0 +1,302 @@
+"""The virtual mouse: a floating, mouse-shaped widget with a
+crosshair pointer tip hovering above it. Dragging the body aims the
+tip precisely while the finger stays below the target — the classic
+assistive offset. Tapping the left/right button zones synthesizes
+real clicks at the tip; dragging the wheel strip synthesizes wheel
+events there. Qt-event synthesis only, so it works on every widget
+inside the application (and only there)."""
+import time
+
+import shiboken6
+from PySide6.QtCore import QPoint, QPointF, QEvent, QRect, Qt
+from PySide6.QtGui import (
+    QColor, QContextMenuEvent, QMouseEvent, QPainter, QPen, QWheelEvent,
+)
+from PySide6.QtWidgets import QApplication, QWidget
+
+from microdrop_style.colors import GREY, PRIMARY_COLOR, WHITE
+
+from .consts import (
+    MOUSE_BODY_HEIGHT_PX, MOUSE_BODY_WIDTH_PX, MOUSE_TAP_SLOP_PX,
+    MOUSE_TIP_GAP_PX, MOUSE_TIP_SIZE_PX, MOUSE_WHEEL_PX_PER_NOTCH,
+    MOUSE_WHEEL_WIDTH_PX,
+)
+
+#: One wheel notch in QWheelEvent angle-delta units.
+_WHEEL_NOTCH = 120
+
+#: How far down the body the button zones reach (the split-line of a
+#: real mouse), as a fraction of the body height.
+_BUTTON_ZONE_FRACTION = 0.45
+
+
+class _PointerTip(QWidget):
+    """The crosshair the mouse aims with. Transparent to mouse
+    events, so QApplication.widgetAt() at its centre sees the widget
+    UNDER it, never the crosshair itself."""
+
+    def __init__(self):
+        super().__init__(None, Qt.Tool | Qt.FramelessWindowHint
+                         | Qt.WindowStaysOnTopHint
+                         | Qt.WindowDoesNotAcceptFocus)
+        self.setAttribute(Qt.WA_TransparentForMouseEvents)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setAttribute(Qt.WA_ShowWithoutActivating)
+        self.setFixedSize(MOUSE_TIP_SIZE_PX, MOUSE_TIP_SIZE_PX)
+
+    def hotspot(self):
+        """Where clicks land, in global coordinates."""
+        return self.geometry().center()
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        pen = QPen(QColor(PRIMARY_COLOR), 2)
+        painter.setPen(pen)
+        middle = self.rect().center()
+        painter.drawLine(middle.x(), 0, middle.x(), self.height())
+        painter.drawLine(0, middle.y(), self.width(), middle.y())
+        painter.drawEllipse(middle, 4, 4)
+
+
+class VirtualMouse(QWidget):
+    """The draggable mouse body; owns and positions the pointer tip."""
+
+    #: Set by the manager: called when the user closes the widget
+    #: from its own ✕, so the menu checkbox can follow.
+    closed_by_user = None
+
+    def __init__(self):
+        super().__init__(None, Qt.Tool | Qt.FramelessWindowHint
+                         | Qt.WindowStaysOnTopHint
+                         | Qt.WindowDoesNotAcceptFocus)
+        self.setAttribute(Qt.WA_TranslucentBackground)
+        self.setAttribute(Qt.WA_ShowWithoutActivating)
+        self.setFixedSize(MOUSE_BODY_WIDTH_PX, MOUSE_BODY_HEIGHT_PX)
+        self._tip = _PointerTip()
+        self._press_pos = None      # global, at press
+        self._press_zone = None
+        self._start_corner = None   # widget top-left at press
+        self._wheel_sent = 0        # notches already sent this drag
+        self._wheel_target = None   # resolved once per wheel gesture
+        self._last_click = (0.0, None)  # (time, zone) for dbl-click
+
+    # -- lifecycle ----------------------------------------------------
+    def setVisible(self, visible):
+        super().setVisible(visible)
+        self._tip.setVisible(visible)
+        if visible:
+            self._place_tip()
+            self._tip.raise_()
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        if not event.spontaneous() and not self.property("placed"):
+            self.setProperty("placed", True)
+            area = self.screen().availableGeometry()
+            self.move(area.center().x() - self.width() // 2,
+                      area.bottom() - self.height() - 80)
+            self._place_tip()
+
+    def closeEvent(self, event):
+        self._tip.hide()
+        super().closeEvent(event)
+
+    def moveEvent(self, event):
+        super().moveEvent(event)
+        self._place_tip()
+
+    def _place_tip(self):
+        self._tip.move(
+            self.x() + (self.width() - self._tip.width()) // 2,
+            self.y() - MOUSE_TIP_GAP_PX - self._tip.height())
+
+    # -- zones ---------------------------------------------------------
+    def _zone_at(self, pos):
+        """'left' / 'right' / 'wheel' / 'close' / 'body' for a point
+        in widget coordinates."""
+        if self._close_rect().contains(pos):
+            return "close"
+        button_zone = self.height() * _BUTTON_ZONE_FRACTION
+        wheel_left = (self.width() - MOUSE_WHEEL_WIDTH_PX) // 2
+        if pos.y() <= button_zone:
+            if wheel_left <= pos.x() <= wheel_left + MOUSE_WHEEL_WIDTH_PX:
+                return "wheel"
+            return "left" if pos.x() < wheel_left else "right"
+        return "body"
+
+    def _close_rect(self):
+        return QRect(self.width() - 22, self.height() - 22, 18, 18)
+
+    # -- interaction ----------------------------------------------------
+    def mousePressEvent(self, event):
+        self._press_pos = event.globalPosition().toPoint()
+        self._press_zone = self._zone_at(event.position().toPoint())
+        self._start_corner = self.frameGeometry().topLeft()
+        self._wheel_sent = 0
+        self._wheel_target = None
+
+    def mouseMoveEvent(self, event):
+        if self._press_pos is None:
+            return
+        delta = event.globalPosition().toPoint() - self._press_pos
+        if self._press_zone == "wheel":
+            notches = -delta.y() // MOUSE_WHEEL_PX_PER_NOTCH
+            if notches != self._wheel_sent:
+                self._send_wheel(notches - self._wheel_sent)
+                self._wheel_sent = notches
+            return
+        if (delta.manhattanLength() > MOUSE_TAP_SLOP_PX
+                or self._press_zone == "body"):
+            self.move(self._start_corner + delta)
+
+    def mouseReleaseEvent(self, event):
+        pressed, zone = self._press_pos, self._press_zone
+        self._press_pos = self._press_zone = None
+        if pressed is None or zone in ("wheel", "body"):
+            return
+        travelled = (event.globalPosition().toPoint()
+                     - pressed).manhattanLength()
+        if travelled > MOUSE_TAP_SLOP_PX:
+            return                  # it was a drag, not a tap
+        if zone == "close":
+            self.hide()
+            self._tip.hide()
+            if self.closed_by_user is not None:
+                self.closed_by_user()
+            return
+        self._send_click(Qt.MouseButton.LeftButton if zone == "left"
+                         else Qt.MouseButton.RightButton, zone)
+
+    # -- synthesis -------------------------------------------------------
+    def _is_ours(self, widget):
+        top = widget.window()
+        return top is self or top is self._tip
+
+    def _widget_under_tip(self, global_pos):
+        """The application widget under the tip, or None. The direct
+        probe works where the platform passes hit tests through the
+        mouse-transparent tip window; where it does not, the tip is
+        hidden for the one probe and restored."""
+        target = QApplication.widgetAt(global_pos)
+        if target is not None and not self._is_ours(target):
+            return target
+        self._tip.hide()
+        try:
+            target = QApplication.widgetAt(global_pos)
+        finally:
+            self._tip.show()
+        if target is None or self._is_ours(target):
+            return None
+        return target
+
+    def _target(self):
+        """(widget, local QPointF, global QPointF) under the tip, or
+        None — resolved fresh so a widget destroyed mid-gesture is
+        never dereferenced."""
+        global_pos = self._tip.hotspot()
+        target = self._widget_under_tip(global_pos)
+        if target is None:
+            return None
+        local = target.mapFromGlobal(global_pos)
+        return target, QPointF(local), QPointF(global_pos)
+
+    def _propagate(self, target, event_factory):
+        """Send an event up the parent chain until a widget accepts
+        it. Qt walks this chain itself only for SPONTANEOUS events;
+        a synthesized sendEvent stops dead at the leaf (a QLabel
+        inside a scroll area would swallow every wheel notch)."""
+        global_pos = self._tip.hotspot()
+        while target is not None:
+            event = event_factory(
+                QPointF(target.mapFromGlobal(global_pos)))
+            QApplication.sendEvent(target, event)
+            if event.isAccepted():
+                return
+            target = target.parentWidget()
+
+    def _send_click(self, button, zone):
+        resolved = self._target()
+        if resolved is None:
+            return
+        target, local, global_pos = resolved
+        now = time.monotonic()
+        last_time, last_zone = self._last_click
+        double = (zone == last_zone and (now - last_time) * 1000
+                  <= QApplication.doubleClickInterval())
+        self._last_click = (0.0, None) if double else (now, zone)
+        # Qt only synthesizes DblClick from native events, so two
+        # quick taps are promoted here instead.
+        press = (QEvent.Type.MouseButtonDblClick if double
+                 else QEvent.Type.MouseButtonPress)
+        for event_type, buttons in ((press, button),
+                                    (QEvent.Type.MouseButtonRelease,
+                                     Qt.MouseButton.NoButton)):
+            QApplication.sendEvent(target, QMouseEvent(
+                event_type, local, local, global_pos, button, buttons,
+                Qt.KeyboardModifier.NoModifier))
+        if button == Qt.MouseButton.RightButton:
+            # A context menu is its own event, raised by the window
+            # system after a real right click — synthesized here and
+            # walked up the chain to whoever offers one.
+            self._propagate(target, lambda local_pos:
+                            QContextMenuEvent(
+                                QContextMenuEvent.Reason.Mouse,
+                                local_pos.toPoint(),
+                                self._tip.hotspot()))
+
+    def _send_wheel(self, notches):
+        # Resolved once per gesture (the tip is not moving while the
+        # strip is dragged) so the hide-probe fallback cannot flicker
+        # the crosshair mid-scroll; validity re-checked per notch in
+        # case the target was destroyed under us.
+        if (self._wheel_target is None
+                or not shiboken6.isValid(self._wheel_target)):
+            resolved = self._target()
+            if resolved is None:
+                return
+            self._wheel_target = resolved[0]
+        global_pos = QPointF(self._tip.hotspot())
+        self._propagate(self._wheel_target, lambda local_pos:
+                        QWheelEvent(
+                            local_pos, global_pos, QPoint(),
+                            QPoint(0, notches * _WHEEL_NOTCH),
+                            Qt.MouseButton.NoButton,
+                            Qt.KeyboardModifier.NoModifier,
+                            Qt.ScrollPhase.NoScrollPhase, False))
+
+    # -- painting ---------------------------------------------------------
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.Antialiasing)
+        body = self.rect().adjusted(2, 2, -2, -2)
+        painter.setPen(QPen(QColor(GREY["dark"]), 2))
+        painter.setBrush(QColor(GREY["light"]))
+        radius = body.width() // 2 - 4
+        painter.drawRoundedRect(body, radius, radius // 2)
+        split_y = int(self.height() * _BUTTON_ZONE_FRACTION)
+        wheel_left = (self.width() - MOUSE_WHEEL_WIDTH_PX) // 2
+        # The button split line and the wheel.
+        painter.drawLine(body.left(), split_y, body.right(), split_y)
+        painter.drawLine(wheel_left, body.top(), wheel_left, split_y)
+        painter.drawLine(wheel_left + MOUSE_WHEEL_WIDTH_PX, body.top(),
+                         wheel_left + MOUSE_WHEEL_WIDTH_PX, split_y)
+        painter.setBrush(QColor(PRIMARY_COLOR))
+        painter.drawRoundedRect(
+            wheel_left + 4, body.top() + 12,
+            MOUSE_WHEEL_WIDTH_PX - 8, split_y - 24, 6, 6)
+        # L / R labels and the close ✕.
+        painter.setPen(QPen(QColor(GREY["dark"])))
+        left_zone = QRect(body.left(), body.top(), wheel_left, split_y)
+        right_zone = QRect(wheel_left + MOUSE_WHEEL_WIDTH_PX,
+                           body.top(),
+                           body.right() - wheel_left
+                           - MOUSE_WHEEL_WIDTH_PX, split_y)
+        painter.drawText(left_zone, Qt.AlignCenter, "L")
+        painter.drawText(right_zone, Qt.AlignCenter, "R")
+        painter.drawText(self._close_rect(), Qt.AlignCenter, "✕")
+        painter.setPen(QPen(QColor(WHITE)))
+        painter.drawText(
+            QRect(body.left(), split_y, body.width(),
+                  body.bottom() - split_y),
+            Qt.AlignCenter, "drag\nto aim")

--- a/pluggable_protocol_tree/services/preferences.py
+++ b/pluggable_protocol_tree/services/preferences.py
@@ -158,7 +158,7 @@ class ProtocolPreferences(PreferencesHelper):
 
         default_dir.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Default repo directory is: {default_dir}")
+        logger.debug(f"Default repo directory is: {default_dir}")
 
         return default_dir
 


### PR DESCRIPTION
## What

On a touchscreen bench there is no mouse or keyboard — nothing to scroll with, right-click with, or type into. **Tools → Touch Assist** now offers three independent checkbox tools (no mode switch, no detection — the user decides what is on screen):

- **Virtual Numpad** — digits, sign, decimal point, backspace, spinbox stepping (▲/▼), Enter. The arrows auto-repeat while held (400 ms delay, then every 80 ms), so a spinbox climbs steadily under a finger.
- **Virtual Keyboard** — compact QWERTY with a digit row and one-shot latching **Shift / Ctrl / Alt**: a latched modifier joins the next key's chord (Ctrl+A, Ctrl+C…) and releases itself; Shift uppercases letters and turns the digit row into its symbols.
- **Virtual Mouse** — a mouse-shaped floater with a crosshair pointer tip hovering above it: drag the body to aim (the finger stays below the target), tap L/R to click at the tip, drag the wheel strip to scroll under it. Two quick taps promote to a real double-click. A **Hold pill** latches a left press so dragging the body performs click-drags (sliders, ROI moves, text selection); tapping Hold or L releases at the tip.

## How

New `microdrop_application/touch_assist/` package (application chrome, frontend-local — no Redis/dramatiq):

- Pads are frameless, always-on-top, finger-draggable, and never take focus (`WindowDoesNotAcceptFocus`) — keys post `QKeyEvent`s to whatever field the user last tapped, so TraitsUI editors, plugin panes and dialogs all work with zero per-widget wiring. Key text color is pinned against the app's dark stylesheet.
- The manager creates each widget lazily and mirrors a widget's own ✕ back into its menu checkbox.
- Two Qt synthesis traps handled in the mouse: `widgetAt()` can't always see through the mouse-transparent tip window (momentary hide-and-retest fallback, cached per wheel gesture), and Qt walks the parent chain only for *spontaneous* events, so wheel and context-menu events are propagated up manually until accepted.

Also included: `chore(preferences)` log-level/wording tidy-up.

Design spec: `docs/superpowers/specs/2026-08-12-touch-assist-design.md`

## Testing

Offscreen-verified: numpad typing + backspace, spinbox stepping and ~1 s hold stepping 0→7, one-shot Shift/Ctrl/Alt (Ctrl+A select-all, Shift+1 → `!`, Alt chord types nothing), left click, right-click → `customContextMenuRequested`, wheel both directions through nested widgets, double-click promotion, hold-latch drag streaming with button-down moves. GUI verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)