### PR TITLE
docs(agents): codify TraitsUI-first views and pyface.qt imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,6 +253,25 @@ electrode_ids = List(Str)
   does, and not the history of the change
 - Match the surrounding file's idiom, comment density, and layout
 
+### Style Exemplars
+
+Before writing new code, pattern-match against these files — they carry the
+idiom (chunking, comment density, method order) that rules alone can't:
+
+- **MVC trio, the frontend template**:
+  `portable_dropbot_status_and_controls/` `models/calibration_model.py` +
+  `controllers/calibration_controller.py` + `views/calibration_view.py` —
+  Qt-free `HasTraits` model, a controller whose `@observe` handlers are
+  one-liners publishing to topics, a declarative module-level TraitsUI
+  `View` of named groups with `enabled_when`. The `advanced_controls` trio
+  is the larger sibling and shows `pyface_wrapper.confirm` for destructive
+  actions.
+- **Backend mixin service**:
+  `dropbot_controller/services/dropbot_states_setting_mixin_service.py` —
+  specific exception tuples, f-strings, no cross-plugin imports.
+- **Plugin package overall**: `portable_dropbot_status_and_controls/` —
+  many small files, consts-only cross-plugin imports, `#:` trait docs.
+
 ### Architecture Conventions
 
 - **Design first**: lean on established software design principles and
@@ -275,6 +294,12 @@ electrode_ids = List(Str)
   touched, not in sweeps).
 - **Decoupling**: plugins never call each other directly — communicate via
   Dramatiq pub/sub topics or the Redis app-globals hash
