### PR TITLE
chore: release v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.13.1 (2026-08-27)
+
+### Fix
+
+- **utils**: make ColorColumn cells editable via the trait's own editor
+
 ## v1.13.0 (2026-08-25)
 
 ### Feat


### PR DESCRIPTION
## v1.13.1 (2026-08-27)

### Fix

- **utils**: make ColorColumn cells editable via the trait's own editor

[main 7edbcb79] chore: release v1.13.1
 1 file changed, 6 insertions(+)

