### PR TITLE
fix(ssh-controls-ui): SSH Key Portal stuck on 'Starting key generation'

### DIFF
--- a/ssh_controls/service.py
+++ b/ssh_controls/service.py
@@ -169,7 +169,8 @@ class SSHService(HasTraits):
         config = json.loads(config)
         pub_key = config.get("generated_pub_key")
         if not pub_key:
-            publish_message("No key has been generated or read yet.")
+            publish_message("No key has been generated or read yet.",
+                            SSH_KEY_UPLOAD_ERROR)
             return
 
         if not all([config["host"], config["port"], config["username"], config["password"]]):

--- a/ssh_controls_ui/menus.py
+++ b/ssh_controls_ui/menus.py
@@ -13,6 +13,45 @@ from .sync_dialog.model import SyncDialogModel
 from .sync_dialog.view_model import SyncDialogViewModel, SyncDialogViewModelSignals
 from .sync_dialog.widget import SyncDialogView
 
+# ---------------------------------------------------------------------------
+# One view-model + listener per dialog, shared by every Action instance.
+#
+# The menu bar is REBUILT whenever plugin groups hot-mount, recreating
+# these Actions — but a dramatiq listener name can register only once,
+# so the first registration's view-model receives every message
+# forever. An Action that built its own view-model would show a window
+# wired to signals the listener never fires (the "stuck on Starting…"
+# portal). The session below outlives the Actions, so every rebuild's
+# windows connect to the very view-model the listener drives.
+# ---------------------------------------------------------------------------
+_key_portal_session = None
+_sync_session = None
+
+
+def key_portal_view_model():
+    global _key_portal_session
+    if _key_portal_session is None:
+        view_model = SSHControlViewModel(
+            model=SSHControlModel(),
+            prefs=SSHControlPreferences(),
+            view_signals=SSHControlViewModelSignals(),
+        )
+        _key_portal_session = (view_model,
+                               SSHControlUIListener(ui=view_model))
+    return _key_portal_session[0]
+
+
+def sync_view_model():
+    global _sync_session
+    if _sync_session is None:
+        view_model = SyncDialogViewModel(
+            model=SyncDialogModel(),
+            prefs=SSHControlPreferences(),
+            view_signals=SyncDialogViewModelSignals(),
+        )
+        _sync_session = (view_model, SyncDialogListener(ui=view_model))
+    return _sync_session[0]
+
 
 class SshKeyUploaderApp(QMainWindow):
     """Main window for the SSH Key Portal dialog."""
@@ -32,14 +71,9 @@ class ShowSshKeyUploaderAction(Action):
 
     def traits_init(self, *args, **kwargs):
         self._window = None
-        self.prefs = SSHControlPreferences()
-        self.model = SSHControlModel()
-        self.view_model = SSHControlViewModel(
-            model=self.model,
-            prefs=self.prefs,
-            view_signals=SSHControlViewModelSignals(),
-        )
-        self.listener = SSHControlUIListener(ui=self.view_model)
+        self.view_model = key_portal_view_model()
+        self.prefs = self.view_model.prefs
+        self.model = self.view_model.model
 
     def perform(self, event):
         if self._window is not None:
@@ -79,14 +113,9 @@ class ShowSyncRemoteExperimentsAction(Action):
 
     def traits_init(self, *args, **kwargs):
         self._window = None
-        self.prefs = SSHControlPreferences()
-        self.model = SyncDialogModel()
-        self.view_model = SyncDialogViewModel(
-            model=self.model,
-            prefs=self.prefs,
-            view_signals=SyncDialogViewModelSignals(),
-        )
-        self.listener = SyncDialogListener(ui=self.view_model)
+        self.view_model = sync_view_model()
+        self.prefs = self.view_model.prefs
+        self.model = self.view_model.model
 
     def perform(self, event):
         if self._window is not None:

--- a/ssh_controls_ui/view_model.py
+++ b/ssh_controls_ui/view_model.py
@@ -165,8 +165,12 @@ class SSHControlViewModel(HasTraits):
         self.view_signals.enable_upload_button.emit(True)
 
     def _on_ssh_key_upload_error_triggered(self, message):
-        message = json.loads(message)
-        title, text = message.get("title"), message.get("text")
+        # The service publishes upload errors as plain text (see
+        # _on_key_upload_request) — json.loads here made every upload
+        # failure crash the handler and leave the dialog stuck on
+        # "Starting key upload...".
+        text = str(message)
         self.view_signals.key_upload_status_text_changed.emit(f"Error: {text}")
-        self.view_signals.show_message_box.emit("error", title, text)
+        self.view_signals.show_message_box.emit("error",
+                                                "Key Upload Error", text)
         self.view_signals.enable_upload_button.emit(True)


### PR DESCRIPTION
## Symptom

Clicking **Generate Key** in the SSH Key Portal leaves the dialog stuck on *Starting key generation/reading…* forever — the backend generates the key and publishes success, and the success handler visibly executes (confirmed under a debugger at `view_model.py:145`), yet the window never updates. Same for the Sync Remote Experiments dialog.

## Root cause

The menu bar is **rebuilt whenever plugin groups hot-mount** (e.g. the zstage groups loading at startup), which recreates the pyface Actions. Each `ShowSshKeyUploaderAction.traits_init` built its **own** view-model and tried to register a dramatiq listener under the same listener name — but `generate_class_method_dramatiq_listener_actor` keeps the **first** registration and refuses duplicates with only a warning. Result: every `ssh_service/success/…` message is delivered to the *first* Action's view-model, which emits Qt signals nothing is connected to, while the window the user actually opened is wired to a *later* view-model that never hears anything.

## Fix

One module-level view-model + listener per dialog, created lazily on first use and shared by every Action instance — the session outlives the menu rebuilds, so any window opened from any rebuild's menu connects to the very view-model the registered listener drives. Applied to both the Key Portal and the Sync dialog (identical wiring).

## Testing

Cross-thread signal mechanics verified offscreen with the real classes (close/reopen cycle + emit from a worker thread updates label and re-enables the button). GUI verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)