+- **Validated publishing**: new topics publish through
+  `ValidatedTopicPublisher` (`microdrop_utils/dramatiq_pub_sub_helpers.py`)
+  with a Pydantic message model colocated with the topic constant in the
+  owning plugin's `consts.py` — the topic and its payload schema are one
+  importable contract. Raw `publish_message` is legacy, converted as call
+  sites are touched.
 - Every plugin has a `consts.py` with `PKG`, its topics, and
   `ACTOR_TOPIC_DICT`
 - Styling goes through `microdrop_style/` helpers (colors, button styles,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,7 +283,12 @@ electrode_ids = List(Str)
 ## Commits, PRs, and Changelog
 
 - **Conventional Commits**, CI-enforced: `type(scope): subject` with types
-  `feat`/`fix`/`refactor`/`perf`/`docs`/`ci`/`chore`/`test`
+  `feat`/`fix`/`refactor`/`perf`/`docs`/`ci`/`chore`/`test`; append `!` or a
+  `BREAKING CHANGE:` footer for breaking changes. These messages drive
+  versioning and CHANGELOG.md generation (commitizen).
+- One-time per clone: `pixi run setup-hooks` (from `microdrop-py/`) installs
+  the shared git hooks — commit-format enforcement, scratch-file block,
+  syntax check; config in `.pre-commit-config.yaml`
 - Small, single-purpose commits scoped with explicit pathspecs; never one
   bulk commit for iterative work
 - Branch per issue; never commit directly to `main`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,9 +153,10 @@ import json
 from pathlib import Path
 
 # Third-party imports.
-from PySide6.QtWidgets import QToolButton
+from shapely.geometry import Polygon
 
 # Enthought library imports.
+from pyface.qt import QtWidgets
 from traits.api import HasTraits, Instance, Str, observe
 from traitsui.api import Item, View
 
@@ -254,8 +255,24 @@ electrode_ids = List(Str)
 
 ### Architecture Conventions
 
+- **Design first**: lean on established software design principles and
+  patterns — separation of concerns above all, plus the patterns the app is
+  already built from (MVC, observer via Traits, dependency injection via
+  Envisage services, pub/sub via Dramatiq). Reach for the fitting pattern
+  before inventing structure.
 - **MVC split**: Qt-free `HasTraits` models; controllers translate signals
-  into model changes or published topics; views observe the model
+  into model changes or published topics; views observe the model. Views are
+  the volatile layer — view preferences change often — so keep business
+  logic out of them entirely, and make every view instantiable standalone
+  against just its model (no plugin/app scaffolding) so it can be prototyped
+  and tested alone.
+- **TraitsUI first**: build views with TraitsUI/Pyface abstractions
+  (`View`/`Item`/`Group`, editors, Handlers); drop to raw Qt widgets only
+  when TraitsUI genuinely cannot express the widget or behavior. When raw Qt
+  is needed, import it through the binding shim —
+  `from pyface.qt import QtCore, QtGui, QtWidgets` — never `from PySide6...`
+  directly in new code (existing PySide6 imports are converted as files are
+  touched, not in sweeps).
 - **Decoupling**: plugins never call each other directly — communicate via
   Dramatiq pub/sub topics or the Redis app-globals hash
 - Every plugin has a `consts.py` with `PKG`, its topics, and

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -69,11 +69,9 @@ with proxy.transaction_lock:
 - Issues: https://github.com/Blue-Ocean-Technologies-Inc/Microdrop/issues/
 
 ## Git & PR Workflow
-- Commit early, commit frequently — make multiple small, incremental commits for each iterative change (e.g., add constant, then add listener, then add dialog, then wire it up). Each commit should have a clear, descriptive message.
-- One-time per clone: `pixi run setup-hooks` (from `microdrop-py/`) installs the shared git hooks into this repo and the heater/magnet clones — commit-format enforcement, scratch-file block, syntax check; config in each repo's `.pre-commit-config.yaml`. (Equivalent manual command: `pre-commit install --hook-type commit-msg --hook-type pre-commit`.)
-- Commit messages MUST follow Conventional Commits (a CI check enforces this on PRs): `type(scope): subject` with types `feat` / `fix` / `refactor` / `perf` / `docs` / `ci` / `chore` / `test`; append `!` or a `BREAKING CHANGE:` footer for breaking changes. These messages drive versioning and CHANGELOG.md generation (commitizen).
-- Always create a new branch for resolving issues (never commit directly to main/master)
-- Always submit a PR for reviewing changes after pushing the branch
+
+The commit/PR conventions and hook setup live in `AGENTS.md` (imported above,
+under "Commits, PRs, and Changelog").
 
 ## Releases & changelogs
 - **This repo (the app)**: version = git tags (`.cz.toml`, `version_provider = "scm"`). Cut a release from an up-to-date `main`: `pixi exec --spec "commitizen>=4,<5" -- cz bump` (derives the bump from conventional commits since the last `v*` tag, updates CHANGELOG.md, tags `vX.Y.Z`), then `git push origin main --follow-tags` (requires branch-protection bypass, i.e. an admin).
@@ -84,36 +82,14 @@ with proxy.transaction_lock:
 - See `PRESENTATION-GUIDE.md` (in this same `docs/` folder) for full details: slide structure, brand/design system, CSS architecture, SVG logos, and layout conventions
 - Key corrections (do not revert): `electrodes_state_change` toggles state only (not voltage), architecture is three-way decoupled (Frontend/Backend/Server), DropBot API slides reflect actual Python API
 
-# Below is from a document that provides more guidance to Claude Code (claude.ai/code) when working with code in this repository:
-
-## Project Overview
-
-MicroDrop-Next-Gen is a GUI for the DropBot Digital Microfluidics control system. It uses a plugin-based architecture (Envisage) with async message passing (Dramatiq + Redis) between decoupled components.
-
 ## Running the Application
 
-Redis must be running before launching. Start it via `redis-server` or `python examples/start_redis_server.py`.
+Redis must be running before launching. Start it via `redis-server` or `python examples/start_redis_server.py`. Run through pixi from `src/` (see `AGENTS.md`, "Environment"); besides the full app there are frontend-only and backend-only run scripts:
 
 ```bash
-# Full application (frontend + backend)
-python examples/run_device_viewer_pluggable.py
-
-# Frontend only (needs redis + backend running separately)
-python examples/run_device_viewer_pluggable_frontend.py
-
-# Backend only
-python examples/run_device_viewer_pluggable_backend.py
-```
-
-## Running Tests
-
-Tests are in `examples/tests/` and `electrode_controller/tests/`. Some test subdirectories have external requirements:
-- `tests_with_redis_server_need/` — requires a running Redis server
-- `tests_with_dropbot_connection_need/` — requires physical DropBot hardware
-
-```bash
-pytest examples/tests/
-pytest electrode_controller/tests/
+pixi run python -m examples.run_device_viewer_pluggable            # full app
+pixi run python -m examples.run_device_viewer_pluggable_frontend   # frontend only (needs redis + backend running separately)
+pixi run python -m examples.run_device_viewer_pluggable_backend    # backend only
 ```
 
 ## Architecture
@@ -144,6 +120,7 @@ All inter-plugin communication goes through a pub/sub message router — plugins
 - `MessageRouterActor` in the same file receives and fans out messages to subscribers
 - Topics follow MQTT-style naming: `dropbot/requests/set_voltage`, `dropbot/signals/connected`
 - MQTT wildcards supported: `+` (single level), `#` (multi-level)
+- `ValidatedTopicPublisher` (same module) provides Pydantic-validated message publishing
 - See `MESSAGES.md` for the full topic map of which plugins send/receive what
 
 ### Message Handler Conventions
@@ -165,14 +142,6 @@ All inter-plugin communication goes through a pub/sub message router — plugins
 ### SVG Device Handling
 
 Electrode layouts are defined in SVG files. Metadata is parsed from SVG path elements (`data-channels` attribute). Centers are computed from path vertices and neighbors from distance calculations. Straight path commands (M, L, H, V, Z) contribute endpoints; curved segments (arcs, Béziers — e.g. Inkscape circles) are flattened into polygon vertices by sampling (CURVE_SEGMENT_SAMPLES per segment). See `device_viewer/utils/dmf_utils.py`.
-
-## Coding Conventions
-
-- Every plugin has a `consts.py` with `PKG = '.'.join(__name__.split('.')[:-1])` and `ACTOR_TOPIC_DICT`
-- Logging: `from logger.logger_service import get_logger; logger = get_logger(__name__)`
-- Styling: use `microdrop_style/` helpers (`colors`, `button_styles`, `icons`)
-- Traits/TraitsUI for models and data binding; PySide6/Qt for widgets
-- `ValidatedTopicPublisher` (in `microdrop_utils/dramatiq_pub_sub_helpers.py`) provides Pydantic-validated message publishing
 
 ## Useful Environment Variables
 


### PR DESCRIPTION
## Summary

Codifies three maintainer directives in the AGENTS.md style guide (Architecture Conventions + the import example):

- **Design first** — lean on established design principles and the patterns the app is already built from: separation of concerns, MVC, observer via Traits, dependency injection via Envisage services, pub/sub via Dramatiq.
- **Views are the volatile layer** — view preferences change often, so business logic stays out of views entirely, and every view must be instantiable standalone against just its model (no plugin/app scaffolding) so it can be prototyped and tested alone.
- **TraitsUI first** — build views with TraitsUI/Pyface abstractions; drop to raw Qt only when TraitsUI genuinely cannot express it, and then import via `from pyface.qt import ...`, never `PySide6` directly. Existing PySide6 imports convert incrementally as files are touched, not in sweeps. The import-section example now shows `pyface.qt` under the Enthought section accordingly.

A live exemplar of the target style already exists in-tree: the `portable_dropbot_status_and_controls` calibration model/controller/view trio.

This PR was created with agent assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)