### PR TITLE
chore: release v1.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v1.12.1 (2026-08-25)
+
+### Fix
+
+- **firmware-dialog**: tolerate a missing preferences helper
+
+### Refactor
+
+- **firmware-dialog**: parametrize panel view and intro text
+- **peripherals**: extract flash step into overridable hook
+
 ## v1.12.0 (2026-08-21)
 
 ### Feat


### PR DESCRIPTION
## v1.12.1 (2026-08-25)

### Fix

- **firmware-dialog**: tolerate a missing preferences helper

### Refactor

- **firmware-dialog**: parametrize panel view and intro text
- **peripherals**: extract flash step into overridable hook

[main a66dd0a5] chore: release v1.12.1
 1 file changed, 11 insertions(+)

