### PR TITLE
Generalize the firmware-upload machinery for non-Pico peripherals

### DIFF
--- a/microdrop_utils/firmware_upload_dialog/controller.py
+++ b/microdrop_utils/firmware_upload_dialog/controller.py
@@ -57,6 +57,17 @@ class FirmwareUploadDialogController(HasTraits):
     finished_topic = Str()
     default_device_id = Str()
     dialog_title = Str("Upload Firmware")
+    #: Intro text above the config panel; a device with a different flash
+    #: story (e.g. bundled non-Pico firmware) overrides it alongside
+    #: panel_view.
+    intro_message = Str(
+        "Flash the MicroPython firmware to a connected Pico board. "
+        "Configure the source, port, and options below, then press Upload."
+    )
+    #: TraitsUI view for the config panel; the default shows every Pico
+    #: option, a simpler device injects a slimmed view over (a subclass of)
+    #: FirmwareUploadModel.
+    panel_view = Any(firmware_upload_view)
 
     model = Instance(FirmwareUploadModel)
     preferences = Instance(PreferencesHelper)
@@ -79,9 +90,7 @@ class FirmwareUploadDialogController(HasTraits):
             return
         self.dialog = BaseMessageDialog(
             title=self.dialog_title,
-            message="Flash the MicroPython firmware to a connected Pico "
-                    "board. Configure the source, port, and options below, "
-                    "then press Upload.",
+            message=self.intro_message,
             dialog_type=BaseMessageDialog.TYPE_QUESTION,
             buttons={
                 "Close": {"action": self._request_close, "role": "exit"},
@@ -99,7 +108,8 @@ class FirmwareUploadDialogController(HasTraits):
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
         self.traits_ui = self.model.edit_traits(
-            view=firmware_upload_view, kind="subpanel", parent=self.dialog)
+            view=self.panel_view, kind="subpanel", parent=self.dialog
+        )
         # The built control is the HSplit's QSplitter; the left column's own
         # QScrollArea is made transparent by the panel stylesheet.
         panel = self.traits_ui.control

--- a/microdrop_utils/firmware_upload_dialog/model.py
+++ b/microdrop_utils/firmware_upload_dialog/model.py
@@ -76,12 +76,19 @@ class FirmwareUploadModel(HasTraits):
     preferences = Instance(PreferencesHelper)
 
     def traits_init(self):
+        # No preferences helper → nothing to restore (a device without a
+        # firmware-source preference, e.g. the bundled-firmware Z-Stage,
+        # leaves preferences None).
+        if self.preferences is None:
+            return
         _firmware_source_saved = self.preferences.trait_get("firmware_source")
         if _firmware_source_saved:
             self.firmware_source = _firmware_source_saved["firmware_source"]
 
     @observe("firmware_source")
     def _save_firmware_source(self, event):
+        if self.preferences is None:
+            return
         logger.info(f"Saved firmware source: {event.new}")
         self.preferences.firmware_source = event.new
 

--- a/peripheral_device_controller_base/services/peripheral_firmware_upload_service.py
+++ b/peripheral_device_controller_base/services/peripheral_firmware_upload_service.py
@@ -150,25 +150,33 @@ class PeripheralFirmwareUploadService(HasTraits):
                 return port, True
         return port, False
 
+    def _flash_firmware(self, data, port, cancel_event):
+        """Run the actual flash and return its success. The default flashes a
+        MicroPython Pico board via firmware_uploader.upload_firmware; a
+        non-Pico peripheral overrides just this step (keeping the shared port
+        resolution, proxy release, threading, and topic reporting)."""
+        return upload_firmware(
+            firmware_path=data.firmware_source,
+            port=port or None,
+            reset_device=data.reset_after_upload,
+            single_file=data.single_file or None,
+            no_format=data.skip_filesystem_format,
+            update_config=data.update_config,
+            device_id=data.device_id,
+            dry_run=data.dry_run,
+            hwids=getattr(self, "_default_hwids", None) or None,
+            log=self._publish_upload_log_line,
+            cancel_event=cancel_event,
+        )
+
     def _run_upload(self, data, port, proxy_released, cancel_event):
-        """Upload thread: run the uploader with a topic-publishing log, then
+        """Upload thread: run the flash step with a topic-publishing log, then
         report the outcome; if the proxy was released for this upload,
         re-request monitoring so the freshly flashed board reconnects."""
         try:
-            success = upload_firmware(
-                firmware_path=data.firmware_source,
-                port=port or None,
-                reset_device=data.reset_after_upload,
-                single_file=data.single_file or None,
-                no_format=data.skip_filesystem_format,
-                update_config=data.update_config,
-                device_id=data.device_id,
-                dry_run=data.dry_run,
-                hwids=getattr(self, "_default_hwids", None) or None,
-                log=self._publish_upload_log_line,
-                cancel_event=cancel_event,
-            )
-            finished_payload = {"success": success}
+            finished_payload = {
+                "success": self._flash_firmware(data, port, cancel_event)
+            }
         except Exception as e:
             logger.exception("Firmware upload crashed")
             finished_payload = {"error": str(e)}


### PR DESCRIPTION
## Summary
- Extract the Pico-specific `upload_firmware(...)` call in `PeripheralFirmwareUploadService._run_upload` into an overridable `_flash_firmware(data, port, cancel_event)` hook. The shared port resolution, proxy release via `cleanup()`, upload thread, cancel/timeout handling, started/log/finished topics, and post-upload monitoring restart are unchanged — heater and fluorescence behave exactly as before.
- Parametrize the shared firmware-upload dialog: the hardcoded TraitsUI panel and intro text become `panel_view` / `intro_message` traits (defaults unchanged), so a device whose firmware is bundled can inject a slimmed port-only panel.
- Fix: `FirmwareUploadModel` now tolerates `preferences=None` (Traits resolves the `model` trait default while hooking observers even when a model is passed in, which crashed in `traits_init` for a device without a firmware-source preference).

Companion PR: magnet plugin `feat/zstage-firmware-upload` uses these hooks to add Upload Firmware for the mr-box board.

## Test plan
- `py_compile` + headless import of the touched modules in the pixi env
- Headless construction of a dialog controller with an injected model/view and `preferences=None` (with warnings-as-errors)
- Manual GUI check of the heater upload dialog recommended to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)