### PR TITLE
fix(utils): make ColorColumn cells editable via the trait's own editor

### DIFF
--- a/microdrop_utils/traitsui_qt_helpers.py
+++ b/microdrop_utils/traitsui_qt_helpers.py
@@ -21,6 +21,7 @@ from traits.api import Instance, Any, Bool, Range, List, Str, Int, Property, Flo
 from traitsui.api import (ObjectColumn as ObjectTableColumn_, TableColumn as TableColumn_, Controller,
                           UIInfo, Handler, RangeEditor, EnumEditor, BasicEditorFactory)
 from traitsui.qt.editor import Editor as QtEditor
+from traitsui.qt.table_editor import TableDelegate
 
 from microdrop_style.button_styles import ICON_FONT_FAMILY
 from microdrop_style.colors import WHITE, BLACK, PRIMARY_COLOR, GREY, SUCCESS_COLOR
@@ -92,7 +93,15 @@ class ObjectColumn(ObjectTableColumn_):
         return "white" if is_dark_mode() else "black"
 
 
-class ColorRenderer(QStyledItemDelegate):
+class ColorRenderer(TableDelegate):
+    """Cell delegate that paints the whole cell in the value's color.
+
+    Subclasses TraitsUI's TableDelegate (not a bare QStyledItemDelegate):
+    a column ``renderer`` REPLACES the table's delegate for that column, so
+    it must also provide ``createEditor`` — inherited here — or double-click
+    editing silently dies. Via TableDelegate, editing opens the column
+    trait's own editor (for a Color trait, the standard color picker)."""
+
     def paint(self, painter, option, index):
         value = index.data()
         color = QColor(value)
@@ -115,6 +124,11 @@ class ColorColumn(ObjectColumn):
 
         # force the renderer to be our color renderer
         self.renderer = ColorRenderer()
+        # The renderer rebuilds a QColor from the cell's TEXT, so format the
+        # value to a hex name — a hex string passes through unchanged, and a
+        # Color/QColor trait (whose str() QColor cannot parse) becomes one.
+        if self.format_func is None:
+            self.format_func = lambda value: QColor(value).name()
 
 
 class CustomCheckboxColumn(ObjectColumn):


### PR DESCRIPTION
Fixes #594

## What

Double-clicking a `ColorColumn` cell did nothing (with a `Color` trait) or fell back to a bare line edit (with a `Str` hex trait).

## Why

TraitsUI installs a column's `renderer` as the item delegate **for the whole column** (`setItemDelegateForColumn`), replacing TraitsUI's `TableDelegate` — whose `createEditor` is what builds the column trait's editor. `ColorRenderer` was a bare `QStyledItemDelegate` with only `paint()`, so editing went to Qt's default delegate, which has no editor for `QColor` data.

## How

- `ColorRenderer` now subclasses `traitsui.qt.table_editor.TableDelegate`: swatch painting unchanged, `createEditor` inherited — double-click opens the trait's own editor (the standard `SimpleColorEditor` picker for a `Color` trait).
- `ColorColumn` defaults `format_func` to `QColor(value).name()` so the renderer (which rebuilds a `QColor` from the cell *text*) also works for `Color`/`QColor` traits; hex strings pass through unchanged, existing `Str` users unaffected.

## Testing

Verified in the electrode-zones demo (zone-type color as a `Color` trait): programmatically triggered cell edit opens `SimpleColorEditor`; picking a color recolors table swatch and canvas regions live. Smoke-tested this branch: `ColorColumn` instantiates with a `TableDelegate` renderer and formats both hex strings and `QColor` values to hex names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)