### PR TITLE
docs: require issue metadata to be set via the GitHub API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,39 @@ idiom (chunking, comment density, method order) that rules alone can't:
 - Styling goes through `microdrop_style/` helpers (colors, button styles,
   icon fonts)
 
+## Filing Issues
+
+Issue metadata is **structured data, not prose**. Set it through the GitHub
+API when filing — never write "Low priority" or "blocks #123" in the body,
+where no board, filter, or query can see it.
+
+Set on every issue: **type** (`Task` / `Bug` / `Feature`), **labels** (only
+ones that already exist — `gh label list`), **Priority**, **Effort**,
+**assignee**, and any **sub-issue relationship** to a parent epic.
+
+```bash
+R=Blue-Ocean-Technologies-Inc/Microdrop
+
+gh api -X PATCH repos/$R/issues/N -f type=Task
+
+# org issue fields: Priority=34156766 (Urgent|High|Medium|Low)
+#                   Effort=34156769 (High|Medium|Low)
+gh api -X PUT repos/$R/issues/N/issue-field-values \
+  -H "X-GitHub-Api-Version: 2026-03-10" --input - <<'EOF'
+{"issue_field_values":[{"field_id":34156766,"value":"Low"},
+                       {"field_id":34156769,"value":"Medium"}]}
+EOF
+
+# sub-issue link takes the database id, not the issue number
+gh api -X POST repos/$R/issues/PARENT/sub_issues \
+  -F sub_issue_id=$(gh api repos/$R/issues/CHILD --jq .id)
+```
+
+Discover the current fields and types with
+`gh api orgs/Blue-Ocean-Technologies-Inc/issue-fields` and `.../issue-types`
+rather than trusting the ids above. Quote label names containing spaces
+(`--add-label "UI View"`) or the edit silently no-ops.
+
 ## Commits, PRs, and Changelog
 
 - **Conventional Commits**, CI-enforced: `type(scope): subject` with types


### PR DESCRIPTION
Adds a **Filing Issues** section to AGENTS.md.

Issue metadata is structured data, not prose. Type, labels, Priority, Effort, assignee, and sub-issue relationships belong in the API fields — where boards, filters, and queries can see them — not in body text like "Low priority", which nothing can sort or count.

The section records the working `gh` recipes so they don't have to be rediscovered:

- `PATCH /issues/N -f type=` for the issue type (Task / Bug / Feature)
- `PUT /issues/N/issue-field-values` with `X-GitHub-Api-Version: 2026-03-10` for the org fields (Priority `34156766`, Effort `34156769`)
- `POST /issues/PARENT/sub_issues` for epic relationships — takes the **database id**, not the issue number

Plus two traps worth writing down: label names containing spaces (`UI View`) must be quoted per flag or the edit silently no-ops, and the field ids should be rediscovered via `gh api orgs/Blue-Ocean-Technologies-Inc/issue-fields` rather than trusted from the doc, since they will drift.

Context: this follows a triage pass over all 26 open issues, which now carry type, labels, Priority, and Effort, with #599–#601 linked under the #598 epic and #610/#611 linked under #616.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)